### PR TITLE
chore: take osctl/kubectl out of docker-compose

### DIFF
--- a/hack/dev/Makefile
+++ b/hack/dev/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 GIT_SHORT_SHA = $(shell git rev-parse --short=7 HEAD)
 GIT_DIRTY = $(shell [[ -n `git status -s` ]] && echo -dirty)
 OS_IMAGE_NAME ?= autonomy/talos
-TAG = $(GIT_SHORT_SHA)$(GIT_DIRTY)
+TAG ?= $(GIT_SHORT_SHA)$(GIT_DIRTY)
 DOCKER_COMPOSE ?= IMAGE=$(OS_IMAGE_NAME) TAG=$(TAG) docker-compose
 IP_ADDR ?= 10.5.0.6
 
@@ -24,12 +24,17 @@ talosconfig:
 	@./gen.sh $(IP_ADDR)
 
 kubeconfig:
-	@$(DOCKER_COMPOSE) run --rm osctl kubeconfig > kubeconfig
+	@./osctl.sh kubeconfig > kubeconfig
+
+.PHONY: manifests
+manifests: kubeconfig
+	@./kubectl.sh apply -f /manifests/psp.yaml
+	@./kubectl.sh apply -f /manifests/cni.yaml
 
 .PHONY: clean
 clean: down
 	-@rm talosconfig
-	-@rm -rf kubeconfig
+	-@rm kubeconfig
 	-@rm userdata/master-1.yaml
 	-@rm userdata/master-2.yaml
 	-@rm userdata/master-3.yaml

--- a/hack/dev/README.md
+++ b/hack/dev/README.md
@@ -13,19 +13,19 @@ make TAG=<image_tag>
 
 # connect using ../../build/osctl-linux-amd64
 ## master-1
-TAG= docker-compose run --rm osctl ps
+./osctl ps
 ## master-2
-TAG= docker-compose run --rm osctl -t 10.5.0.7 ps
+./osctl -t master-2 ps
 
 
 # use kubectl
 make kubeconfig
 
-## apply PSP
-TAG= docker-compose run --rm kubectl apply -f ./manifests/psp.yaml
-## apply CNI
-TAG= docker-compose run --rm kubectl apply -f ./manifests/cni.yaml
+## apply PSP & CNI
+make manifests
 
+## get nodes
+./kubectl.sh get nodes
 
 # read init logs  (container stdout equiv. to /dev/kmsg)
 docker-compose logs -f

--- a/hack/dev/docker-compose.yaml
+++ b/hack/dev/docker-compose.yaml
@@ -1,25 +1,6 @@
 version: '3.7'
 
 services:
-  osctl:
-    image: alpine
-    entrypoint: /bin/osctl
-    command: version
-    volumes:
-      - ../../build/osctl-linux-amd64:/bin/osctl:ro
-      - ./talosconfig:/root/.talos/config
-    networks:
-      talosbr:
-
-  kubectl:
-    image: k8s.gcr.io/hyperkube:${HYPERKUBE_TAG:-v1.14.0}
-    entrypoint: kubectl
-    volumes:
-      - ./kubeconfig:/root/.kube/config
-      - ./manifests:/manifests
-    networks:
-      talosbr:
-
   master-1:
     image: ${IMAGE:-autonomy/talos}:${TAG}
     container_name: master-1

--- a/hack/dev/kubectl.sh
+++ b/hack/dev/kubectl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -it --network dev_talosbr -v "${PWD}/kubeconfig":/root/.kube/config -v "${PWD}/manifests":/manifests k8s.gcr.io/hyperkube:${HYPERKUBE_TAG:-v1.14.0} kubectl $@

--- a/hack/dev/osctl.sh
+++ b/hack/dev/osctl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -it -v "${PWD}/../../build/osctl-linux-amd64:/bin/osctl:ro" -v "${PWD}/talosconfig:/root/.talos/config" --network dev_talosbr alpine osctl $@


### PR DESCRIPTION
I think docker-compose doesn't quite work for such use-case, as all we
need is to launch some script on docker network.

osctl runs from host just fine, but I left `docker run` to support
people on OS X where docker networks are not routable by default from
the host.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>