### PR TITLE
fix: stalls in local Docker cluster boot

### DIFF
--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -25,6 +25,11 @@ type Request struct {
 	Image string
 	Name  string
 	IP    net.IP
+
+	// Share of CPUs, in 1e-9 fractions
+	NanoCPUs int64
+	// Memory limit in bytes
+	Memory int64
 }
 
 // NewNode creates a node as a container.
@@ -60,6 +65,10 @@ func NewNode(clusterName string, req *Request) (err error) {
 	hostConfig := &container.HostConfig{
 		Privileged:  true,
 		SecurityOpt: []string{"seccomp:unconfined"},
+		Resources: container.Resources{
+			NanoCPUs: req.NanoCPUs,
+			Memory:   req.Memory,
+		},
 	}
 
 	// Ensure that the container is created in the talos network.

--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -27,7 +27,7 @@ run() {
 	 	k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
 }
 
-${OSCTL} cluster create --name integration --image ${TALOS_IMG} --mtu 1440
+${OSCTL} cluster create --name integration --image ${TALOS_IMG} --mtu 1440 --cpus 4.0
 ${OSCTL} config target 10.5.0.2
 
 ## Fetch kubeconfig


### PR DESCRIPTION
Problem was triggered by udevd trigger, root cause is not clear, but
workaround is to disable it for container mode.

Implement CPU/mem limits for `osctl cluster create`, apply defaults,
bump defaults for cicd.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>