### PR TITLE
chore: fix default pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -321,9 +321,8 @@ steps:
     path: /tmp
   when:
     event:
-      include:
-      - push
       exclude:
+      - pull_request
       - promote
   depends_on:
   - basic-integration
@@ -365,6 +364,7 @@ trigger:
     - nightly
   event:
     exclude:
+    - tag
     - promote
 
 ---
@@ -690,9 +690,8 @@ steps:
     path: /tmp
   when:
     event:
-      include:
-      - push
       exclude:
+      - pull_request
       - promote
   depends_on:
   - basic-integration
@@ -1196,9 +1195,8 @@ steps:
     path: /tmp
   when:
     event:
-      include:
-      - push
       exclude:
+      - pull_request
       - promote
   depends_on:
   - basic-integration
@@ -1704,9 +1702,8 @@ steps:
     path: /tmp
   when:
     event:
-      include:
-      - push
       exclude:
+      - pull_request
       - promote
   depends_on:
   - basic-integration
@@ -2212,9 +2209,8 @@ steps:
     path: /tmp
   when:
     event:
-      include:
-      - push
       exclude:
+      - pull_request
       - promote
   depends_on:
   - basic-integration

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -192,8 +192,10 @@ local push = {
   volumes: volumes.ForStep(),
   when: {
     event: {
-      include: ["push"],
-      exclude: ["promote"],
+      exclude: [
+        "pull_request",
+        "promote",
+      ],
     },
   },
   depends_on: [basic_integration.name],
@@ -226,7 +228,10 @@ local default_trigger = {
       exclude: ["nightly"]
     },
     event: {
-      exclude: ["promote"]
+      exclude: [
+        "tag",
+        "promote",
+      ]
     },
   },
 };


### PR DESCRIPTION
This prevents the default pipeline from running on releases. It also
ensures that the push step is executed on a release.