### PR TITLE
chore: run unique E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ image-azure:
 
 .PHONY: push-image-azure
 push-image-azure:
-	./hack/test/azure-setup.sh
+	@TAG=$(TAG) ./hack/test/azure-setup.sh
 
 .PHONY: image-gce
 image-gce:
@@ -197,7 +197,7 @@ image-gce:
 
 .PHONY: push-image-gce
 push-image-gce:
-	./hack/test/gce-setup.sh
+	@TAG=$(TAG) ./hack/test/gce-setup.sh
 
 .PHONY: image-test
 image-test:

--- a/hack/test/azure-setup.sh
+++ b/hack/test/azure-setup.sh
@@ -31,8 +31,8 @@ tar -C ${TMP} -xf ./build/azure.tar.gz
 ## Login to azure, push blob, create image from blob
 AZURE_STORAGE_CONNECTION_STRING=$( azcli_run "az storage account show-connection-string -n ${STORAGE_ACCOUNT} -g ${GROUP} -o tsv" )
 
-azcli_run "AZURE_STORAGE_CONNECTION_STRING='${AZURE_STORAGE_CONNECTION_STRING}' az storage blob upload --container-name ${STORAGE_CONTAINER} -f ${TMP}/azure.vhd -n azure.vhd"
+azcli_run "AZURE_STORAGE_CONNECTION_STRING='${AZURE_STORAGE_CONNECTION_STRING}' az storage blob upload --container-name ${STORAGE_CONTAINER} -f ${TMP}/azure.vhd -n azure-${TAG}.vhd"
 
-azcli_run "az image delete --name talos-e2e -g ${GROUP}"
+azcli_run "az image delete --name talos-e2e-${TAG} -g ${GROUP}"
 
-azcli_run "az image create --name talos-e2e --source https://${STORAGE_ACCOUNT}.blob.core.windows.net/${STORAGE_CONTAINER}/azure.vhd --os-type linux -g ${GROUP}"
+azcli_run "az image create --name talos-e2e-${TAG} --source https://${STORAGE_ACCOUNT}.blob.core.windows.net/${STORAGE_CONTAINER}/azure-${TAG}.vhd --os-type linux -g ${GROUP}"

--- a/hack/test/gce-setup.sh
+++ b/hack/test/gce-setup.sh
@@ -5,14 +5,14 @@ set -eou pipefail
 ## Setup svc acct
 echo $GCE_SVC_ACCT | base64 -d > /tmp/svc-acct.json
 apk add --no-cache python
-wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-253.0.0-linux-x86_64.tar.gz
-tar -xf google-cloud-sdk-253.0.0-linux-x86_64.tar.gz
-./google-cloud-sdk/install.sh --disable-installation-options --quiet
-./google-cloud-sdk/bin/gcloud auth activate-service-account --key-file /tmp/svc-acct.json
+curl -L -o /tmp/google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-253.0.0-linux-x86_64.tar.gz
+tar -xf /tmp/google-cloud-sdk.tar.gz -C /tmp
+/tmp/google-cloud-sdk/install.sh --disable-installation-options --quiet
+/tmp/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file /tmp/svc-acct.json
 
 ## Push talos-gce to storage bucket
-./google-cloud-sdk/bin/gsutil cp ./build/gce.tar.gz gs://talos-e2e
+/tmp/google-cloud-sdk/bin/gsutil cp ./build/gce.tar.gz gs://talos-e2e/gce-${TAG}.tar.gz
 
 ## Create image from talos-gce
-./google-cloud-sdk/bin/gcloud --quiet --project talos-testbed compute images delete talos-e2e || true ##Ignore error if image doesn't exist
-./google-cloud-sdk/bin/gcloud --quiet --project talos-testbed compute images create talos-e2e --source-uri gs://talos-e2e/gce.tar.gz
+/tmp/google-cloud-sdk/bin/gcloud --quiet --project talos-testbed compute images delete talos-e2e-${TAG} || true ##Ignore error if image doesn't exist
+/tmp/google-cloud-sdk/bin/gcloud --quiet --project talos-testbed compute images create talos-e2e-${TAG} --source-uri gs://talos-e2e/gce-${TAG}.tar.gz

--- a/hack/test/manifests/azure-cluster.yaml
+++ b/hack/test/manifests/azure-cluster.yaml
@@ -2,33 +2,33 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   annotations: null
-  name: talos-e2e-azure
+  name: talos-e2e-{{TAG}}-azure
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      - 192.168.0.0/16
+        - 192.168.0.0/16
     serviceDomain: cluster.local
     services:
       cidrBlocks:
-      - 10.96.0.0/12
+        - 10.96.0.0/12
   providerSpec:
     value:
       apiVersion: talosproviderconfig/v1alpha1
       kind: TalosClusterProviderSpec
       masters:
         ips:
-        - 23.99.218.95
-        - 23.99.220.43
-        - 23.99.225.139
+          - 23.99.218.95
+          - 23.99.220.43
+          - 23.99.225.139
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-azure
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-azure
     set: master
-  name: talos-e2e-azure-master-0
+  name: talos-e2e-{{TAG}}-azure-master-0
 spec:
   providerSpec:
     value:
