### PR TITLE
fix(init): don't close ACPI listen handle too early

### DIFF
--- a/internal/app/init/shutdown.go
+++ b/internal/app/init/shutdown.go
@@ -25,11 +25,11 @@ func listenForPowerButton() (poweroffCh <-chan struct{}, err error) {
 	if err != nil {
 		return nil, err
 	}
-	// nolint: errcheck
-	defer conn.Close()
 
 	f, err := conn.GetFamily(acpiGenlFamilyName)
 	if netlink.IsNotExist(err) {
+		// nolint: errcheck
+		conn.Close()
 		return nil, errors.Wrap(err, acpiGenlFamilyName+" not available")
 	}
 
@@ -40,6 +40,8 @@ func listenForPowerButton() (poweroffCh <-chan struct{}, err error) {
 		}
 	}
 	if err = conn.JoinGroup(id); err != nil {
+		// nolint: errcheck
+		conn.Close()
 		return nil, err
 	}
 
@@ -47,6 +49,9 @@ func listenForPowerButton() (poweroffCh <-chan struct{}, err error) {
 	ch := make(chan struct{})
 
 	go func() {
+		// nolint: errcheck
+		defer conn.Close()
+
 		for {
 			msgs, _, err := conn.Receive()
 			if err != nil {


### PR DESCRIPTION
:man_facepalming:  I broke the code while refactoring it to return the channel
which notifies about poweroff events.

`defer` was executed and immediately closed the channel, breaking any
subsequent `Receive` calls:

```
error reading from ACPI channel: netlink receive: recvmsg: bad file descriptor
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>