### PR TITLE
feat(init): implement health checks for services

### DIFF
--- a/internal/app/init/pkg/system/health/settings.go
+++ b/internal/app/init/pkg/system/health/settings.go
@@ -17,7 +17,7 @@ type Settings struct {
 
 // DefaultSettings provides some default health check settings
 var DefaultSettings = Settings{
-	InitialDelay: 500 * time.Millisecond,
+	InitialDelay: 200 * time.Millisecond,
 	Period:       time.Second,
 	Timeout:      500 * time.Millisecond,
 }

--- a/internal/app/init/pkg/system/service.go
+++ b/internal/app/init/pkg/system/service.go
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package system
+
+import (
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/health"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+// Service is an interface describing a system service.
+type Service interface {
+	// ID is the service id.
+	ID(*userdata.UserData) string
+	// PreFunc is invoked before a runner is created
+	PreFunc(*userdata.UserData) error
+	// Runner creates runner for the service
+	Runner(*userdata.UserData) (runner.Runner, error)
+	// PostFunc is invoked after a runner is closed.
+	PostFunc(*userdata.UserData) error
+	// ConditionFunc describes the conditions under which a service should
+	// start.
+	ConditionFunc(*userdata.UserData) conditions.ConditionFunc
+}
+
+// HealthcheckedService is a service which provides health check
+type HealthcheckedService interface {
+	// HealtFunc provides function that checks health of the service
+	HealthFunc(*userdata.UserData) health.Check
+	// HealthSettings returns settings for the health check
+	HealthSettings(*userdata.UserData) *health.Settings
+}

--- a/internal/app/init/pkg/system/service_runner_test.go
+++ b/internal/app/init/pkg/system/service_runner_test.go
@@ -59,6 +59,73 @@ func (suite *ServiceRunnerSuite) TestFullFlow() {
 	}, sr)
 }
 
+func (suite *ServiceRunnerSuite) TestFullFlowHealthy() {
+	sr := system.NewServiceRunner(&MockHealthcheckedService{}, nil)
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		sr.Start()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	select {
+	case <-finished:
+		suite.Require().Fail("service running should be still running")
+	default:
+	}
+
+	sr.Shutdown()
+
+	<-finished
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StatePreparing,
+		events.StateRunning,
+		events.StateRunning, // one more notification when service is healthy
+		events.StateFinished,
+	}, sr)
+}
+
+func (suite *ServiceRunnerSuite) TestFullFlowHealthChanges() {
+	m := MockHealthcheckedService{}
+	sr := system.NewServiceRunner(&m, nil)
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		sr.Start()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	m.SetHealthy(false)
+
+	time.Sleep(50 * time.Millisecond)
+
+	m.SetHealthy(true)
+
+	time.Sleep(50 * time.Millisecond)
+
+	sr.Shutdown()
+
+	<-finished
+
+	suite.assertStateSequence([]events.ServiceState{
+		events.StatePreparing,
+		events.StateWaiting,
+		events.StatePreparing,
+		events.StateRunning,
+		events.StateRunning, // initial: healthy
+		events.StateRunning, // not healthy
+		events.StateRunning, // one again healthy
+		events.StateFinished,
+	}, sr)
+}
+
 func (suite *ServiceRunnerSuite) TestPreStageFail() {
 	svc := &MockService{
 		preError: errors.New("pre failed"),

--- a/internal/app/init/pkg/system/system.go
+++ b/internal/app/init/pkg/system/system.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
-	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -26,21 +24,6 @@ type singleton struct {
 
 var instance *singleton
 var once sync.Once
-
-// Service is an interface describing a system service.
-type Service interface {
-	// ID is the service id.
-	ID(*userdata.UserData) string
-	// PreFunc is invoked before a runner is created
-	PreFunc(*userdata.UserData) error
-	// Runner creates runner for the service
-	Runner(*userdata.UserData) (runner.Runner, error)
-	// PostFunc is invoked after a runner is closed.
-	PostFunc(*userdata.UserData) error
-	// ConditionFunc describes the conditions under which a service should
-	// start.
-	ConditionFunc(*userdata.UserData) conditions.ConditionFunc
-}
 
 // Services returns the instance of the system services API.
 // TODO(andrewrynhard): This should be a gRPC based API availale on a local


### PR DESCRIPTION
This connects work on health state with service runner: if service
supports health checks, health check runs with specified schedule
against service when service runner is active. Health state changes are
captured and health status changes are reported via service events.

Idea is that future `osctl services` (or similar which returns service
list/status) reports last known status (including last health check
failure if any), while events capture only changes (health good/bad).

Health check is implemented only for `containerd` service as an example,
but any service implementing `HealthcheckedService` interface gets
health checking for free now.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>