### PR TITLE
chore: add race-enabled test run

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -145,6 +145,20 @@ steps:
     depends_on:
       - build.Lint
 
+  - name: test.UnitTestRace
+    image: autonomy/build-container:latest
+    pull: always
+    environment:
+      BUILDKIT_HOST: tcp://buildkitd.ci.svc:1234
+      BINDIR: /usr/local/bin
+    commands:
+      - make test-race
+    volumes:
+      - name: dockersock
+        path: /var/run/
+    depends_on:
+      - build.Lint
+
 # Phase 3
   - name: build.Rootfs
     image: autonomy/build-container:latest

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TOOLS ?= autonomy/tools:b473afb
 # TODO(andrewrynhard): Move this logic to a shell script.
 BUILDKIT_VERSION ?= v0.6.0
 KUBECTL_VERSION ?= v1.14.1
+GO_VERSION ?= 1.12
 BUILDKIT_IMAGE ?= moby/buildkit:$(BUILDKIT_VERSION)
 BUILDKIT_HOST ?= tcp://0.0.0.0:1234
 BUILDKIT_CONTAINER_NAME ?= talos-buildkit
@@ -47,6 +48,7 @@ COMMON_ARGS += --local dockerfile=.
 COMMON_ARGS += --opt build-arg:TOOLS=$(TOOLS)
 COMMON_ARGS += --opt build-arg:SHA=$(SHA)
 COMMON_ARGS += --opt build-arg:TAG=$(TAG)
+COMMON_ARGS += --opt build-arg:GO_VERSION=$(GO_VERSION)
 
 DOCKER_ARGS ?=
 # to allow tests to run containerd
@@ -229,11 +231,18 @@ e2e-integration:
 
 .PHONY: test
 test: buildkitd
-	@mkdir -p build
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
 		--opt target=$@ \
 		--output type=local,dest=./ \
+		--opt build-arg:TESTPKGS=$(TESTPKGS) \
+		$(COMMON_ARGS)
+
+.PHONY: test-race
+test-race: buildkitd
+	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
+		build \
+		--opt target=$@ \
 		--opt build-arg:TESTPKGS=$(TESTPKGS) \
 		$(COMMON_ARGS)
 


### PR DESCRIPTION
As Go race detector doesn't work under libmuscl, use stock glibc-based
golang container.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>