### PR TITLE
feat(init): implement init gRPC API, forward reboot to init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,14 @@ RUN protoc -I/usr/local/include -I./proto --go_out=plugins=grpc:proto proto/api.
 WORKDIR /trustd
 COPY ./internal/app/trustd/proto ./proto
 RUN protoc -I/usr/local/include -I./proto --go_out=plugins=grpc:proto proto/api.proto
+WORKDIR /init
+COPY ./internal/app/init/proto ./proto
+RUN protoc -I/usr/local/include -I./proto --go_out=plugins=grpc:proto proto/api.proto
 
 FROM scratch AS proto
 COPY --from=proto-build /osd/proto/api.pb.go /internal/app/osd/proto/
 COPY --from=proto-build /trustd/proto/api.pb.go /internal/app/trustd/proto/
+COPY --from=proto-build /init/proto/api.pb.go /internal/app/init/proto/
 
 # The base provides a common image to build the Talos source code.
 

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
+	initproto "github.com/talos-systems/talos/internal/app/init/proto"
 	"github.com/talos-systems/talos/internal/app/osd/proto"
 	"github.com/talos-systems/talos/internal/pkg/proc"
 	"google.golang.org/grpc"
@@ -37,8 +38,9 @@ type Credentials struct {
 // Client implements the proto.OSDClient interface. It serves as the
 // concrete type with the required methods.
 type Client struct {
-	conn   *grpc.ClientConn
-	client proto.OSDClient
+	conn       *grpc.ClientConn
+	client     proto.OSDClient
+	initClient initproto.InitClient
 }
 
 // NewDefaultClientCredentials initializes ClientCredentials using default paths
@@ -101,6 +103,7 @@ func NewClient(port int, clientcreds *Credentials) (c *Client, err error) {
 	}
 
 	c.client = proto.NewOSDClient(c.conn)
+	c.initClient = initproto.NewInitClient(c.conn)
 
 	return c, nil
 }
