### PR TITLE
refactor: change conditions to be interface, add descriptions

### DIFF
--- a/internal/app/init/pkg/system/conditions/all.go
+++ b/internal/app/init/pkg/system/conditions/all.go
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package conditions
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+type all struct {
+	mu sync.Mutex
+
+	conditions []Condition
+}
+
+type waitResult struct {
+	i   int
+	err error
+}
+
+func (a *all) Wait(ctx context.Context) error {
+	errCh := make(chan waitResult)
+
+	a.mu.Lock()
+	for i := range a.conditions {
+		go func(i int) {
+			errCh <- waitResult{
+				err: a.conditions[i].Wait(ctx),
+				i:   i,
+			}
+		}(i)
+	}
+	a.mu.Unlock()
+
+	err := (*multierror.Error)(nil)
+
+	for range a.conditions {
+		res := <-errCh
+
+		a.mu.Lock()
+		a.conditions[res.i] = nil
+		a.mu.Unlock()
+
+		err = multierror.Append(err, res.err)
+	}
+
+	// collapse errors if any of them is context canceled
+	if err != nil {
+		for _, e := range err.Errors {
+			if e == context.Canceled {
+				return e
+			}
+		}
+	}
+
+	return err.ErrorOrNil()
+}
+
+func (a *all) String() string {
+	descriptions := []string(nil)
+
+	a.mu.Lock()
+	for _, c := range a.conditions {
+		if c != nil {
+			descriptions = append(descriptions, c.String())
+		}
+	}
+	a.mu.Unlock()
+
+	return strings.Join(descriptions, ", ")
+}
+
+// WaitForAll creates a condition which waits for all the conditions to be successful
+func WaitForAll(conditions ...Condition) Condition {
+	res := &all{}
+	for _, c := range conditions {
+		if multi, ok := c.(*all); ok {
+			// flatten lists
+			res.conditions = append(res.conditions, multi.conditions...)
+		} else {
+			res.conditions = append(res.conditions, c)
+		}
+	}
+
+	return res
+}

--- a/internal/app/init/pkg/system/conditions/all_test.go
+++ b/internal/app/init/pkg/system/conditions/all_test.go
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package conditions_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+)
+
+type AllSuite struct {
+	suite.Suite
+}
+
+type MockCondition struct {
+	description string
+	errCh       chan error
+}
+
+func (mc *MockCondition) String() string {
+	return mc.description
+}
+
+func (mc *MockCondition) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-mc.errCh:
+		return err
+	}
+}
+
+func (suite *AllSuite) TestString() {
+	suite.Require().Equal("A, B", conditions.WaitForAll(
+		&MockCondition{description: "A"},
+		&MockCondition{description: "B"},
+	).String())
+
+	suite.Require().Equal("A", conditions.WaitForAll(
+		&MockCondition{description: "A"},
+	).String())
+
+	conds := []conditions.Condition{
+		&MockCondition{description: "A", errCh: make(chan error)},
+		&MockCondition{description: "B", errCh: make(chan error)},
+	}
+
+	waiter := conditions.WaitForAll(conds...)
+
+	done := make(chan error)
+	go func() {
+		done <- waiter.Wait(context.Background())
+	}()
+
+	suite.Require().Equal("A, B", waiter.String())
+	conds[0].(*MockCondition).errCh <- nil
+	time.Sleep(50 * time.Millisecond)
+
+	// done waiting for 'A', so description should now be shorter
+	suite.Require().Equal("B", waiter.String())
+
+	conds[1].(*MockCondition).errCh <- nil
+	<-done
+}
+
+func (suite *AllSuite) TestFlatten() {
+	conds1 := []conditions.Condition{
+		&MockCondition{description: "A", errCh: make(chan error)},
+		&MockCondition{description: "B", errCh: make(chan error)},
+	}
+	conds2 := []conditions.Condition{
+		&MockCondition{description: "C", errCh: make(chan error)},
+		&MockCondition{description: "D", errCh: make(chan error)},
+	}
+
+	waiter := conditions.WaitForAll(conditions.WaitForAll(conds1...), conditions.WaitForAll(conds2...))
+	suite.Require().Equal("A, B, C, D", waiter.String())
+
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	done := make(chan error)
+	go func() {
+		done <- waiter.Wait(ctx)
+	}()
+
+	conds1[0].(*MockCondition).errCh <- nil
+	conds2[1].(*MockCondition).errCh <- nil
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.Require().Equal("B, C", waiter.String())
+
+	ctxCancel()
+
+	suite.Require().Equal(context.Canceled, <-done)
+}
+
+func TestAllSuite(t *testing.T) {
+	suite.Run(t, new(AllSuite))
+}

