### PR TITLE
chore: bump codecov project target to 33%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 17%
+        target: 33%
         threshold: 0.5%
         base: auto
     patch: off


### PR DESCRIPTION
This gives ~0.7% of buffer.