### PR TITLE
fix: Explicitly set upstream/forward servers for coredns in dev setup

### DIFF
--- a/hack/dev/Makefile
+++ b/hack/dev/Makefile
@@ -31,6 +31,7 @@ enter: kubeconfig
 manifests: kubeconfig
 	@./kubectl.sh apply -f /manifests/psp.yaml
 	@./kubectl.sh apply -f /manifests/cni.yaml
+	@./kubectl.sh apply -f /manifests/coredns.yaml
 
 integration: up
 	@./integration.sh

--- a/hack/dev/manifests/coredns.yaml
+++ b/hack/dev/manifests/coredns.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           upstream
+           fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . 1.1.1.1 8.8.8.8
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system


### PR DESCRIPTION
fixes talos-systems/talos#575 

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>

