### PR TITLE
chore: make unit-tests use isolated instances of containerd

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -170,8 +170,7 @@ steps:
       - name: dockersock
         path: /var/run/
     depends_on:
-      - build-osd
-      - build-proxyd
+      - rootfs
 
   - name: coverage
     image: plugins/codecov

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ COMMON_ARGS += --opt build-arg:TAG=$(TAG)
 
 DOCKER_ARGS ?=
 # to allow tests to run containerd
-DOCKER_TEST_ARGS = --security-opt seccomp:unconfined --privileged -v /var/lib/containerd/
+DOCKER_TEST_ARGS = --security-opt seccomp:unconfined --privileged -v /var/lib/containerd/ -v /tmp/
 
 all: ci drone
 

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -6,12 +6,12 @@ CGO_ENABLED=1
 
 perform_tests() {
   echo "Performing tests"
-  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt -p 1 ./...
+  go test -v -covermode=atomic -coverprofile=artifacts/coverage.txt ./...
 }
 
 perform_short_tests() {
   echo "Performing short tests"
-  go test -v -short -p 1 ./...
+  go test -v -short ./...
 }
 
 case $1 in

--- a/internal/app/init/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/init/pkg/system/runner/containerd/containerd.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/runner"
-	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -59,7 +58,7 @@ func (c *containerdRunner) Open(ctx context.Context) error {
 	// Create the containerd client.
 	var err error
 	c.ctx = namespaces.WithNamespace(context.Background(), c.opts.Namespace)
-	c.client, err = containerd.New(constants.ContainerdAddress)
+	c.client, err = containerd.New(c.opts.ContainerdAddress)
 	if err != nil {
 		return err
 	}

--- a/internal/app/init/pkg/system/runner/runner.go
+++ b/internal/app/init/pkg/system/runner/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/oci"
 
 	"github.com/talos-systems/talos/internal/app/init/pkg/system/events"
+	"github.com/talos-systems/talos/internal/pkg/constants"
 )
 
 // Runner describes the requirements for running a process.
@@ -35,6 +36,8 @@ type Options struct {
 	// Env describes the service's environment variables. Elements should be in
 	// the format <key=<value>
 	Env []string
+	// ContainerdAddress is containerd socket address.
+	ContainerdAddress string
 	// ContainerOpts describes the container options.
 	ContainerOpts []containerd.NewContainerOpts
 	// OCISpecOpts describes the OCI spec options.
@@ -60,6 +63,7 @@ func DefaultOptions() *Options {
 		Namespace:               "system",
 		LogPath:                 "/var/log",
 		GracefulShutdownTimeout: 10 * time.Second,
+		ContainerdAddress:       constants.ContainerdAddress,
 	}
 }
 
@@ -74,6 +78,13 @@ func WithEnv(o []string) Option {
 func WithNamespace(o string) Option {
 	return func(args *Options) {
 		args.Namespace = o
+	}
+}
+
+// WithContainerdAddress sets the containerd socket path.
+func WithContainerdAddress(a string) Option {
+	return func(args *Options) {
+		args.ContainerdAddress = a
 	}
 }
 

--- a/internal/pkg/containers/containerd/containerd.go
+++ b/internal/pkg/containers/containerd/containerd.go
@@ -30,12 +30,34 @@ type inspector struct {
 	nsctx  context.Context
 }
 
+type inspectorOptions struct {
+	containerdAddress string
+}
+
+// Option configures containerd Inspector
+type Option func(*inspectorOptions)
+
+// WithContainerdAddress configures containerd address to use
+func WithContainerdAddress(address string) Option {
+	return func(o *inspectorOptions) {
+		o.containerdAddress = address
+	}
+}
+
 // NewInspector builds new Inspector instance in specified namespace
-func NewInspector(ctx context.Context, namespace string) (ctrs.Inspector, error) {
+func NewInspector(ctx context.Context, namespace string, options ...Option) (ctrs.Inspector, error) {
 	var err error
 
+	opt := inspectorOptions{
+		containerdAddress: constants.ContainerdAddress,
+	}
+
+	for _, o := range options {
+		o(&opt)
+	}
+
 	i := inspector{}
-	i.client, err = containerd.New(constants.ContainerdAddress)
+	i.client, err = containerd.New(opt.containerdAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/containers/cri/cri.go
+++ b/internal/pkg/containers/cri/cri.go
@@ -23,14 +23,36 @@ type inspector struct {
 	ctx    context.Context
 }
 
+type inspectorOptions struct {
+	criEndpoint string
+}
+
+// Option configures containerd Inspector
+type Option func(*inspectorOptions)
+
+// WithCRIEndpoint configures CRI endpoint to use
+func WithCRIEndpoint(endpoint string) Option {
+	return func(o *inspectorOptions) {
+		o.criEndpoint = endpoint
+	}
+}
+
 // NewInspector builds new Inspector instance for CRI
-func NewInspector(ctx context.Context) (ctrs.Inspector, error) {
+func NewInspector(ctx context.Context, options ...Option) (ctrs.Inspector, error) {
 	var err error
+
+	opt := inspectorOptions{
+		criEndpoint: "unix:" + constants.ContainerdAddress,
+	}
+
+	for _, o := range options {
+		o(&opt)
+	}
 
 	i := inspector{
 		ctx: ctx,
 	}
-	i.client, err = NewClient("unix:"+constants.ContainerdAddress, 10*time.Second)
+	i.client, err = NewClient(opt.criEndpoint, 10*time.Second)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes test launch their own isolated instance of containerd with
its own root/state directories and listening socket address. Each test
brings this instance up/down on its own.

Add options to override containerd address in the code (used only in the
tests).

Enable parallel go test runs once again.

P.S. I wish I could share that 'SetupSuite' phase across the tests, but
afaik there's no way in Go to share `_test.go` code across packages. If
we put it as normal package, this might pull in test dependencies (like
`testify`) into production code, which I don't like.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>