### PR TITLE
chore: remove ready plugin from CoreDNS

### DIFF
--- a/hack/dev/manifests/coredns.yaml
+++ b/hack/dev/manifests/coredns.yaml
@@ -13,7 +13,6 @@ data:
         forward . 1.1.1.1 8.8.8.8
         cache 30
         loop
-        ready
         reload
         loadbalance
     }


### PR DESCRIPTION
This plugin is not available in CoreDNS v1.3.1

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>