### PR TITLE
refactor(osctl): DRY up osctl sources by using common client setup

### DIFF
--- a/cmd/osctl/cmd/df.go
+++ b/cmd/osctl/cmd/df.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // dfCmd represents the df command.
@@ -18,21 +19,16 @@ var dfCmd = &cobra.Command{
 	Short: "List disk usage",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
-		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
 
-		if err := c.DF(); err != nil {
-			helpers.Fatalf("error getting df: %s", err)
-		}
+		setupClient(func(c *client.Client) {
+			if err := c.DF(); err != nil {
+				helpers.Fatalf("error getting df: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // dmesgCmd represents the dmesg command
@@ -23,20 +22,12 @@ var dmesgCmd = &cobra.Command{
 			helpers.Should(cmd.Usage())
 			os.Exit(1)
 		}
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
-		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		if err := c.Dmesg(); err != nil {
-			helpers.Fatalf("error getting dmesg: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			if err := c.Dmesg(); err != nil {
+				helpers.Fatalf("error getting dmesg: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/kubeconfig.go
+++ b/cmd/osctl/cmd/kubeconfig.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // kubeconfigCmd represents the kubeconfig command
@@ -18,17 +19,16 @@ var kubeconfigCmd = &cobra.Command{
 	Short: "Download the admin.conf from the node",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		if err := c.Kubeconfig(); err != nil {
-			helpers.Fatalf("error fetching kubeconfig: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			if err := c.Kubeconfig(); err != nil {
+				helpers.Fatalf("error fetching kubeconfig: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/logs.go
+++ b/cmd/osctl/cmd/logs.go
@@ -25,30 +25,22 @@ var logsCmd = &cobra.Command{
 			helpers.Should(cmd.Usage())
 			os.Exit(1)
 		}
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
-		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		var namespace string
-		if kubernetes {
-			namespace = criconstants.K8sContainerdNamespace
-		} else {
-			namespace = constants.SystemContainerdNamespace
-		}
-		r := &proto.LogsRequest{
-			Id:        args[0],
-			Namespace: namespace,
-		}
-		if err := c.Logs(r); err != nil {
-			helpers.Fatalf("error fetching logs: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			var namespace string
+			if kubernetes {
+				namespace = criconstants.K8sContainerdNamespace
+			} else {
+				namespace = constants.SystemContainerdNamespace
+			}
+			r := &proto.LogsRequest{
+				Id:        args[0],
+				Namespace: namespace,
+			}
+			if err := c.Logs(r); err != nil {
+				helpers.Fatalf("error fetching logs: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/ps.go
+++ b/cmd/osctl/cmd/ps.go
@@ -6,6 +6,8 @@
 package cmd
 
 import (
+	"os"
+
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
@@ -19,26 +21,22 @@ var psCmd = &cobra.Command{
 	Short: "List processes",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		var namespace string
-		if kubernetes {
-			namespace = criconstants.K8sContainerdNamespace
-		} else {
-			namespace = constants.SystemContainerdNamespace
-		}
-		if err := c.Processes(namespace); err != nil {
-			helpers.Fatalf("error getting process list: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			var namespace string
+			if kubernetes {
+				namespace = criconstants.K8sContainerdNamespace
+			} else {
+				namespace = constants.SystemContainerdNamespace
+			}
+			if err := c.Processes(namespace); err != nil {
+				helpers.Fatalf("error getting process list: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/reboot.go
+++ b/cmd/osctl/cmd/reboot.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // rebootCmd represents the reboot command
@@ -18,20 +19,16 @@ var rebootCmd = &cobra.Command{
 	Short: "Reboot a node",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		if err := c.Reboot(); err != nil {
-			helpers.Fatalf("error executing reboot: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			if err := c.Reboot(); err != nil {
+				helpers.Fatalf("error executing reboot: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/reset.go
+++ b/cmd/osctl/cmd/reset.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // resetCmd represents the reset command
@@ -18,20 +19,16 @@ var resetCmd = &cobra.Command{
 	Short: "Reset a node",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		if err := c.Reset(); err != nil {
-			helpers.Fatalf("error executing reset: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			if err := c.Reset(); err != nil {
+				helpers.Fatalf("error executing reset: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/restart.go
+++ b/cmd/osctl/cmd/restart.go
@@ -32,31 +32,24 @@ var restartCmd = &cobra.Command{
 			}
 			os.Exit(1)
 		}
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		var namespace string
-		if kubernetes {
-			namespace = criconstants.K8sContainerdNamespace
-		} else {
-			namespace = constants.SystemContainerdNamespace
-		}
-		r := &proto.RestartRequest{
-			Id:        args[0],
-			Namespace: namespace,
-			Timeout:   timeout,
-		}
-		if err := c.Restart(r); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
+
+		setupClient(func(c *client.Client) {
+			var namespace string
+			if kubernetes {
+				namespace = criconstants.K8sContainerdNamespace
+			} else {
+				namespace = constants.SystemContainerdNamespace
+			}
+			r := &proto.RestartRequest{
+				Id:        args[0],
+				Namespace: namespace,
+				Timeout:   timeout,
+			}
+			if err := c.Restart(r); err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/routes.go
+++ b/cmd/osctl/cmd/routes.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // routesCmd represents the net routes command
@@ -18,21 +19,16 @@ var routesCmd = &cobra.Command{
 	Short: "List network routes",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
-		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
 
-		if err := c.Routes(); err != nil {
-			helpers.Fatalf("error getting routes: %s", err)
-		}
+		setupClient(func(c *client.Client) {
+			if err := c.Routes(); err != nil {
+				helpers.Fatalf("error getting routes: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/shutdown.go
+++ b/cmd/osctl/cmd/shutdown.go
@@ -6,10 +6,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // shutdownCmd represents the shutdown command
@@ -18,20 +19,16 @@ var shutdownCmd = &cobra.Command{
 	Short: "Shutdown a node",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		if err := c.Shutdown(); err != nil {
-			helpers.Fatalf("error executing shutdown: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			if err := c.Shutdown(); err != nil {
+				helpers.Fatalf("error executing shutdown: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/stats.go
+++ b/cmd/osctl/cmd/stats.go
@@ -6,6 +6,8 @@
 package cmd
 
 import (
+	"os"
+
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
@@ -19,26 +21,22 @@ var statsCmd = &cobra.Command{
 	Short: "Get processes stats",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
 		}
-		if target != "" {
-			creds.Target = target
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		var namespace string
-		if kubernetes {
-			namespace = criconstants.K8sContainerdNamespace
-		} else {
-			namespace = constants.SystemContainerdNamespace
-		}
-		if err := c.Stats(namespace); err != nil {
-			helpers.Fatalf("error getting stats: %s", err)
-		}
+
+		setupClient(func(c *client.Client) {
+			var namespace string
+			if kubernetes {
+				namespace = criconstants.K8sContainerdNamespace
+			} else {
+				namespace = constants.SystemContainerdNamespace
+			}
+			if err := c.Stats(namespace); err != nil {
+				helpers.Fatalf("error getting stats: %s", err)
+			}
+		})
 	},
 }
 

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 var (
@@ -45,19 +44,13 @@ func init() {
 }
 
 func remoteUpgrade() error {
-	creds, err := client.NewDefaultClientCredentials(talosconfig)
-	if err != nil {
-		return err
-	}
-	if target != "" {
-		creds.Target = target
-	}
-	c, err := client.NewClient(constants.OsdPort, creds)
-	if err != nil {
-		return err
-	}
+	var err error
 
-	// TODO: See if we can validate version and prevent
-	// starting upgrades to an unknown version
-	return c.Upgrade(assetURL)
+	setupClient(func(c *client.Client) {
+		// TODO: See if we can validate version and prevent
+		// starting upgrades to an unknown version
+		err = c.Upgrade(assetURL)
+	})
+
+	return err
 }

--- a/cmd/osctl/cmd/version.go
+++ b/cmd/osctl/cmd/version.go
@@ -5,10 +5,11 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/internal/pkg/version"
 )
 
@@ -22,6 +23,11 @@ var versionCmd = &cobra.Command{
 	Short: "Prints the version",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
+		}
+
 		if shortVersion {
 			version.PrintShortVersion()
 		} else {
@@ -29,17 +35,11 @@ var versionCmd = &cobra.Command{
 				helpers.Fatalf("error printing long version: %s", err)
 			}
 		}
-		creds, err := client.NewDefaultClientCredentials(talosconfig)
-		if err != nil {
-			helpers.Fatalf("error getting client credentials: %s", err)
-		}
-		c, err := client.NewClient(constants.OsdPort, creds)
-		if err != nil {
-			helpers.Fatalf("error constructing client: %s", err)
-		}
-		if err := c.Version(); err != nil {
-			helpers.Fatalf("error getting version: %s", err)
-		}
+		setupClient(func(c *client.Client) {
+			if err := c.Version(); err != nil {
+				helpers.Fatalf("error getting version: %s", err)
+			}
+		})
 	},
 }
 

--- a/hack/golang/golangci-lint.yaml
+++ b/hack/golang/golangci-lint.yaml
@@ -112,6 +112,11 @@ issues:
   # excluded by default patterns execute `golangci-lint run --help`
   exclude: []
 
+  exclude-rules:
+    - path: cmd/osctl/cmd
+      linters:
+        - dupl
+
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.


### PR DESCRIPTION
Remove duplicated code which was setting up grpc client with common
method. Should have no functional changes otherwise.

Add args len check where missing.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>