### PR TITLE
fix: use existing logic to perform reset

### DIFF
--- a/internal/app/init/internal/reg/reg.go
+++ b/internal/app/init/internal/reg/reg.go
@@ -121,7 +121,7 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (data *proto.R
 		return data, err
 	}
 
-	return data, err
+	return &proto.ResetReply{}, err
 }
 
 // ServiceList returns list of the registered services and their status

--- a/internal/app/init/internal/rootfs/rootfs.go
+++ b/internal/app/init/internal/rootfs/rootfs.go
@@ -66,6 +66,24 @@ func Prepare(s string, inContainer bool, data *userdata.UserData) (err error) {
 		}
 	}
 
+	// Create required directories that are not part of FHS.
+	for _, path := range []string{"/etc/kubernetes/manifests", "/etc/cni", "/var/lib/kubelet", "/var/log/pods", "/usr/libexec/kubernetes"} {
+		if err = os.MkdirAll(filepath.Join(s, path), 0700); err != nil {
+			return err
+		}
+	}
+	// Create symlinks to /etc/ssl/certs as required by the control plane.
+	for _, path := range []string{"/etc/pki", "/usr/share/ca-certificates", "/usr/local/share/ca-certificates", "/etc/ca-certificates"} {
+		target := filepath.Join(s, path)
+		if _, err = os.Stat(target); os.IsNotExist(err) {
+			if err = os.MkdirAll(filepath.Dir(target), 0700); err != nil {
+				return err
+			}
+			if err = os.Symlink("/etc/ssl/certs", target); err != nil {
+				return err
+			}
+		}
+	}
 	// Create /etc/os-release.
 	if err = etc.OSRelease(s); err != nil {
 		return

--- a/internal/app/init/pkg/system/services/kubeadm.go
+++ b/internal/app/init/pkg/system/services/kubeadm.go
@@ -39,25 +39,6 @@ func (k *Kubeadm) ID(data *userdata.UserData) string {
 // PreFunc implements the Service interface.
 // nolint: gocyclo
 func (k *Kubeadm) PreFunc(ctx context.Context, data *userdata.UserData) (err error) {
-	requiredMounts := []string{
-		"/dev/disk/by-path",
-		"/etc/kubernetes",
-		"/etc/kubernetes/manifests",
-		"/lib/modules",
-		"/run",
-		"/sys/fs/cgroup",
-		"/usr/libexec/kubernetes",
-		"/var/lib/containerd",
-		"/var/lib/kubelet",
-		"/var/log/pods",
-	}
-
-	for _, dir := range requiredMounts {
-		if err = os.MkdirAll(dir, os.ModeDir); err != nil {
-			return errors.Wrapf(err, "create %s", dir)
-		}
-	}
-
 	reqs := []*containerd.ImportRequest{
 		{
 			Path: "/usr/images/hyperkube.tar",

--- a/internal/app/init/pkg/system/services/osd.go
+++ b/internal/app/init/pkg/system/services/osd.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
@@ -35,10 +34,6 @@ func (o *OSD) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (o *OSD) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	if err := os.MkdirAll("/etc/kubernetes", os.ModeDir); err != nil {
-		return err
-	}
-
 	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
 		Path: "/usr/images/osd.tar",
 		Options: []containerdapi.ImportOpt{

--- a/internal/app/init/pkg/system/services/proxyd.go
+++ b/internal/app/init/pkg/system/services/proxyd.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
@@ -35,10 +34,6 @@ func (p *Proxyd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (p *Proxyd) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	if err := os.MkdirAll("/etc/kubernetes", os.ModeDir); err != nil {
-		return err
-	}
-
 	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
 		Path: "/usr/images/proxyd.tar",
 		Options: []containerdapi.ImportOpt{

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -281,7 +281,11 @@ func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (*proto.Route
 		var ifaceName string
 		ifaceData, err := conn.Link.Get(rMesg.Attributes.OutIface)
 		if err != nil {
-			return nil, errors.Errorf("failed to get interface details for interface index %d: %v", rMesg.Attributes.OutIface, err)
+			log.Printf("failed to get interface details for interface index %d: %v", rMesg.Attributes.OutIface, err)
+			// TODO: Remove once we get this sorted on why there's a
+			// failure here
+			log.Printf("%+v", rMesg)
+			continue
 		}
 		if ifaceData.Attributes != nil {
 			ifaceName = ifaceData.Attributes.Name

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -80,7 +80,7 @@ func WithRetry(mountpoint *Point, setters ...Option) (err error) {
 	opts := NewDefaultOptions(setters...)
 
 	if opts.ReadOnly {
-		mountpoint.flags |= unix.O_RDONLY
+		mountpoint.flags |= unix.MS_RDONLY
 	}
 
 	target := path.Join(opts.Prefix, mountpoint.target)


### PR DESCRIPTION
This PR moves the reset API to the init API definition.
It leverages the same code we use for upgrades.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>
(cherry picked from commit 5d8ee0a3a5fb5e927513f710fb7e462a34bf3446)

fix(init): Fix routes endpoint

Temporary workaround while we get more information on the
specifics for what is failing.

Ref: #795
Signed-off-by: Brad Beam <brad.beam@talos-systems.com>
(cherry picked from commit 58537faa8b9a41a938248afe54eba955c60d39db)

fix(init) mount root partition as read-only

This uses the correct mount flag for read-only.
We mistakenly had the flag for opening a file as read-only.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>
(cherry picked from commit d4a59b7c1433e31736656589282487c01080f8d1)

fix: return non-nil response in reset

The gRPC response will fail to be decoded because our reply is nil.

Signed-off-by: Andrew Rynhard <andrew@andrewrynhard.com>
(cherry picked from commit c40802b12257399874461d93ab025b51ce655cb1)

fix: mount the rootfs as read-only

There was not a clean commit we could pull this from so the changes were
made directly onto the release branch.