### PR TITLE
chore(ci): modularize integration test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,11 +230,6 @@ COPY --from=talos-build /rootfs /
 COPY --from=init-build /init /init
 ENTRYPOINT ["/init"]
 
-# The kernel target is the linux kernel.
-
-ARG KERNEL_IMAGE
-FROM ${KERNEL_IMAGE} as kernel
-
 # The installer target generates an image that can be used to install Talos to
 # various environments.
 

--- a/hack/test/integration.sh
+++ b/hack/test/integration.sh
@@ -2,41 +2,18 @@
 
 set -eou pipefail
 
-TMP="$(mktemp -d)"
-OSCTL="${PWD}/build/osctl-linux-amd64"
-
+export TMP="$(mktemp -d)"
+export OSCTL="${PWD}/build/osctl-linux-amd64"
 export TALOSCONFIG="${TMP}/talosconfig"
 export KUBECONFIG="${TMP}/kubeconfig"
+
 
 cleanup() {
 	${OSCTL} cluster destroy --name integration
 	rm -rf ${TMP}
 }
-
-run() {
-	docker run \
-	 	--rm \
-	 	--interactive \
-	 	--net=integration \
-		--entrypoint=bash \
-		--mount type=bind,source=${TMP},target=${TMP} \
-		--mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
-	 	-v ${OSCTL}:/bin/osctl:ro \
-	 	-e KUBECONFIG=${KUBECONFIG} \
-	 	-e TALOSCONFIG=${TALOSCONFIG} \
-	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
-}
-
 trap cleanup EXIT
 
-${OSCTL} cluster create --name integration
-${OSCTL} config target 10.5.0.2
-
-run "until osctl kubeconfig > ${KUBECONFIG}; do cat ${KUBECONFIG}; sleep 5; done"
-run "until kubectl get nodes -o json | jq '.items | length' | grep 4 >/dev/null; do kubectl get nodes -o wide; sleep 5; done"
-run "kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
-run "kubectl wait --for=condition=ready=true --all nodes"
-# Verify that we have an HA controlplane
-run "kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 3 >/dev/null"
+./hack/test/osctl-docker-create.sh
 
 exit 0

--- a/hack/test/osctl-docker-create.sh
+++ b/hack/test/osctl-docker-create.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eou pipefail
+
+run() {
+	docker run \
+	 	--rm \
+	 	--interactive \
+	 	--net=integration \
+		--entrypoint=bash \
+		--mount type=bind,source=${TMP},target=${TMP} \
+		--mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
+	 	-v ${OSCTL}:/bin/osctl:ro \
+	 	-e KUBECONFIG=${KUBECONFIG} \
+	 	-e TALOSCONFIG=${TALOSCONFIG} \
+	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
+}
+
+${OSCTL} cluster create --name integration
+${OSCTL} config target 10.5.0.2
+
+run "until osctl kubeconfig > ${KUBECONFIG}; do cat ${KUBECONFIG}; sleep 5; done"
+run "until kubectl get nodes -o json | jq '.items | length' | grep 4 >/dev/null; do kubectl get nodes -o wide; sleep 5; done"
+run "kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
+run "kubectl wait --for=condition=ready=true --all nodes"
+# Verify that we have an HA controlplane
+run "kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 3 >/dev/null"


### PR DESCRIPTION
This is just the first bit of the CI stuff I've been working on. Thought it might be easier to chunk it up a bit so it won't be massive. This PR will break the "osctl cluster create" flow into its own script, so that we can just call it from the basic integration test, as well as the e2e test I'm working on. 

I also noticed that there was duplication in the Dockerfile for the kernel image. So I removed one of the references there.