### PR TITLE
feat: set default mtu for gce platform

### DIFF
--- a/internal/app/init/internal/platform/cloud/googlecloud/googlecloud.go
+++ b/internal/app/init/internal/platform/cloud/googlecloud/googlecloud.go
@@ -5,6 +5,7 @@
 package googlecloud
 
 import (
+	"github.com/talos-systems/talos/internal/pkg/network"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -23,7 +24,26 @@ func (gc *GoogleCloud) Name() string {
 
 // UserData implements the platform.Platform interface.
 func (gc *GoogleCloud) UserData() (data *userdata.UserData, err error) {
-	return userdata.Download(GCUserDataEndpoint, userdata.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
+	ud, err := userdata.Download(GCUserDataEndpoint, userdata.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
+	if err != nil {
+		return nil, err
+	}
+
+	if ud.Networking == nil {
+		ud.Networking = &userdata.Networking{
+			OS: &userdata.OSNet{
+				Devices: []userdata.Device{
+					{
+						Interface: network.DefaultInterface,
+						DHCP:      true,
+						MTU:       1460,
+					},
+				},
+			},
+		}
+	}
+
+	return ud, nil
 }
 
 // Prepare implements the platform.Platform interface and handles initial host preparation.


### PR DESCRIPTION
This PR is needed so that the eth0 device will have the proper mtu when
coming online in google cloud

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>