### PR TITLE
chore: Add longer waits in health tests

### DIFF
--- a/internal/app/machined/pkg/system/health/health_test.go
+++ b/internal/app/machined/pkg/system/health/health_test.go
@@ -93,7 +93,12 @@ func (suite *CheckSuite) TestHealthChange() {
 		errCh <- health.Run(ctx, &settings, &state, check)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if *state != nil {
+			break
+		}
+	}
 
 	suite.Require().False(*state.Get().Healthy)
 	suite.Require().Equal("health failed", state.Get().LastMessage)
@@ -152,7 +157,12 @@ func (suite *CheckSuite) TestCheckAbort() {
 		errCh <- health.Run(ctx, &settings, &state, check)
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if *state != nil {
+			break
+		}
+	}
 
 	suite.Require().False(*state.Get().Healthy)
 	suite.Require().Equal("context deadline exceeded", state.Get().LastMessage)
@@ -177,7 +187,12 @@ func (suite *CheckSuite) TestInitialState() {
 		errCh <- health.Run(ctx, &settings, &state, nil)
 	}()
 
-	time.Sleep(50 * time.Millisecond)
+	for i := 0; i < 10; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if *state != nil {
+			break
+		}
+	}
 
 	suite.Require().Nil(state.Get().Healthy)
 	suite.Require().Equal("Unknown", state.Get().LastMessage)


### PR DESCRIPTION
Primarily to guard against state.Get() panics.

```630   #97  38.01 --- FAIL: TestCheckSuite (0.24s)    80s
631    #97  38.01 --- PASS: TestCheckSuite/TestCheckAbort (0.10s)    80s
632    #97  38.01 --- FAIL: TestCheckSuite/TestHealthChange (0.06s)    80s
633    #97  38.01 suite.go:62: test panicked: runtime error: invalid memory address or nil pointer dereference    80s
634    #97  38.01 goroutine 68 [running]:    80s
635    #97  38.01 runtime/debug.Stack(0xc0000f58e0, 0x8c93a0, 0xd7b5a0)    80s
636    #97  38.01 /toolchain/go/src/runtime/debug/stack.go:24 +0x9d    80s
637    #97  38.01 github.com/stretchr/testify/suite.failOnPanic(0xc000180500)    80s
638    #97  38.01 /go/pkg/mod/github.com/stretchr/testify@v1.3.1-0.20190311161405-34c6fa2dc709/suite/suite.go:62 +0x57    80s
639    #97  38.01 panic(0x8c93a0, 0xd7b5a0)    80s
640    #97  38.01 /toolchain/go/src/runtime/panic.go:522 +0x1b5    80s
641    #97  38.01 github.com/talos-systems/talos/internal/app/machined/pkg/system/health_test.(*CheckSuite).TestHealthChange(0xc0001025e0)    80s
642    #97  38.01 /src/internal/app/machined/pkg/system/health/health_test.go:98 +0x23f    80s
643    #97  38.01 reflect.Value.call(0xc0001a35c0, 0xc0000f89b8, 0x13, 0x954509, 0x4, 0xc0000f5f30, 0x1, 0x1, 0xc00009de68, 0x78, ...)    80s
644    #97  38.01 /toolchain/go/src/reflect/value.go:447 +0x461    80s
645    #97  38.01 reflect.Value.Call(0xc0001a35c0, 0xc0000f89b8, 0x13, 0xc00009df30, 0x1, 0x1, 0x863119, 0x10, 0x0)    80s
646    #97  38.01 /toolchain/go/src/reflect/value.go:308 +0xa4    80s
647    #97  38.01 github.com/stretchr/testify/suite.Run.func2(0xc000180500)    80s
648    #97  38.01 /go/pkg/mod/github.com/stretchr/testify@v1.3.1-0.20190311161405-34c6fa2dc709/suite/suite.go:133 +0x2fb    81s
649    #97  38.01 testing.tRunner(0xc000180500, 0xc0001ac900)    81s
650    #97  38.01 /toolchain/go/src/testing/testing.go:865 +0xc0    81s
651    #97  38.01 created by testing.(*T).Run    81s
652    talos-systems/talos#97 38.01 /toolchain/go/src/testing/testing.go:916 +0x35a
```


Signed-off-by: Brad Beam <brad.beam@talos-systems.com>