### PR TITLE
chore: rework process runner, add tests and stop method

### DIFF
--- a/internal/app/init/pkg/system/runner/process/log/log.go
+++ b/internal/app/init/pkg/system/runner/process/log/log.go
@@ -26,7 +26,7 @@ type Log struct {
 }
 
 // New initializes and registers a log for a service.
-func New(name string) (*Log, error) {
+func New(name, rootPath string) (*Log, error) {
 	mu.Lock()
 	if l, ok := instance[name]; ok {
 		mu.Unlock()
@@ -34,7 +34,7 @@ func New(name string) (*Log, error) {
 	}
 	mu.Unlock()
 
-	logpath := FormatLogPath(name)
+	logpath := FormatLogPath(name, rootPath)
 	w, err := os.Create(logpath)
 	if err != nil {
 		return nil, fmt.Errorf("create log file: %s", err.Error())
@@ -74,6 +74,6 @@ func (l *Log) Read(ctx context.Context) <-chan []byte {
 }
 
 // FormatLogPath formats the path the log file.
-func FormatLogPath(p string) string {
-	return filepath.Join("/var/log", p+".log")
+func FormatLogPath(p, rootPath string) string {
+	return filepath.Join(rootPath, p+".log")
 }

--- a/internal/app/init/pkg/system/runner/process/process.go
+++ b/internal/app/init/pkg/system/runner/process/process.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,45 +20,76 @@ import (
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
-// Process is a runner.Runner that runs a process on the host.
-type Process struct{}
+// processRunner is a runner.Runner that runs a process on the host.
+type processRunner struct {
+	data *userdata.UserData
+	args *runner.Args
+	opts *runner.Options
 
-// Run implements the Runner interface.
-func (p *Process) Run(data *userdata.UserData, args *runner.Args, setters ...runner.Option) error {
-	opts := runner.DefaultOptions()
-	for _, setter := range setters {
-		setter(opts)
+	stop    chan struct{}
+	stopped chan struct{}
+}
+
+// errStopped is used internally to signal that task was stopped
+var errStopped = errors.New("stopped")
+
+// NewRunner creates runner.Runner that runs a process on the host
+func NewRunner(data *userdata.UserData, args *runner.Args, setters ...runner.Option) runner.Runner {
+	r := &processRunner{
+		data:    data,
+		args:    args,
+		opts:    runner.DefaultOptions(),
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
 	}
 
-	switch opts.Type {
+	for _, setter := range setters {
+		setter(r.opts)
+	}
+
+	return r
+}
+
+// Run implements the Runner interface.
+func (p *processRunner) Run() error {
+	defer close(p.stopped)
+
+	switch p.opts.Type {
 	case runner.Forever:
-		if err := p.waitAndRestart(data, args, opts); err != nil {
-			return err
-		}
+		p.waitAndRestart()
 	case runner.Once:
-		if err := p.waitForSuccess(data, args, opts); err != nil {
-			return err
-		}
+		p.waitForSuccess()
+	default:
+		panic("unexpected runner type")
 	}
 
 	return nil
 }
 
-func (p *Process) build(data *userdata.UserData, args *runner.Args, opts *runner.Options) (cmd *exec.Cmd, err error) {
-	cmd = exec.Command(args.ProcessArgs[0], args.ProcessArgs[1:]...)
+// Stop implements the Runner interface
+func (p *processRunner) Stop() error {
+	close(p.stop)
+
+	<-p.stopped
+
+	return nil
+}
+
+func (p *processRunner) build() (cmd *exec.Cmd, err error) {
+	cmd = exec.Command(p.args.ProcessArgs[0], p.args.ProcessArgs[1:]...)
 
 	// Set the environment for the service.
-	cmd.Env = append([]string{fmt.Sprintf("PATH=%s", constants.PATH)}, opts.Env...)
+	cmd.Env = append([]string{fmt.Sprintf("PATH=%s", constants.PATH)}, p.opts.Env...)
 
 	// Setup logging.
-	w, err := processlogger.New(args.ID)
+	w, err := processlogger.New(p.args.ID, p.opts.LogPath)
 	if err != nil {
 		err = fmt.Errorf("service log handler: %v", err)
 		return
 	}
 
 	var writer io.Writer
-	if data.Debug {
+	if p.data.Debug {
 		writer = io.MultiWriter(w, os.Stdout)
 	} else {
 		writer = w
@@ -68,8 +100,8 @@ func (p *Process) build(data *userdata.UserData, args *runner.Args, opts *runner
 	return cmd, nil
 }
 
-func (p *Process) run(data *userdata.UserData, args *runner.Args, opts *runner.Options) error {
-	cmd, err := p.build(data, args, opts)
+func (p *processRunner) run() error {
+	cmd, err := p.build()
 	if err != nil {
 		return errors.Wrap(err, "error building command")
 	}
@@ -78,30 +110,70 @@ func (p *Process) run(data *userdata.UserData, args *runner.Args, opts *runner.O
 		return errors.Wrap(err, "error starting process")
 	}
 
-	return cmd.Wait()
+	waitCh := make(chan error)
+
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	select {
+	case err = <-waitCh:
+		// process exited
+		return err
+	case <-p.stop:
+		// graceful stop the service
+
+		// nolint: errcheck
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+	}
+
+	select {
+	case <-waitCh:
+		// stopped process exited
+		return errStopped
+	case <-time.After(p.opts.GracefulShutdownTimeout):
+		// kill the process
+
+		// nolint: errcheck
+		_ = cmd.Process.Kill()
+	}
+
+	// wait for process to terminate
+	<-waitCh
+	return errStopped
 }
 
-func (p *Process) waitAndRestart(data *userdata.UserData, args *runner.Args, opts *runner.Options) error {
+func (p *processRunner) waitAndRestart() {
 	for {
-		err := p.run(data, args, opts)
+		err := p.run()
+		if err == errStopped {
+			return
+		}
 		if err != nil {
-			log.Printf("error running %v, going to restart forever: %s", args.ProcessArgs, err)
+			log.Printf("error running %v, going to restart forever: %s", p.args.ProcessArgs, err)
 		}
 
-		time.Sleep(5 * time.Second)
+		select {
+		case <-p.stop:
+			return
+		case <-time.After(p.opts.RestartInterval):
+		}
 	}
 }
 
-func (p *Process) waitForSuccess(data *userdata.UserData, args *runner.Args, opts *runner.Options) error {
+func (p *processRunner) waitForSuccess() {
 	for {
-		err := p.run(data, args, opts)
-		if err == nil {
+		err := p.run()
+		if err == errStopped || err == nil {
 			break
 		}
 
-		log.Printf("error running %v, going to restart until it succeeds: %s", args.ProcessArgs, err)
-		time.Sleep(5 * time.Second)
-	}
+		log.Printf("error running %v, going to restart until it succeeds: %s", p.args.ProcessArgs, err)
 
-	return nil
+		select {
+		case <-p.stop:
+			return
+		case <-time.After(p.opts.RestartInterval):
+		}
+	}
 }

--- a/internal/app/init/pkg/system/runner/process/process_test.go
+++ b/internal/app/init/pkg/system/runner/process/process_test.go
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package process_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/process"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+type ProcessSuite struct {
+	suite.Suite
+
+	tmpDir string
+}
+
+func (suite *ProcessSuite) SetupSuite() {
+	var err error
+
+	suite.tmpDir, err = ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+}
+
+func (suite *ProcessSuite) TeardownSuite() {
+	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
+}
+
+func (suite *ProcessSuite) TestRunSuccess() {
+	r := process.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "test",
+		ProcessArgs: []string{"/bin/bash", "-c", "exit 0"},
+	}, runner.WithType(runner.Once), runner.WithLogPath(suite.tmpDir))
+
+	suite.Assert().NoError(r.Run())
+	// calling stop when Run has finished is no-op
+	suite.Assert().NoError(r.Stop())
+}
+
+func (suite *ProcessSuite) TestRunLogs() {
+	r := process.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "logtest",
+		ProcessArgs: []string{"/bin/bash", "-c", "echo -n \"Test 1\nTest 2\n\""},
+	}, runner.WithType(runner.Once), runner.WithLogPath(suite.tmpDir))
+
+	suite.Assert().NoError(r.Run())
+
+	logFile, err := os.Open(filepath.Join(suite.tmpDir, "logtest.log"))
+	suite.Assert().NoError(err)
+
+	// nolint: errcheck
+	defer logFile.Close()
+
+	logContents, err := ioutil.ReadAll(logFile)
+	suite.Assert().NoError(err)
+
+	suite.Assert().Equal([]byte("Test 1\nTest 2\n"), logContents)
+}
+
+func (suite *ProcessSuite) TestRunRestartFailed() {
+	testFile := filepath.Join(suite.tmpDir, "talos-test")
+	// nolint: errcheck
+	_ = os.Remove(testFile)
+
+	r := process.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "restarter",
+		ProcessArgs: []string{"/bin/bash", "-c", "echo \"ran\"; test -f " + testFile},
+	}, runner.WithType(runner.Once), runner.WithLogPath(suite.tmpDir), runner.WithRestartInterval(time.Millisecond))
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		suite.Assert().NoError(r.Run())
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	f, err := os.Create(testFile)
+	suite.Assert().NoError(err)
+	suite.Assert().NoError(f.Close())
+
+	wg.Wait()
+
+	logFile, err := os.Open(filepath.Join(suite.tmpDir, "restarter.log"))
+	suite.Assert().NoError(err)
+	// nolint: errcheck
+	defer logFile.Close()
+
+	logContents, err := ioutil.ReadAll(logFile)
+	suite.Assert().NoError(err)
+
+	suite.Assert().True(len(logContents) > 20)
+}
+
+func (suite *ProcessSuite) TestStopFailingAndRestarting() {
+	testFile := filepath.Join(suite.tmpDir, "talos-test")
+	// nolint: errcheck
+	_ = os.Remove(testFile)
+
+	r := process.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "endless",
+		ProcessArgs: []string{"/bin/bash", "-c", "test -f " + testFile},
+	}, runner.WithType(runner.Forever), runner.WithLogPath(suite.tmpDir), runner.WithRestartInterval(5*time.Millisecond))
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.Run()
+	}()
+
+	time.Sleep(40 * time.Millisecond)
+
+	select {
+	case <-done:
+		suite.Assert().Fail("task should be running")
+		return
+	default:
+	}
+
+	f, err := os.Create(testFile)
+	suite.Assert().NoError(err)
+	suite.Assert().NoError(f.Close())
+
+	time.Sleep(40 * time.Millisecond)
+
+	select {
+	case <-done:
+		suite.Assert().Fail("task should be running")
+		return
+	default:
+	}
+
+	suite.Assert().NoError(r.Stop())
+	<-done
+}
+
+func (suite *ProcessSuite) TestStopSigKill() {
+	r := process.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "nokill",
+		ProcessArgs: []string{"/bin/bash", "-c", "trap -- '' SIGTERM; while true; do sleep 1; done"},
+	}, runner.WithType(runner.Forever), runner.WithLogPath(suite.tmpDir),
+		runner.WithRestartInterval(5*time.Millisecond), runner.WithGracefulShutdownTimeout(10*time.Millisecond))
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.Run()
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	suite.Assert().NoError(r.Stop())
+	<-done
+}
+
+func TestProcessSuite(t *testing.T) {
+	suite.Run(t, new(ProcessSuite))
+}

--- a/internal/app/init/pkg/system/services/containerd.go
+++ b/internal/app/init/pkg/system/services/containerd.go
@@ -52,11 +52,11 @@ func (c *Containerd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := process.Process{}
-
-	return r.Run(
+	r := process.NewRunner(
 		data,
 		args,
 		runner.WithEnv(env),
 	)
+
+	return r.Run()
 }

--- a/internal/app/init/pkg/system/services/udevd.go
+++ b/internal/app/init/pkg/system/services/udevd.go
@@ -50,11 +50,11 @@ func (c *Udevd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := process.Process{}
-
-	return r.Run(
+	r := process.NewRunner(
 		data,
 		args,
 		runner.WithEnv(env),
 	)
+
+	return r.Run()
 }


### PR DESCRIPTION
This is just first step towards better control of the services. Service
eventually uses either Process or Containerd runners to launch the
program. We don't have a way to control the service (stop it, figure out
whether it's actually running) unless we can pass back Runner instance
from the Service.

The idea is to return interface `runner.Runner` from the `Service` so
that controller (`init`) can figure out current state of the running
services and stop them on shutdown.

I haven't touched containerd runner yet (and as interface is not
enforced, code compiles fine). Only process runner is updated to allow
process to be stopped (either when it's running or while waiting to be
restarted).

For the sake of unit-tests, some additional runner options were exposed:
log path, restart interval, etc.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>