### PR TITLE
fix(osd): Fix osctl ps output

### DIFF
--- a/internal/app/osd/internal/reg/containerd.go
+++ b/internal/app/osd/internal/reg/containerd.go
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+	"log"
+	"path"
+	"strings"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/namespaces"
+)
+
+type containerProc struct {
+	Name   string // Friendly name
+	ID     string // container sha/id
+	Digest string // Container Digest
+	Status string // Running state of container
+	Pid    uint32
+
+	Container containerd.Container
+	Context   context.Context
+}
+
+func connect(namespace string) (*containerd.Client, context.Context, error) {
+	client, err := containerd.New(defaults.DefaultAddress)
+	return client, namespaces.WithNamespace(context.Background(), namespace), err
+}
+
+func containerID(namespace string) ([]containerProc, error) {
+	client, ctx, err := connect(namespace)
+	if err != nil {
+		return nil, err
+	}
+	// nolint: errcheck
+	defer client.Close()
+
+	containers, err := client.Containers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cps := make([]containerProc, len(containers))
+
+	for _, container := range containers {
+		cp := containerProc{}
+
+		info, err := container.Info(ctx)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		img, err := container.Image(ctx)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		task, err := container.Task(ctx, nil)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		status, err := task.Status(ctx)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		cp.ID = container.ID()
+		cp.Name = container.ID()
+		cp.Digest = img.Target().Digest.String()
+		cp.Container = container
+		cp.Context = ctx
+		cp.Pid = task.Pid()
+		cp.Status = strings.ToUpper(string(status.Status))
+
+		if _, ok := info.Labels["io.kubernetes.pod.name"]; ok {
+			cp.Name = path.Join(info.Labels["io.kubernetes.pod.namespace"], info.Labels["io.kubernetes.pod.name"])
+		}
+
+		cps = append(cps, cp)
+	}
+
+	return cps, nil
+}
+
+func images(namespace string) (map[string]string, error) {
+	client, ctx, err := connect(namespace)
+	if err != nil {
+		return nil, err
+	}
+	// nolint: errcheck
+	defer client.Close()
+
+	images, err := client.ListImages(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// create a map[sha]name for easier lookups later
+	imageList := make(map[string]string, len(images))
+	for _, image := range images {
+		imageList[image.Target().Digest.String()] = image.Name()
+	}
+	return imageList, nil
+}


### PR DESCRIPTION
```
root@f417a2d23378:/# osctl ps                                                                                                                                                           
NAMESPACE   ID       IMAGE          PID   STATUS
system      ntpd     talos/ntpd     84    RUNNING
system      osd      talos/osd      120   RUNNING
system      proxyd   talos/proxyd   493   RUNNING
system      trustd   talos/trustd   103   RUNNING
root@f417a2d23378:/# osctl ps -k
NAMESPACE   ID                                             IMAGE                                                                     PID   STATUS
k8s.io      kube-system/kube-scheduler-master-2            sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e   666   RUNNING
k8s.io      kube-system/kube-apiserver-master-2            sha256:bf72f7f1f646f0eeda65cbb62f9b7a71a97ca43574c2c420df5456e9e88ff9b1   815   RUNNING
k8s.io      kube-system/kube-apiserver-master-2            sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e   654   RUNNING
k8s.io      kube-system/kube-controller-manager-master-2   sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e   670   RUNNING
k8s.io      kube-system/kube-controller-manager-master-2   sha256:bf72f7f1f646f0eeda65cbb62f9b7a71a97ca43574c2c420df5456e9e88ff9b1   774   RUNNING
k8s.io      kube-system/kube-scheduler-master-2            sha256:bf72f7f1f646f0eeda65cbb62f9b7a71a97ca43574c2c420df5456e9e88ff9b1   823   RUNNING
k8s.io      kubeadm                                        sha256:bf72f7f1f646f0eeda65cbb62f9b7a71a97ca43574c2c420df5456e9e88ff9b1   278   RUNNING
k8s.io      kubelet                                        sha256:bf72f7f1f646f0eeda65cbb62f9b7a71a97ca43574c2c420df5456e9e88ff9b1   542   RUNNING
```

I think I still need to finish out this for the other endpoints, but this seems to be working. 