### PR TITLE
fix(init): flip concurrency of tasks/services, fix small issues 

### DIFF
--- a/internal/app/machined/internal/phase/phase_test.go
+++ b/internal/app/machined/internal/phase/phase_test.go
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package phase_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
+	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+type PhaseSuite struct {
+	suite.Suite
+
+	platformExists bool
+	platformValue  string
+}
+
+type regularTask struct {
+	errCh <-chan error
+}
+
+func (t *regularTask) RuntimeFunc(runtime.Mode) phase.RuntimeFunc {
+	return func(platform.Platform, *userdata.UserData) error {
+		return <-t.errCh
+	}
+}
+
+type nilTask struct{}
+
+func (t *nilTask) RuntimeFunc(runtime.Mode) phase.RuntimeFunc {
+	return nil
+}
+
+type panicTask struct{}
+
+func (t *panicTask) RuntimeFunc(runtime.Mode) phase.RuntimeFunc {
+	return func(platform.Platform, *userdata.UserData) error {
+		panic("in task")
+	}
+}
+
+func (suite *PhaseSuite) SetupSuite() {
+	suite.platformValue, suite.platformExists = os.LookupEnv("PLATFORM")
+	suite.Require().NoError(os.Setenv("PLATFORM", "container"))
+}
+
+func (suite *PhaseSuite) TearDownSuite() {
+	if !suite.platformExists {
+		suite.Require().NoError(os.Unsetenv("PLATFORM"))
+	} else {
+		suite.Require().NoError(os.Setenv("PLATFORM", suite.platformValue))
+	}
+}
+
+func (suite *PhaseSuite) TestRunSuccess() {
+	r, err := phase.NewRunner(nil)
+	suite.Require().NoError(err)
+
+	taskErr := make(chan error)
+
+	r.Add(phase.NewPhase("empty"))
+	r.Add(phase.NewPhase("phase1", &regularTask{errCh: taskErr}, &regularTask{errCh: taskErr}))
+	r.Add(phase.NewPhase("phase2", &regularTask{errCh: taskErr}, &nilTask{}))
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- r.Run()
+	}()
+
+	taskErr <- nil
+	taskErr <- nil
+
+	select {
+	case <-errCh:
+		suite.Require().Fail("should be still running")
+	default:
+	}
+
+	taskErr <- nil
+
+	suite.Require().NoError(<-errCh)
+}
+
+func (suite *PhaseSuite) TestRunFailures() {
+	r, err := phase.NewRunner(nil)
+	suite.Require().NoError(err)
+
+	taskErr := make(chan error, 1)
+
+	r.Add(phase.NewPhase("empty"))
+	r.Add(phase.NewPhase("failphase", &panicTask{}, &regularTask{errCh: taskErr}, &nilTask{}))
+	r.Add(phase.NewPhase("neverreached",
+		&regularTask{}, // should never be reached
+	))
+
+	taskErr <- errors.New("test error")
+
+	err = r.Run()
+	suite.Require().Error(err)
+	suite.Assert().Contains(err.Error(), "2 errors occurred")
+	suite.Assert().Contains(err.Error(), "test error")
+	suite.Assert().Contains(err.Error(), "panic recovered: in task")
+}
+
+func TestPhaseSuite(t *testing.T) {
+	suite.Run(t, new(PhaseSuite))
+}

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -105,6 +105,7 @@ func recovery() {
 }
 
 func main() {
+	// TODO: this comment is outdated
 	// This is main entrypoint into init() execution, after kernel boot control is passsed
 	// to this function.
 	//


### PR DESCRIPTION
Phases should run sequentially, while tasks concurrently in a phase.

There are two potential issues fixed:

1. `result` multierror was updated inside goroutine without any
synchronization, so this is a data race
2. panic inside task/phase runner might happen and as unhandled panic in a
goroutine aborts whole process, this might lead to a system halt as
as the 'machined' exits

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>