### PR TITLE
feat(init): implement healthchecks for the services

### DIFF
--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -6,12 +6,16 @@
 package services
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
@@ -82,3 +86,26 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		restart.WithType(restart.Forever),
 	), nil
 }
+
+// HealthFunc implements the HealthcheckedService interface
+func (o *OSD) HealthFunc(*userdata.UserData) health.Check {
+	return func(ctx context.Context) error {
+		var d net.Dialer
+		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "localhost", constants.OsdPort))
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}
+}
+
+// HealthSettings implements the HealthcheckedService interface
+func (o *OSD) HealthSettings(*userdata.UserData) *health.Settings {
+	return &health.DefaultSettings
+}
+
+// Verify healthchecked interface
+var (
+	_ system.HealthcheckedService = &OSD{}
+)


### PR DESCRIPTION
This includes kubelet, osd, proxyd and trustd.

I believe we can't do healthchecks for other services unless we do some
trick (publish some ports? or file sockets?).

Example:

```
containerd   Running   OK       29s ago       Health check successful
kubeadm      Running   ?        14s ago       Started task kubeadm (PID 285) for container kubeadm
kubelet      Running   OK       6s ago        Health check successful
ntpd         Running   ?        22s ago       Started task ntpd (PID 134) for container ntpd
osd          Running   OK       16s ago       Health check successful
proxyd       Running   OK       9s ago        Health check successful
trustd       Running   OK       16s ago       Health check successful
udevd        Running   ?        22s ago       Started task udevd (PID 127) for container udevd
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>