### PR TITLE
fix(osctl): allow '-target' flag for `osctl restart`

### DIFF
--- a/cmd/osctl/cmd/restart.go
+++ b/cmd/osctl/cmd/restart.go
@@ -15,10 +15,6 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
-var (
-	timeout int32
-)
-
 // restartCmd represents the restart command
 var restartCmd = &cobra.Command{
 	Use:   "restart",
@@ -39,7 +35,7 @@ var restartCmd = &cobra.Command{
 			} else {
 				namespace = constants.SystemContainerdNamespace
 			}
-			if err := c.Restart(globalCtx, namespace, args[0], timeout); err != nil {
+			if err := c.Restart(globalCtx, namespace, args[0]); err != nil {
 				helpers.Fatalf("error restarting process: %s", err)
 			}
 		})
@@ -47,7 +43,7 @@ var restartCmd = &cobra.Command{
 }
 
 func init() {
-	restartCmd.Flags().Int32VarP(&timeout, "timeout", "t", 60, "the timeout duration in seconds")
+	restartCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
 	restartCmd.Flags().BoolVarP(&kubernetes, "kubernetes", "k", false, "use the k8s.io containerd namespace")
 	rootCmd.AddCommand(restartCmd)
 }

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -140,11 +140,10 @@ func (c *Client) Processes(ctx context.Context, namespace string) (reply *proto.
 }
 
 // Restart implements the proto.OSDClient interface.
-func (c *Client) Restart(ctx context.Context, namespace, id string, timeoutSecs int32) (err error) {
+func (c *Client) Restart(ctx context.Context, namespace, id string) (err error) {
 	_, err = c.client.Restart(ctx, &proto.RestartRequest{
 		Id:        id,
 		Namespace: namespace,
-		Timeout:   timeoutSecs,
 	})
 	return
 }

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -56,7 +56,6 @@ message Stat {
 message RestartRequest {
   string namespace = 1;
   string id = 2;
-  int32 timeout = 3;
 }
 
 // The response message containing the restart status.


### PR DESCRIPTION
I couldn't find any use for the `timeout` flag nor the value passed in
the API, but it block much more useful and present in other commands
flag 'target'.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>