### PR TITLE
feat(init): implement complete API for service lifecycle (start/stop)

### DIFF
--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -316,3 +316,23 @@ func (c *Client) ServiceInfo(ctx context.Context, id string) (*initproto.Service
 
 	return nil, nil
 }
+
+// Start starts a service.
+func (c *Client) Start(ctx context.Context, id string) (string, error) {
+	r, err := c.initClient.Start(ctx, &initproto.StartRequest{Id: id})
+	if err != nil {
+		return "", err
+	}
+
+	return r.Resp, nil
+}
+
+// Stop stops a service.
+func (c *Client) Stop(ctx context.Context, id string) (string, error) {
+	r, err := c.initClient.Stop(ctx, &initproto.StopRequest{Id: id})
+	if err != nil {
+		return "", err
+	}
+
+	return r.Resp, nil
+}

--- a/internal/app/machined/internal/phase/api/reg/reg.go
+++ b/internal/app/machined/internal/phase/api/reg/reg.go
@@ -142,6 +142,17 @@ func (r *Registrator) ServiceList(ctx context.Context, in *empty.Empty) (result 
 	return result, nil
 }
 
+// Start implements the proto.InitServer interface and starts a
+// service running on Talos.
+func (r *Registrator) Start(ctx context.Context, in *proto.StartRequest) (reply *proto.StartReply, err error) {
+	if err = system.Services(r.Data).Start(in.Id); err != nil {
+		return &proto.StartReply{}, err
+	}
+
+	reply = &proto.StartReply{Resp: fmt.Sprintf("Service %q started", in.Id)}
+	return reply, err
+}
+
 // Stop implements the proto.InitServer interface and stops a
 // service running on Talos.
 func (r *Registrator) Stop(ctx context.Context, in *proto.StopRequest) (reply *proto.StopReply, err error) {

--- a/internal/app/machined/internal/phase/services/services.go
+++ b/internal/app/machined/internal/phase/services/services.go
@@ -36,7 +36,7 @@ func (task *Services) runtime(platform platform.Platform, data *userdata.UserDat
 func startSystemServices(data *userdata.UserData) {
 	svcs := system.Services(data)
 	// Start the services common to all nodes.
-	svcs.Start(
+	svcs.LoadAndStart(
 		&services.Networkd{},
 		&services.Containerd{},
 		&services.Udevd{},
@@ -46,7 +46,7 @@ func startSystemServices(data *userdata.UserData) {
 	)
 	// Start the services common to all master nodes.
 	if data.Services.Kubeadm.IsControlPlane() {
-		svcs.Start(
+		svcs.LoadAndStart(
 			&services.Trustd{},
 			&services.Proxyd{},
 		)
@@ -56,7 +56,7 @@ func startSystemServices(data *userdata.UserData) {
 
 func startKubernetesServices(data *userdata.UserData) {
 	svcs := system.Services(data)
-	svcs.Start(
+	svcs.LoadAndStart(
 		&services.Kubelet{},
 		&services.Kubeadm{},
 	)

--- a/internal/app/machined/pkg/system/service_events.go
+++ b/internal/app/machined/pkg/system/service_events.go
@@ -28,7 +28,7 @@ type serviceCondition struct {
 
 func (sc *serviceCondition) Wait(ctx context.Context) error {
 	instance.mu.Lock()
-	svcrunner := instance.State[sc.service]
+	svcrunner := instance.state[sc.service]
 	instance.mu.Unlock()
 
 	if svcrunner == nil {

--- a/internal/app/machined/pkg/system/system_test.go
+++ b/internal/app/machined/pkg/system/system_test.go
@@ -18,7 +18,7 @@ type SystemServicesSuite struct {
 }
 
 func (suite *SystemServicesSuite) TestStartShutdown() {
-	system.Services(nil).Start(
+	system.Services(nil).LoadAndStart(
 		&MockService{name: "containerd"},
 		&MockService{name: "proxyd", dependencies: []string{"containerd"}},
 		&MockService{name: "trustd", dependencies: []string{"containerd", "proxyd"}},
@@ -33,7 +33,7 @@ func TestSystemServicesSuite(t *testing.T) {
 }
 
 func (suite *SystemServicesSuite) TestStartStop() {
-	system.Services(nil).Start(
+	system.Services(nil).LoadAndStart(
 		&MockService{name: "yolo"},
 	)
 	time.Sleep(10 * time.Millisecond)

--- a/internal/app/machined/proto/api.proto
+++ b/internal/app/machined/proto/api.proto
@@ -14,6 +14,8 @@ service Init {
   rpc Reboot(google.protobuf.Empty) returns (RebootReply) {}
   rpc Reset(google.protobuf.Empty) returns (ResetReply) {}
   rpc Shutdown(google.protobuf.Empty) returns (ShutdownReply) {}
+  rpc Start(StartRequest) returns (StartReply) {}
+  rpc Stop(StopRequest) returns (StopReply) {}
   rpc Upgrade(UpgradeRequest) returns (UpgradeReply) {}
   rpc ServiceList(google.protobuf.Empty) returns (ServiceListReply) {}
 }
@@ -54,6 +56,10 @@ message ServiceHealth {
   string lastMessage = 3;
   google.protobuf.Timestamp lastChange = 4;
 }
+
+message StartRequest { string id = 1; }
+
+message StartReply { string resp = 1; }
 
 message StopRequest { string id = 1; }
 

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -54,6 +54,16 @@ func (c *InitServiceClient) Reset(ctx context.Context, in *empty.Empty) (data *p
 	return c.InitClient.Reset(ctx, in)
 }
 
+// Start executes the init Start() API.
+func (c *InitServiceClient) Start(ctx context.Context, in *proto.StartRequest) (data *proto.StartReply, err error) {
+	return c.InitClient.Start(ctx, in)
+}
+
+// Stop executes the init Stop() API.
+func (c *InitServiceClient) Stop(ctx context.Context, in *proto.StopRequest) (data *proto.StopReply, err error) {
+	return c.InitClient.Stop(ctx, in)
+}
+
 // ServiceList executes the init ServiceList() API.
 func (c *InitServiceClient) ServiceList(ctx context.Context, in *empty.Empty) (data *proto.ServiceListReply, err error) {
 	return c.InitClient.ServiceList(ctx, in)


### PR DESCRIPTION
It is now possible to `start`/`stop`/`restart` any service via `osctl`
commands.

There are some changes in `ServiceRunner` to support re-use (re-entering
running state). `Services` singleton now tracks service running state to
avoid calling `Start()` on already running `ServiceRunner` instance.
Method `Start()` was renamed to `LoadAndStart()` to break up service
loading (adding to the list of service) and actual service start.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>