### PR TITLE
chore: publish gce images with releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -140,6 +140,23 @@ steps:
       ## Should change to e2e once we get things more stable
       - basic-integration
 
+  - name: gce
+    image: autonomy/build-container:latest
+    pull: always
+    environment:
+      BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+      BINDIR: /usr/local/bin
+    commands:
+      - make talos-gce
+    volumes:
+      - name: dockersock
+        path: /var/run
+    when:
+      event: tag
+    depends_on:
+      ## Should change to e2e once we get things more stable
+      - basic-integration
+
   - name: push
     image: autonomy/build-container:latest
     pull: always
@@ -180,6 +197,7 @@ steps:
       ## Should change to e2e once we get things more stable
       - basic-integration
       - iso
+      - gce
 
 volumes:
   - name: dockersock

--- a/Makefile
+++ b/Makefile
@@ -172,8 +172,8 @@ proto: buildkitd
 .PHONY: talos-gce
 talos-gce:
 	@docker run --rm -v /dev:/dev -v $(PWD)/build:/out --privileged $(DOCKER_ARGS) autonomy/installer:$(TAG) install -n disk -r -p googlecloud -u none
-	@tar -C $(PWD)/build -Sczf $(PWD)/build/$@.tar.gz disk.raw
-	@rm $(PWD)/build/disk.raw
+	@tar -C $(PWD)/build -czf $(PWD)/build/$@.tar.gz disk.raw
+	@rm -rf $(PWD)/build/disk.raw
 
 .PHONY: talos-iso
 talos-iso:


### PR DESCRIPTION
This is somewhat tough to test, since you can't use the github release for anything but tags (it throws an error), but this PR will build the GCE image and output it to the build directory on tag events. It should, then, get added to the release assets. Once merged, I'll push a test tag to make sure the draft looks correct.