### PR TITLE
fix: return non-nil response in reset

### DIFF
--- a/internal/app/init/internal/reg/reg.go
+++ b/internal/app/init/internal/reg/reg.go
@@ -121,7 +121,7 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (data *proto.R
 		return data, err
 	}
 
-	return data, err
+	return &proto.ResetReply{}, err
 }
 
 // ServiceList returns list of the registered services and their status


### PR DESCRIPTION
The gRPC response will fail to be decoded because our reply is nil.