### PR TITLE
feat: break up osctl cluster create and basic/e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -386,7 +386,23 @@ services:
         path: /tmp
 
 steps:
-  - name: gce
+  - name: osctl-cluster-create
+    image: autonomy/build-container:latest
+    pull: always
+    environment:
+      BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+      BINDIR: /usr/local/bin
+      TAG: latest
+    commands:
+      - make osctl-linux
+      - make osctl-cluster-create
+    volumes:
+      - name: dockersock
+        path: /var/run
+      - name: tmp
+        path: /tmp
+
+  - name: gce-image
     image: autonomy/build-container:latest
     pull: always
     environment:
@@ -403,8 +419,10 @@ steps:
         path: /var/run
       - name: dev
         path: /dev
+    depends_on:
+      - osctl-cluster-create
 
-  - name: e2e-integration
+  - name: gce-e2e-integration
     image: autonomy/build-container:latest
     pull: always
     environment:
@@ -418,14 +436,18 @@ steps:
         from_secret: packet_pxe_server
       GCE_SVC_ACCT:
         from_secret: gce_svc_acct
+      AZURE_SVC_ACCT:
+        from_secret: azure_svc_acct
+      PLATFORM: gce
     commands:
-      - make osctl-linux
       - make e2e-integration
     volumes:
       - name: dockersock
         path: /var/run
       - name: tmp
         path: /tmp
+    depends_on:
+      - gce-image
 
 volumes:
   - name: dockersock

--- a/Makefile
+++ b/Makefile
@@ -194,9 +194,9 @@ talos-azure:
 		convert \
 		-f raw \
 		-o subformat=fixed,force_size \
-		-O vpc /out/disk.raw /out/disk.vhd
-	@tar -C $(PWD)/build -czf $(PWD)/build/$@.tar.gz disk.vhd
-	@rm -rf $(PWD)/build/disk.raw $(PWD)/build/disk.vhd
+		-O vpc /out/disk.raw /out/talos-azure.vhd
+	@tar -C $(PWD)/build -czf $(PWD)/build/$@.tar.gz talos-azure.vhd
+	@rm -rf $(PWD)/build/disk.raw $(PWD)/build/talos-azure.vhd
 
 .PHONY: talos-raw
 talos-raw:
@@ -211,14 +211,18 @@ talos: buildkitd
 		$(COMMON_ARGS)
 	@docker load < build/$@.tar
 
+.PHONY: osctl-cluster-create
+osctl-cluster-create:
+	@TAG=$(TAG) ./hack/test/$@.sh
+
 .PHONY: basic-integration
 basic-integration:
-	@KUBERNETES_VERSION=v1.15.0 TAG=$(TAG) ./hack/test/$@.sh
+	@TAG=$(TAG) ./hack/test/$@.sh
 
 .PHONY: e2e
 e2e-integration:
     ## TODO(rsmitty): Bump this k8s version back up once the bug is fixed where kubectl can't scale crds
-	@KUBERNETES_VERSION=v1.14.4 TAG=latest ./hack/test/$@.sh
+	@TAG=$(TAG) ./hack/test/$@.sh
 
 .PHONY: test
 test: buildkitd

--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -2,15 +2,9 @@
 
 set -eou pipefail
 
-export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
-export TMP="$(mktemp -d)"
-export OSCTL="${PWD}/build/osctl-linux-amd64"
-export TALOSCONFIG="${TMP}/talosconfig"
-export KUBECONFIG="${TMP}/kubeconfig"
-
+export TMP="/tmp/e2e"
 
 cleanup() {
-	${OSCTL} cluster destroy --name integration
 	rm -rf ${TMP}
 }
 trap cleanup EXIT

--- a/hack/test/e2e-integration.sh
+++ b/hack/test/e2e-integration.sh
@@ -2,63 +2,16 @@
 
 set -eou pipefail
 
-export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
-export TMP="$(mktemp -d)"
-export OSCTL="${PWD}/build/osctl-linux-amd64"
-export TALOSCONFIG="${TMP}/talosconfig"
-export KUBECONFIG="${TMP}/kubeconfig"
+source ./hack/test/e2e-runner.sh
 
