### PR TITLE
refactor: extract 'restart' piece of the runners into wrapper runner

### DIFF
--- a/internal/app/init/pkg/system/runner/restart/restart_test.go
+++ b/internal/app/init/pkg/system/runner/restart/restart_test.go
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package restart_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
+)
+
+type RestartSuite struct {
+	suite.Suite
+}
+
+type MockRunner struct {
+	exitCh  chan error
+	times   int
+	stop    chan struct{}
+	stopped chan struct{}
+}
+
+func (m *MockRunner) Open() error {
+	m.stop = make(chan struct{})
+	m.stopped = make(chan struct{})
+	return nil
+}
+
+func (m *MockRunner) Close() error {
+	close(m.exitCh)
+	return nil
+}
+
+func (m *MockRunner) Run() error {
+	defer close(m.stopped)
+
+	select {
+	case err := <-m.exitCh:
+		m.times++
+		return err
+	case <-m.stop:
+		return nil
+	}
+}
+
+func (m *MockRunner) Stop() error {
+	close(m.stop)
+
+	<-m.stopped
+
+	m.stop = make(chan struct{})
+	m.stopped = make(chan struct{})
+
+	return nil
+}
+
+func (m *MockRunner) String() string {
+	return "MockRunner()"
+}
+
+func (suite *RestartSuite) TestString() {
+	suite.Assert().Equal("Restart(UntilSuccess, MockRunner())", restart.New(&MockRunner{}, restart.WithType(restart.UntilSuccess)).String())
+}
+
+func (suite *RestartSuite) TestRunOnce() {
+	mock := MockRunner{
+		exitCh: make(chan error),
+	}
+
+	r := restart.New(&mock, restart.WithType(restart.Once))
+	suite.Assert().NoError(r.Open())
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	failed := errors.New("failed")
+
+	go func() {
+		mock.exitCh <- failed
+	}()
+
+	suite.Assert().EqualError(r.Run(), failed.Error())
+	suite.Assert().NoError(r.Stop())
+}
+
+func (suite *RestartSuite) TestRunOnceStop() {
+	mock := MockRunner{
+		exitCh: make(chan error),
+	}
+
+	r := restart.New(&mock, restart.WithType(restart.Once))
+	suite.Assert().NoError(r.Open())
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- r.Run()
+	}()
+
+	suite.Assert().NoError(r.Stop())
+	suite.Assert().NoError(<-errCh)
+}
+
+func (suite *RestartSuite) TestRunUntilSuccess() {
+	mock := MockRunner{
+		exitCh: make(chan error),
+	}
+
+	r := restart.New(&mock, restart.WithType(restart.UntilSuccess), restart.WithRestartInterval(time.Millisecond))
+	suite.Assert().NoError(r.Open())
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	failed := errors.New("failed")
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- r.Run()
+	}()
+
+	mock.exitCh <- failed
+	mock.exitCh <- failed
+	mock.exitCh <- failed
+	mock.exitCh <- nil
+
+	suite.Assert().NoError(<-errCh)
+	suite.Assert().NoError(r.Stop())
+	suite.Assert().Equal(4, mock.times)
+}
+
+func (suite *RestartSuite) TestRunForever() {
+	mock := MockRunner{
+		exitCh: make(chan error),
+	}
+
+	r := restart.New(&mock, restart.WithType(restart.Forever), restart.WithRestartInterval(time.Millisecond))
+	suite.Assert().NoError(r.Open())
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	failed := errors.New("failed")
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- r.Run()
+	}()
+
+	mock.exitCh <- failed
+	mock.exitCh <- nil
+	mock.exitCh <- failed
+	mock.exitCh <- nil
+
+	select {
+	case <-errCh:
+		suite.Assert().Fail("runner should be still running")
+	default:
+	}
+
+	suite.Assert().NoError(r.Stop())
+	suite.Assert().NoError(<-errCh)
+	suite.Assert().Equal(4, mock.times)
+}
+
+func TestRestartSuite(t *testing.T) {
+	suite.Run(t, new(RestartSuite))
+}

--- a/internal/app/init/pkg/system/services/containerd.go
+++ b/internal/app/init/pkg/system/services/containerd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/process"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
@@ -40,8 +41,8 @@ func (c *Containerd) ConditionFunc(data *userdata.UserData) conditions.Condition
 	return conditions.None()
 }
 
