### PR TITLE
fix: Update filesystem check to open device as a device

### DIFF
--- a/internal/pkg/blockdevice/probe/probe.go
+++ b/internal/pkg/blockdevice/probe/probe.go
@@ -111,7 +111,7 @@ func All() (probed []*ProbedBlockDevice, err error) {
 // FileSystem probes the provided path's file system.
 func FileSystem(path string) (sb filesystem.SuperBlocker, err error) {
 	var f *os.File
-	if f, err = os.Open(path); err != nil {
+	if f, err = os.OpenFile(path, os.O_RDONLY, os.ModeDevice); err != nil {
 		return nil, err
 	}
 	// nolint: errcheck


### PR DESCRIPTION
Should fix some of the issues we were seeing with being unable to identify a filesystem by label. 

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>