@@ -40,7 +40,7 @@ spec:
           resourcegroup: "talos"
           instances:
             type:  "Standard_D2_v3"
-            image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos"
+            image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos-e2e-{{TAG}}"
             network: "talos-vnet"
             subnet: "default"
             disks:
@@ -51,9 +51,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-azure
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-azure
     set: master
-  name: talos-e2e-azure-master-1
+  name: talos-e2e-{{TAG}}-azure-master-1
 spec:
   providerSpec:
     value:
@@ -65,7 +65,7 @@ spec:
           resourcegroup: "talos"
           instances:
             type:  "Standard_D2_v3"
-            image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos"
+            image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos-e2e-{{TAG}}"
             network: "talos-vnet"
             subnet: "default"
             disks:
@@ -76,9 +76,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-azure
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-azure
     set: master
-  name: talos-e2e-azure-master-2
+  name: talos-e2e-{{TAG}}-azure-master-2
 spec:
   providerSpec:
     value:
@@ -90,7 +90,7 @@ spec:
           resourcegroup: "talos"
           instances:
             type:  "Standard_D2_v3"
-            image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos"
+            image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos-e2e-{{TAG}}"
             network: "talos-vnet"
             subnet: "default"
             disks:
@@ -101,19 +101,19 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-azure
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-azure
     set: worker
-  name: talos-e2e-azure-workers
+  name: talos-e2e-{{TAG}}-azure-workers
 spec:
   replicas: 3
   selector:
     matchLabels:
-      cluster.k8s.io/cluster-name: talos-e2e-azure
+      cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-azure
       set: worker
   template:
     metadata:
       labels:
-        cluster.k8s.io/cluster-name: talos-e2e-azure
+        cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-azure
         set: worker
     spec:
       providerSpec:
@@ -126,7 +126,7 @@ spec:
               resourcegroup: "talos"
               instances:
                 type:  "Standard_D2_v3"
-                image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos"
+                image: "/subscriptions/64739c64-c063-4c9d-bf2c-d1191ed8befa/resourceGroups/talos/providers/Microsoft.Compute/images/talos-e2e-{{TAG}}"
                 network: "talos-vnet"
                 subnet: "default"
                 disks:

--- a/hack/test/manifests/gce-cluster.yaml
+++ b/hack/test/manifests/gce-cluster.yaml
@@ -2,33 +2,33 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Cluster
 metadata:
   annotations: null
-  name: talos-e2e-gce
+  name: talos-e2e-{{TAG}}-gce
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-      - 192.168.0.0/16
+        - 192.168.0.0/16
     serviceDomain: cluster.local
     services:
       cidrBlocks:
-      - 10.96.0.0/12
+        - 10.96.0.0/12
   providerSpec:
     value:
       apiVersion: talosproviderconfig/v1alpha1
       kind: TalosClusterProviderSpec
       masters:
         ips:
-        - 35.208.196.229
-        - 35.208.64.45
-        - 35.208.118.119
+          - 35.208.196.229
+          - 35.208.64.45
+          - 35.208.118.119
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-gce
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gce
     set: master
-  name: talos-e2e-gce-master-0
+  name: talos-e2e-{{TAG}}-gce-master-0
 spec:
   providerSpec:
     value:
@@ -40,7 +40,7 @@ spec:
           project: "talos-testbed"
           instances:
             type:  "n1-standard-2"
-            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e"
+            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
             disks:
               size: 50
         type: gce
@@ -49,9 +49,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-gce
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gce
     set: master
-  name: talos-e2e-gce-master-1
+  name: talos-e2e-{{TAG}}-gce-master-1
 spec:
   providerSpec:
     value:
@@ -63,7 +63,7 @@ spec:
           project: "talos-testbed"
           instances:
             type:  "n1-standard-2"
-            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e"
+            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
             disks:
               size: 50
         type: gce
@@ -72,9 +72,9 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-gce
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gce
     set: master
-  name: talos-e2e-gce-master-2
+  name: talos-e2e-{{TAG}}-gce-master-2
 spec:
   providerSpec:
     value:
@@ -86,7 +86,7 @@ spec:
           project: "talos-testbed"
           instances:
             type:  "n1-standard-2"
-            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e"
+            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
             disks:
               size: 50
         type: gce
@@ -95,19 +95,19 @@ apiVersion: cluster.k8s.io/v1alpha1
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-gce
+    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gce
     set: worker
-  name: talos-e2e-gce-workers
+  name: talos-e2e-{{TAG}}-gce-workers
 spec:
   replicas: 3
   selector:
     matchLabels:
-      cluster.k8s.io/cluster-name: talos-e2e-gce
+      cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gce
       set: worker
   template:
     metadata:
       labels:
-        cluster.k8s.io/cluster-name: talos-e2e-gce
+        cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gce
         set: worker
     spec:
       providerSpec:
@@ -120,7 +120,7 @@ spec:
               project: "talos-testbed"
               instances:
                 type:  "n1-standard-2"
-                image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e"
+                image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
                 disks:
                   size: 50
             type: gce


### PR DESCRIPTION
In order to run more than one instance of E2E testing at a time, we need
to ensure that all resources are unique to the run.