### PR TITLE
test(proxyd): Add tests for proxyd watch

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -26,6 +26,7 @@ policies:
       - proxyd
       - osctl
       - osd
+      - proxyd
       - rootfs
       - tools
       - trustd

--- a/internal/app/proxyd/internal/frontend/frontend_test.go
+++ b/internal/app/proxyd/internal/frontend/frontend_test.go
@@ -2,13 +2,169 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package frontend_test
+package frontend
 
-import "testing"
+import (
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net"
+	"strconv"
+	"testing"
+	"time"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/proxyd/internal/backend"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type ProxydSuite struct {
+	suite.Suite
+}
+
+func TestFrontendSuite(t *testing.T) {
+	// Hide all our state transition messages
+	log.SetOutput(ioutil.Discard)
+	suite.Run(t, new(ProxydSuite))
+}
+
+func (suite *ProxydSuite) TestWatch() {
+	// Overwrite the caCert for testing
+	caCertFile = ""
+	r, err := NewReverseProxy(net.ParseIP("127.0.0.1"))
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	// Generate a simple pod
+	p := genPod()
+
+	// Create our fake k8s client
+	client := fake.NewSimpleClientset()
+	go r.Watch(client)
+
+	output := make(chan string)
+	go func() {
+		var be map[string]*backend.Backend
+		for {
+			be = r.Backends()
+			if _, ok := be[string(p.UID)]; ok {
+				output <- be[string(p.UID)].UID
+			}
+		}
+	}()
+
+	// Verify we have a bootstrap backend
+	_, err = client.CoreV1().Pods("kube-system").Create(p)
+	suite.Assert().NoError(err)
+
+	timeout := time.NewTicker(time.Second * 2)
+	select {
+	case <-timeout.C:
+		suite.T().Error("failed to get updated backend")
+	case uid := <-output:
+		suite.Equal(string(p.UID), uid)
+	}
+}
+
+func (suite *ProxydSuite) TestAddBackendFunc() {
+	// Overwrite the caCert for testing
+	caCertFile = ""
+	r, err := NewReverseProxy(net.ParseIP("127.0.0.1"))
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	for i := 0; i < 5; i++ {
+		r.AddFunc()(genPod())
+	}
+
+	bes := r.Backends()
+
+	// Ensure bootstrap backend was removed
+	_, bootstrap := bes["bootstrap"]
+	suite.Equal(bootstrap, false)
+
+	// Verify we have the appropriate number of new backends
+	suite.Equal(len(bes), 5)
+}
+
+func (suite *ProxydSuite) TestDeleteBackendFunc() {
+	// Overwrite the caCert for testing
+	caCertFile = ""
+	r, err := NewReverseProxy(net.ParseIP("127.0.0.1"))
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	// Add some sample backends
+	pods := make([]*v1.Pod, 5)
+	for i := 0; i < 5; i++ {
+		pods[i] = genPod()
+	}
+	for _, pod := range pods {
+		r.AddFunc()(pod)
+	}
+	// Delete all sample backends
+	for _, pod := range pods {
+		r.DeleteFunc()(pod)
+	}
+
+	bes := r.Backends()
+	suite.Equal(len(bes), 0)
+}
+
+func (suite *ProxydSuite) TestUpdateBackendFunc() {
+	// Overwrite the caCert for testing
+	caCertFile = ""
+	r, err := NewReverseProxy(net.ParseIP("127.0.0.1"))
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	// Add some sample backend
+	pod := genPod()
+	r.AddFunc()(pod)
+
+	// Generate a new UID for the pod to simulate(?) a
+	// pod getting updated
+	oldpod := *pod
+
+	pod.ObjectMeta.UID = types.UID(uuid.New().String())
+	r.UpdateFunc()(&oldpod, pod)
+
+	bes := r.Backends()
+
+	_, olduid := bes[string(oldpod.ObjectMeta.UID)]
+	suite.Equal(olduid, false)
+	suite.Equal(bes[string(pod.ObjectMeta.UID)].UID, string(pod.ObjectMeta.UID))
+}
+
+func genPod() (p *v1.Pod) {
+	id := rand.Intn(255)
+
+	labels := map[string]string{}
+	if id%2 == 0 {
+		labels["component"] = "kube-apiserver"
+	} else {
+		labels["k8s-app"] = "self-hosted-kube-apiserver"
+	}
+
+	p = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "fakeapi-" + strconv.Itoa(id),
+			Labels: labels,
+			UID:    types.UID(uuid.New().String()),
+		},
+		Status: v1.PodStatus{
+			PodIP: "127.0.0." + strconv.Itoa(id),
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Ready: true,
+				},
+			},
+		},
+	}
+	return p
 }

--- a/internal/app/proxyd/main.go
+++ b/internal/app/proxyd/main.go
@@ -8,16 +8,44 @@ import (
 	"log"
 
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
+	pkgnet "github.com/talos-systems/talos/internal/pkg/net"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func main() {
-	r, err := frontend.NewReverseProxy()
+
+	// Discovey local non loopback ips
+	ips, err := pkgnet.IPAddrs()
+	if err != nil {
+		log.Fatalf("failed to get local address: %v", err)
+	}
+	if len(ips) == 0 {
+		log.Fatalf("no IP address found for bootstrap backend")
+	}
+	ip := ips[0]
+
+	r, err := frontend.NewReverseProxy(ip)
 	if err != nil {
 		log.Fatalf("failed to initialize the reverse proxy: %v", err)
 	}
 
-	// nolint: errcheck
-	go r.Watch()
+	// Set up kubernetes client
+	kubeconfig := "/etc/kubernetes/admin.conf"
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return
+	}
+
+	// Update the host to the node's IP.
+	config.Host = ip.String() + ":6443"
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return
+	}
+
+	go r.Watch(clientset)
 
 	// nolint: errcheck
 	r.Listen(":443")


### PR DESCRIPTION
- Switched up the client informer based on fake example and to work
  around a crash when testing
- Moved around some of the initializaiton bits to make testing happen

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>