### PR TITLE
refactor(init): add helper for getting specific kernel parameters

### DIFF
--- a/internal/app/init/internal/platform/baremetal/baremetal.go
+++ b/internal/app/init/internal/platform/baremetal/baremetal.go
@@ -35,12 +35,7 @@ func (b *BareMetal) Name() string {
 
 // UserData implements the platform.Platform interface.
 func (b *BareMetal) UserData() (data *userdata.UserData, err error) {
-	arguments, err := kernel.ParseProcCmdline()
-	if err != nil {
-		return
-	}
-
-	option, ok := arguments[constants.KernelParamUserData]
+	option, ok := kernel.GetParameter(constants.KernelParamUserData)
 	if !ok {
 		return data, errors.Errorf("no user data option was found")
 	}

--- a/internal/app/init/internal/platform/cloud/vmware/vmware.go
+++ b/internal/app/init/internal/platform/cloud/vmware/vmware.go
@@ -27,12 +27,7 @@ func (vmw *VMware) Name() string {
 
 // UserData implements the platform.Platform interface.
 func (vmw *VMware) UserData() (data *userdata.UserData, err error) {
-	arguments, err := kernel.ParseProcCmdline()
-	if err != nil {
-		return
-	}
-
-	option, ok := arguments[constants.KernelParamUserData]
+	option, ok := kernel.GetParameter(constants.KernelParamUserData)
 	if !ok {
 		return data, fmt.Errorf("no user data option was found")
 	}

--- a/internal/app/init/internal/platform/platform.go
+++ b/internal/app/init/internal/platform/platform.go
@@ -27,11 +27,7 @@ type Platform interface {
 
 // NewPlatform is a helper func for discovering the current platform.
 func NewPlatform() (p Platform, err error) {
-	arguments, err := kernel.ParseProcCmdline()
-	if err != nil {
-		return
-	}
-	if platform, ok := arguments[constants.KernelParamPlatform]; ok {
+	if platform, ok := kernel.GetParameter(constants.KernelParamPlatform); ok {
 		switch platform {
 		case "aws":
 			if aws.IsEC2() {

--- a/internal/app/init/internal/security/kspp/kspp.go
+++ b/internal/app/init/internal/security/kspp/kspp.go
@@ -18,18 +18,13 @@ var RequiredKSPPKernelParameters = map[string]string{"page_poison": "1", "slab_n
 // EnforceKSPPKernelParameters verifies that all required KSPP kernel
 // parameters are present with the right value.
 func EnforceKSPPKernelParameters() error {
-	arguments, err := kernel.ParseProcCmdline()
-	if err != nil {
-		return err
-	}
-
 	var result *multierror.Error
 	for param, expected := range RequiredKSPPKernelParameters {
 		var (
 			ok  bool
 			val string
 		)
-		if val, ok = arguments[param]; !ok {
+		if val, ok = kernel.GetParameter(param); !ok {
 			result = multierror.Append(result, errors.Errorf("KSPP kernel parameter %s is required", param))
 			continue
 		}

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -132,15 +132,12 @@ func initram() (err error) {
 		return err
 	}
 	// Setup hostname if provided
-	var kargs map[string]string
-	if kargs, err = kernel.ParseProcCmdline(); err != nil {
-		if hostname, ok := kargs[constants.KernelParamHostname]; ok {
-			log.Println("setting hostname")
-			if err = unix.Sethostname([]byte(hostname)); err != nil {
-				return err
-			}
-			log.Printf("hostname is: %s", hostname)
+	if hostname, ok := kernel.GetParameter(constants.KernelParamHostname); ok {
+		log.Println("setting hostname")
+		if err = unix.Sethostname([]byte(hostname)); err != nil {
+			return err
 		}
+		log.Printf("hostname is: %s", hostname)
 	}
 	// Discover the platform.
 	log.Println("discovering the platform")

--- a/internal/app/init/pkg/network/dhcp.go
+++ b/internal/app/init/pkg/network/dhcp.go
@@ -106,11 +106,8 @@ func dhclient4(ifname string, modifiers ...dhcpv4.Modifier) (*netboot.NetConf, e
 			}
 
 			// Ignore DHCP-offered hostname if the kernel parameter is set
-			var kargs map[string]string
-			if kargs, err = kernel.ParseProcCmdline(); err != nil {
-				if kernHostname, ok := kargs[constants.KernelParamHostname]; ok {
-					hostname = kernHostname
-				}
+			if kernHostname, ok := kernel.GetParameter(constants.KernelParamHostname); ok {
+				hostname = kernHostname
 			}
 
 			log.Printf("using hostname: %s", hostname)

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -53,3 +53,14 @@ func ParseKernelBootParameters(parameters []byte) (parsed map[string]string) {
 
 	return
 }
+
+// GetParameter attempts to get a specific kernel
+// boot time parameter.
+func GetParameter(parameter string) (string, bool) {
+	kargs, err := ParseProcCmdline()
+	if err != nil {
+		return "", false
+	}
+	value, ok := kargs[parameter]
+	return value, ok
+}


### PR DESCRIPTION
Adds a simple wrapper to get a specific kernel parameter on request.

There is a section in the `kspp` package that I specifically didn't refactor as it is in a loop.
https://github.com/talos-systems/talos/blob/83363c7a17539614fd491f5bb8453c77c5ab9385/internal/app/init/internal/security/kspp/kspp.go#L18-L42
Let me know if you think the code re-use\clarity is worth the extra cycles of calling `kernel.ParseProcCmdline()` for each loop iteration and I'll refactor it too.