### PR TITLE
feat(init): implement graceful shutdown of 'init'

### DIFF
--- a/internal/app/init/pkg/system/conditions/conditions_test.go
+++ b/internal/app/init/pkg/system/conditions/conditions_test.go
@@ -4,11 +4,160 @@
 
 package conditions_test
 
-import "testing"
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+)
+
+type ConditionsSuite struct {
+	suite.Suite
+
+	tempDir string
+}
+
+func (suite *ConditionsSuite) SetupSuite() {
+	var err error
+	suite.tempDir, err = ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+}
+
+func (suite *ConditionsSuite) TearDownSuite() {
+	suite.Require().NoError(os.RemoveAll(suite.tempDir))
+}
+
+func (suite *ConditionsSuite) createFile(name string) (path string) {
+	path = filepath.Join(suite.tempDir, name)
+	f, err := os.Create(path)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(f.Close())
+
+	return
+}
+
+func (suite *ConditionsSuite) TestFileExists() {
+	exists, err := conditions.FileExists("no-such-file")(context.Background())
+	suite.Require().NoError(err)
+	suite.Require().False(exists)
+
+	exists, err = conditions.FileExists(suite.createFile("a.txt"))(context.Background())
+	suite.Require().NoError(err)
+	suite.Require().True(exists)
+}
+
+func (suite *ConditionsSuite) TestWaitForFileToExist() {
+	path := suite.createFile("w.txt")
+
+	exists, err := conditions.WaitForFileToExist(path)(context.Background())
+	suite.Require().NoError(err)
+	suite.Require().True(exists)
+
+	suite.Require().NoError(os.Remove(path))
+
+	errCh := make(chan error)
+
+	go func() {
+		exists, err = conditions.WaitForFileToExist(path)(context.Background())
+		suite.Require().True(exists)
+
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-errCh:
+		suite.Fail("unexpected return")
+	default:
+	}
+
+	suite.createFile("w.txt")
+
+	suite.Require().NoError(<-errCh)
+
+	suite.Require().NoError(os.Remove(path))
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		_, err = conditions.WaitForFileToExist(path)(ctx)
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-errCh:
+		suite.Fail("unexpected return")
+	default:
+	}
+
+	ctxCancel()
+
+	suite.Require().EqualError(<-errCh, context.Canceled.Error())
+}
+
+func (suite *ConditionsSuite) TestWaitForFilesToExist() {
+	pathA := suite.createFile("wA.txt")
+	pathB := suite.createFile("wB.txt")
+
+	exists, err := conditions.WaitForFilesToExist(pathA, pathB)(context.Background())
+	suite.Require().NoError(err)
+	suite.Require().True(exists)
+
+	suite.Require().NoError(os.Remove(pathB))
+
+	errCh := make(chan error)
+
+	go func() {
+		exists, err = conditions.WaitForFilesToExist(pathA, pathB)(context.Background())
+		suite.Require().True(exists)
+
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-errCh:
+		suite.Fail("unexpected return")
+	default:
+	}
+
+	suite.createFile("wB.txt")
+
+	suite.Require().NoError(<-errCh)
+
+	suite.Require().NoError(os.Remove(pathA))
+	suite.Require().NoError(os.Remove(pathB))
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		_, err = conditions.WaitForFilesToExist(pathA, pathB)(ctx)
+		errCh <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-errCh:
+		suite.Fail("unexpected return")
+	default:
+	}
+
+	ctxCancel()
+
+	suite.Require().EqualError(<-errCh, context.Canceled.Error())
+}
+
+func TestConditionsSuite(t *testing.T) {
+	suite.Run(t, new(ConditionsSuite))
 }

