### PR TITLE
fix(init): move directory creation to kubeadm pre-func

### DIFF
--- a/internal/app/init/pkg/system/services/kubelet.go
+++ b/internal/app/init/pkg/system/services/kubelet.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -40,24 +39,6 @@ func (k *Kubelet) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (k *Kubelet) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	requiredMounts := []string{
-		"/dev/disk/by-path",
-		"/etc/kubernetes",
-		"/etc/kubernetes/manifests",
-		"/run",
-		"/sys/fs/cgroup",
-		"/usr/libexec/kubernetes",
-		"/var/lib/containerd",
-		"/var/lib/kubelet",
-		"/var/log/pods",
-	}
-
-	for _, dir := range requiredMounts {
-		if err := os.MkdirAll(dir, os.ModeDir); err != nil {
-			return fmt.Errorf("create %s: %s", dir, err.Error())
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Fix kubeadm startup errors as required mounts are missing:

`stat /var/lib/kubelet: no such file or directory\\\"\"": unknown`

As kubelet depends on kubeadm, this should be no-op for kubelet.

Also remove forgotten wait condition for containerd socket, it is no
longer required as service depends on containerd health.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>