### PR TITLE
fix: run basic-integration always

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -97,8 +97,6 @@ steps:
     path: /tmp
   depends_on:
   - build
-  when:
-    event: pull_request
 
 - name: e2e-integration
   image: autonomy/build-container:latest


### PR DESCRIPTION
I don't really have a good way to test this I don't think, but I think the e2e test didn't get run b/c of its dependency on the basic integration test. That test was only occurring during PR events, so I added cron to the list of triggers as well.