### PR TITLE
feat(osctl): improve output of `stats` and `ps` commands

### DIFF
--- a/cmd/osctl/cmd/ls.go
+++ b/cmd/osctl/cmd/ls.go
@@ -86,15 +86,15 @@ var lsCmd = &cobra.Command{
 				if info.Error != "" {
 					fmt.Fprintf(os.Stderr, "error reading file %s: %s\n", info.Name, info.Error)
 				} else {
-					name := info.RelativeName
+					display := info.RelativeName
 					if info.Link != "" {
-						name += " -> " + info.Link
+						display += " -> " + info.Link
 					}
 					fmt.Fprintf(w, "%s\t%d\t%s\t%s\n",
 						os.FileMode(info.Mode).String(),
 						info.Size,
 						time.Unix(info.Modified, 0).Format("Jan 2 2006"),
-						name,
+						display,
 					)
 				}
 			}

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -95,11 +95,13 @@ func (r *Registrator) Processes(ctx context.Context, in *proto.ProcessesRequest)
 
 	processes := []*proto.Process{}
 
-	for _, containers := range pods {
-		for _, container := range containers.Containers {
+	for _, pod := range pods {
+		for _, container := range pod.Containers {
 			process := &proto.Process{
 				Namespace: in.Namespace,
 				Id:        container.Display,
+				PodId:     pod.Name,
+				Name:      container.Name,
 				Image:     container.Image,
 				Pid:       container.Pid,
 				Status:    strings.ToUpper(string(container.Status.Status)),
@@ -134,8 +136,8 @@ func (r *Registrator) Stats(ctx context.Context, in *proto.StatsRequest) (reply 
 
 	stats := []*proto.Stat{}
 
-	for _, containers := range pods {
-		for _, container := range containers.Containers {
+	for _, pod := range pods {
+		for _, container := range pod.Containers {
 			if container.Metrics == nil {
 				continue
 			}
@@ -163,6 +165,8 @@ func (r *Registrator) Stats(ctx context.Context, in *proto.StatsRequest) (reply 
 			stat := &proto.Stat{
 				Namespace:   in.Namespace,
 				Id:          container.Display,
+				PodId:       pod.Name,
+				Name:        container.Name,
 				MemoryUsage: used,
 				CpuUsage:    data.CPU.Usage.Total,
 			}

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -35,6 +35,8 @@ message Process {
   string image = 3;
   uint32 pid = 4;
   string status = 5;
+  string pod_id = 6;
+  string name = 7;
 }
 
 // The request message containing the containerd namespace.
@@ -49,6 +51,8 @@ message Stat {
   string id = 2;
   uint64 memory_usage = 4;
   uint64 cpu_usage = 5;
+  string pod_id = 6;
+  string name = 7;
 }
 
 // The request message containing the process to restart.
@@ -86,7 +90,7 @@ message Route {
 
   // Gateway is the gateway address to which traffic to this destination should be sent
   string gateway = 3;
-  
+
   // Metric is the priority of the route, where lower metrics have higher priorities
   uint32 metric = 4;
 


### PR DESCRIPTION
Sort output so that sandboxes and containers go together, use tree-like
characters to display relationships for them. (No change for talos
namespace):

```
$ osctl ps -k
NAMESPACE   ID                                                                        IMAGE                          PID   STATUS
k8s.io      kube-system/etcd-master-1                                                 k8s.gcr.io/pause:3.1           649   RUNNING
k8s.io      └─ kube-system/etcd-master-1:etcd                                         k8s.gcr.io/etcd:3.3.10         875   RUNNING
k8s.io      kube-system/kube-apiserver-master-1                                       k8s.gcr.io/pause:3.1           685   RUNNING
k8s.io      └─ kube-system/kube-apiserver-master-1:kube-apiserver                     k8s.gcr.io/hyperkube:v1.15.0   886   RUNNING
k8s.io      kube-system/kube-controller-manager-master-1                              k8s.gcr.io/pause:3.1           715   RUNNING
k8s.io      └─ kube-system/kube-controller-manager-master-1:kube-controller-manager   k8s.gcr.io/hyperkube:v1.15.0   872   RUNNING
k8s.io      kube-system/kube-scheduler-master-1                                       k8s.gcr.io/pause:3.1           731   RUNNING
k8s.io      └─ kube-system/kube-scheduler-master-1:kube-scheduler                     k8s.gcr.io/hyperkube:v1.15.0   898   RUNNING
k8s.io      kubelet                                                                   k8s.gcr.io/hyperkube:v1.15.0   537   RUNNING
```

```
$ osctl stats -k
NAMESPACE   ID                                                                        MEMORY(MB)   CPU
k8s.io      kube-system/etcd-master-1                                                 1.08         16911079
k8s.io      └─ kube-system/etcd-master-1:etcd                                         27.35        2464704677
k8s.io      kube-system/kube-apiserver-master-1                                       1.25         9753798
k8s.io      └─ kube-system/kube-apiserver-master-1:kube-apiserver                     214.04       7153017388
k8s.io      kube-system/kube-controller-manager-master-1                              1.21         9149420
k8s.io      └─ kube-system/kube-controller-manager-master-1:kube-controller-manager   31.70        2265963330
k8s.io      kube-system/kube-scheduler-master-1                                       1.09         11464745
k8s.io      └─ kube-system/kube-scheduler-master-1:kube-scheduler                     20.32        1290264912
k8s.io      kubelet                                                                   64.00        1558387645
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>