### PR TITLE
chore: enable and use properly go build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage.txt
 # buildkit cache
 .buildkit/
 
+# generated files
+internal/pkg/version/tags.go
+
 sha256sum.txt
 sha512sum.txt
 

--- a/cmd/osctl/cmd/cp.go
+++ b/cmd/osctl/cmd/cp.go
@@ -46,8 +46,10 @@ captures ownership and permission bits.`,
 			var wg sync.WaitGroup
 
 			wg.Add(1)
+
 			go func() {
 				defer wg.Done()
+
 				for err := range errCh {
 					fmt.Fprintln(os.Stderr, err.Error())
 				}

--- a/hack/dev/gen.sh
+++ b/hack/dev/gen.sh
@@ -72,3 +72,4 @@ ${OSCTL} config add "talos-local" \
 ${OSCTL} config context "talos-local"
 ${OSCTL} config target "${IP_ADDR}"
 
+echo

--- a/hack/gen/version-gen.sh
+++ b/hack/gen/version-gen.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+OUTPUT=$1
+BUILT=`date -Iseconds`
+
+cat > "$OUTPUT" <<EOF
+// Code generated automatically by version-gen.sh DO NOT EDIT.
+
+package version
+
+const Tag="${TAG}"
+const SHA="${SHA}"
+const Built="${BUILT}"
+EOF

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -11,15 +11,11 @@ import (
 	"text/template"
 )
 
+//go:generate ../../../hack/gen/version-gen.sh .//tags.go
+
 var (
 	// Name is set at build time.
 	Name string
-	// Tag is set at build time.
-	Tag string
-	// SHA is set at build time.
-	SHA string
-	// Built is set at build time.
-	Built string
 )
 
 const versionTemplate = `{{ .Name }}:


### PR DESCRIPTION
There are two parts of the change:

1. Use `go generate` to generate file with version tags instead of
passing them as linker flags. (This might need some cleanup).

2. Remove `-a` to `go build`, clean up cache mounts.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>