### PR TITLE
feat: Add automatic AWS AMI building and publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
 - export BUILDKIT_HOST=tcp://0.0.0.0:1234
 script:
 - make
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash make publish-aws; fi'
 - if [[ -n $(git status -s) ]];then echo 'working tree is dirty' && git status -s
   && exit 1; fi
 branches:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ BUILDCTL_ARCHIVE := https://github.com/moby/buildkit/releases/download/$(BUILDKI
 endif
 BINDIR ?= /usr/local/bin
 CONFORM_VERSION ?= v0.1.0-alpha.10
+AWS_PUBLISH_REGIONS ?= us-west-1,us-west-2,us-east-1,us-east-2,eu-central-1
 
 COMMON_ARGS := --progress=plain
 COMMON_ARGS += --frontend=dockerfile.v0
@@ -59,7 +60,7 @@ ifneq ($(BUILDKIT_CONTAINER_RUNNING),$(BUILDKIT_CONTAINER_NAME))
 		--name $(BUILDKIT_CONTAINER_NAME) \
 		-d \
 		--privileged \
-		 -p 1234:1234 \
+		-p 1234:1234 \
 		$(BUILDKIT_IMAGE) \
 		--addr $(BUILDKIT_HOST)
 	@echo "Wait for buildkitd to become available"
@@ -126,6 +127,12 @@ image-gcloud: installer
 
 image-vanilla: installer
 	@docker run --rm -v /dev:/dev -v $(PWD)/build:/out --privileged $(DOCKER_ARGS) autonomy/installer:$(TAG) image -l
+
+publish-aws:
+	@docker run \
+    	--rm \
+    	--env AWS_DEFAULT_REGION="us-west-2" \
+    	autonomy/talos:latest ami -var regions=${AWS_PUBLISH_REGIONS} -var version=$(TAG) -var visibility=all
 
 .PHONY: docs
 docs:

--- a/hack/installer/packer.json
+++ b/hack/installer/packer.json
@@ -32,6 +32,7 @@
             "ami_description": "Talos (HVM)",
             "ami_virtualization_type": "hvm",
             "ami_regions": "{{ user `regions` }}",
+            "ami_groups": "{{ user `visibility` }}",
             "ami_root_device": {
                 "source_device_name": "/dev/xvdf",
                 "device_name": "/dev/xvda",


### PR DESCRIPTION
## Description

This PR add the automatic ability for the CI to build the AWS AMI and publish it to the public on the regions specified inside the `Makefile`.

## Important information

- This PR won't work without these two environment variables passed inside the Travis CI project's settings or using the secret in the `.travis.yml`:
  * `AWS_ACCESS_KEY_ID="anaccesskey"`
  * `AWS_SECRET_ACCESS_KEY="asecretkey"`

  ![](https://i.imgur.com/ucaAArS.png)
  More information on that available here: https://www.packer.io/docs/builders/amazon.html#environment-variables

- This PR needs the automatic deployment of the Docker images on the Docker hub to work because it pulls the image based on latest commit ID.