### PR TITLE
chore: split 'base' target, run tests in docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ vendor
 
 # Go
 coverage.txt
+.artifacts/
 
 # buildkit cache
 .buildkit/

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -6,7 +6,7 @@ CGO_ENABLED=1
 
 perform_tests() {
   echo "Performing tests"
-  go test -v -covermode=atomic -coverprofile=coverage.txt ./...
+  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt ./...
 }
 
 perform_short_tests() {


### PR DESCRIPTION
There are two changes which are not directly related to each other:

* `base` target in Dockerfile was split into `base` without our Go
sources and `base-src` with our Go sources; this enables stuff which
depends on `base` only to use cache when Go sources are changed, so less
stuff to rebuild when only Go sources are changed

* tests are run in docker container in privileged mode, this is required
for upcoming tests for containerd runner; containerd is started during
the test run, containers are run in containerd

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>