### PR TITLE
chore: add step to drone for kernel

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -231,6 +231,23 @@ steps:
   #   depends_on:
   #     - basic-integration
 
+  - name: kernel
+    image: autonomy/build-container:latest
+    pull: always
+    environment:
+      BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+      BINDIR: /usr/local/bin
+    commands:
+      - make kernel
+    volumes:
+      - name: dockersock
+        path: /var/run
+    when:
+      event: tag
+    depends_on:
+      ## Should change to e2e once we get things more stable
+      - basic-integration
+
   - name: iso
     image: autonomy/build-container:latest
     pull: always
@@ -306,6 +323,7 @@ steps:
     depends_on:
       ## Should change to e2e once we get things more stable
       - basic-integration
+      - kernel
       - iso
       - gce
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,8 @@ COPY --from=osctl-darwin-build /osctl-darwin-amd64 /osctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:2ac99a0 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:ebaa167 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:ebaa167 /boot/vmlinux /vmlinux
 
 # The initramfs target provides the Talos initramfs image.
 
@@ -190,7 +191,7 @@ COPY --from=docker.io/autonomy/crictl:ddbeea1 / /rootfs
 COPY --from=docker.io/autonomy/base:f9a4941 /toolchain/lib/libblkid.* /rootfs/lib
 COPY --from=docker.io/autonomy/base:f9a4941 /toolchain/lib/libuuid.* /rootfs/lib
 COPY --from=docker.io/autonomy/base:f9a4941 /toolchain/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:2ac99a0 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/kernel:ebaa167 /lib/modules /rootfs/lib/modules
 COPY images/*.tar /rootfs/usr/images
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs


### PR DESCRIPTION
Now that we manage dependencies manually, we need to explicitly build
the kernel target so that vmlinuz and vmlinux are placed into the build
directory.