### PR TITLE
chore: create raw image as sparse file

### DIFF
--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -39,7 +39,7 @@ var installCmd = &cobra.Command{
 				ExtraKernelArgs: extraKernelArgs,
 				Data: &userdata.InstallDevice{
 					Device: device,
-					Size:   512 * 1000 * 1000,
+					Size:   16 * 1024 * 1024,
 				},
 			},
 		}
@@ -50,7 +50,7 @@ var installCmd = &cobra.Command{
 				Initramfs: "file:///usr/install/initramfs.xz",
 				InstallDevice: userdata.InstallDevice{
 					Device: device,
-					Size:   512 * 1000 * 1000,
+					Size:   512 * 1024 * 1024,
 				},
 			}
 		}

--- a/hack/installer/entrypoint.sh
+++ b/hack/installer/entrypoint.sh
@@ -19,7 +19,7 @@ function setup_raw_device(){
   if [[ -f ${TALOS_RAW} ]]; then
     rm ${TALOS_RAW}
   fi
-  dd if=/dev/zero of="${TALOS_RAW}" bs=512M count=10
+  dd if=/dev/zero of="${TALOS_RAW}" bs=1M count=0 seek=544
   DEVICE=$(losetup -f)
   # NB: Since we use BLKRRPART to tell the kernel to re-read the partition
   # table, it is required to create a partitioned loop device. The BLKRRPART

--- a/internal/pkg/install/prepare.go
+++ b/internal/pkg/install/prepare.go
@@ -33,9 +33,6 @@ const (
 	// TODO(andrewrynhard): We should inspect the tarball's uncompressed size and dynamically set the root partition's size.
 	DefaultSizeRootDevice = 2048 * 1000 * 1000
 
-	// DefaultSizeDataDevice is the default size of the data partition.
-	DefaultSizeDataDevice = 1024 * 1000 * 1000
-
 	// DefaultSizeBootDevice is the default size of the boot partition.
 	// TODO(andrewrynhard): We should inspect the sizes of the artifacts and dynamically set the boot partition's size.
 	DefaultSizeBootDevice = 512 * 1000 * 1000
@@ -137,10 +134,6 @@ func VerifyDataDevice(data *userdata.UserData) (err error) {
 
 	if data.Install.Data.Device == "" {
 		return errors.New("a data device is required")
-	}
-
-	if data.Install.Data.Size == 0 {
-		data.Install.Data.Size = DefaultSizeDataDevice
 	}
 
 	if !data.Install.Force {


### PR DESCRIPTION
This change reduces the size of raw disk significantly by creating it as
a sparse file.