--- a/internal/app/init/pkg/system/events/events.go
+++ b/internal/app/init/pkg/system/events/events.go
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package events
+
+import (
+	"time"
+)
+
+// MaxEventsToKeep is maximum number of events to keep per service before dropping old entries
+const MaxEventsToKeep = 64
+
+// ServiceState is enum of service run states
+type ServiceState int
+
+// ServiceState constants
+const (
+	StateInitialized ServiceState = iota
+	StatePreparing
+	StateWaiting
+	StateRunning
+	StateStopping
+	StateFinished
+	StateFailed
+)
+
+func (state ServiceState) String() string {
+	switch state {
+	case StateInitialized:
+		return "Initialized"
+	case StatePreparing:
+		return "Preparing"
+	case StateWaiting:
+		return "Waiting"
+	case StateRunning:
+		return "Running"
+	case StateStopping:
+		return "Stopping"
+	case StateFinished:
+		return "Finished"
+	case StateFailed:
+		return "Failed"
+	default:
+		return "Unknown"
+	}
+}
+
+// ServiceEvent describes state change of the running service
+type ServiceEvent struct {
+	Message   string
+	State     ServiceState
+	Timestamp time.Time
+}
+
+// ServiceEvents is a fixed length history of events
+type ServiceEvents struct {
+	events    []ServiceEvent
+	pos       int
+	discarded uint
+}
+
+// Push appends new event to the history popping out oldest event on overflow
+func (events *ServiceEvents) Push(event ServiceEvent) {
+	if events.events == nil {
+		events.events = make([]ServiceEvent, MaxEventsToKeep)
+	}
+
+	if events.events[events.pos].Message != "" {
+		// overwriting some entry
+		events.discarded++
+	}
+	events.events[events.pos] = event
+	events.pos = (events.pos + 1) % len(events.events)
+}
+
+// Get return a copy of event history, with most recent event being the last one
+func (events *ServiceEvents) Get(count int) (result []ServiceEvent) {
+	if events.events == nil {
+		return
+	}
+
+	if count > MaxEventsToKeep {
+		count = MaxEventsToKeep
+	}
+
+	n := len(events.events)
+
+	for i := (events.pos - count + n) % n; count > 0; i = (i + 1) % n {
+		if events.events[i].Message != "" {
+			result = append(result, events.events[i])
+		}
+		count--
+	}
+
+	return
+}
+
+// Recorder adds new event to the history of events, formatting message with args using Sprintf
+type Recorder func(newstate ServiceState, message string, args ...interface{})
+
+// NullRecorder discards events
+func NullRecorder(newstate ServiceState, message string, args ...interface{}) {
+}

--- a/internal/app/init/pkg/system/events/events_test.go
+++ b/internal/app/init/pkg/system/events/events_test.go
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package events_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
+)
+
+type EventsSuite struct {
+	suite.Suite
+}
+
+func (suite *EventsSuite) assertEvents(expectedMessages []string, evs []events.ServiceEvent) {
+	messages := make([]string, len(evs))
+
+	for i := range evs {
+		messages[i] = evs[i].Message
+	}
+
+	suite.Assert().Equal(expectedMessages, messages)
+}
+
+func (suite *EventsSuite) TestEmpty() {
+	var e events.ServiceEvents
+
+	suite.Assert().Equal([]events.ServiceEvent(nil), e.Get(100))
+}
+
+func (suite *EventsSuite) TestSome() {
+	var e events.ServiceEvents
+
+	for i := 0; i < 5; i++ {
+		e.Push(events.ServiceEvent{
+			Message: strconv.Itoa(i),
+		})
+	}
+
+	suite.Assert().Equal([]events.ServiceEvent(nil), e.Get(0))
+	suite.assertEvents([]string{"4"}, e.Get(1))
+	suite.assertEvents([]string{"1", "2", "3", "4"}, e.Get(4))
+	suite.assertEvents([]string{"0", "1", "2", "3", "4"}, e.Get(5))
+	suite.assertEvents([]string{"0", "1", "2", "3", "4"}, e.Get(6))
+	suite.assertEvents([]string{"0", "1", "2", "3", "4"}, e.Get(100))
+}
+
+func (suite *EventsSuite) TestOverflow() {
+	var e events.ServiceEvents
+
+	numEvents := events.MaxEventsToKeep*2 + 3
+
+	for i := 0; i < numEvents; i++ {
+		e.Push(events.ServiceEvent{
+			Message: strconv.Itoa(i),
+		})
+	}
+
+	suite.Assert().Equal([]events.ServiceEvent(nil), e.Get(0))
+	suite.assertEvents([]string{strconv.Itoa(numEvents - 1)}, e.Get(1))
+
+	expected := []string{}
+	for i := numEvents - events.MaxEventsToKeep; i < numEvents; i++ {
+		expected = append(expected, strconv.Itoa(i))
+	}
+	suite.assertEvents(expected, e.Get(events.MaxEventsToKeep*10))
+	suite.assertEvents(expected[len(expected)-3:], e.Get(3))
+}
+
+func TestEventsSuite(t *testing.T) {
+	suite.Run(t, new(EventsSuite))
+}

