### PR TITLE
chore: add ability to promote to a release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1196,6 +1196,29 @@ steps:
   depends_on:
   - basic-integration
 
+- name: capi
+  image: autonomy/build-container:latest
+  commands:
+  - make capi
+  environment:
+    AZURE_SVC_ACCT:
+      from_secret: azure_svc_acct
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+    GCE_SVC_ACCT:
+      from_secret: gce_svc_acct
+    PACKET_AUTH_TOKEN:
+      from_secret: packet_auth_token
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - basic-integration
+
 - name: image-azure
   image: autonomy/build-container:latest
   commands:
@@ -1275,29 +1298,6 @@ steps:
     path: /tmp
   depends_on:
   - image-gce
-
-- name: capi
-  image: autonomy/build-container:latest
-  commands:
-  - make capi
-  environment:
-    AZURE_SVC_ACCT:
-      from_secret: azure_svc_acct
-    BINDIR: /usr/local/bin
-    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
-    GCE_SVC_ACCT:
-      from_secret: gce_svc_acct
-    PACKET_AUTH_TOKEN:
-      from_secret: packet_auth_token
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - basic-integration
 
 - name: conformance-azure
   image: autonomy/build-container:latest
@@ -1701,6 +1701,29 @@ steps:
   depends_on:
   - basic-integration
 
+- name: capi
+  image: autonomy/build-container:latest
+  commands:
+  - make capi
+  environment:
+    AZURE_SVC_ACCT:
+      from_secret: azure_svc_acct
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+    GCE_SVC_ACCT:
+      from_secret: gce_svc_acct
+    PACKET_AUTH_TOKEN:
+      from_secret: packet_auth_token
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - basic-integration
+
 - name: image-azure
   image: autonomy/build-container:latest
   commands:
@@ -1780,29 +1803,6 @@ steps:
     path: /tmp
   depends_on:
   - image-gce
-
-- name: capi
-  image: autonomy/build-container:latest
-  commands:
-  - make capi
-  environment:
-    AZURE_SVC_ACCT:
-      from_secret: azure_svc_acct
-    BINDIR: /usr/local/bin
-    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
-    GCE_SVC_ACCT:
-      from_secret: gce_svc_acct
-    PACKET_AUTH_TOKEN:
-      from_secret: packet_auth_token
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - basic-integration
 
 - name: conformance-azure
   image: autonomy/build-container:latest
@@ -2356,6 +2356,9 @@ node:
 trigger:
   event:
   - tag
+  - promote
+  target:
+  - release
 
 ---
 kind: pipeline

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -272,11 +272,11 @@ local conformance_azure = Step("conformance-azure", "e2e-integration", depends_o
 local conformance_gce = Step("conformance-gce", "e2e-integration", depends_on=[capi, push_image_gce], environment={PLATFORM: "gce", CONFORMANCE: "run"});
 
 local conformance_steps = default_steps + [
+  capi,
   image_azure,
   image_gce,
   push_image_azure,
   push_image_gce,
-  capi,
   conformance_azure,
   conformance_gce,
 ];
@@ -349,7 +349,13 @@ local release_steps = default_steps + [
 
 local release_trigger = {
   trigger: {
-    event: ["tag"],
+    event: [
+      "tag",
+      "promote",
+    ],
+    target: {
+      include: ["release"]
+    },
   },
 };
 


### PR DESCRIPTION
Although the GitHub release plug requires a tag and will fail on a
promotion, this is still useful as it will allow us to mimic a release
before we tag.