### PR TITLE
fix: update toolchain components to use kubernetes 1.15.2 

### DIFF
--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -106,7 +106,7 @@ const (
 	KubeadmEtcdPeerKey = v1beta1.DefaultCertificatesDir + "/" + constants.EtcdPeerKeyName
 
 	// KubernetesVersion is the enforced target version of the control plane.
-	KubernetesVersion = "v1.15.0"
+	KubernetesVersion = "v1.15.2"
 
 	// KubernetesImage is the enforced hyperkube image to use for the control plane.
 	KubernetesImage = "k8s.gcr.io/hyperkube:" + KubernetesVersion


### PR DESCRIPTION
This PR updates the images specified in the Makefile so that we can
catch kubernetes 1.15.2 components

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>