### PR TITLE
feat(init): implement service dependencies, correct start and shutdown

### DIFF
--- a/internal/app/init/pkg/system/events/events.go
+++ b/internal/app/init/pkg/system/events/events.go
@@ -27,6 +27,7 @@ const (
 	StateStopping
 	StateFinished
 	StateFailed
+	StateSkipped
 )
 
 func (state ServiceState) String() string {
@@ -45,6 +46,8 @@ func (state ServiceState) String() string {
 		return "Finished"
 	case StateFailed:
 		return "Failed"
+	case StateSkipped:
+		return "Skipped"
 	default:
 		return "Unknown"
 	}

--- a/internal/app/init/pkg/system/health/status.go
+++ b/internal/app/init/pkg/system/health/status.go
@@ -81,11 +81,13 @@ func (state *State) Unsubscribe(ch chan<- StateChange) {
 	state.Lock()
 	defer state.Unlock()
 
-	for i := range state.subscribers {
+	for i := 0; i < len(state.subscribers); {
 		if state.subscribers[i] == ch {
 			state.subscribers[i] = state.subscribers[len(state.subscribers)-1]
 			state.subscribers[len(state.subscribers)-1] = nil
 			state.subscribers = state.subscribers[:len(state.subscribers)-1]
+		} else {
+			i++
 		}
 	}
 }

--- a/internal/app/init/pkg/system/mocks_test.go
+++ b/internal/app/init/pkg/system/mocks_test.go
@@ -18,12 +18,14 @@ import (
 )
 
 type MockService struct {
-	name        string
-	preError    error
-	runnerError error
-	runner      runner.Runner
-	condition   conditions.Condition
-	postError   error
+	name         string
+	preError     error
+	runnerError  error
+	nilRunner    bool
+	runner       runner.Runner
+	condition    conditions.Condition
+	postError    error
+	dependencies []string
 }
 
 func (m *MockService) ID(*userdata.UserData) string {
@@ -41,6 +43,10 @@ func (m *MockService) Runner(*userdata.UserData) (runner.Runner, error) {
 		return m.runner, m.runnerError
 	}
 
+	if m.nilRunner {
+		return nil, nil
+	}
+
 	return &MockRunner{exitCh: make(chan error)}, m.runnerError
 }
 
@@ -49,11 +55,11 @@ func (m *MockService) PostFunc(*userdata.UserData) error {
 }
 
 func (m *MockService) Condition(*userdata.UserData) conditions.Condition {
-	if m.condition != nil {
-		return m.condition
-	}
+	return m.condition
+}
 
-	return conditions.None()
+func (m *MockService) DependsOn(*userdata.UserData) []string {
+	return m.dependencies
 }
 
 type MockHealthcheckedService struct {

--- a/internal/app/init/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/init/pkg/system/runner/containerd/containerd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/pkg/constants"
@@ -57,15 +56,8 @@ func NewRunner(data *userdata.UserData, args *runner.Args, setters ...runner.Opt
 
 // Open implements the Runner interface.
 func (c *containerdRunner) Open(ctx context.Context) error {
-
-	// Wait for the containerd socket.
-	err := conditions.WaitForFileToExist(constants.ContainerdAddress).Wait(ctx)
-	if err != nil {
-		return err
-	}
-
 	// Create the containerd client.
-
+	var err error
 	c.ctx = namespaces.WithNamespace(context.Background(), c.opts.Namespace)
 	c.client, err = containerd.New(constants.ContainerdAddress)
 	if err != nil {

--- a/internal/app/init/pkg/system/service.go
+++ b/internal/app/init/pkg/system/service.go
@@ -24,6 +24,8 @@ type Service interface {
 	// Condition describes the conditions under which a service should
 	// start.
 	Condition(*userdata.UserData) conditions.Condition
+	// DependsOn returns list of service IDs this service depends on.
+	DependsOn(*userdata.UserData) []string
 }
 
 // HealthcheckedService is a service which provides health check

--- a/internal/app/init/pkg/system/service_events.go
+++ b/internal/app/init/pkg/system/service_events.go
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package system
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
+)
+
+// StateEvent is a service event (e.g. 'up', 'down')
+type StateEvent string
+
+// Service event list
+const (
+	StateEventUp   = StateEvent("up")
+	StateEventDown = StateEvent("down")
+)
+
+type serviceCondition struct {
+	event   StateEvent
+	service string
+}
+
+func (sc *serviceCondition) Wait(ctx context.Context) error {
+	instance.mu.Lock()
+	svcrunner := instance.State[sc.service]
+	instance.mu.Unlock()
+
+	if svcrunner == nil {
+		return errors.Errorf("service %q is not registered", sc.service)
+	}
+
+	notifyCh := make(chan struct{}, 1)
+	svcrunner.Subscribe(sc.event, notifyCh)
+	defer svcrunner.Unsubscribe(sc.event, notifyCh)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-notifyCh:
+		return nil
+	}
+}
+
+func (sc *serviceCondition) String() string {
+	return fmt.Sprintf("service %q to be %q", sc.service, string(sc.event))
+}
+
+// WaitForService waits for service to reach some state event
+func WaitForService(event StateEvent, service string) conditions.Condition {
+	return &serviceCondition{event, service}
+}

--- a/internal/app/init/pkg/system/services/containerd.go
+++ b/internal/app/init/pkg/system/services/containerd.go
@@ -45,7 +45,12 @@ func (c *Containerd) PostFunc(data *userdata.UserData) (err error) {
 
 // Condition implements the Service interface.
 func (c *Containerd) Condition(data *userdata.UserData) conditions.Condition {
-	return conditions.None()
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (c *Containerd) DependsOn(data *userdata.UserData) []string {
+	return nil
 }
 
 // Runner implements the Service interface.

--- a/internal/app/init/pkg/system/services/kubelet.go
+++ b/internal/app/init/pkg/system/services/kubelet.go
@@ -68,7 +68,12 @@ func (k *Kubelet) PostFunc(data *userdata.UserData) (err error) {
 
 // Condition implements the Service interface.
 func (k *Kubelet) Condition(data *userdata.UserData) conditions.Condition {
-	return conditions.WaitForFilesToExist("/var/lib/kubelet/kubeadm-flags.env", constants.ContainerdAddress)
+	return conditions.WaitForFilesToExist("/var/lib/kubelet/kubeadm-flags.env")
+}
+
+// DependsOn implements the Service interface.
+func (k *Kubelet) DependsOn(data *userdata.UserData) []string {
+	return []string{"containerd", "kubeadm"}
 }
 
 // Runner implements the Service interface.

--- a/internal/app/init/pkg/system/services/ntpd.go
+++ b/internal/app/init/pkg/system/services/ntpd.go
@@ -8,6 +8,7 @@ package services
 import (
 	"fmt"
 
+	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
@@ -29,7 +30,12 @@ func (n *NTPd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (n *NTPd) PreFunc(data *userdata.UserData) error {
-	return nil
+	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
+		Path: "/usr/images/ntpd.tar",
+		Options: []containerdapi.ImportOpt{
+			containerdapi.WithIndexName("talos/ntpd"),
+		},
+	})
 }
 
 // PostFunc implements the Service interface.
@@ -39,7 +45,12 @@ func (n *NTPd) PostFunc(data *userdata.UserData) (err error) {
 
 // Condition implements the Service interface.
 func (n *NTPd) Condition(data *userdata.UserData) conditions.Condition {
-	return conditions.None()
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (n *NTPd) DependsOn(data *userdata.UserData) []string {
+	return []string{"containerd"}
 }
 
 func (n *NTPd) Runner(data *userdata.UserData) (runner.Runner, error) {

--- a/internal/app/init/pkg/system/services/trustd.go
+++ b/internal/app/init/pkg/system/services/trustd.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 
+	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system"
@@ -33,7 +34,12 @@ func (t *Trustd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (t *Trustd) PreFunc(data *userdata.UserData) error {
-	return nil
+	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
+		Path: "/usr/images/trustd.tar",
+		Options: []containerdapi.ImportOpt{
+			containerdapi.WithIndexName("talos/trustd"),
+		},
+	})
 }
 
 // PostFunc implements the Service interface.
@@ -43,7 +49,12 @@ func (t *Trustd) PostFunc(data *userdata.UserData) (err error) {
 
 // Condition implements the Service interface.
 func (t *Trustd) Condition(data *userdata.UserData) conditions.Condition {
-	return conditions.None()
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (t *Trustd) DependsOn(data *userdata.UserData) []string {
+	return []string{"containerd"}
 }
 
 func (t *Trustd) Runner(data *userdata.UserData) (runner.Runner, error) {

--- a/internal/app/init/pkg/system/services/udevd.go
+++ b/internal/app/init/pkg/system/services/udevd.go
@@ -7,12 +7,14 @@ package services
 import (
 	"fmt"
 
+	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -27,7 +29,12 @@ func (c *Udevd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (c *Udevd) PreFunc(data *userdata.UserData) error {
-	return nil
+	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
+		Path: "/usr/images/udevd.tar",
+		Options: []containerdapi.ImportOpt{
+			containerdapi.WithIndexName("talos/udevd"),
+		},
+	})
 }
 
 // PostFunc implements the Service interface.
@@ -37,7 +44,12 @@ func (c *Udevd) PostFunc(data *userdata.UserData) (err error) {
 
 // Condition implements the Service interface.
 func (c *Udevd) Condition(data *userdata.UserData) conditions.Condition {
-	return conditions.None()
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (c *Udevd) DependsOn(data *userdata.UserData) []string {
+	return []string{"containerd"}
 }
 
 // Runner implements the Service interface.


### PR DESCRIPTION
This PR introduces dependencies between the services. Now each service
has two virtual events associated with it: 'up' (running and healthy)
and 'down' (finished or failed). These events are used to establish
correct order via conditions abstraction.

Service image unpacking was moved into 'pre' stage simplifying
`init/main.go`, service images are now closer to the code which runs the
service itself.

Step 'pre' now runs after 'wait' step, and service dependencies are now
mixed into other conditions of 'wait' step on startup.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>