### PR TITLE
fix(machined): Clean up installation process

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -25,6 +25,7 @@ policies:
           - init
           - initramfs
           - kernel
+          - machined
           - proxyd
           - osctl
           - osd

--- a/internal/app/machined/internal/phase/rootfs/check_install.go
+++ b/internal/app/machined/internal/phase/rootfs/check_install.go
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package rootfs
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
+	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+// CheckInstall represents the CheckInstall task.
+type CheckInstall struct{}
+
+// NewCheckInstallTask initializes and returns a CheckInstall task.
+func NewCheckInstallTask() phase.Task {
+	return &CheckInstall{}
+}
+
+// RuntimeFunc returns the runtime function.
+func (task *CheckInstall) RuntimeFunc(mode runtime.Mode) phase.RuntimeFunc {
+	switch mode {
+	case runtime.Standard:
+		return task.standard
+	default:
+		return nil
+	}
+}
+
+func (task *CheckInstall) standard(platform platform.Platform, data *userdata.UserData) (err error) {
+	_, err = os.Stat(filepath.Join(constants.BootMountPoint, "installed"))
+	return err
+}

--- a/internal/app/machined/internal/platform/baremetal/baremetal.go
+++ b/internal/app/machined/internal/platform/baremetal/baremetal.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/talos-systems/talos/internal/pkg/installer"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
@@ -88,9 +91,27 @@ func (b *BareMetal) Initialize(data *userdata.UserData) (err error) {
 		return err
 	}
 
-	i := installer.NewInstaller(cmdline, data)
-	if err = i.Install(); err != nil {
-		return errors.Wrap(err, "failed to install")
+	// Attempt to discover a previous installation
+	// An err case should only happen if no partitions
+	// with matching labels were found
+	var mountpoints *mount.Points
+	mountpoints, err = owned.MountPointsFromLabels()
+	if err != nil {
+		// No previous installation was found, attempt an install
+		i := installer.NewInstaller(cmdline, data)
+		if err = i.Install(); err != nil {
+			return errors.Wrap(err, "failed to install")
+		}
+
+		mountpoints, err = owned.MountPointsFromLabels()
+		if err != nil {
+			return err
+		}
+	}
+
+	m := manager.NewManager(mountpoints)
+	if err = m.MountAll(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -78,6 +78,10 @@ func run() (err error) {
 			platform.NewPlatformTask(),
 		),
 		phase.NewPhase(
+			"installation verification",
+			rootfs.NewCheckInstallTask(),
+		),
+		phase.NewPhase(
 			"overlay mounts",
 			rootfs.NewMountOverlayTask(),
 		),

--- a/internal/pkg/installer/bootloader/syslinux/syslinux.go
+++ b/internal/pkg/installer/bootloader/syslinux/syslinux.go
@@ -132,7 +132,7 @@ func WriteSyslinuxCfg(base, path string, syslinuxcfg *Cfg) (err error) {
 		return err
 	}
 
-	log.Println("writing syslinux.cfg to disk")
+	log.Printf("writing %s to disk", path)
 	if err = ioutil.WriteFile(path, wr.Bytes(), 0600); err != nil {
 		return err
 	}

--- a/internal/pkg/installer/manifest/manifest.go
+++ b/internal/pkg/installer/manifest/manifest.go
@@ -205,10 +205,11 @@ func (t *Target) Partition(bd *blockdevice.BlockDevice) (err error) {
 
 // Format creates a filesystem on the device/partition.
 func (t *Target) Format() error {
-	log.Printf("formatting partition %s - %s\n", t.PartitionName, t.Label)
 	if t.Label == constants.BootPartitionLabel {
+		log.Printf("formatting partition %s - %s as %s\n", t.PartitionName, t.Label, "fat")
 		return vfat.MakeFS(t.PartitionName, vfat.WithLabel(t.Label))
 	}
+	log.Printf("formatting partition %s - %s as %s\n", t.PartitionName, t.Label, "xfs")
 	opts := []xfs.Option{xfs.WithForce(t.Force)}
 	if t.Label != "" {
 		opts = append(opts, xfs.WithLabel(t.Label))


### PR DESCRIPTION
This also includes a fix for #955 which had the unintended side effect
of breaking image creation ( since it would attempt to grow the filesystem
always ).

The refactor standardizes around looking for the DATA and ESP labels to
discover any existing installations/filesystems. If none are found, an
installation will proceed -- for both image creation and bare metal.
During bootup, the DATA partition will always attempt to expand/grow.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>