-## ClusterAPI Provider Talos (CAPT)
-CAPT_VERSION="0.1.0-alpha.2"
-PROVIDER_COMPONENTS="https://github.com/talos-systems/cluster-api-provider-talos/releases/download/v${CAPT_VERSION}/provider-components.yaml"
-KUSTOMIZE_VERSION="1.0.11"
-KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64"
-SONOBUOY_VERSION="0.15.0"
-SONOBUOY_URL="https://github.com/heptio/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
-
-## Total number of nodes we'll be waiting to come up
-NUM_NODES=6
-MASTER_IPS=""
-
-## GCE-specific vars
-GCE_PROJECT_NAME="talos-testbed"
-GCE_IMAGE_NAME="talos-e2e"
-
-## Long timeout due to packet provisioning times
-TIMEOUT=9000
-
-e2e_run() {
-	docker run \
-	 	--rm \
-		--interactive \
-	 	--net=integration \
-		--entrypoint=bash \
-		--mount type=bind,source=${TMP},target=${TMP} \
-		--mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
-		--mount type=bind,source=${PWD}/hack/test/manifests,target=/e2emanifests \
-	 	-v ${OSCTL}:/bin/osctl:ro \
-	 	-e KUBECONFIG=${KUBECONFIG} \
-	 	-e TALOSCONFIG=${TALOSCONFIG} \
-	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
-}
-
-cleanup() {
- e2e_run "kubectl delete machine talos-e2e-master-0 talos-e2e-master-1 talos-e2e-master-2
-          kubectl scale machinedeployment talos-e2e-workers --replicas=0
-          kubectl delete machinedeployment talos-e2e-workers
-          kubectl delete cluster talos-e2e"
- ${OSCTL} cluster destroy --name integration
- rm -rf ${TMP}
-}
-trap cleanup EXIT
-
-./hack/test/osctl-cluster-create.sh
+## Create tmp dir
+mkdir -p $TMP
 
 ## Drop in capi stuff
-# wget --quiet -O ${PWD}/hack/test/manifests/provider-components.yaml ${PROVIDER_COMPONENTS}
 sed -i "s/{{PACKET_AUTH_TOKEN}}/${PACKET_AUTH_TOKEN}/" ${PWD}/hack/test/manifests/provider-components.yaml
 sed -i "s#{{GCE_SVC_ACCT}}#${GCE_SVC_ACCT}#" ${PWD}/hack/test/manifests/capi-secrets.yaml
-cat ${PWD}/hack/test/manifests/capi-secrets.yaml
+sed -i "s#{{AZURE_SVC_ACCT}}#${AZURE_SVC_ACCT}#" ${PWD}/hack/test/manifests/capi-secrets.yaml
+
 e2e_run "kubectl apply -f /e2emanifests/provider-components.yaml -f /e2emanifests/capi-secrets.yaml"
 
 ## Wait for talosconfig in cm then dump it out
@@ -73,68 +26,6 @@ e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
 		   sleep 10
 		 done"
 
-## Download kustomize and template out capi cluster, then deploy it
-e2e_run "kubectl apply -f /e2emanifests/gce-cluster.yaml"		   
-
-## Wait for talosconfig in cm then dump it out
-e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until kubectl get cm -n cluster-api-provider-talos-system talos-e2e-master-0
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-		     exit 1
-		   fi
-		   sleep 10
-		 done
-         kubectl get cm -n cluster-api-provider-talos-system talos-e2e-master-0 -o jsonpath='{.data.talosconfig}' > ${TALOSCONFIG}-capi"
-
-## Wait for kubeconfig from capi master-0
-e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until /bin/osctl --talosconfig ${TALOSCONFIG}-capi kubeconfig > ${KUBECONFIG}-capi
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-		     exit 1
-		   fi
-		   sleep 10
-		 done"
-
-##  Wait for nodes to check in
-e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until KUBECONFIG=${KUBECONFIG}-capi kubectl get nodes -o json | jq '.items | length' | grep ${NUM_NODES} >/dev/null
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-			exit 1
-		   fi
-		   KUBECONFIG=${KUBECONFIG}-capi kubectl get nodes -o wide
-		   sleep 10
-		 done"
-
-##  Apply psp and flannel
-e2e_run "KUBECONFIG=${KUBECONFIG}-capi kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
-
-##  Wait for nodes ready
-e2e_run "KUBECONFIG=${KUBECONFIG}-capi kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true --all nodes"
-
-## Verify that we have an HA controlplane
-e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-		 until KUBECONFIG=${KUBECONFIG}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 3 > /dev/null
-		 do
-		   if  [[ \$(date +%s) -gt \$timeout ]]
-		   then
-			exit 1
-		   fi
-		   KUBECONFIG=${KUBECONFIG}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length'
-		   sleep 10
-		 done"
-
-## Download sonobuoy and run conformance
-e2e_run "apt-get update && apt-get install wget
-		 wget --quiet -O /tmp/sonobuoy.tar.gz ${SONOBUOY_URL}
-		 tar -xf /tmp/sonobuoy.tar.gz -C /usr/local/bin
-		 sonobuoy run --kubeconfig ${KUBECONFIG}-capi --wait --skip-preflight --plugin e2e
-		 results=\$(sonobuoy retrieve --kubeconfig ${KUBECONFIG}-capi)
-		 sonobuoy e2e --kubeconfig ${KUBECONFIG}-capi \$results"
+./hack/test/e2e-platform.sh
 
 exit 0