--- a/internal/app/init/pkg/system/mocks_test.go
+++ b/internal/app/init/pkg/system/mocks_test.go
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package system_test
+
+import (
+	"context"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+type MockService struct {
+	name        string
+	preError    error
+	runnerError error
+	runner      runner.Runner
+	condition   conditions.ConditionFunc
+	postError   error
+}
+
+func (m *MockService) ID(*userdata.UserData) string {
+	if m.name != "" {
+		return m.name
+	}
+	return "MockRunner"
+}
+func (m *MockService) PreFunc(*userdata.UserData) error {
+	return m.preError
+}
+
+func (m *MockService) Runner(*userdata.UserData) (runner.Runner, error) {
+	if m.runner != nil {
+		return m.runner, m.runnerError
+	}
+
+	return &MockRunner{exitCh: make(chan error)}, m.runnerError
+}
+
+func (m *MockService) PostFunc(*userdata.UserData) error {
+	return m.postError
+}
+
+func (m *MockService) ConditionFunc(*userdata.UserData) conditions.ConditionFunc {
+	if m.condition != nil {
+		return m.condition
+	}
+
+	return conditions.None()
+}
+
+type MockRunner struct {
+	exitCh chan error
+}
+
+func (m *MockRunner) Open(ctx context.Context) error {
+	return nil
+}
+
+func (m *MockRunner) Close() error {
+	return nil
+}
+
+func (m *MockRunner) Run(eventSink events.Recorder) error {
+	eventSink(events.StateRunning, "Running")
+	return <-m.exitCh
+}
+
+func (m *MockRunner) Stop() error {
+	close(m.exitCh)
+
+	return nil
+}
+
+func (m *MockRunner) String() string {
+	return "MockRunner()"
+}

--- a/internal/app/init/pkg/system/runner/containerd/import.go
+++ b/internal/app/init/pkg/system/runner/containerd/import.go
@@ -25,7 +25,7 @@ type ImportRequest struct {
 
 // Import imports the images specified by the import requests.
 func Import(namespace string, reqs ...*ImportRequest) error {
-	_, err := conditions.WaitForFileToExist(constants.ContainerdAddress)()
+	_, err := conditions.WaitForFileToExist(constants.ContainerdAddress)(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/app/init/pkg/system/runner/runner.go
+++ b/internal/app/init/pkg/system/runner/runner.go
@@ -5,18 +5,21 @@
 package runner
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
 )
 
 // Runner describes the requirements for running a process.
 type Runner interface {
 	fmt.Stringer
-	Open() error
-	Run() error
+	Open(ctx context.Context) error
+	Run(events.Recorder) error
 	Stop() error
 	Close() error
 }

--- a/internal/app/init/pkg/system/service_runner.go
+++ b/internal/app/init/pkg/system/service_runner.go
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package system
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+// ServiceRunner wraps the state of the service (running, stopped, ...)
+type ServiceRunner struct {
+	mu sync.Mutex
+
+	userData *userdata.UserData
+	service  Service
+	id       string
+
+	state  events.ServiceState
+	events events.ServiceEvents
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+// NewServiceRunner creates new ServiceRunner around Service instance
+func NewServiceRunner(service Service, userData *userdata.UserData) *ServiceRunner {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	return &ServiceRunner{
+		service:   service,
+		userData:  userData,
+		id:        service.ID(userData),
+		ctx:       ctx,
+		ctxCancel: ctxCancel,
+		state:     events.StateInitialized,
+	}
+}
+
+// UpdateState implements events.Recorder
+func (svcrunner *ServiceRunner) UpdateState(newstate events.ServiceState, message string, args ...interface{}) {
+	svcrunner.mu.Lock()
+	defer svcrunner.mu.Unlock()
+
+	event := events.ServiceEvent{
+		Message:   fmt.Sprintf(message, args...),
+		State:     newstate,
+		Timestamp: time.Now(),
+	}
+
+	svcrunner.state = newstate
+	svcrunner.events.Push(event)
+
+	log.Printf("service[%s](%s): %s", svcrunner.id, svcrunner.state, event.Message)
+}
+
+// GetEventHistory returns history of events for this service
+func (svcrunner *ServiceRunner) GetEventHistory(count int) []events.ServiceEvent {
+	svcrunner.mu.Lock()
+	defer svcrunner.mu.Unlock()
+
+	return svcrunner.events.Get(count)
+}
+
+// Start initializes the service and runs it
+//
+// Start should be run in a goroutine.
+func (svcrunner *ServiceRunner) Start() {
+	svcrunner.UpdateState(events.StatePreparing, "Running pre state")
+	if err := svcrunner.service.PreFunc(svcrunner.userData); err != nil {
+		svcrunner.UpdateState(events.StateFailed, "Failed to run pre stage: %v", err)
+		return
+	}
+
+	svcrunner.UpdateState(events.StateWaiting, "Waiting for conditions")
+	_, err := svcrunner.service.ConditionFunc(svcrunner.userData)(svcrunner.ctx)
+	if err != nil {
+		svcrunner.UpdateState(events.StateFailed, "Condition failed: %v", err)
+		return
+	}
+
+	svcrunner.UpdateState(events.StatePreparing, "Creating service runner")
+	runnr, err := svcrunner.service.Runner(svcrunner.userData)
+	if err != nil {
+		svcrunner.UpdateState(events.StateFailed, "Failed to create runner: %v", err)
+		return
+	}
+
+	if err := svcrunner.run(runnr); err != nil {
+		svcrunner.UpdateState(events.StateFailed, "Failed running service: %v", err)
+	} else {
+		svcrunner.UpdateState(events.StateFinished, "Service finished successfully")
+	}
+
+	if err := svcrunner.service.PostFunc(svcrunner.userData); err != nil {
+		svcrunner.UpdateState(events.StateFailed, "Failed to run post stage: %v", err)
+		return
+	}
+}
+
+func (svcrunner *ServiceRunner) run(runnr runner.Runner) error {
+	if runnr == nil {
+		// special case - run nothing (TODO: we should handle it better, e.g. in PreFunc)
+		return nil
+	}
+
+	if err := runnr.Open(svcrunner.ctx); err != nil {
+		return errors.Wrap(err, "error opening runner")
+	}
+
+	// nolint: errcheck
+	defer runnr.Close()
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- runnr.Run(svcrunner.UpdateState)
+	}()
+
+	select {
+	case <-svcrunner.ctx.Done():
+		err := runnr.Stop()
+		<-errCh
+		if err != nil {
+			return errors.Wrap(err, "error stopping service")
+		}
+	case err := <-errCh:
+		if err != nil {
+			return errors.Wrap(err, "error running service")
+		}
+	}
+
+	return nil
+}
+
+// Shutdown initiates shutdown of the service runner
+//
+// Shutdown completes when Start() returns
+func (svcrunner *ServiceRunner) Shutdown() {
+	svcrunner.ctxCancel()
+}

--- a/internal/app/init/pkg/system/service_runner_test.go
+++ b/internal/app/init/pkg/system/service_runner_test.go
@@ -1,0 +1,176 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package system_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
+)
+
+type ServiceRunnerSuite struct {
+	suite.Suite
+}
+
+func (suite *ServiceRunnerSuite) assertStateSequence(expectedStates []events.ServiceState, sr *system.ServiceRunner) {
+	states := []events.ServiceState{}
+
+	for _, event := range sr.GetEventHistory(1000) {
+		states = append(states, event.State)
+	}
+
+	suite.Assert().Equal(expectedStates, states)
+}
+
+func (suite *ServiceRunnerSuite) TestFullFlow() {
+	sr := system.NewServiceRunner(&MockService{}, nil)
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		sr.Start()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-finished:
+		suite.Require().Fail("service running should be still running")
+	default:
+	}
+
+	sr.Shutdown()
+
+	<-finished
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StatePreparing,
+		events.StateRunning,
+		events.StateFinished,
+	}, sr)
+}
+
+func (suite *ServiceRunnerSuite) TestPreStageFail() {
+	svc := &MockService{
+		preError: errors.New("pre failed"),
+	}
+	sr := system.NewServiceRunner(svc, nil)
+	sr.Start()
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateFailed,
+	}, sr)
+}
+
+func (suite *ServiceRunnerSuite) TestRunnerStageFail() {
+	svc := &MockService{
+		runnerError: errors.New("runner failed"),
+	}
+	sr := system.NewServiceRunner(svc, nil)
+	sr.Start()
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StatePreparing,
+		events.StateFailed,
+	}, sr)
+}
+
+func (suite *ServiceRunnerSuite) TestAbortOnCondition() {
+	svc := &MockService{
+		condition: conditions.WaitForFileToExist("/doesntexistever"),
+	}
+	sr := system.NewServiceRunner(svc, nil)
+
+	finished := make(chan struct{})
+
+	go func() {
+		defer close(finished)
+		sr.Start()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-finished:
+		suite.Require().Fail("service running should be still running")
+	default:
+	}
+
+	sr.Shutdown()
+
+	<-finished
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StateFailed,
+	}, sr)
+}
+
+func (suite *ServiceRunnerSuite) TestPostStateFail() {
+	svc := &MockService{
+		postError: errors.New("post failed"),
+	}
+	sr := system.NewServiceRunner(svc, nil)
+
+	finished := make(chan struct{})
+
+	go func() {
+		defer close(finished)
+		sr.Start()
+	}()
+
+	sr.Shutdown()
+
+	<-finished
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StatePreparing,
+		events.StateRunning,
+		events.StateFinished,
+		events.StateFailed,
+	}, sr)
+}
+
+func (suite *ServiceRunnerSuite) TestRunFail() {
+	runner := &MockRunner{exitCh: make(chan error)}
+	svc := &MockService{runner: runner}
+	sr := system.NewServiceRunner(svc, nil)
+
+	finished := make(chan struct{})
+
+	go func() {
+		defer close(finished)
+		sr.Start()
+	}()
+
+	runner.exitCh <- errors.New("run failed")
+
+	<-finished
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StatePreparing,
+		events.StateRunning,
+		events.StateFailed,
+	}, sr)
+}
+
+func TestServiceRunnerSuite(t *testing.T) {
+	suite.Run(t, new(ServiceRunnerSuite))
+}

