### PR TITLE
feat(osctl): allow configurable number of masters to `cluster create`

### DIFF
--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -21,7 +21,7 @@ import (
 // Request represents the set of options available for configuring a node.
 type Request struct {
 	Type  generate.Type
-	Input *generate.Input
+	Input generate.Input
 	Image string
 	Name  string
 	IP    net.IP
@@ -31,7 +31,7 @@ type Request struct {
 func NewNode(clusterName string, req *Request) (err error) {
 	// Generate the userdata for the node.
 
-	data, err := generate.Userdata(req.Type, req.Input)
+	data, err := generate.Userdata(req.Type, &req.Input)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows to run tiny Talos clusters (which is sometimes nice for
local testing), e.g. with just a single master and zero workers.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>