### PR TITLE
fix: append probed block devices

### DIFF
--- a/internal/pkg/blockdevice/probe/probe.go
+++ b/internal/pkg/blockdevice/probe/probe.go
@@ -31,7 +31,7 @@ type ProbedBlockDevice struct {
 }
 
 // All probes a block device's file system for the given label.
-func All() (probed []*ProbedBlockDevice, err error) {
+func All() (all []*ProbedBlockDevice, err error) {
 	var infos []os.FileInfo
 	if infos, err = ioutil.ReadDir("/sys/block"); err != nil {
 		return nil, err
@@ -39,13 +39,15 @@ func All() (probed []*ProbedBlockDevice, err error) {
 
 	for _, info := range infos {
 		devpath := "/dev/" + info.Name()
+		var probed []*ProbedBlockDevice
 		probed, err = probeFilesystem(devpath)
 		if err != nil {
 			return nil, err
 		}
+		all = append(all, probed...)
 	}
 
-	return probed, nil
+	return all, nil
 }
 
 // FileSystem probes the provided path's file system.


### PR DESCRIPTION
This change fixes a bug that caused installations to fail.
On each iteration, the previously discovered block devices were dropped because the `probed` variable was reassigned.
We now append the discovered block devices to a slice declared outside the for loop.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>