### PR TITLE
chore: enforce go.mod completeness and better buildkit cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,14 +69,15 @@ RUN mkdir -p ${GOPATH}
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 WORKDIR /src
+COPY ./go.mod ./
+COPY ./go.sum ./
+RUN go mod download
+RUN go mod verify
 COPY ./cmd ./cmd
 COPY ./pkg ./pkg
 COPY ./internal ./internal
-COPY ./go.mod ./
-COPY ./go.sum ./
 COPY --from=proto /internal/app ./internal/app
-RUN go mod download
-RUN go mod verify
+RUN go list -mod=readonly all
 
 # The udevd target builds the udevd binary.
 

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
+	golang.org/x/net v0.0.0-20190313220215-9f648a60d977
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	golang.org/x/sys v0.0.0-20190312061237-fead79001313
 	golang.org/x/text v0.3.0


### PR DESCRIPTION
There are two changes:

1. `go list` verifies that `go.mod` & `go.sum` are complete and fails if
they're not.

2. `go mod download` runs with just `go.mod`, so if we change Go
sources, time-consuming `go mod download` is not triggered anymore.

Added missing dependency to `go.mod` to make the check pass.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>