### PR TITLE
fix: use existing logic to perform reset

### DIFF
--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -155,7 +155,7 @@ func (c *Client) Restart(ctx context.Context, namespace, id string) (err error) 
 
 // Reset implements the proto.OSDClient interface.
 func (c *Client) Reset(ctx context.Context) (err error) {
-	_, err = c.client.Reset(ctx, &empty.Empty{})
+	_, err = c.initClient.Reset(ctx, &empty.Empty{})
 	return
 }
 

--- a/internal/app/init/internal/reg/reg.go
+++ b/internal/app/init/internal/reg/reg.go
@@ -109,6 +109,21 @@ func (r *Registrator) Upgrade(ctx context.Context, in *proto.UpgradeRequest) (da
 	return data, err
 }
 
+// Reset initiates a Talos upgrade
+func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (data *proto.ResetReply, err error) {
+	// stop kubelet
+	if _, err = r.Stop(ctx, &proto.StopRequest{Id: "kubelet"}); err != nil {
+		return data, err
+	}
+
+	// kubeadm Reset
+	if err = upgrade.Reset(); err != nil {
+		return data, err
+	}
+
+	return data, err
+}
+
 // ServiceList returns list of the registered services and their status
 func (r *Registrator) ServiceList(ctx context.Context, in *empty.Empty) (result *proto.ServiceListReply, err error) {
 	services := system.Services(r.Data).List()

--- a/internal/app/init/proto/api.proto
+++ b/internal/app/init/proto/api.proto
@@ -11,6 +11,7 @@ service Init {
   rpc CopyOut(CopyOutRequest) returns (stream StreamingData) {}
   rpc LS(LSRequest) returns (stream FileInfo) {}
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
+  rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
   rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
   rpc Upgrade(UpgradeRequest) returns (UpgradeReply) {}
   rpc ServiceList(google.protobuf.Empty) returns (ServiceListReply) {}
@@ -19,6 +20,9 @@ service Init {
 
 // The response message containing the reboot status.
 message RebootReply {}
+
+// The response message containing the restart status.
+message ResetReply {}
 
 // The response message containing the shutdown status.
 message ShutdownReply {}

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -35,13 +35,13 @@ func NewInitServiceClient() (*InitServiceClient, error) {
 }
 
 // Reboot executes init Reboot() API
-func (c *InitServiceClient) Reboot(ctx context.Context, empty *empty.Empty) (*proto.RebootReply, error) {
-	return c.InitClient.Reboot(ctx, empty)
+func (c *InitServiceClient) Reboot(ctx context.Context, in *empty.Empty) (*proto.RebootReply, error) {
+	return c.InitClient.Reboot(ctx, in)
 }
 
 // Shutdown executes init Shutdown() API.
-func (c *InitServiceClient) Shutdown(ctx context.Context, empty *empty.Empty) (*proto.ShutdownReply, error) {
-	return c.InitClient.Shutdown(ctx, empty)
+func (c *InitServiceClient) Shutdown(ctx context.Context, in *empty.Empty) (*proto.ShutdownReply, error) {
+	return c.InitClient.Shutdown(ctx, in)
 }
 
 // Upgrade executes the init Upgrade() API.
@@ -49,9 +49,14 @@ func (c *InitServiceClient) Upgrade(ctx context.Context, in *proto.UpgradeReques
 	return c.InitClient.Upgrade(ctx, in)
 }
 
+// Reset executes the init Reset() API.
+func (c *InitServiceClient) Reset(ctx context.Context, in *empty.Empty) (data *proto.ResetReply, err error) {
+	return c.InitClient.Reset(ctx, in)
+}
+
 // ServiceList executes the init ServiceList() API.
-func (c *InitServiceClient) ServiceList(ctx context.Context, empty *empty.Empty) (data *proto.ServiceListReply, err error) {
-	return c.InitClient.ServiceList(ctx, empty)
+func (c *InitServiceClient) ServiceList(ctx context.Context, in *empty.Empty) (data *proto.ServiceListReply, err error) {
+	return c.InitClient.ServiceList(ctx, in)
 }
 
 func copyClientServer(msg interface{}, client grpc.ClientStream, srv grpc.ServerStream) error {

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -14,7 +14,6 @@ service OSD {
   rpc Kubeconfig(google.protobuf.Empty) returns (Data) {}
   rpc Logs(LogsRequest) returns (stream Data) {}
   rpc Processes(ProcessesRequest) returns (ProcessesReply) {}
-  rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
   rpc Restart(RestartRequest) returns (RestartReply) {}
   rpc Routes(google.protobuf.Empty) returns (RoutesReply) {}
   rpc Stats(StatsRequest) returns (StatsReply) {}
@@ -63,9 +62,6 @@ message RestartRequest {
 
 // The response message containing the restart status.
 message RestartReply {}
-
-// The response message containing the restart status.
-message ResetReply {}
 
 // The request message containing the process name.
 message LogsRequest {


### PR DESCRIPTION
This PR moves the reset API to the init API definition.
It leverages the same code we use for upgrades.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>
(cherry picked from commit 5d8ee0a3a5fb5e927513f710fb7e462a34bf3446)