--- a/internal/app/init/pkg/system/conditions/files.go
+++ b/internal/app/init/pkg/system/conditions/files.go
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package conditions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+type file string
+
+func (filename file) Wait(ctx context.Context) error {
+	for {
+		_, err := os.Stat(string(filename))
+		if err == nil {
+			return nil
+		}
+
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+func (filename file) String() string {
+	return fmt.Sprintf("for file %q to exist", string(filename))
+}
+
+// WaitForFileToExist is a service condition that will wait for the existence of
+// a file.
+func WaitForFileToExist(filename string) Condition {
+	return file(filename)
+}
+
+// WaitForFilesToExist is a service condition that will wait for the existence of all the files.
+func WaitForFilesToExist(filenames ...string) Condition {
+	conditions := make([]Condition, len(filenames))
+	for i := range filenames {
+		conditions[i] = WaitForFileToExist(filenames[i])
+	}
+	return WaitForAll(conditions...)
+}

--- a/internal/app/init/pkg/system/conditions/none.go
+++ b/internal/app/init/pkg/system/conditions/none.go
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package conditions
+
+import "context"
+
+type condition struct{}
+
+func (condition) Wait(ctx context.Context) error {
+	return nil
+}
+
+func (condition) String() string {
+	return "nothing"
+}
+
+// None is a service condition that has no conditions.
+func None() Condition {
+	return condition{}
+}

--- a/internal/app/init/pkg/system/mocks_test.go
+++ b/internal/app/init/pkg/system/mocks_test.go
@@ -22,7 +22,7 @@ type MockService struct {
 	preError    error
 	runnerError error
 	runner      runner.Runner
-	condition   conditions.ConditionFunc
+	condition   conditions.Condition
 	postError   error
 }
 
@@ -48,7 +48,7 @@ func (m *MockService) PostFunc(*userdata.UserData) error {
 	return m.postError
 }
 
-func (m *MockService) ConditionFunc(*userdata.UserData) conditions.ConditionFunc {
+func (m *MockService) Condition(*userdata.UserData) conditions.Condition {
 	if m.condition != nil {
 		return m.condition
 	}

--- a/internal/app/init/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/init/pkg/system/runner/containerd/containerd.go
@@ -59,7 +59,7 @@ func NewRunner(data *userdata.UserData, args *runner.Args, setters ...runner.Opt
 func (c *containerdRunner) Open(ctx context.Context) error {
 
 	// Wait for the containerd socket.
-	_, err := conditions.WaitForFileToExist(constants.ContainerdAddress)(ctx)
+	err := conditions.WaitForFileToExist(constants.ContainerdAddress).Wait(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/app/init/pkg/system/runner/containerd/import.go
+++ b/internal/app/init/pkg/system/runner/containerd/import.go
@@ -25,7 +25,7 @@ type ImportRequest struct {
 
 // Import imports the images specified by the import requests.
 func Import(namespace string, reqs ...*ImportRequest) error {
-	_, err := conditions.WaitForFileToExist(constants.ContainerdAddress)(context.Background())
+	err := conditions.WaitForFileToExist(constants.ContainerdAddress).Wait(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/app/init/pkg/system/service.go
+++ b/internal/app/init/pkg/system/service.go
@@ -21,9 +21,9 @@ type Service interface {
 	Runner(*userdata.UserData) (runner.Runner, error)
 	// PostFunc is invoked after a runner is closed.
 	PostFunc(*userdata.UserData) error
-	// ConditionFunc describes the conditions under which a service should
+	// Condition describes the conditions under which a service should
 	// start.
-	ConditionFunc(*userdata.UserData) conditions.ConditionFunc
+	Condition(*userdata.UserData) conditions.Condition
 }
 
 // HealthcheckedService is a service which provides health check

--- a/internal/app/init/pkg/system/service_runner.go
+++ b/internal/app/init/pkg/system/service_runner.go
@@ -111,8 +111,9 @@ func (svcrunner *ServiceRunner) Start() {
 		return
 	}
 
-	svcrunner.UpdateState(events.StateWaiting, "Waiting for conditions")
-	_, err := svcrunner.service.ConditionFunc(svcrunner.userData)(svcrunner.ctx)
+	condition := svcrunner.service.Condition(svcrunner.userData)
+	svcrunner.UpdateState(events.StateWaiting, "Waiting for %s", condition)
+	err := condition.Wait(svcrunner.ctx)
 	if err != nil {
 		svcrunner.UpdateState(events.StateFailed, "Condition failed: %v", err)
 		return

--- a/internal/app/init/pkg/system/services/containerd.go
+++ b/internal/app/init/pkg/system/services/containerd.go
@@ -43,8 +43,8 @@ func (c *Containerd) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (c *Containerd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (c *Containerd) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.None()
 }
 

--- a/internal/app/init/pkg/system/services/kubeadm.go
+++ b/internal/app/init/pkg/system/services/kubeadm.go
@@ -123,11 +123,9 @@ func (k *Kubeadm) PostFunc(data *userdata.UserData) error {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (k *Kubeadm) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
-	files := []string{constants.ContainerdAddress}
-
-	return conditions.WaitForFilesToExist(files...)
+// Condition implements the Service interface.
+func (k *Kubeadm) Condition(data *userdata.UserData) conditions.Condition {
+	return conditions.WaitForFileToExist(constants.ContainerdAddress)
 }
 
 // Runner implements the Service interface.

--- a/internal/app/init/pkg/system/services/kubelet.go
+++ b/internal/app/init/pkg/system/services/kubelet.go
@@ -66,8 +66,8 @@ func (k *Kubelet) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (k *Kubelet) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (k *Kubelet) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.WaitForFilesToExist("/var/lib/kubelet/kubeadm-flags.env", constants.ContainerdAddress)
 }
 

--- a/internal/app/init/pkg/system/services/ntpd.go
+++ b/internal/app/init/pkg/system/services/ntpd.go
@@ -37,8 +37,8 @@ func (n *NTPd) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (n *NTPd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (n *NTPd) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.None()
 }
 

--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -42,8 +42,8 @@ func (o *OSD) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (o *OSD) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (o *OSD) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.None()
 }
 

--- a/internal/app/init/pkg/system/services/proxyd.go
+++ b/internal/app/init/pkg/system/services/proxyd.go
@@ -41,8 +41,8 @@ func (p *Proxyd) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (p *Proxyd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (p *Proxyd) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.WaitForFilesToExist("/etc/kubernetes/pki/ca.crt", "/etc/kubernetes/admin.conf")
 }
 

--- a/internal/app/init/pkg/system/services/trustd.go
+++ b/internal/app/init/pkg/system/services/trustd.go
@@ -41,8 +41,8 @@ func (t *Trustd) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (t *Trustd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (t *Trustd) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.None()
 }
 

--- a/internal/app/init/pkg/system/services/udevd.go
+++ b/internal/app/init/pkg/system/services/udevd.go
@@ -35,8 +35,8 @@ func (c *Udevd) PostFunc(data *userdata.UserData) (err error) {
 	return nil
 }
 
-// ConditionFunc implements the Service interface.
-func (c *Udevd) ConditionFunc(data *userdata.UserData) conditions.ConditionFunc {
+// Condition implements the Service interface.
+func (c *Udevd) Condition(data *userdata.UserData) conditions.Condition {
 	return conditions.None()
 }
 


### PR DESCRIPTION
Conditions are now implemented as interface with two methods: `Wait` for
condition to be true (cancelable via context) and 'String' which
describes what condition is waiting for.

Generic 'WaitForAll' was implemented to wait for multiple conditions at
once.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>