### PR TITLE
fix(osctl): don't print message on first ^C

### DIFF
--- a/cmd/osctl/cmd/logs.go
+++ b/cmd/osctl/cmd/logs.go
@@ -10,6 +10,9 @@ import (
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/internal/pkg/constants"
@@ -42,7 +45,7 @@ var logsCmd = &cobra.Command{
 			for {
 				data, err := stream.Recv()
 				if err != nil {
-					if err == io.EOF {
+					if err == io.EOF || status.Code(err) == codes.Canceled {
 						return
 					}
 					helpers.Fatalf("error streaming logs: %s", err)


### PR DESCRIPTION
This resolves extra messages when user does ^C to stop osctl. Message is
still printed on the second ^C and process is aborted on the third.

For the `logs` command, as it is streaming, suppress context canceled
error (before context changes process was crashing before printing an error).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>