### PR TITLE
fix(init): use 127.0.0.1 IP in healthchecks to avoid resolver weirdness

### DIFF
--- a/internal/app/init/pkg/system/services/kubelet.go
+++ b/internal/app/init/pkg/system/services/kubelet.go
@@ -139,7 +139,7 @@ func (k *Kubelet) Runner(data *userdata.UserData) (runner.Runner, error) {
 // HealthFunc implements the HealthcheckedService interface
 func (k *Kubelet) HealthFunc(*userdata.UserData) health.Check {
 	return func(ctx context.Context) error {
-		req, err := http.NewRequest("GET", "http://localhost:10248/healthz", nil)
+		req, err := http.NewRequest("GET", "http://127.0.0.1:10248/healthz", nil)
 		if err != nil {
 			return err
 		}

--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -106,7 +106,7 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 func (o *OSD) HealthFunc(*userdata.UserData) health.Check {
 	return func(ctx context.Context) error {
 		var d net.Dialer
-		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "localhost", constants.OsdPort))
+		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "127.0.0.1", constants.OsdPort))
 		if err != nil {
 			return err
 		}

--- a/internal/app/init/pkg/system/services/proxyd.go
+++ b/internal/app/init/pkg/system/services/proxyd.go
@@ -102,7 +102,7 @@ func (p *Proxyd) Runner(data *userdata.UserData) (runner.Runner, error) {
 func (p *Proxyd) HealthFunc(*userdata.UserData) health.Check {
 	return func(ctx context.Context) error {
 		var d net.Dialer
-		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "localhost", 443))
+		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "127.0.0.1", 443))
 		if err != nil {
 			return err
 		}

--- a/internal/app/init/pkg/system/services/trustd.go
+++ b/internal/app/init/pkg/system/services/trustd.go
@@ -96,7 +96,7 @@ func (t *Trustd) Runner(data *userdata.UserData) (runner.Runner, error) {
 func (t *Trustd) HealthFunc(*userdata.UserData) health.Check {
 	return func(ctx context.Context) error {
 		var d net.Dialer
-		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "localhost", constants.TrustdPort))
+		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "127.0.0.1", constants.TrustdPort))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>