### PR TITLE
fix(osctl): display non-fatal errors from ps/stats in osctl

### DIFF
--- a/cmd/osctl/cmd/ps.go
+++ b/cmd/osctl/cmd/ps.go
@@ -38,11 +38,17 @@ var psCmd = &cobra.Command{
 			}
 			reply, err := c.Processes(globalCtx, namespace)
 
-			if err != nil {
+			if reply == nil && err != nil {
+				// fatal error
 				helpers.Fatalf("error getting process list: %s", err)
 			}
 
 			processesRender(reply)
+
+			if err != nil {
+				// some errors encountered, but not fatal
+				fmt.Fprintf(os.Stderr, "errors while listing processes: %s", err)
+			}
 		})
 	},
 }

--- a/cmd/osctl/cmd/stats.go
+++ b/cmd/osctl/cmd/stats.go
@@ -37,11 +37,17 @@ var statsCmd = &cobra.Command{
 				namespace = constants.SystemContainerdNamespace
 			}
 			reply, err := c.Stats(globalCtx, namespace)
-			if err != nil {
+			if reply == nil && err != nil {
+				// fatal error
 				helpers.Fatalf("error getting stats: %s", err)
 			}
 
 			statsRender(reply)
+
+			if err != nil {
+				// some errors encountered, but not fatal
+				fmt.Fprintf(os.Stderr, "errors while getting stats: %s", err)
+			}
 		})
 	},
 }


### PR DESCRIPTION
Logging those errors in osd makes them hard to discover.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>