### PR TITLE
feat: add install flag for extra kernel args

### DIFF
--- a/internal/app/init/internal/platform/baremetal/baremetal.go
+++ b/internal/app/init/internal/platform/baremetal/baremetal.go
@@ -88,6 +88,9 @@ func (b *BareMetal) Install(data *userdata.UserData) (err error) {
 	cmdline.Append("initrd", filepath.Join("/", constants.CurrentRootPartitionLabel(), "initramfs.xz"))
 	cmdline.Append(constants.KernelParamPlatform, "bare-metal")
 	cmdline.Append(constants.KernelParamUserData, *endpoint)
+	if err = cmdline.AppendAll(data.Install.ExtraKernelArgs); err != nil {
+		return err
+	}
 	if err = install.Install(cmdline.String(), data); err != nil {
 		return errors.Wrap(err, "failed to install")
 	}

--- a/internal/app/init/internal/platform/cloud/packet/packet.go
+++ b/internal/app/init/internal/platform/cloud/packet/packet.go
@@ -49,6 +49,9 @@ func (p *Packet) Install(data *userdata.UserData) (err error) {
 	cmdline.Append("initrd", filepath.Join("/", constants.CurrentRootPartitionLabel(), "initramfs.xz"))
 	cmdline.Append(constants.KernelParamPlatform, "packet")
 	cmdline.Append(constants.KernelParamUserData, *endpoint)
+	if err = cmdline.AppendAll(data.Install.ExtraKernelArgs); err != nil {
+		return err
+	}
 	if err = install.Install(cmdline.String(), data); err != nil {
 		return errors.Wrap(err, "failed to install")
 	}

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -184,6 +184,14 @@ func (c *cmdline) Append(k string, v string) {
 	insert(&c.Parameters, k, v)
 }
 
+// AppendAll appends a set of kernel parameters.
+func (c *cmdline) AppendAll(args []string) error {
+	parameters := parse(strings.Join(args, " "))
+	c.Parameters = append(c.Parameters, parameters...)
+
+	return nil
+}
+
 // Bytes returns the byte slice representation of the cmdline struct.
 func (c *cmdline) Bytes() []byte {
 	return []byte(c.String())

--- a/internal/pkg/kernel/kernel_test.go
+++ b/internal/pkg/kernel/kernel_test.go
@@ -128,6 +128,30 @@ func (suite *KernelSuite) TestCmdlineAppend() {
 	}
 }
 
+func (suite *KernelSuite) TestCmdlineAppendAll() {
+	for _, t := range []struct {
+		initial  string
+		params   []string
+		expected string
+	}{
+		{
+			"ip=dhcp console=x",
+			[]string{"root=/dev/sda", "root=/dev/sdb"},
+			"ip=dhcp console=x root=/dev/sda root=/dev/sdb",
+		},
+		{
+			"root=/dev/sdb",
+			[]string{"this=that=those"},
+			"root=/dev/sdb this=that=those",
+		},
+	} {
+		cmdline := NewCmdline(t.initial)
+		err := cmdline.AppendAll(t.params)
+		suite.Assert().NoError(err)
+		suite.Assert().Equal(t.expected, cmdline.String())
+	}
+}
+
 func (suite *KernelSuite) TestCmdlineString() {
 	for _, t := range []struct {
 		params   string

--- a/pkg/userdata/install.go
+++ b/pkg/userdata/install.go
@@ -6,12 +6,13 @@ package userdata
 
 // Install represents the installation options for preparing a node.
 type Install struct {
-	Boot         *BootDevice    `yaml:"boot,omitempty"`
-	Root         *RootDevice    `yaml:"root"`
-	Data         *InstallDevice `yaml:"data,omitempty"`
-	ExtraDevices []*ExtraDevice `yaml:"extraDevices,omitempty"`
-	Wipe         bool           `yaml:"wipe"`
-	Force        bool           `yaml:"force"`
+	Boot            *BootDevice    `yaml:"boot,omitempty"`
+	Root            *RootDevice    `yaml:"root"`
+	Data            *InstallDevice `yaml:"data,omitempty"`
+	ExtraDevices    []*ExtraDevice `yaml:"extraDevices,omitempty"`
+	ExtraKernelArgs []string       `yaml:"extraKernelArgs,omitempty"`
+	Wipe            bool           `yaml:"wipe"`
+	Force           bool           `yaml:"force"`
 }
 
 // BootDevice represents the install options specific to the boot partition.


### PR DESCRIPTION
In addition to adding a flag, this adds a field to the user data that allows
for extra kernel arguments to be specified.