### PR TITLE
chore: implement first version of CRI runner

### DIFF
--- a/internal/app/machined/pkg/system/runner/cri/cri.go
+++ b/internal/app/machined/pkg/system/runner/cri/cri.go
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package cri implements runner via CRI interface
+package cri

--- a/internal/app/machined/pkg/system/runner/cri/cri_test.go
+++ b/internal/app/machined/pkg/system/runner/cri/cri_test.go
@@ -1,0 +1,338 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cri_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
+	crirunner "github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/cri"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
+	"github.com/talos-systems/talos/internal/pkg/constants"
+	criclient "github.com/talos-systems/talos/internal/pkg/cri"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+const (
+	busyboxImage = "docker.io/library/busybox:latest"
+)
+
+func MockEventSink(state events.ServiceState, message string, args ...interface{}) {
+	log.Printf("state %s: %s", state, fmt.Sprintf(message, args...))
+}
+
+type CRISuite struct {
+	suite.Suite
+
+	tmpDir string
+
+	containerdRunner  runner.Runner
+	containerdWg      sync.WaitGroup
+	containerdAddress string
+
+	client   *criclient.Client
+	imageRef string
+}
+
+// nolint: dupl
+func (suite *CRISuite) SetupSuite() {
+	var err error
+
+	suite.tmpDir, err = ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
+	suite.Require().NoError(os.Mkdir(stateDir, 0777))
+	suite.Require().NoError(os.Mkdir(rootDir, 0777))
+
+	suite.containerdAddress = filepath.Join(suite.tmpDir, "run.sock")
+
+	args := &runner.Args{
+		ID: "containerd",
+		ProcessArgs: []string{
+			"/bin/containerd",
+			"--address", suite.containerdAddress,
+			"--state", stateDir,
+			"--root", rootDir,
+		},
+	}
+
+	suite.containerdRunner = process.NewRunner(
+		&userdata.UserData{},
+		args,
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithEnv([]string{"PATH=/bin:" + constants.PATH}),
+	)
+	suite.Require().NoError(suite.containerdRunner.Open(context.Background()))
+	suite.containerdWg.Add(1)
+	go func() {
+		defer suite.containerdWg.Done()
+		defer func() { suite.Require().NoError(suite.containerdRunner.Close()) }()
+		suite.Require().NoError(suite.containerdRunner.Run(MockEventSink))
+	}()
+
+	suite.client, err = criclient.NewClient("unix:"+suite.containerdAddress, 30*time.Second)
+	suite.Require().NoError(err)
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	suite.imageRef, err = suite.client.PullImage(ctx, &runtimeapi.ImageSpec{
+		Image: busyboxImage,
+	}, &runtimeapi.PodSandboxConfig{})
+	suite.Require().NoError(err)
+}
+
+func (suite *CRISuite) TearDownSuite() {
+	suite.Require().NoError(suite.client.Close())
+
+	suite.Require().NoError(suite.containerdRunner.Stop())
+	suite.containerdWg.Wait()
+
+	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
+}
+
+func (suite *CRISuite) getLogContents(filename string) []byte {
+	logFile, err := os.Open(filepath.Join(suite.tmpDir, filename))
+	suite.Assert().NoError(err)
+
+	// nolint: errcheck
+	defer logFile.Close()
+
+	logContents, err := ioutil.ReadAll(logFile)
+	suite.Assert().NoError(err)
+
+	return logContents
+}
+
+func (suite *CRISuite) TestRunSuccess() {
+	r := crirunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "test",
+		ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithContainerdAddress(suite.containerdAddress),
+	)
+
+	suite.Require().NoError(r.Open(context.Background()))
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	suite.Assert().NoError(r.Run(MockEventSink))
+	// calling stop when Run has finished is no-op
+	suite.Assert().NoError(r.Stop())
+}
+
+func (suite *CRISuite) TestRunTwice() {
+	r := crirunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "runtwice",
+		ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithContainerImage(suite.imageRef),
+		runner.WithContainerdAddress(suite.containerdAddress),
+	)
+
+	suite.Require().NoError(r.Open(context.Background()))
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	// running same container twice should be fine
+	// (checks that containerd state is cleaned up properly)
+	for i := 0; i < 2; i++ {
+		suite.Assert().NoError(r.Run(MockEventSink))
+		// calling stop when Run has finished is no-op
+		suite.Assert().NoError(r.Stop())
+
+		// TODO: workaround containerd (?) bug: https://github.com/docker/for-linux/issues/643
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (suite *CRISuite) TestPodCleanup() {
+	// create two runners with the same  ID
+	//
+	// open first runner, but don't close it; second runner should be
+	// able to start the pod by cleaning up pod created by the first
+	// runner
+	r1 := crirunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "cleanup1",
+		ProcessArgs: []string{"/bin/sh", "-c", "exit 1"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithContainerdAddress(suite.containerdAddress),
+	)
+
+	suite.Require().NoError(r1.Open(context.Background()))
+
+	r2 := crirunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "cleanup1",
+		ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithContainerdAddress(suite.containerdAddress),
+	)
+	suite.Require().NoError(r2.Open(context.Background()))
+	defer func() { suite.Assert().NoError(r2.Close()) }()
+
+	suite.Assert().NoError(r2.Run(MockEventSink))
+	// calling stop when Run has finished is no-op
+	suite.Assert().NoError(r2.Stop())
+}
+
+func (suite *CRISuite) TestRunLogs() {
+	r := crirunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "logtest",
+		ProcessArgs: []string{"/bin/sh", "-c", "echo -n \"Test 1\nTest 2\n\""},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithContainerdAddress(suite.containerdAddress),
+	)
+
+	suite.Require().NoError(r.Open(context.Background()))
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	suite.Assert().NoError(r.Run(MockEventSink))
+
+	logContents := suite.getLogContents("logtest.log")
+
+	suite.Assert().Contains(string(logContents), "Test 1\n")
+	suite.Assert().Contains(string(logContents), "Test 2\n")
+}
+
+// func (suite *CRISuite) TestStopFailingAndRestarting() {
+// 	testDir := filepath.Join(suite.tmpDir, "test")
+// 	suite.Assert().NoError(os.Mkdir(testDir, 0770))
+
+// 	testFile := filepath.Join(testDir, "talos-test")
+// 	// nolint: errcheck
+// 	_ = os.Remove(testFile)
+
+// 	r := restart.New(containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
+// 		ID:          "endless",
+// 		ProcessArgs: []string{"/bin/sh", "-c", "test -f " + testFile + " && echo ok || (echo fail; false)"},
+// 	},
+// 		runner.WithLogPath(suite.tmpDir),
+// 		runner.WithNamespace(containerdNamespace),
+// 		runner.WithContainerImage(busyboxImage),
+// 		runner.WithOCISpecOpts(
+// 			oci.WithMounts([]specs.Mount{
+// 				{Type: "bind", Destination: testDir, Source: testDir, Options: []string{"bind", "ro"}},
+// 			}),
+// 		),
+// 		runner.WithContainerdAddress(suite.containerdAddress),
+// 	),
+// 		restart.WithType(restart.Forever),
+// 		restart.WithRestartInterval(5*time.Millisecond),
+// 	)
+
+// 	suite.Require().NoError(r.Open(context.Background()))
+// 	defer func() { suite.Assert().NoError(r.Close()) }()
+
+// 	done := make(chan error, 1)
+
+// 	go func() {
+// 		done <- r.Run(MockEventSink)
+// 	}()
+
+// 	for i := 0; i < 10; i++ {
+// 		time.Sleep(500 * time.Millisecond)
+// 		if bytes.Contains(suite.getLogContents("endless.log"), []byte("fail\n")) {
+// 			break
+// 		}
+// 	}
+
+// 	select {
+// 	case err := <-done:
+// 		suite.Assert().Failf("task should be running", "error: %s", err)
+// 		return
+// 	default:
+// 	}
+
+// 	f, err := os.Create(testFile)
+// 	suite.Assert().NoError(err)
+// 	suite.Assert().NoError(f.Close())
+
+// 	for i := 0; i < 10; i++ {
+// 		time.Sleep(500 * time.Millisecond)
+// 		if bytes.Contains(suite.getLogContents("endless.log"), []byte("ok\n")) {
+// 			break
+// 		}
+// 	}
+
+// 	select {
+// 	case err = <-done:
+// 		suite.Assert().Failf("task should be running", "error: %s", err)
+// 		return
+// 	default:
+// 	}
+
+// 	suite.Assert().NoError(r.Stop())
+// 	<-done
+
+// 	logContents := suite.getLogContents("endless.log")
+
+// 	suite.Assert().Truef(bytes.Contains(logContents, []byte("ok\n")), "logContents doesn't contain success entry: %v", logContents)
+// 	suite.Assert().Truef(bytes.Contains(logContents, []byte("fail\n")), "logContents doesn't contain fail entry: %v", logContents)
+// }
+
+func (suite *CRISuite) TestStopSigKill() {
+	r := crirunner.NewRunner(&userdata.UserData{}, &runner.Args{
+		ID:          "nokill",
+		ProcessArgs: []string{"/bin/sh", "-c", "trap -- '' SIGTERM; while :; do :; done"},
+	},
+		runner.WithLogPath(suite.tmpDir),
+		runner.WithContainerImage(busyboxImage),
+		runner.WithGracefulShutdownTimeout(10*time.Millisecond),
+		runner.WithContainerdAddress(suite.containerdAddress),
+	)
+
+	suite.Require().NoError(r.Open(context.Background()))
+	defer func() { suite.Assert().NoError(r.Close()) }()
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- r.Run(MockEventSink)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-done:
+		suite.Assert().Fail("container should be still running")
+	default:
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	suite.Assert().NoError(r.Stop())
+	<-done
+}
+
+func TestCRISuite(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("can't run the test as non-root")
+	}
+	_, err := os.Stat("/bin/containerd")
+	if err != nil {
+		t.Skip("containerd binary is not available, skipping the test")
+	}
+
+	suite.Run(t, new(CRISuite))
+}

