### PR TITLE
chore: prepare release v0.1.0-beta.1 (#811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [](https://github.com/talos-systems/talos/compare/v0.1.0-beta.0...v0.1.0-beta.1) (2019-07-02)
+
+
+### Bug Fixes
+
+* move to crypto/rand for token gen ([#794](https://github.com/talos-systems/talos/issues/794)) ([402c597](https://github.com/talos-systems/talos/commit/402c597))
+* **init:** secret data at rest encryption key should be truly random ([#799](https://github.com/talos-systems/talos/issues/799)) ([349aabf](https://github.com/talos-systems/talos/commit/349aabf))
+
+
+
 # [v0.1.0-beta.0](https://github.com/talos-systems/talos/compare/v0.1.0-alpha.28...v0.1.0-beta.0) (2019-06-27)
 
 


### PR DESCRIPTION
Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>
(cherry picked from commit bfe3f247916ac9872c8b30690d29ab75fb4fabe5)