### PR TITLE
feat(osctl): implement 'cp' to copy files out of the Talos node

### DIFF
--- a/cmd/osctl/cmd/cp.go
+++ b/cmd/osctl/cmd/cp.go
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cmd
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
+)
+
+// cpCmd represents the cp command
+var cpCmd = &cobra.Command{
+	Use:   "cp <src-path> -|<local-path>",
+	Short: "Copy data out from the node",
+	Long: `Creates an .tar.gz archive at the node starting at <src-path> and
+streams it back to the client.
+
+If '-' is given for <local-path>, archive is written to stdout.
+Otherwise archive is extracted to <local-path> which should be an empty directory or
+osctl creates a directory if <local-path> doesn't exist. Command doesn't preserve
+ownership and access mode for the files in extract mode, while  streamed .tar archive
+captures ownership and permission bits.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 2 {
+			helpers.Should(cmd.Usage())
+			os.Exit(1)
+		}
+
+		setupClient(func(c *client.Client) {
+			r, errCh, err := c.CopyOut(globalCtx, args[0])
+			if err != nil {
+				helpers.Fatalf("error copying: %s", err)
+			}
+
+			go func() {
+				for err := range errCh {
+					fmt.Fprintln(os.Stderr, err.Error())
+				}
+			}()
+
+			localPath := args[1]
+
+			if localPath == "-" {
+				// nolint: errcheck
+				_, err = io.Copy(os.Stdout, r)
+				if err != nil {
+					helpers.Fatalf("error copying: %s", err)
+				}
+				return
+			}
+
+			localPath = filepath.Clean(localPath)
+
+			fi, err := os.Stat(localPath)
+			if err == nil && !fi.IsDir() {
+				helpers.Fatalf("local path %q should be a directory", args[1])
+			}
+			if err != nil {
+				if !os.IsNotExist(err) {
+					helpers.Fatalf("failed to stat local path: %s", err)
+				}
+				if err = os.MkdirAll(localPath, 0777); err != nil {
+					helpers.Fatalf("error creating local path %q: %s", localPath, err)
+				}
+			}
+
+			zr, err := gzip.NewReader(r)
+			if err != nil {
+				helpers.Fatalf("error initializing gzip: %s", err)
+			}
+			tr := tar.NewReader(zr)
+
+			for {
+				hdr, err := tr.Next()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					helpers.Fatalf("error reading tar header: %s", err)
+				}
+
+				path := filepath.Clean(filepath.Join(localPath, hdr.Name))
+				// TODO: do we need to clean up any '..' references?
+
+				switch hdr.Typeflag {
+				case tar.TypeDir:
+					mode := hdr.FileInfo().Mode()
+					mode |= 0700 // make rwx for the owner
+					if err = os.Mkdir(path, mode); err != nil {
+						helpers.Fatalf("error creating directory %q mode %s: %s", path, mode, err)
+					}
+					if err = os.Chmod(path, mode); err != nil {
+						helpers.Fatalf("error updating mode %s for %q: %s", mode, path, err)
+					}
+				case tar.TypeSymlink:
+					if err = os.Symlink(hdr.Linkname, path); err != nil {
+						helpers.Fatalf("error creating symlink %q -> %q: %s", path, hdr.Linkname, err)
+					}
+				default:
+					mode := hdr.FileInfo().Mode()
+					fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
+					if err != nil {
+						helpers.Fatalf("error creating file %q mode %s: %s", path, mode, err)
+					}
+
+					_, err = io.Copy(fp, tr)
+					if err != nil {
+						helpers.Fatalf("error copying data to %q: %s", path, err)
+					}
+
+					if err = fp.Close(); err != nil {
+						helpers.Fatalf("error closing %q: %s", path, err)
+					}
+
+					if err = os.Chmod(path, mode); err != nil {
+						helpers.Fatalf("error updating mode %s for %q: %s", mode, path, err)
+					}
+				}
+			}
+
+		})
+	},
+}
+
+func init() {
+	cpCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
+	rootCmd.AddCommand(cpCmd)
+}

--- a/internal/app/init/proto/api.proto
+++ b/internal/app/init/proto/api.proto
@@ -8,6 +8,7 @@ import "google/protobuf/timestamp.proto";
 
 // The Init service definition.
 service Init {
+  rpc CopyOut(CopyOutRequest) returns (stream StreamingData) {}
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
   rpc Upgrade(UpgradeRequest) returns (UpgradeReply) {}
@@ -58,3 +59,17 @@ message ServiceHealth {
 message StopRequest { string id = 1; }
 
 message StopReply { string resp = 1; }
+
+// StreamingData is used to stream back responses
+message StreamingData {
+  bytes bytes = 1;
+  string errors = 2;
+}
+
+// CopyOutRequest describes a request to copy data out of Talos node
+//
+// CopyOut produces .tar.gz archive which is streamed back to the caller
+message CopyOutRequest {
+  // Root path to start copying data out, it might be either a file or directory
+  string root_path = 1;
+}

--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package archiver provides a service to archive part of the filesystem into tar archive
+package archiver
+
+import (
+	"compress/gzip"
+	"context"
+	"io"
+)
+
+// TarGz produces .tar.gz archive of filesystem starting at rootPath
+func TarGz(ctx context.Context, rootPath string, output io.Writer) error {
+	paths, errCh, err := Walker(ctx, rootPath)
+	if err != nil {
+		return err
+	}
+
+	zw := gzip.NewWriter(output)
+	//nolint: errcheck
+	defer zw.Close()
+
+	err = Tar(ctx, paths, zw)
+	if err != nil {
+		return err
+	}
+
+	if err = <-errCh; err != nil {
+		return err
+	}
+
+	return zw.Close()
+}

--- a/internal/pkg/archiver/archiver_test.go
+++ b/internal/pkg/archiver/archiver_test.go
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package archiver provides a service to archive part of the filesystem into tar archive
+package archiver_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CommonSuite struct {
+	suite.Suite
+
+	tmpDir string
+}
+
+var filesFixture = []struct {
+	Path     string
+	Mode     os.FileMode
+	Contents []byte
+	Size     int
+}{
+	{
+		Path:     "/etc/hostname",
+		Mode:     0644,
+		Contents: []byte("localhost"),
+	},
+	{
+		Path:     "/etc/certs/ca.crt",
+		Mode:     0600,
+		Contents: []byte("-- CA PEM CERT -- VERY SECRET"),
+	},
+	{
+		Path: "/dev/random",
+		Mode: 0600 | os.ModeCharDevice,
+	},
+	{
+		Path:     "/usr/bin/cp",
+		Mode:     0755,
+		Contents: []byte("ELF EXECUTABLE IIRC"),
+	},
+	{
+		Path:     "/usr/bin/mv",
+		Mode:     0644 | os.ModeSymlink,
+		Contents: []byte("/usr/bin/cp"),
+	},
+	{
+		Path:     "/lib/dynalib.so",
+		Mode:     0644,
+		Contents: []byte("SOME LIBRARY OUT THERE"),
+		Size:     20 * 1024,
+	},
+}
+
+func (suite *CommonSuite) SetupSuite() {
+	var err error
+
+	suite.tmpDir, err = ioutil.TempDir("", "archiver")
+	suite.Require().NoError(err)
+
+	for _, file := range filesFixture {
+		suite.Require().NoError(os.MkdirAll(filepath.Join(suite.tmpDir, filepath.Dir(file.Path)), 0777))
+
+		if file.Mode&os.ModeSymlink != 0 {
+			suite.Require().NoError(os.Symlink(string(file.Contents), filepath.Join(suite.tmpDir, file.Path)))
+			continue
+		}
+
+		f, err := os.OpenFile(filepath.Join(suite.tmpDir, file.Path), os.O_CREATE|os.O_WRONLY, file.Mode)
+		suite.Require().NoError(err)
+
+		var contents []byte
+
+		if file.Size > 0 {
+			contents = bytes.Repeat(file.Contents, file.Size/len(file.Contents))
+			contents = append(contents, file.Contents[:file.Size-file.Size/len(file.Contents)*len(file.Contents)]...)
+		} else {
+			contents = file.Contents
+		}
+
+		_, err = f.Write(contents)
+		suite.Require().NoError(err)
+
+		suite.Require().NoError(f.Close())
+	}
+}
+
+func (suite *CommonSuite) TearDownSuite() {
+	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
+}

--- a/internal/pkg/archiver/tar.go
+++ b/internal/pkg/archiver/tar.go
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package archiver
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"log"
+	"os"
+)
+
+// Tar creates .tar archive and writes it to output for every item in paths channel
+//
+//nolint: gocyclo
+func Tar(ctx context.Context, paths <-chan FileItem, output io.Writer) error {
+	tw := tar.NewWriter(output)
+	//nolint: errcheck
+	defer tw.Close()
+
+	for fi := range paths {
+		header, err := tar.FileInfoHeader(fi.FileInfo, fi.Link)
+		if err != nil {
+			// not supported by tar
+			log.Printf("skipping %q: %s", fi.FullPath, err)
+			continue
+		}
+
+		header.Name = fi.RelPath
+		if fi.FileInfo.IsDir() {
+			header.Name += string(os.PathSeparator)
+		}
+
+		skipData := false
+
+		switch header.Typeflag {
+		case tar.TypeLink, tar.TypeSymlink, tar.TypeChar, tar.TypeBlock, tar.TypeDir, tar.TypeFifo:
+			// no data for these types, move on
+			skipData = true
+		}
+
+		if header.Size == 0 {
+			// skip files with zero length
+			//
+			// this might skip contents for special files in /proc, but
+			// anyways we can't archive them properly if we don't know size beforehand
+			skipData = true
+		}
+
+		var fp *os.File
+		if !skipData {
+			fp, err = os.Open(fi.FullPath)
+			if err != nil {
+				log.Printf("skipping %q: %s", fi.FullPath, err)
+				continue
+			}
+		}
+
+		err = tw.WriteHeader(header)
+		if err != nil {
+			//nolint: errcheck
+			fp.Close()
+			return err
+		}
+
+		if !skipData {
+			err = archiveFile(ctx, tw, fi, fp)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return tw.Close()
+}
+
+func archiveFile(ctx context.Context, tw io.Writer, fi FileItem, fp *os.File) error {
+	//nolint: errcheck
+	defer fp.Close()
+
+	buf := make([]byte, 4096)
+
+	for {
+		n, err := fp.Read(buf)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		_, err = tw.Write(buf[:n])
+		if err != nil {
+			if err == tar.ErrWriteTooLong {
+				log.Printf("ignoring long write for %q", fi.FullPath)
+				return nil
+			}
+			return err
+		}
+	}
+
+	return fp.Close()
+}

--- a/internal/pkg/archiver/tar_test.go
+++ b/internal/pkg/archiver/tar_test.go
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package archiver provides a service to archive part of the filesystem into tar archive
+package archiver_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/pkg/archiver"
+)
+
+type TarSuite struct {
+	CommonSuite
+}
+
+//nolint: gocyclo
+func (suite *TarSuite) TestArchiveDir() {
+	ch, errCh, err := archiver.Walker(context.Background(), suite.tmpDir)
+	suite.Require().NoError(err)
+
+	var buf bytes.Buffer
+
+	err = archiver.Tar(context.Background(), ch, &buf)
+	suite.Require().NoError(err)
+	suite.Require().NoError(<-errCh)
+
+	pathsSeen := map[string]struct{}{}
+
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		suite.Require().NoError(err)
+
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+
+		contents, err := ioutil.ReadAll(tr)
+		suite.Require().NoError(err)
+
+		found := false
+		for _, fi := range filesFixture {
+			if fi.Path[1:] == hdr.Name {
+				found = true
+				pathsSeen[fi.Path] = struct{}{}
+
+				switch {
+				case fi.Mode&os.ModeSymlink != 0:
+					suite.Require().Equal(string(fi.Contents), hdr.Linkname)
+				case fi.Size > 0:
+					suite.Require().Len(contents, fi.Size)
+				case fi.Contents != nil:
+					suite.Require().EqualValues(fi.Contents, contents)
+				default:
+					suite.Require().Len(contents, 0)
+				}
+			}
+		}
+
+		suite.Require().True(found, "file %q", hdr.Name)
+	}
+
+	for _, fi := range filesFixture {
+		_, ok := pathsSeen[fi.Path]
+		suite.Require().True(ok, "path %q", fi.Path)
+	}
+}
+
+func (suite *TarSuite) TestArchiveFile() {
+	ch, errCh, err := archiver.Walker(context.Background(), filepath.Join(suite.tmpDir, "/usr/bin/cp"))
+	suite.Require().NoError(err)
+
+	var buf bytes.Buffer
+
+	err = archiver.Tar(context.Background(), ch, &buf)
+	suite.Require().NoError(err)
+	suite.Require().NoError(<-errCh)
+
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		suite.Require().NoError(err)
+
+		expectedContents := []byte("ELF EXECUTABLE IIRC")
+
+		suite.Require().EqualValues(hdr.Typeflag, tar.TypeReg)
+		suite.Require().EqualValues(hdr.Name, "cp")
+		suite.Require().EqualValues(hdr.Size, len(expectedContents))
+
+		contents, err := ioutil.ReadAll(tr)
+		suite.Require().NoError(err)
+
+		suite.Require().Equal(expectedContents, contents)
+	}
+}
+
+func TestTarSuite(t *testing.T) {
+	suite.Run(t, new(TarSuite))
+}

--- a/internal/pkg/archiver/walker.go
+++ b/internal/pkg/archiver/walker.go
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package archiver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// FileItem is unit of work for archive
+type FileItem struct {
+	FullPath string
+	RelPath  string
+	FileInfo os.FileInfo
+	Link     string
+}
+
+// Walker provides a channel of file info/paths for archival
+//
+//nolint: gocyclo
+func Walker(ctx context.Context, rootPath string) (<-chan FileItem, <-chan error, error) {
+	_, err := os.Stat(rootPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ch := make(chan FileItem)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(ch)
+
+		multiErr := &multierror.Error{}
+
+		defer func() {
+			errCh <- multiErr.ErrorOrNil()
+		}()
+
+		err := filepath.Walk(rootPath, func(path string, fileInfo os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				multiErr = multierror.Append(multiErr, walkErr)
+				return nil
+			}
+
+			var (
+				relPath string
+				err     error
+			)
+
+			if path == rootPath {
+				if fileInfo.IsDir() {
+					// skip containing directory
+					return nil
+				}
+
+				// only one file
+				relPath = filepath.Base(path)
+			} else {
+				relPath, err = filepath.Rel(rootPath, path)
+				if err != nil {
+					return err
+				}
+			}
+
+			item := FileItem{
+				FullPath: path,
+				RelPath:  relPath,
+				FileInfo: fileInfo,
+			}
+
+			if fileInfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+				item.Link, err = os.Readlink(path)
+				if err != nil {
+					multiErr = multierror.Append(multiErr, fmt.Errorf("error reading symlink %q: %s", path, err))
+					return nil
+				}
+			}
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case ch <- item:
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			multiErr = multierror.Append(multiErr, err)
+		}
+
+	}()
+
+	return ch, errCh, nil
+}

--- a/internal/pkg/archiver/walker_test.go
+++ b/internal/pkg/archiver/walker_test.go
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package archiver provides a service to archive part of the filesystem into tar archive
+package archiver_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/pkg/archiver"
+)
+
+type WalkerSuite struct {
+	CommonSuite
+}
+
+func (suite *WalkerSuite) TestIterationDir() {
+	ch, errCh, err := archiver.Walker(context.Background(), suite.tmpDir)
+	suite.Require().NoError(err)
+
+	relPaths := []string(nil)
+
+	for fi := range ch {
+		relPaths = append(relPaths, fi.RelPath)
+
+		if fi.RelPath == "usr/bin/mv" {
+			suite.Assert().Equal("/usr/bin/cp", fi.Link)
+		}
+	}
+
+	suite.Require().NoError(<-errCh)
+
+	suite.Assert().Equal([]string{
+		"dev", "dev/random",
+		"etc", "etc/certs", "etc/certs/ca.crt", "etc/hostname",
+		"lib", "lib/dynalib.so",
+		"usr", "usr/bin", "usr/bin/cp", "usr/bin/mv"},
+		relPaths)
+}
+
+func (suite *WalkerSuite) TestIterationFile() {
+	ch, errCh, err := archiver.Walker(context.Background(), filepath.Join(suite.tmpDir, "usr/bin/cp"))
+	suite.Require().NoError(err)
+
+	relPaths := []string(nil)
+
+	for fi := range ch {
+		relPaths = append(relPaths, fi.RelPath)
+	}
+
+	suite.Require().NoError(<-errCh)
+
+	suite.Assert().Equal([]string{"cp"},
+		relPaths)
+}
+
+func (suite *WalkerSuite) TestIterationNotFound() {
+	_, _, err := archiver.Walker(context.Background(), filepath.Join(suite.tmpDir, "doesntlivehere"))
+	suite.Require().Error(err)
+}
+
+func TestWalkerSuite(t *testing.T) {
+	suite.Run(t, new(WalkerSuite))
+}


### PR DESCRIPTION
Actual API is implemented in the `init`, as it has access to root
filesystem. `osd` proxies API back to `init` with some tricks to support
grpc streaming.

Given some absolute path, `init` produces and streams back .tar.gz
archive with filesystem contents.

`osctl cp` works in two modes. First mode streams data to stdout, so
that we can do e.g.: `osctl cp /etc - | tar tz`. Second mode extracts
archive to specified location, dropping ownership info and adjusting
permissions a bit. Timestamps are not preserved.

If full dump with owner/permisisons is required, it's better to stream
data to `tar xz`, for quick and dirty look into filesystem contents
under unprivileged user it's easier to use in-place extraction.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>