### PR TITLE
fix(init): fix containerd healthcheck leaking memory in init/containerd

### DIFF
--- a/internal/app/init/pkg/system/services/containerd.go
+++ b/internal/app/init/pkg/system/services/containerd.go
@@ -77,6 +77,8 @@ func (c *Containerd) HealthFunc(*userdata.UserData) health.Check {
 		if err != nil {
 			return err
 		}
+		// nolint: errcheck
+		defer client.Close()
 
 		resp, err := client.HealthService().Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 		if err != nil {


### PR DESCRIPTION
As containerd client API wasn't closed after use, connection was leaking
every time healthcheck was run.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>