### PR TITLE
chore: export coverage info from unit-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ vendor
 
 # protoc-generated files
 *.pb.go
+
+# Go
+coverage.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -223,12 +223,14 @@ ENTRYPOINT ["entrypoint.sh"]
 
 # The test target performs tests on the codebase.
 
-FROM base AS test
+FROM base AS test-runner
 # xfsprogs is required by the tests
 ENV PATH /rootfs/bin:$PATH
 COPY hack/golang/test.sh /bin
 RUN test.sh --short
 RUN test.sh
+FROM scratch AS test
+COPY --from=test-runner /src/coverage.txt /coverage.txt
 
 # The lint target performs linting on the codebase.
 

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,8 @@ release: all talos-raw talos-gce talos
 test: buildkitd
 	@buildctl --addr $(BUILDKIT_HOST) \
 		build \
+		--exporter=local \
+		--exporter-opt output=./ \
 		--frontend-opt target=$@ \
 		$(COMMON_ARGS)
 

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -3,11 +3,10 @@
 set -e
 
 CGO_ENABLED=1
-GOPACKAGES=$(go list ./...)
 
 perform_tests() {
   echo "Performing tests"
-  go test -v ./...
+  go test -v -covermode=atomic -coverprofile=coverage.txt ./...
 }
 
 perform_short_tests() {
@@ -15,29 +14,9 @@ perform_short_tests() {
   go test -v -short ./...
 }
 
-perform_coverage_tests() {
-  echo "Performing coverage tests"
-  local coverage_report="coverage.txt"
-  local profile="profile.out"
-  if [[ -f ${coverage_report} ]]; then
-    rm ${coverage_report}
-  fi
-  touch ${coverage_report}
-  for package in ${GOPACKAGES[@]}; do
-    go test -v -short -race -coverprofile=${profile} -covermode=atomic $package
-    if [ -f ${profile} ]; then
-      cat ${profile} >> ${coverage_report}
-      rm ${profile}
-    fi
-  done
-}
-
 case $1 in
   --short)
   perform_short_tests
-  ;;
-  --coverage)
-  perform_coverage_tests
   ;;
   *)
   perform_tests


### PR DESCRIPTION
Since some recent Go version `go test` is able to collect coverage info
across packages, so hacks are no longer required.

With simple addition to .travis.yaml and codecov.io setup, we can enable
code coverage via:

```
after_success:
  - bash <(curl -s https://codecov.io/bash)
```

When tests run, coverage.txt is copied back to the working directory.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>