### PR TITLE
feat(init): unify filesystem walkers for `ls`/`cp` APIs

### DIFF
--- a/cmd/osctl/cmd/cp.go
+++ b/cmd/osctl/cmd/cp.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -42,11 +43,17 @@ captures ownership and permission bits.`,
 				helpers.Fatalf("error copying: %s", err)
 			}
 
+			var wg sync.WaitGroup
+
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				for err := range errCh {
 					fmt.Fprintln(os.Stderr, err.Error())
 				}
 			}()
+
+			defer wg.Wait()
 
 			localPath := args[1]
 

--- a/cmd/osctl/cmd/ls.go
+++ b/cmd/osctl/cmd/ls.go
@@ -61,12 +61,12 @@ var lsCmd = &cobra.Command{
 						if err == io.EOF || status.Code(err) == codes.Canceled {
 							return
 						}
-						helpers.Fatalf("error streaming logs: %s", err)
+						helpers.Fatalf("error streaming results: %s", err)
 					}
 					if info.Error != "" {
 						fmt.Fprintf(os.Stderr, "error reading file %s: %s\n", info.Name, info.Error)
 					} else {
-						fmt.Println(info.Name)
+						fmt.Println(info.RelativeName)
 					}
 				}
 			}
@@ -80,17 +80,21 @@ var lsCmd = &cobra.Command{
 						helpers.Should(w.Flush())
 						return
 					}
-					helpers.Fatalf("error streaming logs: %s", err)
+					helpers.Fatalf("error streaming results: %s", err)
 				}
 
 				if info.Error != "" {
 					fmt.Fprintf(os.Stderr, "error reading file %s: %s\n", info.Name, info.Error)
 				} else {
+					name := info.RelativeName
+					if info.Link != "" {
+						name += " -> " + info.Link
+					}
 					fmt.Fprintf(w, "%s\t%d\t%s\t%s\n",
 						os.FileMode(info.Mode).String(),
 						info.Size,
 						time.Unix(info.Modified, 0).Format("Jan 2 2006"),
-						info.Name,
+						name,
 					)
 				}
 			}

--- a/internal/app/init/proto/api.proto
+++ b/internal/app/init/proto/api.proto
@@ -108,4 +108,10 @@ message FileInfo {
 
   // Error describes any error encountered while trying to read the file information.
   string error = 6;
+
+  // Link is filled with symlink target
+  string link = 7;
+
+  // RelativeName is the name of the file or directory relative to the RootPath
+  string relative_name = 8;
 }

--- a/internal/pkg/archiver/archiver.go
+++ b/internal/pkg/archiver/archiver.go
@@ -13,7 +13,7 @@ import (
 
 // TarGz produces .tar.gz archive of filesystem starting at rootPath
 func TarGz(ctx context.Context, rootPath string, output io.Writer) error {
-	paths, errCh, err := Walker(ctx, rootPath)
+	paths, err := Walker(ctx, rootPath, WithSkipRoot())
 	if err != nil {
 		return err
 	}
@@ -24,10 +24,6 @@ func TarGz(ctx context.Context, rootPath string, output io.Writer) error {
 
 	err = Tar(ctx, paths, zw)
 	if err != nil {
-		return err
-	}
-
-	if err = <-errCh; err != nil {
 		return err
 	}
 

--- a/internal/pkg/archiver/tar_test.go
+++ b/internal/pkg/archiver/tar_test.go
@@ -25,14 +25,13 @@ type TarSuite struct {
 
 //nolint: gocyclo
 func (suite *TarSuite) TestArchiveDir() {
-	ch, errCh, err := archiver.Walker(context.Background(), suite.tmpDir)
+	ch, err := archiver.Walker(context.Background(), suite.tmpDir)
 	suite.Require().NoError(err)
 
 	var buf bytes.Buffer
 
 	err = archiver.Tar(context.Background(), ch, &buf)
 	suite.Require().NoError(err)
-	suite.Require().NoError(<-errCh)
 
 	pathsSeen := map[string]struct{}{}
 
@@ -80,14 +79,13 @@ func (suite *TarSuite) TestArchiveDir() {
 }
 
 func (suite *TarSuite) TestArchiveFile() {
-	ch, errCh, err := archiver.Walker(context.Background(), filepath.Join(suite.tmpDir, "/usr/bin/cp"))
+	ch, err := archiver.Walker(context.Background(), filepath.Join(suite.tmpDir, "/usr/bin/cp"))
 	suite.Require().NoError(err)
 
 	var buf bytes.Buffer
 
 	err = archiver.Tar(context.Background(), ch, &buf)
 	suite.Require().NoError(err)
-	suite.Require().NoError(<-errCh)
 
 	tr := tar.NewReader(&buf)
 	for {


### PR DESCRIPTION
This unifies low-level filesystem walker code for `ls` and `cp`.

New features:

* `ls` now reports relative filenames
* `ls` now prints symlink destination for symlinks
* `cp` now properly always reports errors from the API
* `cp` now reports all the errors back to the client

Example for `ls`:

```
osctl-linux-amd64 --talosconfig talosconfig ls -l /var
MODE          SIZE(B)   LASTMOD       NAME
drwxr-xr-x    4096      Jun 26 2019   .
Lrwxrwxrwx    4         Jun 25 2019   etc -> /etc
drwxr-xr-x    4096      Jun 26 2019   lib
drwxr-xr-x    4096      Jun 21 2019   libexec
drwxr-xr-x    4096      Jun 26 2019   log
drwxr-xr-x    4096      Jun 21 2019   mail
drwxr-xr-x    4096      Jun 26 2019   opt
Lrwxrwxrwx    6         Jun 21 2019   run -> ../run
drwxr-xr-x    4096      Jun 21 2019   spool
dtrwxrwxrwx   4096      Jun 21 2019   tmp
-rw-------    14979     Jun 26 2019   userdata.yaml
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>