### PR TITLE
chore: containerd runner refactoring and unit-tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -64,7 +64,6 @@ steps:
   environment:
     BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
   commands:
-    - make clean
     - make
   depends_on:
   - fetch

--- a/Dockerfile
+++ b/Dockerfile
@@ -227,7 +227,8 @@ ENTRYPOINT ["entrypoint.sh"]
 # The test target performs tests on the codebase.
 
 FROM base-src AS test
-# xfsprogs is required by the tests
+# xfsprogs and containerd are required by the tests
+COPY --from=rootfs-build /rootfs /rootfs
 ENV PATH /rootfs/bin:$PATH
 COPY hack/golang/test.sh /bin
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ talos: buildkitd
 		$(COMMON_ARGS)
 	@docker load < build/$@.tar
 
-test: buildkitd
+test: buildkitd rootfs
 	@mkdir -p build
 	@buildctl --addr $(BUILDKIT_HOST) \
 		build \

--- a/internal/app/init/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/init/pkg/system/runner/containerd/containerd_test.go
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package containerd_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
+	containerdrunner "github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/process"
+	"github.com/talos-systems/talos/internal/pkg/constants"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+const (
+	containerdNamespace = "talostest"
+	busyboxImage        = "docker.io/library/busybox:latest"
+)
+
+type ContainerdSuite struct {
+	suite.Suite
+
+	tmpDir string
+
+	containerdRunner runner.Runner
+	containerdWg     sync.WaitGroup
+
+	client *containerd.Client
+	image  containerd.Image
+}
+
+func (suite *ContainerdSuite) SetupSuite() {
+	var err error
+
+	args := &runner.Args{
+		ID:          "containerd",
+		ProcessArgs: []string{"/rootfs/bin/containerd"},
+	}
+
+	suite.tmpDir, err = ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+	suite.containerdRunner = process.NewRunner(
+		&userdata.UserData{},
+		args,
+		runner.WithType(runner.Once),
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithEnv([]string{"PATH=/rootfs/bin:" + constants.PATH}),
+	)
+	suite.containerdWg.Add(1)
+	go func() {
+		defer suite.containerdWg.Done()
+		suite.Require().NoError(suite.containerdRunner.Run())
+	}()
+
+	suite.client, err = containerd.New(defaults.DefaultAddress)
+	suite.Require().NoError(err)
+
+	ctx := namespaces.WithNamespace(context.Background(), containerdNamespace)
+
+	suite.image, err = suite.client.Pull(ctx, busyboxImage, containerd.WithPullUnpack)
+	suite.Require().NoError(err)
+}
+
+func (suite *ContainerdSuite) TeardownSuite() {
+	suite.Require().NoError(suite.client.Close())
+
+	suite.Require().NoError(suite.containerdRunner.Stop())
+	suite.containerdWg.Wait()
+
+	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
+}
+
+func (suite *ContainerdSuite) TestRunSuccess() {
+	r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "test",
+		ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
+	},
+		runner.WithType(runner.Once),
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+	)
+
+	suite.Assert().NoError(r.Run())
+	// calling stop when Run has finished is no-op
+	suite.Assert().NoError(r.Stop())
+}
+
+func (suite *ContainerdSuite) TestRunTwice() {
+	// running same container twice should be fine
+	// (checks that containerd state is cleaned up properly)
+	for i := 0; i < 2; i++ {
+		r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+			ID:          "runtwice",
+			ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
+		},
+			runner.WithType(runner.Once),
+			runner.WithLogPath(suite.tmpDir),
+			runner.WithNamespace(containerdNamespace),
+			runner.WithContainerImage(busyboxImage),
+		)
+
+		suite.Assert().NoError(r.Run())
+		// calling stop when Run has finished is no-op
+		suite.Assert().NoError(r.Stop())
+	}
+}
+
+func (suite *ContainerdSuite) TestRunLogs() {
+	r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "logtest",
+		ProcessArgs: []string{"/bin/sh", "-c", "echo -n \"Test 1\nTest 2\n\""},
+	},
+		runner.WithType(runner.Once),
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+	)
+
+	suite.Assert().NoError(r.Run())
+
+	logFile, err := os.Open(filepath.Join(suite.tmpDir, "logtest.log"))
+	suite.Assert().NoError(err)
+
+	// nolint: errcheck
+	defer logFile.Close()
+
+	logContents, err := ioutil.ReadAll(logFile)
+	suite.Assert().NoError(err)
+
+	suite.Assert().Equal([]byte("Test 1\nTest 2\n"), logContents)
+}
+
+func (suite *ContainerdSuite) TestStopFailingAndRestarting() {
+	testDir := filepath.Join(suite.tmpDir, "test")
+	suite.Assert().NoError(os.Mkdir(testDir, 0770))
+
+	testFile := filepath.Join(testDir, "talos-test")
+	// nolint: errcheck
+	_ = os.Remove(testFile)
+
+	r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "endless",
+		ProcessArgs: []string{"/bin/sh", "-c", "test -f " + testFile + " && echo ok || (echo fail; false)"},
+	},
+		runner.WithType(runner.Forever),
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithRestartInterval(5*time.Millisecond),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithOCISpecOpts(
+			oci.WithMounts([]specs.Mount{
+				{Type: "bind", Destination: testDir, Source: testDir, Options: []string{"bind", "ro"}},
+			}),
+		),
+	)
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.Run()
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case err := <-done:
+		suite.Assert().Failf("task should be running", "error: %s", err)
+		return
+	default:
+	}
+
+	f, err := os.Create(testFile)
+	suite.Assert().NoError(err)
+	suite.Assert().NoError(f.Close())
+
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case err = <-done:
+		suite.Assert().Failf("task should be running", "error: %s", err)
+		return
+	default:
+	}
+
+	suite.Assert().NoError(r.Stop())
+	<-done
+
+	logFile, err := os.Open(filepath.Join(suite.tmpDir, "endless.log"))
+	suite.Assert().NoError(err)
+
+	// nolint: errcheck
+	defer logFile.Close()
+
+	logContents, err := ioutil.ReadAll(logFile)
+	suite.Assert().NoError(err)
+
+	suite.Assert().Truef(bytes.Contains(logContents, []byte("ok\n")), "logContents doesn't contain success entry: %v", logContents)
+	suite.Assert().Truef(bytes.Contains(logContents, []byte("fail\n")), "logContents doesn't contain fail entry: %v", logContents)
+}
+
+func (suite *ContainerdSuite) TestStopSigKill() {
+	r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "nokill",
+		ProcessArgs: []string{"/bin/sh", "-c", "trap -- '' SIGTERM; while true; do sleep 1; done"},
+	},
+		runner.WithType(runner.Forever),
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithRestartInterval(5*time.Millisecond),
+		runner.WithGracefulShutdownTimeout(10*time.Millisecond))
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.Run()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-done:
+		suite.Assert().Fail("container should be still running")
+	default:
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	suite.Assert().NoError(r.Stop())
+	<-done
+}
+
+func TestContainerdSuite(t *testing.T) {
+	suite.Run(t, new(ContainerdSuite))
+}

