### PR TITLE
fix: use the correct param in root label check

### DIFF
--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -162,7 +162,7 @@ const (
 // CurrentRootPartitionLabel returns the label of the currently active root
 // partition.
 func CurrentRootPartitionLabel() string {
-	param, _ := kernel.GetParameter(RootBPartitionLabel)
+	param, _ := kernel.GetParameter(KernelCurrentRoot)
 	switch param {
 	case "B":
 		return RootBPartitionLabel


### PR DESCRIPTION
Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>