### PR TITLE
fix(osctl): Revert "display non-fatal errors from ps/stats in osctl"

### DIFF
--- a/cmd/osctl/cmd/ps.go
+++ b/cmd/osctl/cmd/ps.go
@@ -38,17 +38,11 @@ var psCmd = &cobra.Command{
 			}
 			reply, err := c.Processes(globalCtx, namespace)
 
-			if reply == nil && err != nil {
-				// fatal error
+			if err != nil {
 				helpers.Fatalf("error getting process list: %s", err)
 			}
 
 			processesRender(reply)
-
-			if err != nil {
-				// some errors encountered, but not fatal
-				fmt.Fprintf(os.Stderr, "errors while listing processes: %s", err)
-			}
 		})
 	},
 }

--- a/cmd/osctl/cmd/stats.go
+++ b/cmd/osctl/cmd/stats.go
@@ -37,17 +37,11 @@ var statsCmd = &cobra.Command{
 				namespace = constants.SystemContainerdNamespace
 			}
 			reply, err := c.Stats(globalCtx, namespace)
-			if reply == nil && err != nil {
-				// fatal error
+			if err != nil {
 				helpers.Fatalf("error getting stats: %s", err)
 			}
 
 			statsRender(reply)
-
-			if err != nil {
-				// some errors encountered, but not fatal
-				fmt.Fprintf(os.Stderr, "errors while getting stats: %s", err)
-			}
 		})
 	},
 }


### PR DESCRIPTION
This reverts commit f200eb7a8a0b7c2d29710f695000eb7680ce8b7d. (#724)

grpc can't send back both response and an error.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>