### PR TITLE
fix: Only generate pki from trustd if not control plane

### DIFF
--- a/internal/pkg/rootfs/rootfs.go
+++ b/internal/pkg/rootfs/rootfs.go
@@ -121,7 +121,7 @@ func Prepare(s string, inContainer bool, data *userdata.UserData) (err error) {
 
 func generatePKI(data *userdata.UserData) (err error) {
 	log.Println("generating node identity PKI")
-	if data.Services.Kubeadm.IsBootstrap() {
+	if data.Services.Kubeadm.IsControlPlane() {
 		log.Println("generating PKI locally")
 		var csr *x509.CertificateSigningRequest
 		if csr, err = data.NewIdentityCSR(); err != nil {


### PR DESCRIPTION
This PR will fix a bug where the non-init nodes were not generating their certs locally and relying on trustd instead. This broke down for other control plane nodes because we aren't saving the CA key when we're generating with the trustd identity function (because we don't need it for workers).