### PR TITLE
feat: move df API to init

### DIFF
--- a/cmd/osctl/cmd/df.go
+++ b/cmd/osctl/cmd/df.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/internal/app/osd/proto"
+	"github.com/talos-systems/talos/internal/app/machined/proto"
 )
 
 // dfCmd represents the df command.

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -228,8 +228,8 @@ func (c *Client) Top(ctx context.Context) (pl []proc.ProcessList, err error) {
 }
 
 // DF implements the proto.OSDClient interface.
-func (c *Client) DF(ctx context.Context) (*proto.DFReply, error) {
-	return c.client.DF(ctx, &empty.Empty{})
+func (c *Client) DF(ctx context.Context) (*initproto.DFReply, error) {
+	return c.initClient.DF(ctx, &empty.Empty{})
 }
 
 // LS implements the proto.OSDClient interface.

--- a/internal/app/machined/proto/api.proto
+++ b/internal/app/machined/proto/api.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 // The Init service definition.
 service Init {
   rpc CopyOut(CopyOutRequest) returns (stream StreamingData) {}
+  rpc DF(google.protobuf.Empty) returns (DFReply) {}
   rpc LS(LSRequest) returns (stream FileInfo) {}
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
@@ -16,7 +17,6 @@ service Init {
   rpc Upgrade(UpgradeRequest) returns (UpgradeReply) {}
   rpc ServiceList(google.protobuf.Empty) returns (ServiceListReply) {}
 }
-
 
 // The response message containing the reboot status.
 message RebootReply {}
@@ -27,15 +27,11 @@ message ResetReply {}
 // The response message containing the shutdown status.
 message ShutdownReply {}
 
-message UpgradeRequest {
-	string url = 1;
-}
+message UpgradeRequest { string url = 1; }
 
 message UpgradeReply { string ack = 1; }
 
-message ServiceListReply {
-  repeated ServiceInfo services = 1;
-}
+message ServiceListReply { repeated ServiceInfo services = 1; }
 
 message ServiceInfo {
   string id = 1;
@@ -44,9 +40,7 @@ message ServiceInfo {
   ServiceHealth health = 4;
 }
 
-message ServiceEvents {
-  repeated ServiceEvent events = 1;
-}
+message ServiceEvents { repeated ServiceEvent events = 1; }
 
 message ServiceEvent {
   string msg = 1;
@@ -82,13 +76,15 @@ message CopyOutRequest {
 // LSRequest describes a request to list the contents of a directory
 message LSRequest {
 
-  // Root indicates the root directory for the list.  If not indicated, '/' is presumed.
+  // Root indicates the root directory for the list.  If not indicated, '/' is
+  // presumed.
   string root = 1;
 
   // Recurse indicates that subdirectories should be recursed.
   bool recurse = 2;
 
-  // RecursionDepth indicates how many levels of subdirectories should be recursed.  The default (0) indicates that no limit should be enforced.
+  // RecursionDepth indicates how many levels of subdirectories should be
+  // recursed.  The default (0) indicates that no limit should be enforced.
   int32 recursion_depth = 3;
 }
 
@@ -110,7 +106,8 @@ message FileInfo {
   // IsDir indicates that the file is a directory
   bool is_dir = 5;
 
-  // Error describes any error encountered while trying to read the file information.
+  // Error describes any error encountered while trying to read the file
+  // information.
   string error = 6;
 
   // Link is filled with symlink target
@@ -118,4 +115,15 @@ message FileInfo {
 
   // RelativeName is the name of the file or directory relative to the RootPath
   string relative_name = 8;
+}
+
+// The response message containing the requested df stats.
+message DFReply { repeated DFStat stats = 1; }
+
+// The response message containing the requested processes.
+message DFStat {
+  string filesystem = 1;
+  uint64 size = 2;
+  uint64 available = 3;
+  string mounted_on = 4;
 }

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -100,3 +100,8 @@ func (c *InitServiceClient) LS(req *proto.LSRequest, srv proto.Init_LSServer) er
 
 	return copyClientServer(&msg, client, srv)
 }
+
+// DF implements the proto.OSDServer interface.
+func (c *InitServiceClient) DF(ctx context.Context, in *empty.Empty) (reply *proto.DFReply, err error) {
+	return c.InitClient.DF(ctx, in)
+}

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -5,7 +5,6 @@
 package reg
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/gob"
@@ -16,12 +15,10 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/hashicorp/go-multierror"
 	"github.com/jsimonetti/rtnetlink"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -320,71 +317,6 @@ func (r *Registrator) Top(ctx context.Context, in *empty.Empty) (reply *proto.To
 	p := &proto.ProcessList{Bytes: plist.Bytes()}
 	reply = &proto.TopReply{ProcessList: p}
 	return
-}
-
-// DF implements the proto.OSDServer interface.
-func (r *Registrator) DF(ctx context.Context, in *empty.Empty) (reply *proto.DFReply, err error) {
-	file, err := os.Open("/proc/mounts")
-	if err != nil {
-		return nil, err
-	}
-	// nolint: errcheck
-	defer file.Close()
-
-	var (
-		stat     unix.Statfs_t
-		multiErr *multierror.Error
-	)
-
-	stats := []*proto.DFStat{}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-
-		if len(fields) < 2 {
-			continue
-		}
-
-		filesystem := fields[0]
-		mountpoint := fields[1]
-
-		f, err := os.Stat(mountpoint)
-		if err != nil {
-			multiErr = multierror.Append(multiErr, err)
-			continue
-		}
-
-		if mode := f.Mode(); !mode.IsDir() {
-			continue
-		}
-
-		if err := unix.Statfs(mountpoint, &stat); err != nil {
-			multiErr = multierror.Append(multiErr, err)
-			continue
-		}
-
-		totalSize := uint64(stat.Bsize) * stat.Blocks
-		totalAvail := uint64(stat.Bsize) * stat.Bavail
-
-		stat := &proto.DFStat{
-			Filesystem: filesystem,
-			Size:       totalSize,
-			Available:  totalAvail,
-			MountedOn:  mountpoint,
-		}
-
-		stats = append(stats, stat)
-	}
-
-	if err := scanner.Err(); err != nil {
-		multiErr = multierror.Append(multiErr, err)
-	}
-
-	reply = &proto.DFReply{
-		Stats: stats,
-	}
-
-	return reply, multiErr.ErrorOrNil()
 }
 
 func getContainerInspector(ctx context.Context, namespace string, driver proto.ContainerDriver) (containers.Inspector, error) {

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -9,7 +9,6 @@ import "google/protobuf/empty.proto";
 //
 // OSD Service also implements all the API of Init Service
 service OSD {
-  rpc DF(google.protobuf.Empty) returns (DFReply) {}
   rpc Dmesg(google.protobuf.Empty) returns (Data) {}
   rpc Kubeconfig(google.protobuf.Empty) returns (Data) {}
   rpc Logs(LogsRequest) returns (stream Data) {}
@@ -156,14 +155,3 @@ message TopRequest {}
 message TopReply { ProcessList process_list = 1; }
 
 message ProcessList { bytes bytes = 1; }
-
-// The response message containing the requested df stats.
-message DFReply { repeated DFStat stats = 1; }
-
-// The response message containing the requested processes.
-message DFStat {
-  string filesystem = 1;
-  uint64 size = 2;
-  uint64 available = 3;
-  string mounted_on = 4;
-}


### PR DESCRIPTION
This change allows for more accurate mount reporting as /proc/mounts is
a symlink to /proc/self/mounts and contains mounts that are relative to
the running process. In our case this was osd. This caused inaccurate
reporting of mounts since they were relative to osd when we really
wanted mounts relative to machined.