--- a/internal/app/init/pkg/system/system_test.go
+++ b/internal/app/init/pkg/system/system_test.go
@@ -4,11 +4,27 @@
 
 package system_test
 
-import "testing"
+import (
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system"
+)
+
+type SystemServicesSuite struct {
+	suite.Suite
+}
+
+func (suite *SystemServicesSuite) TestStartShutdown() {
+	prevShutdownHackySleep := system.ShutdownHackySleep
+	defer func() { system.ShutdownHackySleep = prevShutdownHackySleep }()
+
+	system.ShutdownHackySleep = 0
+
+	system.Services(nil).Start(&MockService{name: "containerd"}, &MockService{name: "proxyd"})
+	system.Services(nil).Shutdown()
+}
+
+func TestSystemServicesSuite(t *testing.T) {
+	suite.Run(t, new(SystemServicesSuite))
 }

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	containerdrunner "github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/osd/proto"
@@ -217,7 +218,7 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (reply *proto.
 		),
 	)
 
-	err = cr.Open()
+	err = cr.Open(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +226,8 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (reply *proto.
 	// nolint: errcheck
 	defer cr.Close()
 
-	err = cr.Run()
+	// TODO: should this go through system.Services?
+	err = cr.Run(events.NullRecorder)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Most crucial changes in `init/main.go`: on shutdown now Talos tries
to stop gracefully all the services. All the shutdown paths are unified,
including poweroff, reboot and panic handling on startup.

While I was at it, I also fixed bug with containers failing to start
when old snapshot is still around.

Service lifecycle is wrapped with `ServiceRunner` object now which
handles state transitions and captures events related to state changes.
Every change goes to the log as well.

There's no way to capture service state yet, but that is planned to be
implemented as RPC API for `init` which is exposed via `osd` to `osctl`.

Future steps:

1. Implement service dependencies for correct startup order and
shutdown order.

2. Implement service health, so that we can say "start trustd when
containerd is up and healthy".

3. Implement gRPC API for init, expose via osd (service status, restart,
poweroff, ...)

4. Impement 'String()' for conditions, so that we can see what service
is waiting on right now.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>