### PR TITLE
chore: allow to run tests only for specified packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = smira/dockerfile:master-experimental
+# syntax = docker/dockerfile-upstream:master-experimental
 
 ARG TOOLS
 FROM $TOOLS AS tools
@@ -258,7 +258,8 @@ FROM base AS test-runner
 RUN unlink /etc/ssl
 COPY --from=rootfs-base / /
 COPY hack/golang/test.sh /bin
-RUN --security=insecure --mount=type=cache,target=/tmp --mount=type=cache,target=/root/.cache /bin/test.sh
+ARG TESTPKGS
+RUN --security=insecure --mount=type=cache,target=/tmp --mount=type=cache,target=/root/.cache /bin/test.sh ${TESTPKGS}
 FROM scratch AS test
 COPY --from=test-runner /src/coverage.txt /coverage.txt
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,8 @@ DOCKER_ARGS ?=
 # to allow tests to run containerd
 DOCKER_TEST_ARGS = --security-opt seccomp:unconfined --privileged -v /var/lib/containerd/ -v /tmp/
 
+TESTPKGS ?= ./...
+
 all: ci drone
 
 .PHONY: drone
@@ -209,6 +211,7 @@ test: buildkitd
 		build \
 		--opt target=$@ \
 		--output type=local,dest=./ \
+		--opt build-arg:TESTPKGS=$(TESTPKGS) \
 		$(COMMON_ARGS)
 
 .PHONY: lint

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -2,24 +2,23 @@
 
 set -e
 
-CGO_ENABLED=1
-
 perform_tests() {
-  echo "Performing tests"
-  go test -v -covermode=atomic -coverprofile=coverage.txt ./...
+  echo "Performing tests on $1"
+  go test -v -covermode=atomic -coverprofile=coverage.txt "$1"
 }
 
 perform_short_tests() {
-  echo "Performing short tests"
-  go test -v -short ./...
+  echo "Performing short tests on $1"
+  go test -v -short "$1"
 }
 
 case $1 in
   --short)
-  perform_short_tests
+  shift
+  perform_short_tests "${1:-./...}"
   ;;
   *)
-  perform_tests
+  perform_tests "${1:-./...}"
   ;;
 esac
 


### PR DESCRIPTION
This allows to do `make test TESTPKGS=./internal/app/machined`.

Also update Dockerfile slug as
https://github.com/moby/buildkit/pull/1081 was merged into master.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>