### PR TITLE
chore: workaround flaky tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,6 @@ test: buildkitd
 		--opt target=$@ \
 		$(COMMON_ARGS)
 	@docker load < /tmp/$@.tar
-	@docker run -i --rm $(DOCKER_TEST_ARGS) autonomy/$@:$(TAG) /bin/test.sh --short
 	@trap "rm -rf ./.artifacts" EXIT; mkdir -p ./.artifacts && \
 		docker run -i --rm $(DOCKER_TEST_ARGS) -v $(PWD)/.artifacts:/src/artifacts autonomy/$@:$(TAG) /bin/test.sh && \
 		cp ./.artifacts/coverage.txt coverage.txt

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -6,7 +6,7 @@ CGO_ENABLED=1
 
 perform_tests() {
   echo "Performing tests"
-  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt ./...
+  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt -p 4 ./...
 }
 
 perform_short_tests() {

--- a/internal/app/init/pkg/system/health/health_test.go
+++ b/internal/app/init/pkg/system/health/health_test.go
@@ -107,7 +107,7 @@ func (suite *CheckSuite) TestCheckAbort() {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(25 * time.Millisecond):
 			return nil
 		}
 	}


### PR DESCRIPTION
Some unit-tests depend on timing as they're testin concurrent code and
tests do things like `time.Sleep(...)` to let the code in concurrent
goroutine proceed so that side-effect can be observed.

One issue is that `go test` (and `go build`) by default launch builds
with the number of CPUs available which might be too much and overloads
system so that tests which are also concurrent are not allowed to
execute due to high load average. I observe "lock-ups" when running
`make test` locally. I'm trying to limit number of executors to 4 as an
experiment.

Disable short test run, as we don't seem to have any short tests, and
running short and full run just means running all the tests twice.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>