### PR TITLE
fix: create overlay mounts after install

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -70,6 +70,9 @@ func run() (err error) {
 		phase.NewPhase(
 			"installation",
 			install.NewInstallTask(),
+		),
+		phase.NewPhase(
+			"overlay",
 			rootfs.NewMountOverlayTask(),
 		),
 		phase.NewPhase(


### PR DESCRIPTION
Without running the install task first, /var is read-only. This causes
the overlay phase to fail as it tries to create /var/system.