### PR TITLE
fix: Address lint warning for unknown linter

### DIFF
--- a/cmd/osctl/cmd/service.go
+++ b/cmd/osctl/cmd/service.go
@@ -97,7 +97,7 @@ func (svc serviceInfoWrapper) LastUpdated() string {
 		return ""
 	}
 
-	// nolint: error
+	// nolint: errcheck
 	ts, _ := ptypes.Timestamp(svc.Events.Events[len(svc.Events.Events)-1].Ts)
 
 	return time.Since(ts).Round(time.Second).String()


### PR DESCRIPTION
Fixes
```
#31 39.85 level=warning msg="[runner/nolint] Found unknown linters in //nolint directives: error"
```

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>