@@ -180,7 +183,7 @@ func (c *Client) Reset() (err error) {
 // Reboot implements the proto.OSDClient interface.
 func (c *Client) Reboot() (err error) {
 	ctx := context.Background()
-	_, err = c.client.Reboot(ctx, &empty.Empty{})
+	_, err = c.initClient.Reboot(ctx, &empty.Empty{})
 	if err != nil {
 		return
 	}
@@ -191,7 +194,7 @@ func (c *Client) Reboot() (err error) {
 // Shutdown implements the proto.OSDClient interface.
 func (c *Client) Shutdown() (err error) {
 	ctx := context.Background()
-	_, err = c.client.Shutdown(ctx, &empty.Empty{})
+	_, err = c.initClient.Shutdown(ctx, &empty.Empty{})
 	if err != nil {
 		return
 	}

--- a/internal/app/init/internal/reg/reg.go
+++ b/internal/app/init/internal/reg/reg.go
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/talos-systems/talos/internal/app/init/proto"
+	"github.com/talos-systems/talos/pkg/userdata"
+	"google.golang.org/grpc"
+)
+
+// Registrator is the concrete type that implements the factory.Registrator and
+// proto.Init interfaces.
+type Registrator struct {
+	Data *userdata.UserData
+
+	ShutdownCh chan struct{}
+	RebootCh   chan struct{}
+
+	rebootCalled uint32
+}
+
+// NewRegistrator builds new Registrator instance
+func NewRegistrator(data *userdata.UserData) *Registrator {
+	return &Registrator{
+		Data:       data,
+		ShutdownCh: make(chan struct{}),
+		RebootCh:   make(chan struct{}),
+	}
+}
+
+// Register implements the factory.Registrator interface.
+func (r *Registrator) Register(s *grpc.Server) {
+	proto.RegisterInitServer(s, r)
+}
+
+// Reboot implements the proto.InitServer interface.
+func (r *Registrator) Reboot(ctx context.Context, in *empty.Empty) (reply *proto.RebootReply, err error) {
+	reply = &proto.RebootReply{}
+
+	// make sure channel is closed only once (and initiate either reboot or shutdown)
+	if atomic.CompareAndSwapUint32(&r.rebootCalled, 0, 1) {
+		close(r.RebootCh)
+	}
+
+	return
+}
+
+// Shutdown implements the proto.InitServer interface.
+func (r *Registrator) Shutdown(ctx context.Context, in *empty.Empty) (reply *proto.ShutdownReply, err error) {
+	reply = &proto.ShutdownReply{}
+
+	// make sure channel is closed only once (and initiate either reboot or shutdown)
+	if atomic.CompareAndSwapUint32(&r.rebootCalled, 0, 1) {
+		close(r.ShutdownCh)
+	}
+
+	return
+}

--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -62,6 +62,7 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		{Type: "bind", Destination: "/etc/kubernetes", Source: "/etc/kubernetes", Options: []string{"bind", "rw"}},
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/var/log", Source: "/var/log", Options: []string{"rbind", "rw"}},
+		{Type: "bind", Destination: "/var/lib/init", Source: "/var/lib/init", Options: []string{"rbind", "rw"}},
 	}
 
 	env := []string{}

--- a/internal/app/init/proto/api.proto
+++ b/internal/app/init/proto/api.proto
@@ -1,0 +1,20 @@
+
+syntax = "proto3";
+
+package proto;
+
+import "google/protobuf/empty.proto";
+
+// The Init service definition.
+service Init {
+  rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
+  rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
+}
+
+
+// The response message containing the reboot status.
+message RebootReply {}
+
+// The response message containing the shutdown status.
+message ShutdownReply {}
+

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/talos-systems/talos/internal/app/init/proto"
+	"github.com/talos-systems/talos/internal/pkg/constants"
+	"google.golang.org/grpc"
+)
+
+// InitServiceClient is a gRPC client for init service API
+type InitServiceClient struct {
+	proto.InitClient
+}
+
+// NewInitServiceClient initializes new client and connects to init
+func NewInitServiceClient() (*InitServiceClient, error) {
+	conn, err := grpc.Dial("unix:"+constants.InitSocketPath,
+		grpc.WithInsecure(),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &InitServiceClient{
+		InitClient: proto.NewInitClient(conn),
+	}, nil
+}
+
+// Reboot executes init Reboot() API
+func (c *InitServiceClient) Reboot(ctx context.Context, empty *empty.Empty) (*proto.RebootReply, error) {
+	return c.InitClient.Reboot(ctx, empty)
+}
+
+// Shutdown executes init Shutdown() API
+func (c *InitServiceClient) Shutdown(ctx context.Context, empty *empty.Empty) (*proto.ShutdownReply, error) {
+	return c.InitClient.Shutdown(ctx, empty)
+}

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -38,9 +38,17 @@ func main() {
 		log.Fatalf("credentials: %v", err)
 	}
 
+	initClient, err := reg.NewInitServiceClient()
+	if err != nil {
+		log.Fatalf("init client: %v", err)
+	}
+
 	log.Println("Starting osd")
-	err = factory.Listen(
-		&reg.Registrator{Data: data},
+	err = factory.ListenAndServe(
+		&reg.Registrator{
+			Data:              data,
+			InitServiceClient: initClient,
+		},
 		factory.Port(constants.OsdPort),
 		factory.ServerOptions(
 			grpc.Creds(

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -6,16 +6,16 @@ package proto;
 import "google/protobuf/empty.proto";
 
 // The OSD service definition.
+//
+// OSD Service also implements all the API of Init Service
 service OSD {
   rpc Dmesg(google.protobuf.Empty) returns (Data) {}
   rpc Kubeconfig(google.protobuf.Empty) returns (Data) {}
   rpc Logs(LogsRequest) returns (stream Data) {}
   rpc Processes(ProcessesRequest) returns (ProcessesReply) {}
-  rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
   rpc Restart(RestartRequest) returns (RestartReply) {}
   rpc Routes(google.protobuf.Empty) returns (RoutesReply) {}
-  rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
   rpc Stats(StatsRequest) returns (StatsReply) {}
   rpc Top(google.protobuf.Empty) returns (TopReply) {}
   rpc DF(google.protobuf.Empty) returns (DFReply) {}
@@ -61,14 +61,8 @@ message RestartRequest {
 // The response message containing the restart status.
 message RestartReply {}
 
-// The response message containing the shutdown status.
-message ShutdownReply {}
-
 // The response message containing the restart status.
 message ResetReply {}
-
-// The response message containing the restart status.
-message RebootReply {}
 
 // The request message containing the process name.
 message LogsRequest {

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -46,7 +46,7 @@ func main() {
 		data.Services.Trustd.Password,
 	)
 
-	err = factory.Listen(
+	err = factory.ListenAndServe(
 		&reg.Registrator{Data: data.Security.OS},
 		factory.Port(constants.TrustdPort),
 		factory.ServerOptions(

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -99,6 +99,9 @@ const (
 
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
+
+	// InitSocketPath is the path to file socket of init API
+	InitSocketPath = "/var/lib/init/init.sock"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
This implements insecure over-file-socket gRPC API for init with two
first simplest APIs: reboot and shutdown (poweroff).

File socket is mounted only to `osd` service, so it is the only service
which can access init API. Osd forwards reboot/shutdown already
implemented APIs to init which actually executes these.

This enables graceful shutdown/reboot with service shutdown, sync, etc.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>