### PR TITLE
feat(osd): implement container metrics for CRI inspector

### DIFF
--- a/internal/pkg/containers/container.go
+++ b/internal/pkg/containers/container.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/containerd/containerd/api/types"
-
 	"github.com/talos-systems/talos/internal/pkg/chunker"
 	"github.com/talos-systems/talos/internal/pkg/chunker/file"
 	"github.com/talos-systems/talos/internal/pkg/chunker/stream"
@@ -33,9 +31,15 @@ type Container struct {
 	Status       string // Running state of container
 	RestartCount string
 	LogPath      string
-	Metrics      *types.Metric
+	Metrics      *ContainerMetrics
 	Pid          uint32
 	IsPodSandbox bool // real container or just pod sandbox
+}
+
+// ContainerMetrics represents container cgroup stats
+type ContainerMetrics struct {
+	MemoryUsage uint64
+	CPUUsage    uint64
 }
 
 // GetProcessStderr returns process stderr


### PR DESCRIPTION
This refactors metrics interface to remove containerd-specific stuff and
make it common for CRI & containerd.

CRI metrics are easy to grab, we also have there filesystem metrics, not
sure how useful they are.

Next step: refactor interfaces so that metrics are optional (we don't
need them for every call, so we can skip them for `osctl ps` to save
time on CRI/containerd API calls).

Example comparing CRI & containerd (CRI doesn't seem to have a way to
get sandbox metrics, which shouldn't be a big deal imho):

```
$ osctl-linux-amd64 --talosconfig talosconfig stats -k
NAMESPACE   ID                                                                        MEMORY(MB)   CPU
k8s.io      kube-system/etcd-master-1                                                 1.51         11208976
k8s.io      └─ kube-system/etcd-master-1:etcd                                         41.46        4552197273
k8s.io      kube-system/kube-apiserver-master-1                                       1.00         10047282
k8s.io      └─ kube-system/kube-apiserver-master-1:kube-apiserver                     221.15       11302739689
k8s.io      kube-system/kube-controller-manager-master-1                              1.04         10603407
k8s.io      └─ kube-system/kube-controller-manager-master-1:kube-controller-manager   51.98        4809192540
k8s.io      kube-system/kube-scheduler-master-1                                       1.18         9745755
k8s.io      └─ kube-system/kube-scheduler-master-1:kube-scheduler                     20.21        1206960570
k8s.io      kubelet                                                                   54.10        3248985533
$ osctl-linux-amd64 --talosconfig talosconfig stats -ck
NAMESPACE   ID                                                                        MEMORY(MB)   CPU
k8s.io      kube-system/etcd-master-1                                                 0.00         0
k8s.io      └─ kube-system/etcd-master-1:etcd                                         41.46        4570994143
k8s.io      kube-system/kube-apiserver-master-1                                       0.00         0
k8s.io      └─ kube-system/kube-apiserver-master-1:kube-apiserver                     221.15       11332913198
k8s.io      kube-system/kube-controller-manager-master-1                              0.00         0
k8s.io      └─ kube-system/kube-controller-manager-master-1:kube-controller-manager   51.98        4837747257
k8s.io      kube-system/kube-scheduler-master-1                                       0.00         0
k8s.io      └─ kube-system/kube-scheduler-master-1:kube-scheduler                     20.21        1209094942
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>