### PR TITLE
chore: fix release pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2369,9 +2369,6 @@ node:
 trigger:
   event:
   - tag
-  - promote
-  target:
-  - release
 
 ---
 kind: pipeline

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -354,11 +354,7 @@ local release_trigger = {
   trigger: {
     event: [
       "tag",
-      "promote",
     ],
-    target: {
-      include: ["release"]
-    },
   },
 };
 


### PR DESCRIPTION
We should only use the "tag" event and remove the promotion event. It
seems like we can't have both.