### PR TITLE
chore: run CI jobs on CI nodes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,9 @@
 kind: pipeline
 name: default
 
+node:
+  node-role.kubernetes.io/ci: ''
+
 services:
   - name: docker
     image: docker:dind
@@ -369,6 +372,9 @@ trigger:
 kind: pipeline
 name: e2e
 
+node:
+  node-role.kubernetes.io/ci: ''
+
 services:
   - name: docker
     image: docker:dind
@@ -464,6 +470,9 @@ trigger:
 ---
 kind: pipeline
 name: notify
+
+node:
+  node-role.kubernetes.io/ci: ''
 
 clone:
   disable: true


### PR DESCRIPTION
This adds a node selector to our drone jobs that runs the jobs on
dedictated CI nodes.