### PR TITLE
chore: address flaky tests instability

### DIFF
--- a/internal/app/init/pkg/system/health/health_test.go
+++ b/internal/app/init/pkg/system/health/health_test.go
@@ -127,7 +127,7 @@ func (suite *CheckSuite) TestCheckAbort() {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(10 * time.Millisecond):
+		case <-time.After(50 * time.Millisecond):
 			return nil
 		}
 	}
@@ -141,7 +141,7 @@ func (suite *CheckSuite) TestCheckAbort() {
 		errCh <- health.Run(ctx, &settings, &state, check)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	suite.Require().False(*state.Get().Healthy)
 	suite.Require().Equal("context deadline exceeded", state.Get().LastMessage)


### PR DESCRIPTION
For #711, this should be a complete fix - waiting for container to be
started.

For #712, this should be more of a workaround - playing with timeouts to
hit the failure less likely. Idea of the test is that health check
should be aborted on timeout (1ms) while health check succeeds if not
aborted in 50ms. Before the fix it was 1ms/10ms, but still concurrently
there was a chance that goroutine exits successfully after 10ms while
1ms context deadline is not reached.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>