### PR TITLE
fix: mount the owned partitions in cloud platforms

### DIFF
--- a/internal/app/machined/internal/platform/cloud/aws/aws.go
+++ b/internal/app/machined/internal/platform/cloud/aws/aws.go
@@ -13,6 +13,9 @@ import (
 	"net/http"
 
 	"github.com/fullsailor/pkcs7"
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"golang.org/x/sys/unix"
 )
@@ -123,6 +126,17 @@ func (a *AWS) UserData() (*userdata.UserData, error) {
 
 // Initialize implements the platform.Platform interface and handles additional system setup.
 func (a *AWS) Initialize(data *userdata.UserData) (err error) {
+	var mountpoints *mount.Points
+	mountpoints, err = owned.MountPointsFromLabels()
+	if err != nil {
+		return err
+	}
+
+	m := manager.NewManager(mountpoints)
+
+	if err = m.MountAll(); err != nil {
+		return err
+	}
 	return hostname()
 }
 

--- a/internal/app/machined/internal/platform/cloud/azure/azure.go
+++ b/internal/app/machined/internal/platform/cloud/azure/azure.go
@@ -5,6 +5,9 @@
 package azure
 
 import (
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -69,5 +72,16 @@ func hostname() (err error) {
 
 // Initialize implements the platform.Platform interface and handles additional system setup.
 func (a *Azure) Initialize(data *userdata.UserData) (err error) {
+	var mountpoints *mount.Points
+	mountpoints, err = owned.MountPointsFromLabels()
+	if err != nil {
+		return err
+	}
+
+	m := manager.NewManager(mountpoints)
+	if err = m.MountAll(); err != nil {
+		return err
+	}
+
 	return hostname()
 }

--- a/internal/app/machined/internal/platform/cloud/googlecloud/googlecloud.go
+++ b/internal/app/machined/internal/platform/cloud/googlecloud/googlecloud.go
@@ -5,6 +5,9 @@
 package googlecloud
 
 import (
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/internal/pkg/network"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
@@ -48,5 +51,13 @@ func (gc *GoogleCloud) UserData() (data *userdata.UserData, err error) {
 
 // Initialize implements the platform.Platform interface and handles additional system setup.
 func (gc *GoogleCloud) Initialize(data *userdata.UserData) (err error) {
-	return nil
+	var mountpoints *mount.Points
+	mountpoints, err = owned.MountPointsFromLabels()
+	if err != nil {
+		return err
+	}
+
+	m := manager.NewManager(mountpoints)
+
+	return m.MountAll()
 }

--- a/internal/app/machined/internal/platform/cloud/vmware/vmware.go
+++ b/internal/app/machined/internal/platform/cloud/vmware/vmware.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/talos-systems/talos/internal/pkg/constants"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/vmware/vmw-guestinfo/rpcvmx"
 	"github.com/vmware/vmw-guestinfo/vmcheck"
@@ -67,5 +70,13 @@ func (vmw *VMware) UserData() (data *userdata.UserData, err error) {
 
 // Initialize implements the platform.Platform interface and handles additional system setup.
 func (vmw *VMware) Initialize(data *userdata.UserData) (err error) {
-	return nil
+	var mountpoints *mount.Points
+	mountpoints, err = owned.MountPointsFromLabels()
+	if err != nil {
+		return err
+	}
+
+	m := manager.NewManager(mountpoints)
+
+	return m.MountAll()
 }

--- a/internal/pkg/mount/manager/owned/owned.go
+++ b/internal/pkg/mount/manager/owned/owned.go
@@ -46,10 +46,12 @@ func MountPointsForDevice(devpath string) (mountpoints *mount.Points, err error)
 func MountPointsFromLabels() (mountpoints *mount.Points, err error) {
 	mountpoints = mount.NewMountPoints()
 	for _, name := range []string{constants.DataPartitionLabel, constants.BootPartitionLabel} {
+		opts := []mount.Option{}
 		var target string
 		switch name {
 		case constants.DataPartitionLabel:
 			target = constants.DataMountPoint
+			opts = append(opts, mount.WithResize(true))
 		case constants.BootPartitionLabel:
 			target = constants.BootMountPoint
 		}
@@ -63,7 +65,7 @@ func MountPointsFromLabels() (mountpoints *mount.Points, err error) {
 			}
 			return nil, errors.Errorf("find device with label %s: %v", name, err)
 		}
-		mountpoint := mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "")
+		mountpoint := mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "", opts...)
 		mountpoints.Set(name, mountpoint)
 	}
 	return mountpoints, nil

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -52,6 +52,7 @@ func NewDefaultOptions(setters ...Option) *Options {
 		Prefix:   "",
 		ReadOnly: false,
 		Shared:   false,
+		Resize:   false,
 	}
 
 	for _, setter := range setters {


### PR DESCRIPTION
This adds the logic for mounting the owned block device and resizing the
ephemeral partition for cloud platforms.