### PR TITLE
feat(initramfs): Add kernel arg for default interface

### DIFF
--- a/internal/app/init/pkg/network/networkd.go
+++ b/internal/app/init/pkg/network/networkd.go
@@ -39,7 +39,7 @@ func (svc *Service) Main(ctx context.Context, data *userdata.UserData, logWriter
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			svc.DHCPd(ctx, DefaultInterface)
+			svc.DHCPd(ctx, defaultInterface())
 		}()
 	} else {
 		for _, netconf := range data.Networking.OS.Devices {

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -26,6 +26,10 @@ const (
 	// hostname.
 	KernelParamHostname = "talos.hostname"
 
+	// KernelParamDefaultInterface is the kernel parameter for specifying the
+	// initial interface used to bootstrap the node
+	KernelParamDefaultInterface = "talos.interface"
+
 	// KernelCurrentRoot is the kernel parameter name for specifying the
 	// current root partition.
 	KernelCurrentRoot = "talos.root"


### PR DESCRIPTION
Should allow us to handle edge cases where eth0 is not the primary interface

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>