### PR TITLE
chore: fixes for talos in docker-compose environment

### DIFF
--- a/hack/dev/Makefile
+++ b/hack/dev/Makefile
@@ -29,7 +29,7 @@ kubeconfig:
 .PHONY: clean
 clean: down
 	-@rm talosconfig
-	-@rm kubeconfig
+	-@rm -rf kubeconfig
 	-@rm userdata/master-1.yaml
 	-@rm userdata/master-2.yaml
 	-@rm userdata/master-3.yaml

--- a/hack/dev/docker-compose.yaml
+++ b/hack/dev/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       talosbr:
 
   master-1:
-    image: ${IMAGE:-autonomy/talos-os}:${TAG}
+    image: ${IMAGE:-autonomy/talos}:${TAG}
     container_name: master-1
     privileged: true
     security_opt:
@@ -45,7 +45,7 @@ services:
         ipv4_address: 10.5.0.6
 
   master-2:
-    image: ${IMAGE:-autonomy/talos-os}:${TAG}
+    image: ${IMAGE:-autonomy/talos}:${TAG}
     container_name: master-2
     privileged: true
     security_opt:
@@ -69,7 +69,7 @@ services:
         ipv4_address: 10.5.0.7
 
   master-3:
-    image: ${IMAGE:-autonomy/talos-os}:${TAG}
+    image: ${IMAGE:-autonomy/talos}:${TAG}
     container_name: master-3
     privileged: true
     security_opt:
@@ -93,7 +93,7 @@ services:
         ipv4_address: 10.5.0.8
 
   worker-1:
-    image: ${IMAGE:-autonomy/talos-os}:${TAG}
+    image: ${IMAGE:-autonomy/talos}:${TAG}
     container_name: worker-1
     privileged: true
     security_opt:

--- a/hack/dev/userdata/.master-1.tpl.yaml
+++ b/hack/dev/userdata/.master-1.tpl.yaml
@@ -2,6 +2,7 @@ services:
   init:
     cni: flannel
   kubeadm:
+    certificateKey: ChangeMe
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
       kind: InitConfiguration
@@ -9,7 +10,11 @@ services:
       - token: 1qbsj9.3oz5hsk6grdfp98b
         ttl: 0s
       nodeRegistration:
+        name: master-1
         criSocket: /run/containerd/containerd.sock
+      localAPIEndpoint:
+        advertiseAddress: 10.5.0.6
+        bindPort: 6443
       ---
       apiVersion: kubeadm.k8s.io/v1beta1
       kind: ClusterConfiguration

--- a/hack/dev/userdata/.master-2.tpl.yaml
+++ b/hack/dev/userdata/.master-2.tpl.yaml
@@ -8,6 +8,7 @@ services:
     cni: flannel
   kubelet: null
   kubeadm:
+    certificateKey: ChangeMe
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
       kind: JoinConfiguration
@@ -24,6 +25,7 @@ services:
         timeout: 5m0s
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
       nodeRegistration:
+        name: master-2
         criSocket: /run/containerd/containerd.sock
     ignorePreflightErrors:
       - FileContent--proc-sys-net-bridge-bridge-nf-call-iptables

--- a/hack/dev/userdata/.master-3.tpl.yaml
+++ b/hack/dev/userdata/.master-3.tpl.yaml
@@ -8,6 +8,7 @@ services:
     cni: flannel
   kubelet: null
   kubeadm:
+    certificateKey: ChangeMe
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
       kind: JoinConfiguration
@@ -24,6 +25,7 @@ services:
         timeout: 5m0s
         tlsBootstrapToken: 1qbsj9.3oz5hsk6grdfp98b
       nodeRegistration:
+        name: master-3
         criSocket: /run/containerd/containerd.sock
     ignorePreflightErrors:
       - FileContent--proc-sys-net-bridge-bridge-nf-call-iptables


### PR DESCRIPTION
* Provides certificate_key (k8s 1.14)

* Fixes local address of master-1, without the fix
it gets default 192.168.x.x assigned when k8s config is updated

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>