### PR TITLE
chore: add dev-test make target to quickly re-run unit-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,14 @@ test: buildkitd
 		docker run -i --rm $(DOCKER_TEST_ARGS) -v $(PWD)/.artifacts:/src/artifacts autonomy/$@:$(TAG) /bin/test.sh && \
 		cp ./.artifacts/coverage.txt coverage.txt
 
+dev-test:
+	@docker run -i --rm $(DOCKER_TEST_ARGS) \
+		-v $(PWD)/internal:/src/internal:ro \
+		-v $(PWD)/pkg:/src/pkg:ro \
+		-v $(PWD)/cmd:/src/cmd:ro \
+		autonomy/test:$(TAG) \
+		go test -v ./...
+
 lint: buildkitd
 	@buildctl --addr $(BUILDKIT_HOST) \
 		build \


### PR DESCRIPTION
This is a shortcut when working on changes in Go code to re-run Go tests
quickly without even trying to rebuild `test` container.

This target doesn't do any checks, it is assumed that `make test` was
run to create initial image of the `test` container. As Go sources are
mapped into the container, it picks up any changes made.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>