### PR TITLE
feat(init): move 'ls' API to init from osd

### DIFF
--- a/cmd/osctl/cmd/ls.go
+++ b/cmd/osctl/cmd/ls.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/app/osd/proto"
+	initproto "github.com/talos-systems/talos/internal/app/init/proto"
 )
 
 // lsCmd represents the ls command
@@ -45,7 +45,7 @@ var lsCmd = &cobra.Command{
 				helpers.Fatalf("failed to parse depth flag: %v", err)
 			}
 
-			stream, err := c.LS(globalCtx, proto.LSRequest{
+			stream, err := c.LS(globalCtx, initproto.LSRequest{
 				Root:           rootDir,
 				Recurse:        recurse,
 				RecursionDepth: recursionDepth,

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -225,8 +225,8 @@ func (c *Client) DF(ctx context.Context) (*proto.DFReply, error) {
 }
 
 // LS implements the proto.OSDClient interface.
-func (c *Client) LS(ctx context.Context, req proto.LSRequest) (stream proto.OSD_LSClient, err error) {
-	return c.client.LS(ctx, &req)
+func (c *Client) LS(ctx context.Context, req initproto.LSRequest) (stream initproto.Init_LSClient, err error) {
+	return c.initClient.LS(ctx, &req)
 }
 
 // CopyOut implements the proto.OSDClient interface

--- a/internal/app/init/internal/reg/reg.go
+++ b/internal/app/init/internal/reg/reg.go
@@ -8,7 +8,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -22,6 +24,9 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/upgrade"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
+
+// OSPathSeparator is the string version of the os.PathSeparator
+const OSPathSeparator = string(os.PathSeparator)
 
 // Registrator is the concrete type that implements the factory.Registrator and
 // proto.Init interfaces.
@@ -168,4 +173,66 @@ func (r *Registrator) CopyOut(req *proto.CopyOutRequest, s proto.Init_CopyOutSer
 	}
 
 	return nil
+}
+
+// LS implements the proto.InitServer interface.
+func (r *Registrator) LS(req *proto.LSRequest, s proto.Init_LSServer) error {
+
+	if req == nil {
+		req = new(proto.LSRequest)
+	}
+	if !strings.HasPrefix(req.Root, OSPathSeparator) {
+		// Make sure we use complete paths
+		req.Root = OSPathSeparator + req.Root
+	}
+	req.Root = strings.TrimSuffix(req.Root, OSPathSeparator)
+	if req.Root == "" {
+		req.Root = "/"
+	}
+
+	var maxDepth int
+	if req.Recurse {
+		if req.RecursionDepth == 0 {
+			maxDepth = -1
+		} else {
+			maxDepth = int(req.RecursionDepth)
+		}
+	}
+
+	return filepath.Walk(req.Root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Send errors upstream so that we do not abort the path walk
+			return s.Send(&proto.FileInfo{
+				Name:  path,
+				Error: err.Error(),
+			})
+		}
+
+		err = s.Send(&proto.FileInfo{
+			Name:     path,
+			Size:     info.Size(),
+			Mode:     uint32(info.Mode()),
+			Modified: info.ModTime().Unix(),
+			IsDir:    info.IsDir(),
+		})
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() && atMaxDepth(maxDepth, req.Root, path) {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+}
+
+func atMaxDepth(max int, root, cur string) bool {
+	if max < 0 {
+		return false
+	}
+	if root == cur {
+		// always recurse the root directory
+		return false
+	}
+	return (strings.Count(cur, OSPathSeparator) - strings.Count(root, OSPathSeparator)) >= max
 }

--- a/internal/app/init/proto/api.proto
+++ b/internal/app/init/proto/api.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 // The Init service definition.
 service Init {
   rpc CopyOut(CopyOutRequest) returns (stream StreamingData) {}
+  rpc LS(LSRequest) returns (stream FileInfo) {}
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
   rpc Upgrade(UpgradeRequest) returns (UpgradeReply) {}
@@ -72,4 +73,39 @@ message StreamingData {
 message CopyOutRequest {
   // Root path to start copying data out, it might be either a file or directory
   string root_path = 1;
+}
+
+// LSRequest describes a request to list the contents of a directory
+message LSRequest {
+
+  // Root indicates the root directory for the list.  If not indicated, '/' is presumed.
+  string root = 1;
+
+  // Recurse indicates that subdirectories should be recursed.
+  bool recurse = 2;
+
+  // RecursionDepth indicates how many levels of subdirectories should be recursed.  The default (0) indicates that no limit should be enforced.
+  int32 recursion_depth = 3;
+}
+
+// FileInfo describes a file or directory's information
+message FileInfo {
+
+  // Name is the name (including prefixed path) of the file or directory
+  string name = 1;
+
+  // Size indicates the number of bytes contained within the file
+  int64 size = 2;
+
+  // Mode is the bitmap of UNIX mode/permission flags of the file
+  uint32 mode = 3;
+
+  // Modified indicates the UNIX timestamp at which the file was last modified
+  int64 modified = 4; // TODO: unix timestamp or include proto's Date type
+
+  // IsDir indicates that the file is a directory
+  bool is_dir = 5;
+
+  // Error describes any error encountered while trying to read the file information.
+  string error = 6;
 }

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -54,15 +54,9 @@ func (c *InitServiceClient) ServiceList(ctx context.Context, empty *empty.Empty)
 	return c.InitClient.ServiceList(ctx, empty)
 }
 
-// CopyOut executes the init CopyOut() API.
-func (c *InitServiceClient) CopyOut(req *proto.CopyOutRequest, srv proto.Init_CopyOutServer) error {
-	client, err := c.InitClient.CopyOut(srv.Context(), req)
-	if err != nil {
-		return err
-	}
-
+func copyClientServer(msg interface{}, client grpc.ClientStream, srv grpc.ServerStream) error {
 	for {
-		msg, err := client.Recv()
+		err := client.RecvMsg(msg)
 		if err == io.EOF {
 			break
 		}
@@ -76,4 +70,28 @@ func (c *InitServiceClient) CopyOut(req *proto.CopyOutRequest, srv proto.Init_Co
 	}
 
 	return nil
+}
+
+// CopyOut executes the init CopyOut() API.
+func (c *InitServiceClient) CopyOut(req *proto.CopyOutRequest, srv proto.Init_CopyOutServer) error {
+	client, err := c.InitClient.CopyOut(srv.Context(), req)
+	if err != nil {
+		return err
+	}
+
+	var msg proto.StreamingData
+
+	return copyClientServer(&msg, client, srv)
+}
+
+// LS executes the init LS() API.
+func (c *InitServiceClient) LS(req *proto.LSRequest, srv proto.Init_LSServer) error {
+	client, err := c.InitClient.LS(srv.Context(), req)
+	if err != nil {
+		return err
+	}
+
+	var msg proto.FileInfo
+
+	return copyClientServer(&msg, client, srv)
 }

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -43,9 +43,6 @@ import (
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
-// OSPathSeparator is the string version of the os.PathSeparator
-const OSPathSeparator = string(os.PathSeparator)
-
 // Registrator is the concrete type that implements the factory.Registrator and
 // proto.OSDServer interfaces.
 type Registrator struct {
@@ -453,58 +450,6 @@ func (r *Registrator) DF(ctx context.Context, in *empty.Empty) (reply *proto.DFR
 
 	return reply, multiErr.ErrorOrNil()
 }
-
-// LS implements the proto.OSDServer interface.
-func (r *Registrator) LS(req *proto.LSRequest, s proto.OSD_LSServer) error {
-
-	if req == nil {
-		req = new(proto.LSRequest)
-	}
-	if !strings.HasPrefix(req.Root, OSPathSeparator) {
-		// Make sure we use complete paths
-		req.Root = OSPathSeparator + req.Root
-	}
-	req.Root = strings.TrimSuffix(req.Root, OSPathSeparator)
-	if req.Root == "" {
-		req.Root = "/"
-	}
-
-	var maxDepth int
-	if req.Recurse {
-		if req.RecursionDepth == 0 {
-			maxDepth = -1
-		} else {
-			maxDepth = int(req.RecursionDepth)
-		}
-	}
-
-	return filepath.Walk(req.Root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			// Send errors upstream so that we do not abort the path walk
-			return s.Send(&proto.FileInfo{
-				Name:  path,
-				Error: err.Error(),
-			})
-		}
-
-		err = s.Send(&proto.FileInfo{
-			Name:     path,
-			Size:     info.Size(),
-			Mode:     uint32(info.Mode()),
-			Modified: info.ModTime().Unix(),
-			IsDir:    info.IsDir(),
-		})
-		if err != nil {
-			return err
-		}
-
-		if info.IsDir() && atMaxDepth(maxDepth, req.Root, path) {
-			return filepath.SkipDir
-		}
-		return nil
-	})
-}
-
 func k8slogs(ctx context.Context, req *proto.LogsRequest) (chunker.Chunker, io.Closer, error) {
 	inspector, err := containers.NewInspector(ctx, req.Namespace)
 	if err != nil {
@@ -522,15 +467,4 @@ func k8slogs(ctx context.Context, req *proto.LogsRequest) (chunker.Chunker, io.C
 	}
 
 	return container.GetLogChunker()
-}
-
-func atMaxDepth(max int, root, cur string) bool {
-	if max < 0 {
-		return false
-	}
-	if root == cur {
-		// always recurse the root directory
-		return false
-	}
-	return (strings.Count(cur, OSPathSeparator) - strings.Count(root, OSPathSeparator)) >= max
 }

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -13,7 +13,6 @@ service OSD {
   rpc Dmesg(google.protobuf.Empty) returns (Data) {}
   rpc Kubeconfig(google.protobuf.Empty) returns (Data) {}
   rpc Logs(LogsRequest) returns (stream Data) {}
-  rpc LS(LSRequest) returns (stream FileInfo) {}
   rpc Processes(ProcessesRequest) returns (ProcessesReply) {}
   rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
   rpc Restart(RestartRequest) returns (RestartReply) {}
@@ -99,38 +98,3 @@ message DFStat {
   uint64 available = 3;
   string mounted_on = 4;
 }
-
-// LSRequest describes a request to list the contents of a directory
-message LSRequest {
-
-  // Root indicates the root directory for the list.  If not indicated, '/' is presumed.
-  string root = 1;
-
-  // Recurse indicates that subdirectories should be recursed.
-  bool recurse = 2;
-
-  // RecursionDepth indicates how many levels of subdirectories should be recursed.  The default (0) indicates that no limit should be enforced.
-  int32 recursion_depth = 3;
-}
-
-// FileInfo describes a file or directory's information
-message FileInfo {
-
-  // Name is the name (including prefixed path) of the file or directory
-  string name = 1;
-
-  // Size indicates the number of bytes contained within the file
-  int64 size = 2;
-
-  // Mode is the bitmap of UNIX mode/permission flags of the file
-  uint32 mode = 3;
-
-  // Modified indicates the UNIX timestamp at which the file was last modified
-  int64 modified = 4; // TODO: unix timestamp or include proto's Date type
-
-  // IsDir indicates that the file is a directory
-  bool is_dir = 5;
-
-  // Error describes any error encountered while trying to read the file information.
-  string error = 6;
-} 


### PR DESCRIPTION
Service `osd` doesn't have access to rootfs, as it is running in a
container, so move API to `init` which has unconstrained access to
rootfs. (This is in line with another API, `osctl cp`).

Fixes: #752

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>