### PR TITLE
chore: enable GOPROXY for go modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ FROM ${TOOLCHAIN_IMAGE} AS base
 ENV GOPATH /toolchain/gopath
 RUN mkdir -p ${GOPATH}
 ENV GO111MODULE on
+ENV GOPROXY https://proxy.golang.org
 ENV CGO_ENABLED 0
 WORKDIR /src
 COPY ./go.mod ./


### PR DESCRIPTION
Announcement: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/golang-announce/0wo8cOhGuAI/v96KeTYtBwAJ

This should improve module download time as `go` no longer needs
to clone full repositories.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>