### PR TITLE
fix(trustd): allow hostnames for trustd endpoints

### DIFF
--- a/pkg/userdata/services_test.go
+++ b/pkg/userdata/services_test.go
@@ -35,8 +35,8 @@ func (suite *validateSuite) TestValidateTrustd() {
 	suite.Require().Error(err)
 	suite.Assert().Equal(2, len(err.(*multierror.Error).Errors))
 
-	svc.Trustd.Endpoints = []string{"1.2.3.4"}
-	err = svc.Trustd.Validate(CheckTrustdEndpointsAreValidIPs())
+	svc.Trustd.Endpoints = []string{"1.2.3.4", "master", "master.testdomain.com", "many-dotted.hostname.with.much.depth.and.odd.tld.engineering", "2001:db8::2"}
+	err = svc.Trustd.Validate(CheckTrustdEndpointsAreValidIPsOrHostnames())
 	suite.Require().NoError(err)
 
 	svc.Trustd.Token = "yolo"

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -42,7 +42,7 @@ func (data *UserData) Validate() error {
 
 	// All nodeType checks
 	result = multierror.Append(result, data.Services.Validate(CheckServices()))
-	result = multierror.Append(result, data.Services.Trustd.Validate(CheckTrustdAuth(), CheckTrustdEndpointsAreValidIPs()))
+	result = multierror.Append(result, data.Services.Trustd.Validate(CheckTrustdAuth(), CheckTrustdEndpointsAreValidIPsOrHostnames()))
 	result = multierror.Append(result, data.Services.Init.Validate(CheckInitCNI()))
 
 	// Surely there's a better way to do this


### PR DESCRIPTION
Fixes #666

Also adds IPv6 to tests for trustd endpoints

Signed-off-by: Seán C McCord <ulexus@gmail.com>