### PR TITLE
chore: update dockerfile/buildkit versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile-upstream:master-experimental
+# syntax = docker/dockerfile-upstream:1.1.2-experimental
 
 ARG TOOLS
 FROM $TOOLS AS tools

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TOOLS ?= autonomy/tools:b473afb
 
 # TODO(andrewrynhard): Move this logic to a shell script.
-BUILDKIT_VERSION ?= master@sha256:455f06ede03149051ce2734d9639c28aed1b6e8b8a0c607cb813e29b469a07d6
+BUILDKIT_VERSION ?= v0.6.0
 KUBECTL_VERSION ?= v1.14.1
 BUILDKIT_IMAGE ?= moby/buildkit:$(BUILDKIT_VERSION)
 BUILDKIT_HOST ?= tcp://0.0.0.0:1234


### PR DESCRIPTION
New buildkit release: https://github.com/moby/buildkit/releases/tag/v0.6.0

New release was published for buildkit's dockerfile:
https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.1.2-experimental,
so we can stick to release version now.

These releases include fixes/implementation for `RUN --security=insecure`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>