### PR TITLE
chore: move init to /sbin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -211,8 +211,8 @@ COPY --from=rootfs-archive /rootfs.tar.gz /rootfs.tar.gz
 
 FROM scratch AS talos
 COPY --from=rootfs-base / /
-COPY --from=init /init /init
-ENTRYPOINT ["/init"]
+COPY --from=init /init /sbin/init
+ENTRYPOINT ["/sbin/init"]
 
 # The installer target generates an image that can be used to install Talos to
 # various environments.

--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -42,10 +42,9 @@ func NewNode(clusterName string, req *Request) (err error) {
 	// Create the container config.
 
 	containerConfig := &container.Config{
-		Hostname:   req.Name,
-		Image:      req.Image,
-		Entrypoint: strslice.StrSlice{"/init"},
-		Cmd:        strslice.StrSlice{"--in-container", "--userdata=" + b64data},
+		Hostname: req.Name,
+		Image:    req.Image,
+		Cmd:      strslice.StrSlice{"--in-container", "--userdata=" + b64data},
 		Labels: map[string]string{
 			"talos.owned":        "true",
 			"talos.cluster.name": clusterName,


### PR DESCRIPTION
In order to run Talos with ignite, we need to have init at /sbin/init.