--- a/internal/app/machined/pkg/system/runner/cri/runner.go
+++ b/internal/app/machined/pkg/system/runner/cri/runner.go
@@ -1,0 +1,289 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cri
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
+	"github.com/talos-systems/talos/internal/pkg/cri"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+type criRunner struct {
+	data *userdata.UserData
+	args *runner.Args
+	opts *runner.Options
+
+	stop    chan struct{}
+	stopped chan struct{}
+
+	client *cri.Client
+
+	podSandboxConfig *runtimeapi.PodSandboxConfig
+	podSandboxID     string
+	imageRef         string
+}
+
+// NewRunner creates runner.Runner that runs a container in a sandbox
+func NewRunner(data *userdata.UserData, args *runner.Args, setters ...runner.Option) runner.Runner {
+	r := &criRunner{
+		data:    data,
+		args:    args,
+		opts:    runner.DefaultOptions(),
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+
+	for _, setter := range setters {
+		setter(r.opts)
+	}
+
+	return r
+}
+
+// Close implements runner.Runner interface
+func (c *criRunner) Close() error {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	if c.podSandboxID != "" {
+		err := c.client.StopPodSandbox(ctx, c.podSandboxID)
+		if err != nil {
+			return err
+		}
+
+		err = c.client.RemovePodSandbox(ctx, c.podSandboxID)
+		if err != nil {
+			return err
+		}
+
+		c.podSandboxID = ""
+
+	}
+
+	if c.client == nil {
+		return nil
+	}
+
+	return c.client.Close()
+}
+
+func (c *criRunner) findImage(ctx context.Context) error {
+	imageInfo, err := c.client.ImageStatus(ctx, &runtimeapi.ImageSpec{
+		Image: c.opts.ContainerImage,
+	})
+	if err != nil {
+		return err
+	}
+
+	if imageInfo != nil {
+		c.imageRef = imageInfo.Id
+		return nil
+	}
+
+	// ListImages API at least in the containerd CRI plugin ignores the filter,
+	// so instead of relying on it, request full list and filter manually
+	images, err := c.client.ListImages(ctx, &runtimeapi.ImageFilter{})
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		if image.Id == c.opts.ContainerImage {
+			c.imageRef = image.Id
+			return nil
+		}
+
+		for _, repoTag := range image.RepoTags {
+			if repoTag == c.opts.ContainerImage {
+				c.imageRef = image.Id
+				return nil
+			}
+		}
+	}
+
+	return errors.Errorf("container image %q hasn't been found", c.opts.ContainerImage)
+}
+
+// Open prepares the runner.
+//
+//nolint: gocyclo
+func (c *criRunner) Open(upstreamCtx context.Context) error {
+	// validate the basic options
+	if c.opts.Namespace != "system" {
+		return errors.New("namespaces not supported by CRI runner")
+	}
+
+	if c.opts.ContainerOpts != nil {
+		return errors.New("containerd options not supported by CRI runner")
+	}
+
+	if c.opts.OCISpecOpts != nil {
+		return errors.New("OCI spec is not supported by CRI runner")
+	}
+
+	ctx, ctxCancel := context.WithTimeout(upstreamCtx, 30*time.Second)
+	defer ctxCancel()
+
+	// Create the CRI client.
+	var err error
+	c.client, err = cri.NewClient("unix:"+c.opts.ContainerdAddress, 10*time.Second)
+	if err != nil {
+		return err
+	}
+
+	if err = c.findImage(ctx); err != nil {
+		return err
+	}
+
+	// See if there's previous pod sandbox to clean up
+	oldSandboxes, err := c.client.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{
+		LabelSelector: map[string]string{
+			"talos.id": c.args.ID,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, oldSandbox := range oldSandboxes {
+		if oldSandbox.State == runtimeapi.PodSandboxState_SANDBOX_READY {
+			if err = c.client.StopPodSandbox(ctx, oldSandbox.Id); err != nil {
+				return err
+			}
+		}
+
+		if err = c.client.RemovePodSandbox(ctx, oldSandbox.Id); err != nil {
+			return err
+		}
+	}
+
+	// Create pod sandbox
+	c.podSandboxConfig = &runtimeapi.PodSandboxConfig{
+		Metadata: &runtimeapi.PodSandboxMetadata{
+			Name:      c.args.ID,
+			Uid:       c.args.ID,
+			Namespace: "talos",
+		},
+		LogDirectory: c.opts.LogPath,
+		Labels: map[string]string{
+			"talos.id": c.args.ID,
+		},
+		Linux: &runtimeapi.LinuxPodSandboxConfig{
+			SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
+				NamespaceOptions: &runtimeapi.NamespaceOption{
+					Network: runtimeapi.NamespaceMode_NODE,
+				},
+			},
+		},
+	}
+
+	// Create the pod
+	c.podSandboxID, err = c.client.RunPodSandbox(ctx, c.podSandboxConfig, "")
+
+	return err
+}
+
+// Run implements runner.Runner interface
+//
+// nolint: gocyclo
+func (c *criRunner) Run(eventSink events.Recorder) error {
+	defer close(c.stopped)
+
+	ctx := context.Background()
+
+	// Create container
+	containerConfig := runtimeapi.ContainerConfig{
+		Metadata: &runtimeapi.ContainerMetadata{
+			Name: c.args.ID,
+		},
+		Image: &runtimeapi.ImageSpec{
+			Image: c.imageRef,
+		},
+		Command: c.args.ProcessArgs,
+		LogPath: c.args.ID + ".log",
+	}
+
+	// Create the container
+	containerID, err := c.client.CreateContainer(ctx, c.podSandboxID, &containerConfig, c.podSandboxConfig)
+	if err != nil {
+		return err
+	}
+	// nolint: errcheck
+	defer c.client.RemoveContainer(ctx, containerID)
+
+	// Start the container
+	err = c.client.StartContainer(ctx, containerID)
+	if err != nil {
+		return err
+	}
+	// nolint: errcheck
+	defer c.client.StopContainer(context.Background(), containerID, 5)
+
+	eventSink(events.StateRunning, "Started container %q in sandbox %q", containerID, c.podSandboxID)
+
+	// TODO: make this polling interval configurable
+	pollTicker := time.NewTicker(1 * time.Second)
+	defer pollTicker.Stop()
+
+WAIT:
+	for {
+		select {
+		case <-c.stop:
+			break WAIT
+		case <-pollTicker.C:
+		}
+
+		var status *runtimeapi.ContainerStatus
+		status, _, err = c.client.ContainerStatus(ctx, containerID, false)
+		if err != nil {
+			return err
+		}
+
+		switch status.State {
+		case runtimeapi.ContainerState_CONTAINER_RUNNING:
+			// ok
+		case runtimeapi.ContainerState_CONTAINER_EXITED:
+			if status.ExitCode == 0 {
+				return nil
+			}
+
+			return errors.Errorf("container exited with code %d (%s)", status.ExitCode, status.Reason)
+		default:
+			return errors.Errorf("container in unexpected state (%d)", status.State)
+		}
+	}
+
+	eventSink(events.StateStopping, "Stopping container %q in sandbox %q", containerID, c.podSandboxID)
+	err = c.client.StopContainer(ctx, containerID, int64(c.opts.GracefulShutdownTimeout/time.Second))
+	if err != nil {
+		return err
+	}
+
+	return c.client.RemoveContainer(ctx, containerID)
+}
+
+// Stop implements runner.Runner interface
+func (c *criRunner) Stop() error {
+	close(c.stop)
+
+	<-c.stopped
+
+	c.stop = make(chan struct{})
+	c.stopped = make(chan struct{})
+
+	return nil
+}
+
+func (c *criRunner) String() string {
+	return fmt.Sprintf("CRI(%v)", c.args.ID)
+}

--- a/internal/pkg/containers/cri/cri.go
+++ b/internal/pkg/containers/cri/cri.go
@@ -206,7 +206,7 @@ func (i *inspector) buildPod(sandbox *runtimeapi.PodSandbox) (*ctrs.Pod, error) 
 }
 
 func (i *inspector) buildContainer(container *runtimeapi.Container) (*ctrs.Container, error) {
-	containerStatus, containerInfo, err := i.client.ContainerStatus(i.ctx, container.Id)
+	containerStatus, containerInfo, err := i.client.ContainerStatus(i.ctx, container.Id, true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cri/containers.go
+++ b/internal/pkg/cri/containers.go
@@ -80,10 +80,10 @@ func (c *Client) ListContainers(ctx context.Context, filter *runtimeapi.Containe
 }
 
 // ContainerStatus returns the container status.
-func (c *Client) ContainerStatus(ctx context.Context, containerID string) (*runtimeapi.ContainerStatus, map[string]string, error) {
+func (c *Client) ContainerStatus(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatus, map[string]string, error) {
 	resp, err := c.runtimeClient.ContainerStatus(ctx, &runtimeapi.ContainerStatusRequest{
 		ContainerId: containerID,
-		Verbose:     true,
+		Verbose:     verbose,
 	})
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "ContainerStatus %q from runtime service failed", containerID)

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -137,6 +137,11 @@ func (suite *CRISuite) TestRunSandboxContainer() {
 	}, podSandboxConfig)
 	suite.Require().NoError(err)
 
+	_, err = suite.client.ImageStatus(suite.ctx, &runtimeapi.ImageSpec{
+		Image: imageRef,
+	})
+	suite.Require().NoError(err)
+
 	ctrID, err := suite.client.CreateContainer(suite.ctx, podSandboxID,
 		&runtimeapi.ContainerConfig{
 			Metadata: &runtimeapi.ContainerMetadata{
@@ -164,7 +169,7 @@ func (suite *CRISuite) TestRunSandboxContainer() {
 	_, err = suite.client.ContainerStats(suite.ctx, ctrID)
 	suite.Require().NoError(err)
 
-	_, _, err = suite.client.ContainerStatus(suite.ctx, ctrID)
+	_, _, err = suite.client.ContainerStatus(suite.ctx, ctrID, true)
 	suite.Require().NoError(err)
 
 	err = suite.client.StopContainer(suite.ctx, ctrID, 10)

--- a/internal/pkg/cri/images.go
+++ b/internal/pkg/cri/images.go
@@ -36,3 +36,21 @@ func (c *Client) ListImages(ctx context.Context, filter *runtimeapi.ImageFilter)
 	return resp.Images, nil
 
 }
+
+// ImageStatus returns the status of the image.
+func (c *Client) ImageStatus(ctx context.Context, image *runtimeapi.ImageSpec) (*runtimeapi.Image, error) {
+	resp, err := c.imagesClient.ImageStatus(ctx, &runtimeapi.ImageStatusRequest{
+		Image: image,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "ImageStatus %q from image service failed", image.Image)
+	}
+
+	if resp.Image != nil {
+		if resp.Image.Id == "" || resp.Image.Size_ == 0 {
+			return nil, errors.Errorf("Id or size of image %q is not set", image.Image)
+		}
+	}
+
+	return resp.Image, nil
+}


### PR DESCRIPTION
It runs containers via CRI interface in a pod sandbox. This is the very
first version:  I tried not to introduce any changes to common runner
interface.

There should be some CRI-speficic options for the runner (like polling
interval, as it doesn't have nice `Wait()` API), plus my plan so far is
to use OCI as the common layer for container options, so that we can
analyze OCI and translate to CRI (when possible, return errors when
option is not implemented).

CRI interface doesn't have a concept of 'unpacking' an image, so we
probably need to unpack via containerd API (or any other
runtime-specific API) by targeting CRI namespace.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>