### PR TITLE
chore: add 'talos-cli' container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -288,3 +288,17 @@ RUN --mount=type=cache,target=/root/.cache/go-build go test -v -race ${TESTPKGS}
 FROM base AS lint
 COPY hack/golang/golangci-lint.yaml .
 RUN --mount=type=cache,target=/.cache/go-build golangci-lint run --config golangci-lint.yaml
+
+# The cli target builds an image for the CLI toolbox
+
+FROM alpine:3.8 AS cli
+RUN apk --update --no-cache add \
+    bash \
+    curl \
+    jq
+ARG KUBECTL_VERSION
+RUN curl -sfL  -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN chmod +x /bin/kubectl
+COPY --from=osctl-linux-build /osctl-linux-amd64 /bin/osctl
+COPY ./hack/dev/manifests /root/manifests
+WORKDIR /root

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,16 @@ talos: buildkitd
 osctl-cluster-create:
 	@TAG=$(TAG) ./hack/test/$@.sh
 
+.PHONY: cli
+cli: buildkitd
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
+		build \
+		--output type=docker,dest=build/$@.tar,name=docker.io/autonomy/$@:$(TAG) \
+		--opt target=$@ \
+		--opt build-arg:KUBECTL_VERSION=$(KUBECTL_VERSION) \
+		$(COMMON_ARGS)
+	@docker load < build/$@.tar
+
 .PHONY: basic-integration
 basic-integration:
 	@TAG=$(TAG) ./hack/test/$@.sh


### PR DESCRIPTION
This is more of PoC now, plan is to integrate this with `osctl` to
provide easy way to get access kubectl to the running Talos cluster.

I haven't added to the list of 'images' being pushed so that we can play
a bit with it before it becomes official.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>