--- a/hack/test/e2e-platform.sh
+++ b/hack/test/e2e-platform.sh
@@ -1,0 +1,87 @@
+source ./hack/test/e2e-runner.sh
+
+## Cleanup the platform resources upon any exit
+cleanup() {
+ e2e_run "kubectl delete machine talos-e2e-${PLATFORM}-master-0 talos-e2e-${PLATFORM}-master-1 talos-e2e-${PLATFORM}-master-2
+          kubectl scale machinedeployment talos-e2e-${PLATFORM}-workers --replicas=0
+          kubectl delete machinedeployment talos-e2e-${PLATFORM}-workers
+          kubectl delete cluster talos-e2e-${PLATFORM}"
+}
+
+trap cleanup EXIT
+
+## Download kustomize and template out capi cluster, then deploy it
+e2e_run "kubectl apply -f /e2emanifests/${PLATFORM}-cluster.yaml"		   
+
+## Wait for talosconfig in cm then dump it out
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+		 until kubectl get cm -n cluster-api-provider-talos-system talos-e2e-${PLATFORM}-master-0
+		 do
+		   if  [[ \$(date +%s) -gt \$timeout ]]
+		   then
+		     exit 1
+		   fi
+		   sleep 10
+		 done
+         kubectl get cm -n cluster-api-provider-talos-system talos-e2e-${PLATFORM}-master-0 -o jsonpath='{.data.talosconfig}' > ${TALOSCONFIG}-${PLATFORM}-capi"
+
+## Wait for kubeconfig from capi master-0
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+		 until /bin/osctl --talosconfig ${TALOSCONFIG}-${PLATFORM}-capi kubeconfig > ${KUBECONFIG}-${PLATFORM}-capi
+		 do
+		   if  [[ \$(date +%s) -gt \$timeout ]]
+		   then
+		     exit 1
+		   fi
+		   sleep 10
+		 done"
+
+##  Wait for nodes to check in
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -o json | jq '.items | length' | grep ${NUM_NODES} >/dev/null
+		 do
+		   if  [[ \$(date +%s) -gt \$timeout ]]
+		   then
+			exit 1
+		   fi
+		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -o wide
+		   sleep 10
+		 done"
+
+##  Apply psp and flannel
+e2e_run "KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
+
+## Wait for kube-proxy up
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get po -n kube-system -l k8s-app=kube-proxy -o json | jq '.items | length' | grep ${NUM_NODES} > /dev/null
+		 do
+		   if  [[ \$(date +%s) -gt \$timeout ]]
+		   then
+			exit 1
+		   fi
+		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get po -n kube-system -l k8s-app=kube-proxy
+		   sleep 10
+		 done"
+
+##  Wait for nodes ready
+e2e_run "KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true --all nodes"
+
+## Verify that we have an HA controlplane
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 3 > /dev/null
+		 do
+		   if  [[ \$(date +%s) -gt \$timeout ]]
+		   then
+			exit 1
+		   fi
+		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length'
+		   sleep 10
+		 done"
+
+## Download sonobuoy and run conformance
+e2e_run "apt-get update && apt-get install wget
+		 wget --quiet -O /tmp/sonobuoy.tar.gz ${SONOBUOY_URL}
+		 tar -xf /tmp/sonobuoy.tar.gz -C /usr/local/bin
+		 sonobuoy run --kubeconfig ${KUBECONFIG}-${PLATFORM}-capi --wait --skip-preflight --plugin e2e
+		 results=\$(sonobuoy retrieve --kubeconfig ${KUBECONFIG}-${PLATFORM}-capi)
+		 sonobuoy e2e --kubeconfig ${KUBECONFIG}-${PLATFORM}-capi \$results"

