### PR TITLE
refactor(osd): implement container inspector for a single container

### DIFF
--- a/internal/pkg/containers/container.go
+++ b/internal/pkg/containers/container.go
@@ -5,40 +5,90 @@
 package containers
 
 import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/containerd/containerd"
 	tasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
+
+	"github.com/talos-systems/talos/internal/pkg/chunker"
+	"github.com/talos-systems/talos/internal/pkg/chunker/file"
+	"github.com/talos-systems/talos/internal/pkg/chunker/stream"
 )
 
 // Container presents information about a container
 type Container struct {
 	inspector *Inspector
 
-	Display string // Friendly Name
-	Name    string // container name
-	ID      string // container sha/id
-	Digest  string // Container Digest
-	Image   string
-	Status  containerd.Status // Running state of container
-	Pid     uint32
-	LogFile string
-	Metrics *types.Metric
+	Display      string // Friendly Name
+	Name         string // container name
+	ID           string // container sha/id
+	Digest       string // Container Digest
+	Image        string
+	PodName      string
+	Sandbox      string
+	Status       containerd.Status // Running state of container
+	Pid          uint32
+	RestartCount string
+	Metrics      *types.Metric
 }
 
-// GetProcessStdout returns process stdout
-func (c *Container) GetProcessStdout() (string, error) {
+// GetProcessStderr returns process stderr
+func (c *Container) GetProcessStderr() (string, error) {
 	task, err := c.inspector.client.TaskService().Get(c.inspector.nsctx, &tasks.GetRequest{ContainerID: c.ID})
 	if err != nil {
 		return "", err
 	}
 
-	return task.Process.Stdout, nil
+	return task.Process.Stderr, nil
+}
+
+// GetLogFile returns path to log file, k8s-style
+func (c *Container) GetLogFile() string {
+	if c.Sandbox == "" || !strings.Contains(c.Display, ":") {
+		return ""
+	}
+
+	return filepath.Join(c.Sandbox, c.Name, c.RestartCount+".log")
 }
 
 // Kill sends signal to container task
 func (c *Container) Kill(signal syscall.Signal) error {
 	_, err := c.inspector.client.TaskService().Kill(c.inspector.nsctx, &tasks.KillRequest{ContainerID: c.ID, Signal: uint32(signal)})
 	return err
+}
+
+// GetLogChunker returns chunker for container log file
+func (c *Container) GetLogChunker() (chunker.Chunker, io.Closer, error) {
+	logFile := c.GetLogFile()
+	log.Printf("logFile = %q", logFile)
+	if logFile != "" {
+		f, err := os.OpenFile(logFile, os.O_RDONLY, 0)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return file.NewChunker(f), f, nil
+	}
+
+	filename, err := c.GetProcessStderr()
+	if err != nil {
+		return nil, nil, err
+	}
+	if filename == "" {
+		return nil, nil, fmt.Errorf("no log available")
+	}
+
+	f, err := os.OpenFile(filename, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return stream.NewChunker(f), f, nil
 }

--- a/internal/pkg/containers/containers_test.go
+++ b/internal/pkg/containers/containers_test.go
@@ -12,7 +12,9 @@ import (
 	"testing"
 
 	"github.com/containerd/containerd"
+	containerdcntrs "github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/oci"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
@@ -32,6 +34,7 @@ const (
 func MockEventSink(state events.ServiceState, message string, args ...interface{}) {
 }
 
+// nolint: maligned
 type ContainersSuite struct {
 	suite.Suite
 
@@ -42,6 +45,25 @@ type ContainersSuite struct {
 
 	client *containerd.Client
 	image  containerd.Image
+
+	containerRunners []runner.Runner
+	containersWg     sync.WaitGroup
+}
+
+// WithAnnotations appends or replaces the annotations on the spec with the
+// provided annotations
+//
+// TODO: taken from containerd/oci > 1.2.6
+func WithAnnotations(annotations map[string]string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containerdcntrs.Container, s *oci.Spec) error {
+		if s.Annotations == nil {
+			s.Annotations = make(map[string]string)
+		}
+		for k, v := range annotations {
+			s.Annotations[k] = v
+		}
+		return nil
+	}
 }
 
 // nolint: dupl
@@ -88,46 +110,100 @@ func (suite *ContainersSuite) TearDownSuite() {
 	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 }
 
-func (suite *ContainersSuite) TestRunSuccess() {
-	r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+func (suite *ContainersSuite) SetupTest() {
+	suite.containerRunners = nil
+}
+
+func (suite *ContainersSuite) run(runners ...runner.Runner) {
+	runningCh := make(chan struct{}, len(runners))
+
+	for _, r := range runners {
+		suite.containerRunners = append(suite.containerRunners, r)
+
+		suite.Require().NoError(r.Open(context.Background()))
+
+		suite.containersWg.Add(1)
+		go func(r runner.Runner) {
+			runningSink := func(state events.ServiceState, message string, args ...interface{}) {
+				if state == events.StateRunning {
+					runningCh <- struct{}{}
+				}
+			}
+
+			defer suite.containersWg.Done()
+			suite.Assert().NoError(r.Run(runningSink))
+		}(r)
+	}
+
+	// wait for the containers to be started actually
+	for range runners {
+		<-runningCh
+	}
+}
+
+func (suite *ContainersSuite) TearDownTest() {
+	for _, r := range suite.containerRunners {
+		suite.Assert().NoError(r.Stop())
+	}
+	suite.containersWg.Wait()
+	for _, r := range suite.containerRunners {
+		suite.Assert().NoError(r.Close())
+	}
+}
+
+func (suite *ContainersSuite) runK8sContainers() {
+	suite.run(containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "test1",
+		ProcessArgs: []string{"/bin/sh", "-c", "sleep 3600"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithContainerOpts(containerd.WithContainerLabels(map[string]string{
+			"io.kubernetes.pod.name":      "fun",
+			"io.kubernetes.pod.namespace": "ns1",
+		})),
+		runner.WithOCISpecOpts(WithAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-log-directory": "sandbox",
+			"io.kubernetes.cri.sandbox-id":            "c888d69b73b5b444c2b0bd70da28c3da102b0aeb327f3a297626e2558def327f",
+		})),
+	), containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "test2",
+		ProcessArgs: []string{"/bin/sh", "-c", "sleep 3600"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithContainerOpts(containerd.WithContainerLabels(map[string]string{
+			"io.kubernetes.pod.name":       "fun",
+			"io.kubernetes.pod.namespace":  "ns1",
+			"io.kubernetes.container.name": "run",
+		})),
+		runner.WithOCISpecOpts(WithAnnotations(map[string]string{
+			"io.kubernetes.cri.sandbox-id": "c888d69b73b5b444c2b0bd70da28c3da102b0aeb327f3a297626e2558def327f",
+		})),
+	))
+}
+
+func (suite *ContainersSuite) TestPodsNonK8s() {
+	suite.run(containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
 		ID:          "test",
 		ProcessArgs: []string{"/bin/sh", "-c", "sleep 3600"},
 	},
 		runner.WithLogPath(suite.tmpDir),
 		runner.WithNamespace(containerdNamespace),
 		runner.WithContainerImage(busyboxImage),
-	)
-
-	suite.Require().NoError(r.Open(context.Background()))
-	defer func() { suite.Assert().NoError(r.Close()) }()
-
-	var wg sync.WaitGroup
-	runningCh := make(chan struct{})
-
-	wg.Add(1)
-	go func() {
-		runningSink := func(state events.ServiceState, message string, args ...interface{}) {
-			if state == events.StateRunning {
-				close(runningCh)
-			}
-		}
-
-		defer wg.Done()
-		suite.Assert().NoError(r.Run(runningSink))
-	}()
-
-	// wait for the container to be started actually
-	<-runningCh
+	))
 
 	i, err := containers.NewInspector(context.Background(), containerdNamespace)
 	suite.Assert().NoError(err)
 
 	pods, err := i.Pods()
-	suite.Assert().NoError(err)
-	suite.Assert().Len(pods, 1)
+	suite.Require().NoError(err)
+	suite.Require().Len(pods, 1)
 	suite.Assert().Equal("test", pods[0].Name)
 	suite.Assert().Equal("", pods[0].Sandbox)
-	suite.Assert().Len(pods[0].Containers, 1)
+	suite.Require().Len(pods[0].Containers, 1)
 	suite.Assert().Equal("test", pods[0].Containers[0].Display)
 	suite.Assert().Equal("test", pods[0].Containers[0].Name)
 	suite.Assert().Equal("test", pods[0].Containers[0].ID)
@@ -136,9 +212,113 @@ func (suite *ContainersSuite) TestRunSuccess() {
 	suite.Assert().NotNil(pods[0].Containers[0].Metrics)
 
 	suite.Assert().NoError(i.Close())
+}
 
-	suite.Assert().NoError(r.Stop())
-	wg.Wait()
+func (suite *ContainersSuite) TestPodsK8s() {
+	suite.runK8sContainers()
+
+	i, err := containers.NewInspector(context.Background(), containerdNamespace)
+	suite.Assert().NoError(err)
+
+	pods, err := i.Pods()
+	suite.Require().NoError(err)
+	suite.Require().Len(pods, 1)
+	suite.Assert().Equal("ns1/fun", pods[0].Name)
+	suite.Assert().Equal("sandbox", pods[0].Sandbox)
+	suite.Require().Len(pods[0].Containers, 2)
+
+	suite.Assert().Equal("ns1/fun", pods[0].Containers[0].Display)
+	suite.Assert().Equal("test1", pods[0].Containers[0].Name)
+	suite.Assert().Equal("test1", pods[0].Containers[0].ID)
+	suite.Assert().Equal("sandbox", pods[0].Containers[0].Sandbox)
+	suite.Assert().Equal("0", pods[0].Containers[0].RestartCount)
+	suite.Assert().Equal("", pods[0].Containers[0].GetLogFile())
+	suite.Assert().Equal(busyboxImage, pods[0].Containers[0].Image)
+	suite.Assert().Equal(containerd.Running, pods[0].Containers[0].Status.Status)
+	suite.Assert().NotNil(pods[0].Containers[0].Metrics)
+
+	suite.Assert().Equal("ns1/fun:run", pods[0].Containers[1].Display)
+	suite.Assert().Equal("run", pods[0].Containers[1].Name)
+	suite.Assert().Equal("test2", pods[0].Containers[1].ID)
+	suite.Assert().Equal("sandbox", pods[0].Containers[1].Sandbox)
+	suite.Assert().Equal("sandbox/run/0.log", pods[0].Containers[1].GetLogFile())
+	suite.Assert().Equal(busyboxImage, pods[0].Containers[1].Image)
+	suite.Assert().Equal(containerd.Running, pods[0].Containers[1].Status.Status)
+	suite.Assert().NotNil(pods[0].Containers[1].Metrics)
+
+	suite.Assert().NoError(i.Close())
+}
+
+func (suite *ContainersSuite) TestContainerNonK8s() {
+	suite.run(containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "shelltest",
+		ProcessArgs: []string{"/bin/sh", "-c", "sleep 3600"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithNamespace(containerdNamespace),
+		runner.WithContainerImage(busyboxImage),
+	))
+
+	i, err := containers.NewInspector(context.Background(), containerdNamespace)
+	suite.Assert().NoError(err)
+
+	cntr, err := i.Container("shelltest")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cntr)
+	suite.Assert().Equal("shelltest", cntr.Name)
+	suite.Assert().Equal("shelltest", cntr.Display)
+	suite.Assert().Equal("shelltest", cntr.ID)
+	suite.Assert().Equal("sha256:c888d69b73b5b444c2b0bd70da28c3da102b0aeb327f3a297626e2558def327f", cntr.Image) // image is not resolved
+	suite.Assert().Equal(containerd.Running, cntr.Status.Status)
+
+	cntr, err = i.Container("nosuchcontainer")
+	suite.Require().NoError(err)
+	suite.Require().Nil(cntr)
+
+	suite.Assert().NoError(i.Close())
+}
+
+func (suite *ContainersSuite) TestContainerK8s() {
+	suite.runK8sContainers()
+
+	i, err := containers.NewInspector(context.Background(), containerdNamespace)
+	suite.Assert().NoError(err)
+
+	cntr, err := i.Container("ns1/fun")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cntr)
+	suite.Assert().Equal("test1", cntr.Name)
+	suite.Assert().Equal("ns1/fun", cntr.Display)
+	suite.Assert().Equal("test1", cntr.ID)
+	suite.Assert().Equal("sandbox", cntr.Sandbox)
+	suite.Assert().Equal("", cntr.GetLogFile())
+	suite.Assert().Equal("sha256:c888d69b73b5b444c2b0bd70da28c3da102b0aeb327f3a297626e2558def327f", cntr.Image) // image is not resolved
+	suite.Assert().Equal(containerd.Running, cntr.Status.Status)
+
+	cntr, err = i.Container("ns1/fun:run")
+	suite.Require().NoError(err)
+	suite.Require().NotNil(cntr)
+	suite.Assert().Equal("run", cntr.Name)
+	suite.Assert().Equal("ns1/fun:run", cntr.Display)
+	suite.Assert().Equal("test2", cntr.ID)
+	suite.Assert().Equal("sandbox", cntr.Sandbox)
+	suite.Assert().Equal("sandbox/run/0.log", cntr.GetLogFile())
+	suite.Assert().Equal("sha256:c888d69b73b5b444c2b0bd70da28c3da102b0aeb327f3a297626e2558def327f", cntr.Image) // image is not resolved
+	suite.Assert().Equal(containerd.Running, cntr.Status.Status)
+
+	cntr, err = i.Container("ns2/fun:run")
+	suite.Require().NoError(err)
+	suite.Require().Nil(cntr)
+
+	cntr, err = i.Container("ns1/run:run")
+	suite.Require().NoError(err)
+	suite.Require().Nil(cntr)
+
+	cntr, err = i.Container("ns1/fun:go")
+	suite.Require().NoError(err)
+	suite.Require().Nil(cntr)
+
+	suite.Assert().NoError(i.Close())
 }
 
 func TestContainersSuite(t *testing.T) {


### PR DESCRIPTION
Instead of pulling a full list of containers, implement inspector query
for a single container following the spec to build display name.

Also adds many more tests for the container inspector.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>