### PR TITLE
fix: check proper value of parseip in dhcp

### DIFF
--- a/internal/pkg/network/dhcp.go
+++ b/internal/pkg/network/dhcp.go
@@ -122,7 +122,7 @@ func (service *Service) dhclient4(ctx context.Context, ifname string, modifiers 
 
 			// Truncate hostname to be betta
 			// Allow IP addrs to be valid hostnames for the time being
-			if ok := net.ParseIP(hostname); ok != nil {
+			if ok := net.ParseIP(hostname); ok == nil {
 				// Pull out the first part of a potential FQDN
 				hostname = strings.Split(hostname, ".")[0]
 			}


### PR DESCRIPTION
This PR fixes a small bug where we weren't properly checking the value of a net.ParseIP() call and setting the hostname to the first octet of an IP.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>