--- a/hack/test/e2e-runner.sh
+++ b/hack/test/e2e-runner.sh
@@ -1,0 +1,34 @@
+export KUBERNETES_VERSION=v1.14.4
+export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
+export TMP="/tmp/e2e"
+export OSCTL="${PWD}/build/osctl-linux-amd64"
+export TALOSCONFIG="${TMP}/talosconfig"
+export KUBECONFIG="${TMP}/kubeconfig"
+## Long timeout due to packet provisioning times
+export TIMEOUT=9000
+
+## Total number of nodes we'll be waiting to come up (3 Masters + 3 Workers)
+export NUM_NODES=6
+
+## ClusterAPI Provider Talos (CAPT)
+export CAPT_VERSION="0.1.0-alpha.2"
+export PROVIDER_COMPONENTS="https://github.com/talos-systems/cluster-api-provider-talos/releases/download/v${CAPT_VERSION}/provider-components.yaml"
+export KUSTOMIZE_VERSION="1.0.11"
+export KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64"
+export SONOBUOY_VERSION="0.15.0"
+export SONOBUOY_URL="https://github.com/heptio/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
+
+e2e_run() {
+	docker run \
+	 	--rm \
+		--interactive \
+	 	--net=integration \
+		--entrypoint=bash \
+		--mount type=bind,source=${TMP},target=${TMP} \
+		--mount type=bind,source=${PWD}/hack/dev/manifests,target=/manifests \
+		--mount type=bind,source=${PWD}/hack/test/manifests,target=/e2emanifests \
+	 	-v ${OSCTL}:/bin/osctl:ro \
+	 	-e KUBECONFIG=${KUBECONFIG} \
+	 	-e TALOSCONFIG=${TALOSCONFIG} \
+	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
+}

--- a/hack/test/gce-setup.sh
+++ b/hack/test/gce-setup.sh
@@ -2,8 +2,6 @@
 
 set -eou pipefail
 
-## Update secret with service acct info
-
 ## Setup svc acct
 echo $GCE_SVC_ACCT | base64 -d > /tmp/svc-acct.json
 apk add --no-cache python

--- a/hack/test/manifests/gce-cluster.yaml
+++ b/hack/test/manifests/gce-cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   annotations: null
-  name: talos-e2e
+  name: talos-e2e-gce
 spec:
   clusterNetwork:
     pods:
@@ -18,17 +18,17 @@ spec:
       kind: TalosClusterProviderSpec
       masters:
         ips:
-        - 35.206.100.52
-        - 35.208.36.204
-        - 35.209.145.137
+        - 35.208.196.229
+        - 35.208.64.45
+        - 35.208.118.119
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e
+    cluster.k8s.io/cluster-name: talos-e2e-gce
     set: master
-  name: talos-e2e-master-0
+  name: talos-e2e-gce-master-0
 spec:
   providerSpec:
     value:
@@ -49,9 +49,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e
+    cluster.k8s.io/cluster-name: talos-e2e-gce
     set: master
-  name: talos-e2e-master-1
+  name: talos-e2e-gce-master-1
 spec:
   providerSpec:
     value:
@@ -72,9 +72,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e
+    cluster.k8s.io/cluster-name: talos-e2e-gce
     set: master
-  name: talos-e2e-master-2
+  name: talos-e2e-gce-master-2
 spec:
   providerSpec:
     value:
@@ -95,19 +95,19 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e
+    cluster.k8s.io/cluster-name: talos-e2e-gce
     set: worker
-  name: talos-e2e-workers
+  name: talos-e2e-gce-workers
 spec:
   replicas: 3
   selector:
     matchLabels:
-      cluster.k8s.io/cluster-name: talos-e2e
+      cluster.k8s.io/cluster-name: talos-e2e-gce
       set: worker
   template:
     metadata:
       labels:
-        cluster.k8s.io/cluster-name: talos-e2e
+        cluster.k8s.io/cluster-name: talos-e2e-gce
         set: worker
     spec:
       providerSpec:

--- a/hack/test/manifests/provider-components.yaml
+++ b/hack/test/manifests/provider-components.yaml
@@ -185,7 +185,7 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /.gce/service-account.json
         - name: PACKET_AUTH_TOKEN
-          value: 'xxx'
+          value: '{{PACKET_AUTH_TOKEN}}'
         image: autonomy/cluster-api-provider-talos:latest
         imagePullPolicy: Always
         name: manager

--- a/hack/test/osctl-cluster-create.sh
+++ b/hack/test/osctl-cluster-create.sh
@@ -2,8 +2,16 @@
 
 set -eou pipefail
 
-## If we take longer than 5m in docker, we're probably boned anyways
-TIMEOUT=300
+export KUBERNETES_VERSION=v1.15.0
+export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
+export TMP="/tmp/e2e"
+export OSCTL="${PWD}/build/osctl-linux-amd64"
+export TALOSCONFIG="${TMP}/talosconfig"
+export KUBECONFIG="${TMP}/kubeconfig"
+export TIMEOUT=300
+
+## Create tmp dir
+mkdir -p $TMP
 
 run() {
 	docker run \


### PR DESCRIPTION
This PR will break cluster create apart from the other steps in
integration tests. It will allow us to run the cluster create, then use
it for parallel e2e builds in different cloud environments.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>