### PR TITLE
fix: formatting problems with IPv6 and osctl gen

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -178,9 +178,6 @@ func createNodes(requests []*node.Request) (err error) {
 			// node comes up
 			// 1 <- 2 <- 3 <- 4 <- 5 ...
 			req.Input.Index = idx
-			if req.Input.Index > 0 {
-				req.Input.Index--
-			}
 			if req.IP != nil {
 				req.Input.IP = req.IP
 			}

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -144,7 +144,6 @@ var configGenerateCmd = &cobra.Command{
 			if input.Index == 0 {
 				udType = generate.TypeInit
 			} else {
-				input.Index--
 				udType = generate.TypeControlPlane
 			}
 

--- a/pkg/userdata/generate/controlplane.go
+++ b/pkg/userdata/generate/controlplane.go
@@ -28,7 +28,7 @@ services:
         bootstrapToken:
           token: '{{ .KubeadmTokens.BootstrapToken }}'
           unsafeSkipCAVerification: true
-          apiServerEndpoint: {{ index .MasterIPs .Index }}:6443
+          apiServerEndpoint: "{{ .GetControlPlaneEndpoint "6443" }}"
       nodeRegistration:
         taints: []
         kubeletExtraArgs:

--- a/pkg/userdata/generate/init.go
+++ b/pkg/userdata/generate/init.go
@@ -36,9 +36,9 @@ services:
       kind: ClusterConfiguration
       clusterName: {{ .ClusterName }}
       kubernetesVersion: {{ .KubernetesVersion }}
-      controlPlaneEndpoint: {{ .IP }}:443
+      controlPlaneEndpoint: "{{ .GetControlPlaneEndpoint "443" }}"
       apiServer:
-        certSANs: [ {{ range $i,$ip := .MasterIPs }}{{if $i}},{{end}}"{{$ip}}"{{end}}, "127.0.0.1" ]
+        certSANs: [ {{ range $i,$ip := .MasterIPs }}{{if $i}},{{end}}"{{$ip}}"{{end}}, "127.0.0.1", "::1" ]
         extraArgs:
           runtime-config: settings.k8s.io/v1alpha1=true
           feature-gates: ExperimentalCriticalPodAnnotation=true
@@ -51,8 +51,8 @@ services:
           feature-gates: ExperimentalCriticalPodAnnotation=true
       networking:
         dnsDomain: {{ .ServiceDomain }}
-        podSubnet: {{ index .PodNet 0 }}
-        serviceSubnet: {{ index .ServiceNet 0 }}
+        podSubnet: "{{ index .PodNet 0 }}"
+        serviceSubnet: "{{ index .ServiceNet 0 }}"
       ---
       apiVersion: kubelet.config.k8s.io/v1beta1
       kind: KubeletConfiguration
@@ -67,5 +67,5 @@ services:
   trustd:
     token: '{{ .TrustdInfo.Token }}'
     endpoints: [ {{ .Endpoints }} ]
-    certSANs: [ "{{ .IP }}", "127.0.0.1" ]
+    certSANs: [ "{{ .IP }}", "127.0.0.1", "::1" ]
 `

--- a/pkg/userdata/generate/join.go
+++ b/pkg/userdata/generate/join.go
@@ -18,7 +18,7 @@ services:
         bootstrapToken:
           token: '{{ .KubeadmTokens.BootstrapToken }}'
           unsafeSkipCAVerification: true
-          apiServerEndpoint: {{ index .MasterIPs 0 }}:443
+          apiServerEndpoint: "{{ .GetControlPlaneEndpoint "443" }}"
       nodeRegistration:
         taints: []
         kubeletExtraArgs:

--- a/pkg/userdata/generate/talosconfig.go
+++ b/pkg/userdata/generate/talosconfig.go
@@ -12,7 +12,7 @@ func Talosconfig(in *Input) (string, error) {
 const talosconfigTempl = `context: {{ .ClusterName }}
 contexts:
   {{ .ClusterName }}:
-    target: {{ index .MasterIPs 0 }}
+    target: {{ .GetControlPlaneEndpoint "" }}
     ca: {{ .Certs.OsCert }}
     crt: {{ .Certs.AdminCert }}
     key: {{ .Certs.AdminKey }}


### PR DESCRIPTION
This reworks a bunch of the formatting for the userdata generation to
output a cleaner talos config when using IPv6 masters and `osctl config
generate`.

Please note that this changes the scope of concern for master indexing,
keeping `osctl` blissfully unaware of the master-reference chaining.
All it does is report the index of the master it is trying to generate.
The generator itself handles the reference chaining.

Fixes #916, fixes #917, and fixes #918

Signed-off-by: Seán C McCord <ulexus@gmail.com>