### PR TITLE
feat: bump k8s version to v1.15.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 KERNEL_IMAGE ?= autonomy/kernel:1f83e85
-TOOLCHAIN_IMAGE ?= autonomy/toolchain:0d43bc8
-ROOTFS_IMAGE ?= autonomy/rootfs-base:0d43bc8
-INITRAMFS_IMAGE ?= autonomy/initramfs-base:0d43bc8
+TOOLCHAIN_IMAGE ?= autonomy/toolchain:8f1a7eb
+ROOTFS_IMAGE ?= autonomy/rootfs-base:8f1a7eb
+INITRAMFS_IMAGE ?= autonomy/initramfs-base:8f1a7eb
 
 # TODO(andrewrynhard): Move this logic to a shell script.
 BUILDKIT_VERSION ?= v0.5.0

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -106,7 +106,7 @@ const (
 	KubeadmEtcdPeerKey = v1beta1.DefaultCertificatesDir + "/" + constants.EtcdPeerKeyName
 
 	// KubernetesVersion is the enforced target version of the control plane.
-	KubernetesVersion = "v1.15.0"
+	KubernetesVersion = "v1.15.2"
 
 	// KubernetesImage is the enforced hyperkube image to use for the control plane.
 	KubernetesImage = "k8s.gcr.io/hyperkube:" + KubernetesVersion


### PR DESCRIPTION
This PR will bump the hyperkube version so that we've got fixes for some
pretty critical CVEs: CVE-2019-11247 and CVE-2019-11249

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
(cherry picked from commit ec3c77d86392ce3fb953fbb4022543661817747b)