-// Start implements the Service interface.
-func (c *Containerd) Start(data *userdata.UserData) error {
+// Runner implements the Service interface.
+func (c *Containerd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	// Set the process arguments.
 	args := &runner.Args{
 		ID:          c.ID(data),
@@ -53,11 +54,11 @@ func (c *Containerd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := process.NewRunner(
+	return restart.New(process.NewRunner(
 		data,
 		args,
 		runner.WithEnv(env),
-	)
-
-	return r.Run()
+	),
+		restart.WithType(restart.Forever),
+	), nil
 }

--- a/internal/app/init/pkg/system/services/ntpd.go
+++ b/internal/app/init/pkg/system/services/ntpd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
@@ -41,7 +42,7 @@ func (n *NTPd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
 	return conditions.None()
 }
 
-func (n *NTPd) Start(data *userdata.UserData) error {
+func (n *NTPd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	image := "talos/ntpd"
 
 	args := runner.Args{
@@ -58,7 +59,7 @@ func (n *NTPd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.NewRunner(
+	return restart.New(containerd.NewRunner(
 		data,
 		&args,
 		runner.WithContainerImage(image),
@@ -67,7 +68,7 @@ func (n *NTPd) Start(data *userdata.UserData) error {
 			containerd.WithMemoryLimit(int64(1000000*32)),
 			oci.WithMounts(mounts),
 		),
-	)
-
-	return r.Run()
+	),
+		restart.WithType(restart.Forever),
+	), nil
 }

--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
@@ -42,7 +43,7 @@ func (o *OSD) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
 	return conditions.None()
 }
 
-func (o *OSD) Start(data *userdata.UserData) error {
+func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 	image := "talos/osd"
 
 	// Set the process arguments.
@@ -68,7 +69,7 @@ func (o *OSD) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.NewRunner(
+	return restart.New(containerd.NewRunner(
 		data,
 		&args,
 		runner.WithContainerImage(image),
@@ -76,7 +77,7 @@ func (o *OSD) Start(data *userdata.UserData) error {
 		runner.WithOCISpecOpts(
 			oci.WithMounts(mounts),
 		),
-	)
-
-	return r.Run()
+	),
+		restart.WithType(restart.Forever),
+	), nil
 }

--- a/internal/app/init/pkg/system/services/trustd.go
+++ b/internal/app/init/pkg/system/services/trustd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
@@ -41,7 +42,7 @@ func (t *Trustd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc
 	return conditions.None()
 }
 
-func (t *Trustd) Start(data *userdata.UserData) error {
+func (t *Trustd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	image := "talos/trustd"
 
 	// Set the process arguments.
@@ -62,7 +63,7 @@ func (t *Trustd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := containerd.NewRunner(
+	return restart.New(containerd.NewRunner(
 		data,
 		&args,
 		runner.WithContainerImage(image),
@@ -71,7 +72,7 @@ func (t *Trustd) Start(data *userdata.UserData) error {
 			containerd.WithMemoryLimit(int64(1000000*512)),
 			oci.WithMounts(mounts),
 		),
-	)
-
-	return r.Run()
+	),
+		restart.WithType(restart.Forever),
+	), nil
 }

--- a/internal/app/init/pkg/system/services/udevd.go
+++ b/internal/app/init/pkg/system/services/udevd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/process"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -37,8 +38,8 @@ func (c *Udevd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc 
 	return conditions.None()
 }
 
-// Start implements the Service interface.
-func (c *Udevd) Start(data *userdata.UserData) error {
+// Runner implements the Service interface.
+func (c *Udevd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	// Set the process arguments.
 	args := &runner.Args{
 		ID:          c.ID(data),
@@ -50,11 +51,11 @@ func (c *Udevd) Start(data *userdata.UserData) error {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
-	r := process.NewRunner(
+	return restart.New(process.NewRunner(
 		data,
 		args,
 		runner.WithEnv(env),
-	)
-
-	return r.Run()
+	),
+		restart.WithType(restart.Forever),
+	), nil
 }

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -212,8 +212,15 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (reply *proto.
 			oci.WithParentCgroupDevices,
 			oci.WithPrivileged,
 		),
-		runner.WithType(runner.Once),
 	)
+
+	err = cr.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	// nolint: errcheck
+	defer cr.Close()
 
 	err = cr.Run()
 	if err != nil {


### PR DESCRIPTION
This changes `runner.Runner` API to support more methods to allow for
containerd runner to create container object only once, and start/stop
tasks to implement restarts.

New API: `Open()` (initialize), `Run()` (run once until exits), `Stop()`
(stop running instance), `Close()` (free resource, no longer available
for new `Run()`).

So the sequence might be: `Open`, `Run`, `Stop`, `Run`, `Stop`, `Close`.

Process and containerd runners were updated for the new API, and
'restart' part was removed, now both runners only run the task once.

Restart piece was implemented in an abstract way for any wrapped
`runner.Runner` in the `runner/restart` package. Restart supports three
restart policies: `Once`, `UntilSuccess` and `Forever`.

Service API was changed slightly to return the `runner.Runner`
interface, and `system.Services` now handles running the service.

For all the services, code was adjusted to either return runner (run
once), or was wrapped with `restart` runner to provide restart policy.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>