### PR TITLE
chore: seed math.rand PRNG on startup in every service

### DIFF
--- a/cmd/osctl/main.go
+++ b/cmd/osctl/main.go
@@ -4,8 +4,14 @@
 
 package main
 
-import "github.com/talos-systems/talos/cmd/osctl/cmd"
+import (
+	"github.com/talos-systems/talos/cmd/osctl/cmd"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
+	"github.com/talos-systems/talos/internal/pkg/startup"
+)
 
 func main() {
+	helpers.Should(startup.RandSeed())
+
 	cmd.Execute()
 }

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/internal/pkg/grpc/factory"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
+	"github.com/talos-systems/talos/internal/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
 
 	"golang.org/x/sys/unix"
@@ -371,6 +372,10 @@ func main() {
 	defer reboot()
 	// handle any panics in the main goroutine, and proceed to reboot() above
 	defer recovery()
+
+	if err := startup.RandSeed(); err != nil {
+		panic(err)
+	}
 
 	// TODO(andrewrynhard): Remove this and be explicit.
 	if err := os.Setenv("PATH", constants.PATH); err != nil {

--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/beevik/ntp"
+	"github.com/talos-systems/talos/internal/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -39,6 +40,10 @@ func init() {
 // New instantiates a new ntp instance against a given server
 // If no servers are specified, the default will be used
 func main() {
+	if err := startup.RandSeed(); err != nil {
+		log.Fatalf("startup: %s", err)
+	}
+
 	server := DEFAULTSERVER
 
 	data, err := userdata.Open(*dataPath)

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/internal/pkg/grpc/factory"
 	"github.com/talos-systems/talos/internal/pkg/grpc/tls"
+	"github.com/talos-systems/talos/internal/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -28,6 +29,10 @@ func init() {
 }
 
 func main() {
+	if err := startup.RandSeed(); err != nil {
+		log.Fatalf("startup: %s", err)
+	}
+
 	data, err := userdata.Open(*dataPath)
 	if err != nil {
 		log.Fatalf("open user data: %v", err)

--- a/internal/app/proxyd/main.go
+++ b/internal/app/proxyd/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
+	"github.com/talos-systems/talos/internal/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -29,6 +30,10 @@ func init() {
 }
 
 func main() {
+	if err := startup.RandSeed(); err != nil {
+		log.Fatalf("startup: %s", err)
+	}
+
 	data, err := userdata.Open(*dataPath)
 	if err != nil {
 		log.Fatalf("open user data: %v", err)

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/grpc/factory"
 	"github.com/talos-systems/talos/internal/pkg/grpc/middleware/auth/basic"
 	"github.com/talos-systems/talos/internal/pkg/grpc/tls"
+	"github.com/talos-systems/talos/internal/pkg/startup"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -30,6 +31,10 @@ func init() {
 
 func main() {
 	var err error
+
+	if err = startup.RandSeed(); err != nil {
+		log.Fatalf("startup: %s", err)
+	}
 
 	data, err := userdata.Open(*dataPath)
 	if err != nil {

--- a/internal/pkg/startup/rand.go
+++ b/internal/pkg/startup/rand.go
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package startup
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+
+	"github.com/pkg/errors"
+)
+
+// RandSeed default math/rand PRNG.
+func RandSeed() error {
+	seed := make([]byte, 8)
+	if _, err := cryptorand.Read(seed); err != nil {
+		return errors.Wrap(err, "error seeding rand")
+	}
+
+	rand.Seed(int64(binary.LittleEndian.Uint64(seed)))
+
+	return nil
+}

--- a/internal/pkg/startup/startup.go
+++ b/internal/pkg/startup/startup.go
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package startup provides utility function for process startup
+package startup


### PR DESCRIPTION
This is important as otherwise `math/rand` outputs predictable sequence
each time.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>