### PR TITLE
chore: don't run tests in parallel across packages

### DIFF
--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -6,12 +6,12 @@ CGO_ENABLED=1
 
 perform_tests() {
   echo "Performing tests"
-  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt -p 4 ./...
+  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt -p 1 ./...
 }
 
 perform_short_tests() {
   echo "Performing short tests"
-  go test -v -short ./...
+  go test -v -short -p 1 ./...
 }
 
 case $1 in


### PR DESCRIPTION
We run tests in parallel mode (`go test -p 4`), default is to run in
parallel in fact. But tests are not isolated, as some of them launch
containerd on a fixed file socket (as socket path is hardcoded in
Talos), and that might lead to any weirdness when tests try to
launch containerd concurrently on the same file socket.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>