### PR TITLE
feat(init): update 'waiting' state descritpion when conditions change

### DIFF
--- a/internal/app/init/pkg/system/conditions/files.go
+++ b/internal/app/init/pkg/system/conditions/files.go
@@ -33,7 +33,7 @@ func (filename file) Wait(ctx context.Context) error {
 }
 
 func (filename file) String() string {
-	return fmt.Sprintf("for file %q to exist", string(filename))
+	return fmt.Sprintf("file %q to exist", string(filename))
 }
 
 // WaitForFileToExist is a service condition that will wait for the existence of

--- a/internal/app/init/pkg/system/conditions/files_test.go
+++ b/internal/app/init/pkg/system/conditions/files_test.go
@@ -45,7 +45,7 @@ func (suite *FilesSuite) createFile(name string) (path string) {
 }
 
 func (suite *FilesSuite) TestString() {
-	suite.Require().Equal("for file \"abc.txt\" to exist", conditions.WaitForFileToExist("abc.txt").String())
+	suite.Require().Equal("file \"abc.txt\" to exist", conditions.WaitForFileToExist("abc.txt").String())
 }
 
 func (suite *FilesSuite) TestWaitForFileToExist() {

--- a/internal/app/init/pkg/system/mocks_test.go
+++ b/internal/app/init/pkg/system/mocks_test.go
@@ -120,3 +120,28 @@ func (m *MockRunner) Stop() error {
 func (m *MockRunner) String() string {
 	return "MockRunner()"
 }
+
+type MockCondition struct {
+	done chan struct{}
+	desc string
+}
+
+func NewMockCondition(desc string) *MockCondition {
+	return &MockCondition{
+		done: make(chan struct{}),
+		desc: desc,
+	}
+}
+
+func (m *MockCondition) String() string {
+	return m.desc
+}
+
+func (m *MockCondition) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.done:
+		return nil
+	}
+}


### PR DESCRIPTION
If some of the conditions are already satisfied, we can update the
description to reflect that, e.g.:

```
EVENTS   [Waiting]: Waiting for service "containerd" to be "up", service "networkd" to be "up", service "trustd" to be "up" (14m17s ago)
         [Waiting]: Waiting for service "trustd" to be "up" (14m16s ago)
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>