### PR TITLE
feat(init): core health check package

### DIFF
--- a/internal/app/init/pkg/system/health/check.go
+++ b/internal/app/init/pkg/system/health/check.go
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package health
+
+import (
+	"context"
+	"time"
+)
+
+// Check runs the health check under given context.
+//
+// Healthcheck is considered successful when func returns no error.
+// Func should terminate when context is canceled.
+type Check func(ctx context.Context) error
+
+// Run the health check publishing the results to state.
+//
+// Run aborts when context is canceled.
+func Run(ctx context.Context, settings *Settings, state *State, check Check) error {
+	state.Init()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(settings.InitialDelay):
+	}
+
+	for {
+		ticker := time.NewTicker(settings.Period)
+		defer ticker.Stop()
+
+		err := func() error {
+			checkCtx, checkCtxCancel := context.WithTimeout(ctx, settings.Timeout)
+			defer checkCtxCancel()
+
+			return check(checkCtx)
+		}()
+
+		healthy := err == nil
+		message := ""
+		if !healthy {
+			message = err.Error()
+		}
+
+		state.Update(healthy, message)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/app/init/pkg/system/health/health_test.go
+++ b/internal/app/init/pkg/system/health/health_test.go
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package health_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/health"
+)
+
+type CheckSuite struct {
+	suite.Suite
+}
+
+func (suite *CheckSuite) TestHealthy() {
+	var settings = health.Settings{
+		InitialDelay: time.Millisecond,
+		Period:       10 * time.Millisecond,
+		Timeout:      time.Millisecond,
+	}
+
+	var called int
+
+	// nolint: unparam
+	check := func(context.Context) error {
+		called++
+
+		return nil
+	}
+
+	var state health.State
+
+	errCh := make(chan error)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		errCh <- health.Run(ctx, &settings, &state, check)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	ctxCancel()
+
+	suite.Assert().EqualError(<-errCh, context.Canceled.Error())
+	suite.Assert().True(called > 2)
+}
+
+func (suite *CheckSuite) TestHealthChange() {
+	var settings = health.Settings{
+		InitialDelay: time.Millisecond,
+		Period:       time.Millisecond,
+		Timeout:      time.Millisecond,
+	}
+
+	var healthy uint32
+
+	check := func(context.Context) error {
+		if atomic.LoadUint32(&healthy) == 1 {
+			return nil
+		}
+
+		return errors.New("health failed")
+	}
+
+	var state health.State
+
+	errCh := make(chan error)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		errCh <- health.Run(ctx, &settings, &state, check)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.Require().False(*state.Get().Healthy)
+	suite.Require().Equal("health failed", state.Get().LastMessage)
+
+	atomic.StoreUint32(&healthy, 1)
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.Require().True(*state.Get().Healthy)
+	suite.Require().Equal("", state.Get().LastMessage)
+
+	ctxCancel()
+
+	suite.Assert().EqualError(<-errCh, context.Canceled.Error())
+}
+
+func (suite *CheckSuite) TestCheckAbort() {
+	var settings = health.Settings{
+		InitialDelay: time.Millisecond,
+		Period:       time.Millisecond,
+		Timeout:      time.Millisecond,
+	}
+
+	check := func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+			return nil
+		}
+	}
+
+	var state health.State
+
+	errCh := make(chan error)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	go func() {
+		errCh <- health.Run(ctx, &settings, &state, check)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.Require().False(*state.Get().Healthy)
+	suite.Require().Equal("context deadline exceeded", state.Get().LastMessage)
+
+	ctxCancel()
+
+	suite.Assert().EqualError(<-errCh, context.Canceled.Error())
+}
+
+func (suite *CheckSuite) TestInitialState() {
+	var settings = health.Settings{
+		InitialDelay: time.Minute,
+	}
+
+	var state health.State
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- health.Run(ctx, &settings, &state, nil)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.Require().Nil(state.Get().Healthy)
+	suite.Require().Equal("Unknown", state.Get().LastMessage)
+
+	ctxCancel()
+
+	suite.Assert().EqualError(<-errCh, context.Canceled.Error())
+}
+
+func TestCheckSuite(t *testing.T) {
+	suite.Run(t, new(CheckSuite))
+}

--- a/internal/app/init/pkg/system/health/settings.go
+++ b/internal/app/init/pkg/system/health/settings.go
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package health
+
+import "time"
+
+// Settings configures health check
+//
+// Fields are similar to k8s pod probe definitions.
+type Settings struct {
+	InitialDelay time.Duration
+	Period       time.Duration
+	Timeout      time.Duration
+}
+
+// DefaultSettings provides some default health check settings
+var DefaultSettings = Settings{
+	InitialDelay: 500 * time.Millisecond,
+	Period:       time.Second,
+	Timeout:      500 * time.Millisecond,
+}

--- a/internal/app/init/pkg/system/health/status.go
+++ b/internal/app/init/pkg/system/health/status.go
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package health
+
+import (
+	"sync"
+	"time"
+)
+
+// Status of the healthcheck
+type Status struct {
+	Healthy     *bool
+	LastChange  time.Time
+	LastMessage string
+}
+
+// State provides proper locking around health state
+type State struct {
+	sync.Mutex
+
+	status Status
+}
+
+// Update health status (locked)
+func (state *State) Update(healthy bool, message string) {
+	state.Lock()
+	defer state.Unlock()
+
+	state.status.LastMessage = message
+	if state.status.Healthy == nil || *state.status.Healthy != healthy {
+		state.status.Healthy = &healthy
+		state.status.LastChange = time.Now()
+	}
+}
+
+// Init health status (locked)
+func (state *State) Init() {
+	state.Lock()
+	defer state.Unlock()
+
+	state.status.LastMessage = "Unknown"
+	state.status.LastChange = time.Now()
+	state.status.Healthy = nil
+}
+
+// Get returns health status (locked)
+func (state *State) Get() Status {
+	state.Lock()
+	defer state.Unlock()
+
+	return state.status
+}


### PR DESCRIPTION
This is a small building block for service health checks: settings,
health state, health check runner.

This is to be integrated with ServiceRunner to provide health for each
service based on per-service health check.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>