### PR TITLE
refactor(osctl): move cli code out of 'client' package

### DIFF
--- a/cmd/osctl/cmd/df.go
+++ b/cmd/osctl/cmd/df.go
@@ -6,11 +6,16 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"math"
 	"os"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
+	"github.com/talos-systems/talos/internal/app/osd/proto"
 )
 
 // dfCmd represents the df command.
@@ -25,11 +30,31 @@ var dfCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			if err := c.DF(); err != nil {
-				helpers.Fatalf("error getting df: %s", err)
-			}
+			dfRender(c.DF(context.TODO()))
 		})
 	},
+}
+
+func dfRender(reply *proto.DFReply, err error) {
+	if reply == nil {
+		if err != nil {
+			helpers.Fatalf("error getting df: %s", err)
+		}
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "FILESYSTEM\tSIZE(GB)\tUSED(GB)\tAVAILABLE(GB)\tPERCENT USED\tMOUNTED ON")
+	for _, r := range reply.Stats {
+		percentAvailable := 100.0 - 100.0*(float64(r.Available)/float64(r.Size))
+
+		if math.IsNaN(percentAvailable) {
+			continue
+		}
+
+		fmt.Fprintf(w, "%s\t%.02f\t%.02f\t%.02f\t%.02f%%\t%s\n", r.Filesystem, float64(r.Size)*1e-9, float64(r.Size-r.Available)*1e-9, float64(r.Available)*1e-9, percentAvailable, r.MountedOn)
+	}
+	helpers.Should(w.Flush())
 }
 
 func init() {

--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -24,9 +25,13 @@ var dmesgCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			if err := c.Dmesg(); err != nil {
+			msg, err := c.Dmesg(context.TODO())
+			if err != nil {
 				helpers.Fatalf("error getting dmesg: %s", err)
 			}
+
+			_, err = os.Stdout.Write(msg)
+			helpers.Should(err)
 		})
 	},
 }

--- a/cmd/osctl/cmd/kubeconfig.go
+++ b/cmd/osctl/cmd/kubeconfig.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -25,9 +26,12 @@ var kubeconfigCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			if err := c.Kubeconfig(); err != nil {
+			kubeconfig, err := c.Kubeconfig(context.TODO())
+			if err != nil {
 				helpers.Fatalf("error fetching kubeconfig: %s", err)
 			}
+			_, err = os.Stdout.Write(kubeconfig)
+			helpers.Should(err)
 		})
 	},
 }

--- a/cmd/osctl/cmd/reboot.go
+++ b/cmd/osctl/cmd/reboot.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -25,7 +26,7 @@ var rebootCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			if err := c.Reboot(); err != nil {
+			if err := c.Reboot(context.TODO()); err != nil {
 				helpers.Fatalf("error executing reboot: %s", err)
 			}
 		})

--- a/cmd/osctl/cmd/reset.go
+++ b/cmd/osctl/cmd/reset.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -25,7 +26,7 @@ var resetCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			if err := c.Reset(); err != nil {
+			if err := c.Reset(context.TODO()); err != nil {
 				helpers.Fatalf("error executing reset: %s", err)
 			}
 		})

--- a/cmd/osctl/cmd/restart.go
+++ b/cmd/osctl/cmd/restart.go
@@ -6,13 +6,13 @@
 package cmd
 
 import (
-	"fmt"
+	"context"
 	"os"
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
-	"github.com/talos-systems/talos/internal/app/osd/proto"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
@@ -40,14 +40,8 @@ var restartCmd = &cobra.Command{
 			} else {
 				namespace = constants.SystemContainerdNamespace
 			}
-			r := &proto.RestartRequest{
-				Id:        args[0],
-				Namespace: namespace,
-				Timeout:   timeout,
-			}
-			if err := c.Restart(r); err != nil {
-				fmt.Println(err)
-				os.Exit(1)
+			if err := c.Restart(context.TODO(), namespace, args[0], timeout); err != nil {
+				helpers.Fatalf("error restarting process: %s", err)
 			}
 		})
 	},

--- a/cmd/osctl/cmd/shutdown.go
+++ b/cmd/osctl/cmd/shutdown.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -25,7 +26,7 @@ var shutdownCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			if err := c.Shutdown(); err != nil {
+			if err := c.Shutdown(context.TODO()); err != nil {
 				helpers.Fatalf("error executing shutdown: %s", err)
 			}
 		})

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -6,6 +6,9 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
@@ -44,13 +47,20 @@ func init() {
 }
 
 func remoteUpgrade() error {
-	var err error
+	var (
+		err error
+		ack string
+	)
 
 	setupClient(func(c *client.Client) {
 		// TODO: See if we can validate version and prevent
 		// starting upgrades to an unknown version
-		err = c.Upgrade(assetURL)
+		ack, err = c.Upgrade(context.TODO(), assetURL)
 	})
+
+	if err == nil {
+		fmt.Println(ack)
+	}
 
 	return err
 }

--- a/cmd/osctl/cmd/version.go
+++ b/cmd/osctl/cmd/version.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -36,9 +37,12 @@ var versionCmd = &cobra.Command{
 			}
 		}
 		setupClient(func(c *client.Client) {
-			if err := c.Version(); err != nil {
+			version, err := c.Version(context.TODO())
+			if err != nil {
 				helpers.Fatalf("error getting version: %s", err)
 			}
+			_, err = os.Stdout.Write(version)
+			helpers.Should(err)
 		})
 	},
 }


### PR DESCRIPTION
This moves cli code (rendering output, etc.) out of 'client' package, so
that client package is usable outside of cli.

Consistently accept context as first param to API methods, so that we
can build graceful request cancellation.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>