### PR TITLE
chore: remove rootfs output param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ initramfs: buildkitd
 rootfs: buildkitd osd trustd proxyd ntpd
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-    --output type=local,dest=build \
 		--opt target=$@ \
 		$(COMMON_ARGS)
 


### PR DESCRIPTION
This removes the `--output` flag from the rootfs target. With the output
specified it was outputting the file directory structure to the build
directory.