--- a/internal/app/init/pkg/system/runner/containerd/opts.go
+++ b/internal/app/init/pkg/system/runner/containerd/opts.go
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package containerd
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// WithMemoryLimit sets the linux resource memory limit field.
+func WithMemoryLimit(limit int64) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		s.Linux.Resources.Memory = &specs.LinuxMemory{
+			Limit: &limit,
+			// DisableOOMKiller: &disable,
+		}
+		return nil
+	}
+}
+
+// WithRootfsPropagation sets the root filesystem propagation.
+func WithRootfsPropagation(rp string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		s.Linux.RootfsPropagation = rp
+		return nil
+	}
+}

--- a/internal/app/init/pkg/system/services/kubeadm.go
+++ b/internal/app/init/pkg/system/services/kubeadm.go
@@ -171,11 +171,9 @@ func (k *Kubeadm) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.Containerd{}
-
-	return r.Run(
+	r := containerd.NewRunner(
 		data,
-		args,
+		&args,
 		runner.WithNamespace(criconstants.K8sContainerdNamespace),
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
@@ -189,6 +187,8 @@ func (k *Kubeadm) Start(data *userdata.UserData) error {
 		),
 		runner.WithType(runner.Once),
 	)
+
+	return r.Run()
 }
 
 func enforceMasterOverrides(initConfiguration *kubeadmapi.InitConfiguration) {

--- a/internal/app/init/pkg/system/services/kubelet.go
+++ b/internal/app/init/pkg/system/services/kubelet.go
@@ -124,11 +124,9 @@ func (k *Kubelet) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.Containerd{}
-
-	return r.Run(
+	r := containerd.NewRunner(
 		data,
-		args,
+		&args,
 		runner.WithNamespace(criconstants.K8sContainerdNamespace),
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
@@ -141,4 +139,6 @@ func (k *Kubelet) Start(data *userdata.UserData) error {
 		),
 		runner.WithType(runner.Forever),
 	)
+
+	return r.Run()
 }

--- a/internal/app/init/pkg/system/services/ntpd.go
+++ b/internal/app/init/pkg/system/services/ntpd.go
@@ -58,11 +58,9 @@ func (n *NTPd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.Containerd{}
-
-	return r.Run(
+	r := containerd.NewRunner(
 		data,
-		args,
+		&args,
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
@@ -70,4 +68,6 @@ func (n *NTPd) Start(data *userdata.UserData) error {
 			oci.WithMounts(mounts),
 		),
 	)
+
+	return r.Run()
 }

--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -69,15 +69,15 @@ func (o *OSD) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.Containerd{}
-
-	return r.Run(
+	r := containerd.NewRunner(
 		data,
-		args,
+		&args,
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			oci.WithMounts(mounts),
 		),
 	)
+
+	return r.Run()
 }

--- a/internal/app/init/pkg/system/services/proxyd.go
+++ b/internal/app/init/pkg/system/services/proxyd.go
@@ -62,11 +62,9 @@ func (p *Proxyd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.Containerd{}
-
-	return r.Run(
+	r := containerd.NewRunner(
 		data,
-		args,
+		&args,
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
@@ -75,4 +73,6 @@ func (p *Proxyd) Start(data *userdata.UserData) error {
 			oci.WithPrivileged,
 		),
 	)
+
+	return r.Run()
 }

--- a/internal/app/init/pkg/system/services/trustd.go
+++ b/internal/app/init/pkg/system/services/trustd.go
@@ -62,11 +62,9 @@ func (t *Trustd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.Containerd{}
-
-	return r.Run(
+	r := containerd.NewRunner(
 		data,
-		args,
+		&args,
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
@@ -74,4 +72,6 @@ func (t *Trustd) Start(data *userdata.UserData) error {
 			oci.WithMounts(mounts),
 		),
 	)
+
+	return r.Run()
 }

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -232,11 +232,9 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (reply *proto.
 		{Type: "bind", Destination: "/bin/kubeadm", Source: "/bin/kubeadm", Options: []string{"bind", "ro"}},
 	}
 
-	cr := containerdrunner.Containerd{}
-
-	err = cr.Run(
+	cr := containerdrunner.NewRunner(
 		r.Data,
-		args,
+		&args,
 		runner.WithContainerImage(constants.KubernetesImage),
 		runner.WithOCISpecOpts(
 			containerdrunner.WithMemoryLimit(int64(1000000*512)),
@@ -249,6 +247,7 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (reply *proto.
 		runner.WithType(runner.Once),
 	)
 
+	err = cr.Run()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is continuing work from PR #506.

Containerd runner is reworked to support `Run()` and `Stop()` methods
of `runner.Runner` interface.

Control on restarts is moved to our code (instead of 'restart'
containerd plugin), this allows to implement correct `Stop()` method
which stops restarting containers.

Container stop is now graceful - with SIGTERM, timeout followed by
SIGKILL.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>