### PR TITLE
chore: fix broken clone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,8 @@ steps:
 - name: clone
   image: autonomy/build-container:latest
   commands:
-  - git clone --depth 1 ${DRONE_REPO_LINK} .
+  - git init
+  - git remote add origin ${DRONE_REPO_LINK}
   - git fetch origin ${DRONE_COMMIT_REF}:${DRONE_SOURCE_BRANCH}
   - git checkout ${DRONE_SOURCE_BRANCH}
   - git fetch --tags
@@ -383,7 +384,8 @@ steps:
 - name: clone
   image: autonomy/build-container:latest
   commands:
-  - git clone --depth 1 ${DRONE_REPO_LINK} .
+  - git init
+  - git remote add origin ${DRONE_REPO_LINK}
   - git fetch origin ${DRONE_COMMIT_REF}:${DRONE_SOURCE_BRANCH}
   - git checkout ${DRONE_SOURCE_BRANCH}
   - git fetch --tags
@@ -802,7 +804,8 @@ steps:
 - name: clone
   image: autonomy/build-container:latest
   commands:
-  - git clone --depth 1 ${DRONE_REPO_LINK} .
+  - git init
+  - git remote add origin ${DRONE_REPO_LINK}
   - git fetch origin ${DRONE_COMMIT_REF}:${DRONE_SOURCE_BRANCH}
   - git checkout ${DRONE_SOURCE_BRANCH}
   - git fetch --tags
@@ -1223,7 +1226,8 @@ steps:
 - name: clone
   image: autonomy/build-container:latest
   commands:
-  - git clone --depth 1 ${DRONE_REPO_LINK} .
+  - git init
+  - git remote add origin ${DRONE_REPO_LINK}
   - git fetch origin ${DRONE_COMMIT_REF}:${DRONE_SOURCE_BRANCH}
   - git checkout ${DRONE_SOURCE_BRANCH}
   - git fetch --tags
@@ -1644,7 +1648,8 @@ steps:
 - name: clone
   image: autonomy/build-container:latest
   commands:
-  - git clone --depth 1 ${DRONE_REPO_LINK} .
+  - git init
+  - git remote add origin ${DRONE_REPO_LINK}
   - git fetch origin ${DRONE_COMMIT_REF}:${DRONE_SOURCE_BRANCH}
   - git checkout ${DRONE_SOURCE_BRANCH}
   - git fetch --tags

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -58,7 +58,8 @@ local clone = {
   name: "clone",
   image: build_container,
   commands: [
-    "git clone --depth 1 ${DRONE_REPO_LINK} .",
+    "git init",
+    "git remote add origin ${DRONE_REPO_LINK}",
     "git fetch origin ${DRONE_COMMIT_REF}:${DRONE_SOURCE_BRANCH}",
     "git checkout ${DRONE_SOURCE_BRANCH}",
     "git fetch --tags",


### PR DESCRIPTION
This fixes and issue with cloning the master branch caused by git
refusing to fetch into the current branch.