### PR TITLE
chore: remove machined from rootfs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ initramfs: buildkitd
 		$(COMMON_ARGS)
 
 .PHONY: rootfs
-rootfs: buildkitd osd trustd proxyd ntpd machined
+rootfs: buildkitd osd trustd proxyd ntpd
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
 		--opt target=$@ \


### PR DESCRIPTION
The machined dependency is not needed in the rootfs target. The
dependency is handled by buildkit.