### PR TITLE
fix(init) mount root partition as read-only

### DIFF
--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -80,7 +80,7 @@ func WithRetry(mountpoint *Point, setters ...Option) (err error) {
 	opts := NewDefaultOptions(setters...)
 
 	if opts.ReadOnly {
-		mountpoint.flags |= unix.O_RDONLY
+		mountpoint.flags |= unix.MS_RDONLY
 	}
 
 	target := path.Join(opts.Prefix, mountpoint.target)


### PR DESCRIPTION
This uses the correct mount flag for read-only.
We mistakenly had the flag for opening a file as read-only.