### PR TITLE
test(proxyd): Add basic suite of tests

### DIFF
--- a/internal/app/proxyd/internal/frontend/frontend_test.go
+++ b/internal/app/proxyd/internal/frontend/frontend_test.go
@@ -2,13 +2,162 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package frontend_test
+package frontend
 
-import "testing"
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/proxyd/internal/backend"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type ProxydSuite struct {
+	suite.Suite
+}
+
+func TestFrontendSuite(t *testing.T) {
+	// Hide all our state transition messages
+	log.SetOutput(ioutil.Discard)
+	suite.Run(t, new(ProxydSuite))
+}
+
+func (suite *ProxydSuite) TestWatch() {
+	_, cancel := context.WithCancel(context.Background())
+	r, err := NewReverseProxy([]string{"127.0.0.1"}, cancel)
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	// Generate a simple pod
+	p := genPod()
+
+	// Create our fake k8s client
+	client := fake.NewSimpleClientset()
+	// nolint: errcheck
+	go r.Watch(client)
+
+	output := make(chan string)
+	go func() {
+		var be map[string]*backend.Backend
+		for {
+			be = r.Backends()
+			if _, ok := be[string(p.UID)]; ok {
+				output <- be[string(p.UID)].UID
+			}
+		}
+	}()
+
+	// Verify we have a bootstrap backend
+	_, err = client.CoreV1().Pods(metav1.NamespaceSystem).Create(p)
+	suite.Assert().NoError(err)
+
+	timeout := time.NewTicker(time.Second * 5)
+	select {
+	case <-timeout.C:
+		suite.T().Error("failed to get updated backend")
+	case uid := <-output:
+		suite.Equal(string(p.UID), uid)
+	}
+}
+
+func (suite *ProxydSuite) TestAddFunc() {
+	_, cancel := context.WithCancel(context.Background())
+	r, err := NewReverseProxy([]string{"127.0.0.1"}, cancel)
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	for i := 0; i < 5; i++ {
+		r.AddFunc()(genPod())
+	}
+
+	bes := r.Backends()
+
+	// Ensure bootstrap backend was removed
+	_, bootstrap := bes["bootstrap"]
+	suite.Equal(bootstrap, false)
+
+	// Verify we have the appropriate number of new backends
+	suite.Equal(len(bes), 5)
+}
+
+func (suite *ProxydSuite) TestDeleteFunc() {
+	_, cancel := context.WithCancel(context.Background())
+	r, err := NewReverseProxy([]string{"127.0.0.1"}, cancel)
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	// Add some sample backends
+	pods := make([]*v1.Pod, 5)
+	for i := 0; i < 5; i++ {
+		pods[i] = genPod()
+	}
+	for _, pod := range pods {
+		r.AddFunc()(pod)
+	}
+	// Delete all sample backends
+	for _, pod := range pods {
+		r.DeleteFunc()(pod)
+	}
+
+	bes := r.Backends()
+	suite.Equal(len(bes), 0)
+}
+
+func (suite *ProxydSuite) TestUpdateFunc() {
+	_, cancel := context.WithCancel(context.Background())
+	r, err := NewReverseProxy([]string{"127.0.0.1"}, cancel)
+	suite.Assert().NoError(err)
+	defer r.Shutdown()
+
+	// Add some sample backend
+	pod := genPod()
+	r.AddFunc()(pod)
+
+	// Generate a new UID for the pod to simulate(?) a
+	// pod getting updated
+	oldpod := *pod
+
+	r.UpdateFunc()(&oldpod, pod)
+
+	bes := r.Backends()
+
+	suite.Equal(len(bes), 1)
+}
+
+func genPod() (p *v1.Pod) {
+	id := rand.Intn(255)
+
+	labels := map[string]string{}
+	labels["component"] = "kube-apiserver"
+
+	p = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "fakeapi-" + strconv.Itoa(id),
+			Labels: labels,
+			UID:    types.UID(uuid.New().String()),
+		},
+		Status: v1.PodStatus{
+			PodIP: "127.0.0." + strconv.Itoa(id),
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Ready: true,
+				},
+			},
+			Phase: v1.PodRunning,
+		},
+	}
+
+	// PodPhase= PodRunning
+	return p
 }

--- a/internal/app/proxyd/main.go
+++ b/internal/app/proxyd/main.go
@@ -5,11 +5,17 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 
+	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
 	"github.com/talos-systems/talos/pkg/userdata"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	pkgnet "github.com/talos-systems/talos/internal/pkg/net"
 )
 
 var (
@@ -28,16 +34,53 @@ func main() {
 		log.Fatalf("open user data: %v", err)
 	}
 
-	r, err := frontend.NewReverseProxy(data.Services.Trustd.Endpoints)
+	bootstrapCtx, bootstrapCancel := context.WithCancel(context.Background())
+	r, err := frontend.NewReverseProxy(data.Services.Trustd.Endpoints, bootstrapCancel)
 	if err != nil {
 		log.Fatalf("failed to initialize the reverse proxy: %v", err)
 	}
 
-	// nolint: errcheck
-	go r.Listen(":443")
+	// Start up with initial bootstrap config
+	go r.Bootstrap(bootstrapCtx)
 
 	// nolint: errcheck
-	r.Watch()
+	go func() {
+		kubeconfig := "/etc/kubernetes/admin.conf"
+		if err = conditions.WaitForFilesToExist(kubeconfig).Wait(context.Background()); err != nil {
+			log.Fatalf("failed to find %s: %v", kubeconfig, err)
+		}
+
+		config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			log.Fatalf("failed to read config %s: %v", kubeconfig, err)
+		}
+
+		// Discover local non loopback ips
+		ips, err := pkgnet.IPAddrs()
+		if err != nil {
+			log.Fatalf("failed to get local address: %v", err)
+		}
+		if len(ips) == 0 {
+			log.Fatalf("no IP address found for local api server")
+		}
+		ip := ips[0]
+
+		// Overwrite defined host so we can target local apiserver
+		// and bypass the admin.conf host which is configured for proxyd
+		config.Host = ip.String() + ":6443"
+
+		clientset, err := kubernetes.NewForConfig(config)
+		if err != nil {
+			log.Fatalf("failed to generate a client from %s: %v", kubeconfig, err)
+		}
+
+		if err = r.Watch(clientset); err != nil {
+			log.Fatalf("failed to watch kubernetes api server: %v", err)
+		}
+	}()
+
+	// nolint: errcheck
+	r.Listen(":443")
 }
 
 func init() {


### PR DESCRIPTION
- dropped `tlsConfig` since it wasn't being used anymore
- consolidated `updateFunc` to use `AddBackend` and `DeleteBackend`
- moved kube client initialization/setup into main so we could test watch independently


I think there's still some work to do around handling shutdown better, but will follow up with another pr for that. 

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>