### PR TITLE
chore: Add ready plugin to coredns

### DIFF
--- a/hack/dev/manifests/coredns.yaml
+++ b/hack/dev/manifests/coredns.yaml
@@ -14,6 +14,7 @@ data:
         cache 30
         loop
         reload
+        ready
         loadbalance
     }
 kind: ConfigMap


### PR DESCRIPTION
Enables ready plugin to handle coredns upgrade to 1.5

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>