### PR TITLE
feat(osd): extend Routes API

### DIFF
--- a/cmd/osctl/cmd/routes.go
+++ b/cmd/osctl/cmd/routes.go
@@ -40,9 +40,9 @@ var routesCmd = &cobra.Command{
 
 func routesRender(reply *proto.RoutesReply) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "INTERFACE\tDESTINATION\tGATEWAY")
+	fmt.Fprintln(w, "INTERFACE\tDESTINATION\tGATEWAY\tMETRIC")
 	for _, r := range reply.Routes {
-		fmt.Fprintf(w, "%s\t%s\t%s\n", r.Interface, r.Destination, r.Gateway)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", r.Interface, r.Destination, r.Gateway, r.Metric)
 	}
 	helpers.Should(w.Flush())
 }

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a
 	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a h1:84IpUNXj4mCR9CuCEvSiCArMbzr/TMbuPIadKDwypkI=
+github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be h1:AHimNtVIpiBjPUhEF5KNCkrUyqTSA5zWUl8sQ2bfGBE=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -103,6 +105,7 @@ github.com/mdlayher/kobject v0.0.0-20190419142510-b96c97ecd94c h1:s14yMY3JN4o8mZ
 github.com/mdlayher/kobject v0.0.0-20190419142510-b96c97ecd94c/go.mod h1:JN5xYMYTkQk5BRB+kbsYTwtLAsIi550X3JzghwUSR4I=
 github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c h1:qYXI+3AN4zBWsTF5drEu1akWPu2juaXPs58tZ4/GaCg=
 github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
 github.com/mdlayher/netlink v0.0.0-20190419142405-71c9566a34ae h1:Ec6B7pKh4YZyKI9VtTeZmN1GGLvAIT/fs2votDcWnMU=
 github.com/mdlayher/netlink v0.0.0-20190419142405-71c9566a34ae/go.mod h1:TR9n0u8mie4+iszGTMjP6QRwUZQNynkhDbXTLF6DUi4=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
@@ -194,6 +197,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313 h1:pczuHS43Cp2ktBEEmLwScxgjWsBSzdaQiKzUyf3DTTc=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190418153312-f0ce4c0180be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190508220229-2d0786266e9c h1:hDn6jm7snBX2O7+EeTk6Q4WXJfKt7MWgtiCCRi1rBoY=

--- a/internal/app/osd/internal/reg/reg_test.go
+++ b/internal/app/osd/internal/reg/reg_test.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestToCIDR(t *testing.T) {
+	assert.Equal(t, toCIDR(unix.AF_INET, net.ParseIP("192.168.254.0"), 24), "192.168.254.0/24")
+	assert.Equal(t, toCIDR(unix.AF_INET6, net.ParseIP("2001:db8::"), 16), "2001:db8::/16")
+}

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -77,9 +77,61 @@ message RoutesReply { repeated Route routes = 1; }
 
 // The response message containing a route.
 message Route {
+
+  // Interface is the interface over which traffic to this destination should be sent
   string interface = 1;
+
+  // Destination is the network prefix CIDR which this route provides
   string destination = 2;
+
+  // Gateway is the gateway address to which traffic to this destination should be sent
   string gateway = 3;
+  
+  // Metric is the priority of the route, where lower metrics have higher priorities
+  uint32 metric = 4;
+
+  // Scope desribes the scope of this route
+  uint32 scope = 5;
+
+  // Source is the source prefix CIDR for the route, if one is defined
+  string source = 6;
+
+  // Family is the address family of the route.  Currently, the only options are AF_INET (IPV4) and AF_INET6 (IPV6).
+  AddressFamily family = 7;
+
+  // Protocol is the protocol by which this route came to be in place
+  RouteProtocol protocol = 8;
+
+  // Flags indicate any special flags on the route
+  uint32 flags = 9;
+}
+
+enum AddressFamily {
+   option allow_alias = true;
+   AF_UNSPEC = 0x0;
+   AF_INET = 0x2;
+   IPV4 = 0x2;
+   AF_INET6 = 0xa;
+   IPV6 = 0xa;
+}
+
+enum RouteProtocol {
+   RTPROT_UNSPEC = 0;
+   RTPROT_REDIRECT = 1;  // Route installed by ICMP redirects
+   RTPROT_KERNEL = 2;    // Route installed by kernel
+   RTPROT_BOOT = 3;      // Route installed during boot
+   RTPROT_STATIC = 4;    // Route installed by administrator
+   RTPROT_GATED = 8;     // Route installed by gated
+   RTPROT_RA = 9;        // Route installed by router advertisement
+   RTPROT_MRT = 10;      // Route installed by Merit MRT
+   RTPROT_ZEBRA = 11;    // Route installed by Zebra/Quagga
+   RTPROT_BIRD = 12;     // Route installed by Bird
+   RTPROT_DNROUTED = 13; // Route installed by DECnet routing daemon
+   RTPROT_XORP = 14;     // Route installed by XORP
+   RTPROT_NTK = 15;      // Route installed by Netsukuku
+   RTPROT_DHCP = 16;     // Route installed by DHCP
+   RTPROT_MROUTED = 17;  // Route installed by Multicast daemon
+   RTPROT_BABEL = 42;    // Route installed by Babel daemon
 }
 
 message TopRequest {}


### PR DESCRIPTION
- Add support for IPv6, route metrics, protocols, sources, families.
- Fix destination string format to be CIDR.

Fixes #753

Signed-off-by: Seán C McCord <ulexus@gmail.com>