### PR TITLE
fix: Remove references to NewRoot in install code.

### DIFF
--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -76,10 +76,10 @@ func Install(args string, data *userdata.UserData) (err error) {
 			},
 		},
 	}
-	if err = syslinux.Install(filepath.Join(constants.NewRoot, constants.BootMountPoint), syslinuxcfg); err != nil {
+	if err = syslinux.Install(constants.BootMountPoint, syslinuxcfg); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(filepath.Join(constants.NewRoot, constants.BootMountPoint, "installed"), []byte{}, 0400); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(constants.BootMountPoint, "installed"), []byte{}, 0400); err != nil {
 		return err
 	}
 

--- a/internal/pkg/install/mount.go
+++ b/internal/pkg/install/mount.go
@@ -26,7 +26,7 @@ func Mount(data *userdata.UserData) (err error) {
 
 	iter := mp.Iter()
 	for iter.Next() {
-		if err = mount.WithRetry(iter.Value(), mount.WithPrefix(constants.NewRoot)); err != nil {
+		if err = mount.WithRetry(iter.Value()); err != nil {
 			return errors.Errorf("error mounting partitions: %v", err)
 		}
 	}

--- a/internal/pkg/install/prepare.go
+++ b/internal/pkg/install/prepare.go
@@ -259,7 +259,7 @@ func NewManifest(data *userdata.UserData) (manifest *Manifest) {
 					Destination: filepath.Join("/", "default", filepath.Base(data.Install.Boot.Initramfs)),
 				},
 			},
-			MountPoint: filepath.Join(constants.NewRoot, constants.BootMountPoint),
+			MountPoint: constants.BootMountPoint,
 		}
 	}
 
@@ -269,7 +269,7 @@ func NewManifest(data *userdata.UserData) (manifest *Manifest) {
 		Size:       data.Install.Data.Size,
 		Force:      data.Install.Force,
 		Test:       false,
-		MountPoint: filepath.Join(constants.NewRoot, constants.DataMountPoint),
+		MountPoint: constants.DataMountPoint,
 	}
 
 	for _, target := range []*Target{bootTarget, dataTarget} {


### PR DESCRIPTION
Since we revamped how init and machine startup happens, we no longer juggle
roots in the same manner. These refereces are no longer needed.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>