### PR TITLE
feat(init): implement services list API and osctl service CLI

### DIFF
--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"path"
 
 	"github.com/spf13/cobra"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/pkg/constants"
 )
@@ -55,4 +56,23 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		helpers.Fatalf("%s", err)
 	}
+}
+
+// setupClient wraps common code to initialize osd client
+func setupClient(action func(*client.Client)) {
+	creds, err := client.NewDefaultClientCredentials(talosconfig)
+	if err != nil {
+		helpers.Fatalf("error getting client credentials: %s", err)
+	}
+	if target != "" {
+		creds.Target = target
+	}
+	c, err := client.NewClient(constants.OsdPort, creds)
+	if err != nil {
+		helpers.Fatalf("error constructing client: %s", err)
+	}
+	// nolint: errcheck
+	defer c.Close()
+
+	action(c)
 }

--- a/cmd/osctl/cmd/service.go
+++ b/cmd/osctl/cmd/service.go
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
+	initproto "github.com/talos-systems/talos/internal/app/init/proto"
+)
+
+// serviceCmd represents the service command
+var serviceCmd = &cobra.Command{
+	Use:   "service [<id>]",
+	Short: "Retrieve the state of a service (or all services)",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 1 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
+		}
+
+		setupClient(func(c *client.Client) {
+			if len(args) == 0 {
+				serviceList(c)
+			} else {
+				serviceInfo(c, args[0])
+			}
+		})
+	},
+}
+
+func serviceList(c *client.Client) {
+	reply, err := c.ServiceList(context.TODO())
+	if err != nil {
+		helpers.Fatalf("error listing services: %s", err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "SERVICE\tSTATE\tHEALTH\tLAST CHANGE\tLAST EVENT")
+	for _, s := range reply.Services {
+		svc := serviceInfoWrapper{s}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", svc.Id, svc.State, svc.HealthStatus(), svc.LastUpdated(), svc.LastEvent())
+	}
+	if err := w.Flush(); err != nil {
+		helpers.Fatalf("error writing response: %s", err)
+	}
+}
+
+func serviceInfo(c *client.Client, id string) {
+	s, err := c.ServiceInfo(context.TODO(), id)
+	if err != nil {
+		helpers.Fatalf("error listing services: %s", err)
+	}
+	if s == nil {
+		helpers.Fatalf("service %q is not registered", id)
+	}
+
+	svc := serviceInfoWrapper{s}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintf(w, "ID\t%s\n", svc.Id)
+	fmt.Fprintf(w, "STATE\t%s\n", svc.State)
+	fmt.Fprintf(w, "HEALTH\t%s\n", svc.HealthStatus())
+	if svc.Health.LastMessage != "" {
+		fmt.Fprintf(w, "LAST HEALTH MESSAGE\t%s\n", svc.Health.LastMessage)
+	}
+	label := "EVENTS"
+	for _, event := range svc.Events.Events {
+		// nolint: errcheck
+		ts, _ := ptypes.Timestamp(event.Ts)
+		fmt.Fprintf(w, "%s\t[%s]: %s (%s ago)\n", label, event.State, event.Msg, time.Since(ts).Round(time.Second))
+		label = ""
+	}
+
+	if err := w.Flush(); err != nil {
+		helpers.Fatalf("error writing response: %s", err)
+	}
+}
+
+type serviceInfoWrapper struct {
+	*initproto.ServiceInfo
+}
+
+func (svc serviceInfoWrapper) LastUpdated() string {
+	if len(svc.Events.Events) == 0 {
+		return ""
+	}
+
+	// nolint: error
+	ts, _ := ptypes.Timestamp(svc.Events.Events[len(svc.Events.Events)-1].Ts)
+
+	return time.Since(ts).Round(time.Second).String()
+}
+
+func (svc serviceInfoWrapper) LastEvent() string {
+	if len(svc.Events.Events) == 0 {
+		return "<none>"
+	}
+
+	return svc.Events.Events[len(svc.Events.Events)-1].Msg
+}
+
+func (svc serviceInfoWrapper) HealthStatus() string {
+	if svc.Health.Unknown {
+		return "?"
+	}
+
+	if svc.Health.Healthy {
+		return "OK"
+	}
+
+	return "Fail"
+}
+
+func init() {
+	serviceCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
+	rootCmd.AddCommand(serviceCmd)
+}

--- a/internal/app/init/internal/reg/reg.go
+++ b/internal/app/init/internal/reg/reg.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system"
 	"github.com/talos-systems/talos/internal/app/init/proto"
 	"github.com/talos-systems/talos/internal/pkg/upgrade"
 	"github.com/talos-systems/talos/pkg/userdata"
@@ -81,4 +82,19 @@ func (r *Registrator) Upgrade(ctx context.Context, in *proto.UpgradeRequest) (da
 	// profit
 	data = &proto.UpgradeReply{Ack: "Upgrade completed, rebooting node"}
 	return data, err
+}
+
+// ServiceList returns list of the registered services and their status
+func (r *Registrator) ServiceList(ctx context.Context, in *empty.Empty) (result *proto.ServiceListReply, err error) {
+	services := system.Services(r.Data).List()
+
+	result = &proto.ServiceListReply{
+		Services: make([]*proto.ServiceInfo, len(services)),
+	}
+
+	for i := range services {
+		result.Services[i] = services[i].AsProto()
+	}
+
+	return result, nil
 }

--- a/internal/app/init/pkg/system/events/events_test.go
+++ b/internal/app/init/pkg/system/events/events_test.go
@@ -48,6 +48,11 @@ func (suite *EventsSuite) TestSome() {
 	suite.assertEvents([]string{"0", "1", "2", "3", "4"}, e.Get(5))
 	suite.assertEvents([]string{"0", "1", "2", "3", "4"}, e.Get(6))
 	suite.assertEvents([]string{"0", "1", "2", "3", "4"}, e.Get(100))
+
+	protoEvents := e.AsProto(1)
+	suite.Assert().Len(protoEvents.Events, 1)
+	suite.Assert().Equal("4", protoEvents.Events[0].Msg)
+	suite.Assert().Equal("Initialized", protoEvents.Events[0].State)
 }
 
 func (suite *EventsSuite) TestOverflow() {

--- a/internal/app/init/pkg/system/health/health_test.go
+++ b/internal/app/init/pkg/system/health/health_test.go
@@ -51,6 +51,11 @@ func (suite *CheckSuite) TestHealthy() {
 
 	suite.Assert().EqualError(<-errCh, context.Canceled.Error())
 	suite.Assert().True(called > 2)
+
+	protoHealth := state.AsProto()
+	suite.Assert().False(protoHealth.Unknown)
+	suite.Assert().True(protoHealth.Healthy)
+	suite.Assert().Equal("", protoHealth.LastMessage)
 }
 
 func (suite *CheckSuite) TestHealthChange() {

--- a/internal/app/init/pkg/system/health/status.go
+++ b/internal/app/init/pkg/system/health/status.go
@@ -7,6 +7,10 @@ package health
 import (
 	"sync"
 	"time"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/talos-systems/talos/internal/app/init/proto"
 )
 
 // Status of the healthcheck
@@ -102,4 +106,19 @@ func (state *State) Get() Status {
 	defer state.Unlock()
 
 	return state.status
+}
+
+// AsProto returns protobuf-ready health state
+func (state *State) AsProto() *proto.ServiceHealth {
+	status := state.Get()
+
+	// nolint: errcheck
+	tspb, _ := ptypes.TimestampProto(status.LastChange)
+
+	return &proto.ServiceHealth{
+		Unknown:     status.Healthy == nil,
+		Healthy:     status.Healthy != nil && *status.Healthy,
+		LastMessage: status.LastMessage,
+		LastChange:  tspb,
+	}
 }

--- a/internal/app/init/pkg/system/service_runner.go
+++ b/internal/app/init/pkg/system/service_runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
+	"github.com/talos-systems/talos/internal/app/init/proto"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -213,4 +214,17 @@ func (svcrunner *ServiceRunner) run(runnr runner.Runner) error {
 // Shutdown completes when Start() returns
 func (svcrunner *ServiceRunner) Shutdown() {
 	svcrunner.ctxCancel()
+}
+
+// AsProto returns protobuf struct with the state of the service runner
+func (svcrunner *ServiceRunner) AsProto() *proto.ServiceInfo {
+	svcrunner.mu.Lock()
+	defer svcrunner.mu.Unlock()
+
+	return &proto.ServiceInfo{
+		Id:     svcrunner.id,
+		State:  svcrunner.state.String(),
+		Events: svcrunner.events.AsProto(events.MaxEventsToKeep),
+		Health: svcrunner.healthState.AsProto(),
+	}
 }

--- a/internal/app/init/pkg/system/service_runner_test.go
+++ b/internal/app/init/pkg/system/service_runner_test.go
@@ -57,6 +57,12 @@ func (suite *ServiceRunnerSuite) TestFullFlow() {
 		events.StateRunning,
 		events.StateFinished,
 	}, sr)
+
+	protoService := sr.AsProto()
+	suite.Assert().Equal("MockRunner", protoService.Id)
+	suite.Assert().Equal("Finished", protoService.State)
+	suite.Assert().True(protoService.Health.Unknown)
+	suite.Assert().Len(protoService.Events.Events, 5)
 }
 
 func (suite *ServiceRunnerSuite) TestFullFlowHealthy() {

--- a/internal/app/init/pkg/system/system.go
+++ b/internal/app/init/pkg/system/system.go
@@ -5,6 +5,7 @@
 package system
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -104,4 +105,21 @@ func (s *singleton) Shutdown() {
 	s.mu.Unlock()
 
 	s.wg.Wait()
+}
+
+// List returns snapshot of ServiceRunner instances
+func (s *singleton) List() (result []*ServiceRunner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result = make([]*ServiceRunner, 0, len(s.State))
+	for _, svcrunner := range s.State {
+		result = append(result, svcrunner)
+	}
+
+	// TODO: results should be sorted properly with topological sort on dependencies
+	//       but, we don't have dependencies yet, so sort by service id for now to get stable order
+	sort.Slice(result, func(i, j int) bool { return result[i].id < result[j].id })
+
+	return
 }

--- a/internal/app/init/proto/api.proto
+++ b/internal/app/init/proto/api.proto
@@ -4,12 +4,14 @@ syntax = "proto3";
 package proto;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
 
 // The Init service definition.
 service Init {
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
   rpc Upgrade(UpgradeRequest) returns (UpgradeReply) {}
+  rpc ServiceList(google.protobuf.Empty) returns (ServiceListReply) {}
 }
 
 
@@ -24,3 +26,32 @@ message UpgradeRequest {
 }
 
 message UpgradeReply { string ack = 1; }
+
+message ServiceListReply {
+  repeated ServiceInfo services = 1;
+}
+
+message ServiceInfo {
+  string id = 1;
+  string state = 2;
+  ServiceEvents events = 3;
+  ServiceHealth health = 4;
+}
+
+message ServiceEvents {
+  repeated ServiceEvent events = 1;
+}
+
+message ServiceEvent {
+  string msg = 1;
+  string state = 2;
+  google.protobuf.Timestamp ts = 3;
+}
+
+message ServiceHealth {
+  bool unknown = 1;
+  bool healthy = 2;
+  string lastMessage = 3;
+  google.protobuf.Timestamp lastChange = 4;
+}
+

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -47,3 +47,8 @@ func (c *InitServiceClient) Shutdown(ctx context.Context, empty *empty.Empty) (*
 func (c *InitServiceClient) Upgrade(ctx context.Context, in *proto.UpgradeRequest) (data *proto.UpgradeReply, err error) {
 	return c.InitClient.Upgrade(ctx, in)
 }
+
+// ServiceList executes the init ServiceList() API.
+func (c *InitServiceClient) ServiceList(ctx context.Context, empty *empty.Empty) (data *proto.ServiceListReply, err error) {
+	return c.InitClient.ServiceList(ctx, empty)
+}


### PR DESCRIPTION
This returns list of all the services registered, with their current
status, past events, health state, etc.

New CLI is `osctl service [<id>]`: without `<id>` it prints list of all
the services, with specific `<id>` it provides details for a service.

I decided to create "parallel" data structures in protobuf as Go
structures don't map nicely onto what protoc generates: pointers vs.
values, additional fields like mutexes, etc. Probably there's a better
approach, I'm open for it.

For CLI, I tried to keep CLI stuff in `cmd/` package, and I also created
simple wrapper to remove duplicated code which sets up client for each
command.

Examples:

```
$ osctl service
SERVICE      STATE     HEALTH   LAST CHANGE   LAST EVENT
containerd   Running   OK       21s ago       Health check successful
kubeadm      Running   ?        2s ago        Started task kubeadm (PID 280) for container kubeadm
kubelet      Running   ?        0s ago        Started task kubelet (PID 383) for container kubelet
ntpd         Running   ?        14s ago       Started task ntpd (PID 129) for container ntpd
osd          Running   ?        14s ago       Started task osd (PID 126) for container osd
proxyd       Waiting   ?        14s ago       Waiting for conditions
trustd       Running   ?        14s ago       Started task trustd (PID 125) for container trustd
udevd        Running   ?        14s ago       Started task udevd (PID 130) for container udevd
```

```
$ osctl service proxyd
ID       proxyd
STATE    Running
HEALTH   ?
EVENTS   [Preparing]: Running pre state (22s ago)
         [Waiting]: Waiting for conditions (22s ago)
         [Preparing]: Creating service runner (6s ago)
         [Running]: Started task proxyd (PID 461) for container proxyd (6s ago)
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>