### PR TITLE
chore(ci): Update buildkit to 0.4

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,7 @@ steps:
   pull: always
   environment:
     BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+    BINDIR: /usr/local/bin
   commands:
     - make lint
   volumes:
@@ -53,6 +54,7 @@ steps:
   pull: always
   environment:
     BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+    BINDIR: /usr/local/bin
   commands:
     - make test
   volumes:
@@ -77,6 +79,7 @@ steps:
   pull: always
   environment:
     BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+    BINDIR: /usr/local/bin
   commands:
     - cd hack/dev
     - make integration

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 build
 cache
 images

--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,9 @@ TOOLCHAIN_IMAGE ?= autonomy/toolchain:255b4fd
 ROOTFS_IMAGE ?= autonomy/rootfs-base:255b4fd
 INITRAMFS_IMAGE ?= autonomy/initramfs-base:255b4fd
 
-DOCKER_ARGS ?=
-DOCKER_TEST_ARGS = --security-opt seccomp:unconfined --privileged -v /var/lib/containerd/
-
-COMMON_ARGS = --progress=plain
-COMMON_ARGS += --frontend=dockerfile.v0
-COMMON_ARGS += --local context=.
-COMMON_ARGS += --local dockerfile=.
-COMMON_ARGS += --frontend-opt build-arg:KERNEL_IMAGE=$(KERNEL_IMAGE)
-COMMON_ARGS += --frontend-opt build-arg:TOOLCHAIN_IMAGE=$(TOOLCHAIN_IMAGE)
-COMMON_ARGS += --frontend-opt build-arg:ROOTFS_IMAGE=$(ROOTFS_IMAGE)
-COMMON_ARGS += --frontend-opt build-arg:INITRAMFS_IMAGE=$(INITRAMFS_IMAGE)
-COMMON_ARGS += --frontend-opt build-arg:SHA=$(SHA)
-COMMON_ARGS += --frontend-opt build-arg:TAG=$(TAG)
-
 # TODO(andrewrynhard): Move this logic to a shell script.
 VPATH = $(PATH)
-BUILDKIT_VERSION ?= v0.3.3
+BUILDKIT_VERSION ?= v0.4.0
 BUILDKIT_IMAGE ?= moby/buildkit:$(BUILDKIT_VERSION)
 BUILDKIT_HOST ?= tcp://0.0.0.0:1234
 BUILDKIT_CACHE ?= -v $(HOME)/.buildkit:/var/lib/buildkit
@@ -36,7 +22,24 @@ endif
 ifeq ($(UNAME_S),Darwin)
 BUILDCTL_ARCHIVE := https://github.com/moby/buildkit/releases/download/$(BUILDKIT_VERSION)/buildkit-$(BUILDKIT_VERSION).darwin-amd64.tar.gz
 endif
-BINDIR ?= /usr/local/bin
+
+BINDIR ?= ./bin
+CONFORM_VERSION ?= 57c9dbd
+
+COMMON_ARGS = --progress=plain
+COMMON_ARGS += --frontend=dockerfile.v0
+COMMON_ARGS += --local context=.
+COMMON_ARGS += --local dockerfile=.
+COMMON_ARGS += --opt build-arg:KERNEL_IMAGE=$(KERNEL_IMAGE)
+COMMON_ARGS += --opt build-arg:TOOLCHAIN_IMAGE=$(TOOLCHAIN_IMAGE)
+COMMON_ARGS += --opt build-arg:ROOTFS_IMAGE=$(ROOTFS_IMAGE)
+COMMON_ARGS += --opt build-arg:INITRAMFS_IMAGE=$(INITRAMFS_IMAGE)
+COMMON_ARGS += --opt build-arg:SHA=$(SHA)
+COMMON_ARGS += --opt build-arg:TAG=$(TAG)
+
+DOCKER_ARGS ?=
+# to allow tests to run containerd
+DOCKER_TEST_ARGS = --security-opt seccomp:unconfined --privileged -v /var/lib/containerd/
 
 all: ci rootfs initramfs kernel installer talos
 
@@ -46,9 +49,12 @@ builddeps: gitmeta buildctl
 gitmeta:
 	GO111MODULE=off go get github.com/talos-systems/gitmeta
 
-buildctl:
+buildctl: $(BINDIR)/buildctl
+
+$(BINDIR)/buildctl:
+	@mkdir $(BINDIR)
 	@wget -qO - $(BUILDCTL_ARCHIVE) | \
-		sudo tar -zxf - -C $(BINDIR) --strip-components 1 bin/buildctl
+		tar -zxf - -C $(BINDIR) --strip-components 1 bin/buildctl
 
 .PHONY: buildkitd
 buildkitd:
@@ -77,59 +83,60 @@ ci: builddeps buildkitd
 
 .PHONY: binaries
 binaries: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
+
+base: buildkitd
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
+		build \
+		--output type=docker,dest=build/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
+		$(COMMON_ARGS)
+
 .PHONY: kernel
 kernel: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 	@-rm -rf ./build/modules
 
 .PHONY: initramfs
 initramfs: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: rootfs
 rootfs: buildkitd binaries osd trustd proxyd ntpd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: installer
 installer: buildkitd
 	@mkdir -p build
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=build/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=build/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 	@docker load < build/$@.tar
 
 .PHONY: proto
 proto: buildkitd
-	buildctl --addr $(BUILDKIT_HOST) \
+	$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=./ \
-		--frontend-opt target=$@ \
+    --output type=local,dest=./ \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: talos-gce
@@ -144,24 +151,20 @@ talos-raw: installer
 
 .PHONY: talos
 talos: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=build/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=build/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 	@docker load < build/$@.tar
 
 .PHONY: test
 test: buildkitd
 	@mkdir -p build
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=/tmp/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=/tmp/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 	@docker load < /tmp/$@.tar
 	@docker run -i --rm $(DOCKER_TEST_ARGS) autonomy/$@:$(TAG) /bin/test.sh --short
@@ -180,83 +183,72 @@ dev-test:
 
 .PHONY: lint
 lint: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--frontend-opt target=$@ \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: osctl-linux-amd64
 osctl-linux-amd64: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: osctl-darwin-amd64
 osctl-darwin-amd64: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: osinstall-linux-amd64
 osinstall-linux-amd64: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=local \
-		--exporter-opt output=build \
-		--frontend-opt target=$@ \
+    --output type=local,dest=build \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: udevd
 udevd: buildkitd
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--frontend-opt target=$@ \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: osd
 osd: buildkitd images
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=images/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=images/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: trustd
 trustd: buildkitd images
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=images/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=images/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: proxyd
 proxyd: buildkitd images
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=images/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=images/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 .PHONY: ntpd
 ntpd: buildkitd images
-	@buildctl --addr $(BUILDKIT_HOST) \
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-		--exporter=docker \
-		--exporter-opt output=images/$@.tar \
-		--exporter-opt name=docker.io/autonomy/$@:$(TAG) \
-		--frontend-opt target=$@ \
+		--output type=docker,dest=images/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
 		$(COMMON_ARGS)
 
 images:


### PR DESCRIPTION
Make use of local bin directory so we can prevent the
need for sudo to install buildctl.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>