### PR TITLE
feat: bump k8s version to v1.15.2

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -103,7 +103,7 @@ const (
 	KubeadmEtcdPeerKey = v1beta1.DefaultCertificatesDir + "/" + constants.EtcdPeerKeyName
 
 	// KubernetesVersion is the enforced target version of the control plane.
-	KubernetesVersion = "v1.15.0"
+	KubernetesVersion = "v1.15.2"
 
 	// KubernetesImage is the enforced hyperkube image to use for the control plane.
 	KubernetesImage = "k8s.gcr.io/hyperkube:" + KubernetesVersion


### PR DESCRIPTION
This PR will bump the hyperkube version so that we've got fixes for some
pretty critical CVEs: CVE-2019-11247 and CVE-2019-11249

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>