### PR TITLE
Backport PRs related to token/key generation

### DIFF
--- a/internal/app/init/internal/security/cis/cis.go
+++ b/internal/app/init/internal/security/cis/cis.go
@@ -6,12 +6,11 @@ package cis
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/base64"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"text/template"
-	"time"
 
 	"github.com/talos-systems/talos/internal/pkg/constants"
 
@@ -64,20 +63,12 @@ func CreateEncryptionToken() error {
 		return nil
 	}
 
-	random := func(min, max int) int {
-		return rand.Intn(max-min) + min
+	encryptionKey := make([]byte, 32)
+	if _, err := rand.Read(encryptionKey); err != nil {
+		return err
 	}
-	var encryptionKeySecret string
-	seed := time.Now().Unix()
-	rand.Seed(seed)
-	for i := 0; i < 32; i++ {
-		n := random(0, 94)
-		start := "!"
-		encryptionKeySecret += string(start[0] + byte(n))
-	}
-	data := []byte(encryptionKeySecret)
 
-	str := base64.StdEncoding.EncodeToString(data)
+	str := base64.StdEncoding.EncodeToString(encryptionKey)
 	aux := struct {
 		AESCBCEncryptionSecret string
 	}{


### PR DESCRIPTION
PRs: #794, #797 

1. fix: move to crypto/rand for token gen

2. fix(init): secret data at rest encryption key should be truly random 

First, use cryptographically secure random number generator.

Second, generate random 32 bytes, don't limit them to any range, as
they're going to be base64-encoded anyways.