### PR TITLE
fix: enclose address in brackets gRPC client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.2.2
-	gotest.tools v2.1.0+incompatible // indirect
+	gotest.tools v2.1.0+incompatible
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apiextensions-apiserver v0.0.0-20190322231200-1c09d17c1352 // indirect
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d

--- a/pkg/grpc/middleware/auth/basic/basic.go
+++ b/pkg/grpc/middleware/auth/basic/basic.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/talos-systems/talos/pkg/net"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -34,7 +35,7 @@ func NewConnection(address string, port int, creds credentials.PerRPCCredentials
 			})),
 		grpc.WithPerRPCCredentials(creds),
 	)
-	conn, err = grpc.Dial(fmt.Sprintf("%s:%d", address, port), grpcOpts...)
+	conn, err = grpc.Dial(fmt.Sprintf("%s:%d", net.FormatAddress(address), port), grpcOpts...)
 	if err != nil {
 		return
 	}

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -34,7 +34,7 @@ func IPAddrs() (ips []net.IP, err error) {
 func FormatAddress(addr string) string {
 	if ip := net.ParseIP(addr); ip != nil {
 		// If this is an IPv6 address, encapsulate it in brackets
-		if ip.To16() != nil {
+		if ip.To4() == nil {
 			return "[" + ip.String() + "]"
 		}
 		return ip.String()

--- a/pkg/net/net_test.go
+++ b/pkg/net/net_test.go
@@ -2,13 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package net_test
+package net
 
-import "testing"
+import (
+	"testing"
+
+	"gotest.tools/assert"
+)
 
 func TestEmpty(t *testing.T) {
 	// added for accurate coverage estimation
 	//
 	// please remove it once any unit-test is added
 	// for this package
+}
+
+func TestFormatAddress(t *testing.T) {
+	assert.Equal(t, FormatAddress("2001:db8::1"), "[2001:db8::1]")
+	assert.Equal(t, FormatAddress("[2001:db8::1]"), "[2001:db8::1]")
+	assert.Equal(t, FormatAddress("192.168.1.1"), "192.168.1.1")
+	assert.Equal(t, FormatAddress("alpha.beta.gamma.com"), "alpha.beta.gamma.com")
 }


### PR DESCRIPTION
When talking to an IPv6 address for a gRPC server, enclose the IPv6
address in brackets.

Also fixes backwards implementation of IPv4/IPv6 test.

Fixes #983

Signed-off-by: Seán C McCord <ulexus@gmail.com>