### PR TITLE
chore: upgrade conform to v0.1.0-alpha.15

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,45 +1,47 @@
 policies:
-- type: commit
-  spec:
-    headerLength: 89
-    dco: true
-    gpg: false
-    imperative: true
-    conventional:
-      types:
-      - chore
-      - docs
-      - perf
-      - refactor
-      - style
-      - test
-      scopes:
-      - ami
-      - ci
-      - conformance
-      - gpt
-      - hack
-      - image
-      - init
-      - initramfs
-      - kernel
-      - proxyd
-      - osctl
-      - osd
-      - rootfs
-      - tools
-      - trustd
-      - '*'
-- type: license
-  spec:
-    skipPaths:
-    - .git/
-    - .buildkit/
-    includeSuffixes:
-    - .go
-    excludeSuffixes:
-    - .pb.go
-    header: |
-      /* This Source Code Form is subject to the terms of the Mozilla Public
-       * License, v. 2.0. If a copy of the MPL was not distributed with this
-       * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+  - type: commit
+    spec:
+      headerLength: 89
+      dco: true
+      gpg: false
+      imperative: true
+      maximumOfOneCommit: true
+      requireCommitBody: true
+      conventional:
+        types:
+          - chore
+          - docs
+          - perf
+          - refactor
+          - style
+          - test
+        scopes:
+          - ami
+          - ci
+          - conformance
+          - gpt
+          - hack
+          - image
+          - init
+          - initramfs
+          - kernel
+          - proxyd
+          - osctl
+          - osd
+          - rootfs
+          - tools
+          - trustd
+          - '*'
+  - type: license
+    spec:
+      skipPaths:
+        - .git/
+        - .buildkit/
+      includeSuffixes:
+        - .go
+      excludeSuffixes:
+        - .pb.go
+      header: |
+        /* This Source Code Form is subject to the terms of the Mozilla Public
+         * License, v. 2.0. If a copy of the MPL was not distributed with this
+         * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -7,7 +7,7 @@ workflow "Conform Pull Request" {
 }
 
 action "conform" {
-  uses    = "docker://autonomy/conform:v0.1.0-alpha.14"
+  uses    = "docker://autonomy/conform:v0.1.0-alpha.15"
 
   secrets = [
     "GITHUB_TOKEN"


### PR DESCRIPTION
This PR also makes use of two new options:

- maximumOfOneCommit: enforces that a commit is only one commit ahead of master
- requireCommitBody: requires that a commit contains a body

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>