### PR TITLE
fix(init): start udevd with parent cgroup devices

### DIFF
--- a/internal/app/init/pkg/system/services/udevd.go
+++ b/internal/app/init/pkg/system/services/udevd.go
@@ -52,6 +52,7 @@ func (c *Udevd) Runner(data *userdata.UserData) (runner.Runner, error) {
 
 	// Set the mounts.
 	mounts := []specs.Mount{
+		// NB: We must mount /dev to ensure that changes on the host are reflected in the container.
 		{Type: "bind", Destination: "/dev", Source: "/dev", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/tmp", Source: "/tmp", Options: []string{"rbind", "rshared", "rw"}},
 	}
@@ -71,6 +72,7 @@ func (c *Udevd) Runner(data *userdata.UserData) (runner.Runner, error) {
 			oci.WithMounts(mounts),
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithHostNamespace(specs.UTSNamespace),
+			oci.WithParentCgroupDevices,
 			oci.WithPrivileged,
 		),
 	),


### PR DESCRIPTION
WithParentCgroupDevices uses the default cgroup setup to inherit the container's parent cgroup's allowed and denied devices
Without this, we get 'operation not permitted' when attempting to read the block devices.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>