### PR TITLE
chore: remove last updated field from proposal template

### DIFF
--- a/docs/proposals/YYYYMMDD-TEMPLATE.md
+++ b/docs/proposals/YYYYMMDD-TEMPLATE.md
@@ -2,8 +2,6 @@
 
 Author(s): [Author Name, Co-Author Name]
 
-Last updated: [Date]
-
 ## Abstract
 
 [A short summary of the proposal.]


### PR DESCRIPTION
This field is superfluous since we can get this from git.