### PR TITLE
chore: update toolchain version and output created config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KERNEL_IMAGE ?= autonomy/kernel:1f83e85
-TOOLCHAIN_IMAGE ?= autonomy/toolchain:0d43bc8
-ROOTFS_IMAGE ?= autonomy/rootfs-base:0d43bc8
-INITRAMFS_IMAGE ?= autonomy/initramfs-base:0d43bc8
+TOOLCHAIN_IMAGE ?= autonomy/toolchain:6cf146a
+ROOTFS_IMAGE ?= autonomy/rootfs-base:6cf146a
+INITRAMFS_IMAGE ?= autonomy/initramfs-base:6cf146a
 
 # TODO(andrewrynhard): Move this logic to a shell script.
 BUILDKIT_VERSION ?= v0.5.0

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
@@ -131,6 +132,11 @@ var configGenerateCmd = &cobra.Command{
 			helpers.Fatalf("failed to generate PKI and tokens: %v", err)
 		}
 
+		workingDir, err := os.Getwd()
+		if err != nil {
+			helpers.Fatalf("failed to fetch current working dir: %v", err)
+		}
+
 		var udType generate.Type
 		for idx, master := range strings.Split(args[1], ",") {
 			input.Index = idx
@@ -145,12 +151,14 @@ var configGenerateCmd = &cobra.Command{
 			if err = writeUserdata(input, udType, "master-"+strconv.Itoa(idx+1)); err != nil {
 				helpers.Fatalf("failed to generate userdata for %s: %v", "master-"+strconv.Itoa(idx+1), err)
 			}
+			fmt.Println("created file", workingDir+"/master-"+strconv.Itoa(idx+1)+".yaml")
 		}
 		input.IP = nil
 
 		if err = writeUserdata(input, generate.TypeJoin, "worker"); err != nil {
 			helpers.Fatalf("failed to generate userdata for %s: %v", "worker", err)
 		}
+		fmt.Println("created file", workingDir+"/worker.yaml")
 
 		data, err := generate.Talosconfig(input)
 		if err != nil {
@@ -159,6 +167,7 @@ var configGenerateCmd = &cobra.Command{
 		if err = ioutil.WriteFile("talosconfig", []byte(data), 0644); err != nil {
 			helpers.Fatalf("%v", err)
 		}
+		fmt.Println("created file", workingDir+"/talosconfig")
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/hcsshim v0.7.0 // indirect
 	github.com/beevik/ntp v0.2.0
 	github.com/containerd/cgroups v0.0.0-20180905221500-58556f5ad844
-	github.com/containerd/containerd v1.2.6
+	github.com/containerd/containerd v1.2.7
 	github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19 // indirect
 	github.com/containerd/cri v1.11.1
 	github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cjbassi/drawille-go v0.0.0-20190126131713-27dc511fe6fd/go.mod h1:vjcQ
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/cgroups v0.0.0-20180905221500-58556f5ad844 h1:W0F6ErEE8B84VNA5yX3sqNm0z7tivzEtvI/3DMo4Mr4=
 github.com/containerd/cgroups v0.0.0-20180905221500-58556f5ad844/go.mod h1:X9rLEHIqSf/wfK8NsPqxJmeZgW4pcfzdXITDrUSJ6uI=
-github.com/containerd/containerd v1.2.6 h1:K38ZSAA9oKSrX3iFNY+4SddZ8hH1TCMCerc8NHfcKBQ=
-github.com/containerd/containerd v1.2.6/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
+github.com/containerd/containerd v1.2.7 h1:8lqLbl7u1j3MmiL9cJ/O275crSq7bfwUayvvatEupQk=
+github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19 h1:HSgjWPBWohO3kHDPwCPUGSLqJjXCjA7ad5057beR2ZU=
 github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/cri v1.11.1 h1:mR8+eNW4zEcbWGTGEpmDd7GzMmK7IMxMSVAZ2aIDKA4=


### PR DESCRIPTION
Decided to combine two very small changes (which I'm now grumpy at myself for doing). 

First, we'll update the toolchain image versions to allow for the use of a new containerd and runc. Also updated go.mod and go.sum to make use of newer containerd version. Closes #743 and #744.

Second, I added the bit of logic to `osctl config generate` to determine the working directory and let the user know that we created the various yaml files there. Closes #760.