### PR TITLE
chore: fix drone clone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,21 +11,8 @@ clone:
 
 steps:
 - name: clone
-  image: autonomy/build-container:latest
-  commands:
-  - git config --global user.email talos@talos.dev
-  - git config --global user.name talos
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - "git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:"
-  - git checkout ${DRONE_COMMIT_BRANCH}
-  - "git fetch origin ${DRONE_COMMIT_REF}:"
-  - git merge ${DRONE_COMMIT_SHA}
-  - git fetch --tags
-  when:
-    event:
-      exclude:
-      - ""
+  pull: always
+  image: autonomy/drone-git:latest
 
 - name: machined
   image: autonomy/build-container:latest
@@ -380,21 +367,8 @@ clone:
 
 steps:
 - name: clone
-  image: autonomy/build-container:latest
-  commands:
-  - git config --global user.email talos@talos.dev
-  - git config --global user.name talos
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - "git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:"
-  - git checkout ${DRONE_COMMIT_BRANCH}
-  - "git fetch origin ${DRONE_COMMIT_REF}:"
-  - git merge ${DRONE_COMMIT_SHA}
-  - git fetch --tags
-  when:
-    event:
-      exclude:
-      - ""
+  pull: always
+  image: autonomy/drone-git:latest
 
 - name: machined
   image: autonomy/build-container:latest
@@ -885,21 +859,8 @@ clone:
 
 steps:
 - name: clone
-  image: autonomy/build-container:latest
-  commands:
-  - git config --global user.email talos@talos.dev
-  - git config --global user.name talos
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - "git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:"
-  - git checkout ${DRONE_COMMIT_BRANCH}
-  - "git fetch origin ${DRONE_COMMIT_REF}:"
-  - git merge ${DRONE_COMMIT_SHA}
-  - git fetch --tags
-  when:
-    event:
-      exclude:
-      - ""
+  pull: always
+  image: autonomy/drone-git:latest
 
 - name: machined
   image: autonomy/build-container:latest
@@ -1392,21 +1353,8 @@ clone:
 
 steps:
 - name: clone
-  image: autonomy/build-container:latest
-  commands:
-  - git config --global user.email talos@talos.dev
-  - git config --global user.name talos
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - "git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:"
-  - git checkout ${DRONE_COMMIT_BRANCH}
-  - "git fetch origin ${DRONE_COMMIT_REF}:"
-  - git merge ${DRONE_COMMIT_SHA}
-  - git fetch --tags
-  when:
-    event:
-      exclude:
-      - ""
+  pull: always
+  image: autonomy/drone-git:latest
 
 - name: machined
   image: autonomy/build-container:latest
@@ -1899,21 +1847,8 @@ clone:
 
 steps:
 - name: clone
-  image: autonomy/build-container:latest
-  commands:
-  - git config --global user.email talos@talos.dev
-  - git config --global user.name talos
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - "git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:"
-  - git checkout ${DRONE_COMMIT_BRANCH}
-  - "git fetch origin ${DRONE_COMMIT_REF}:"
-  - git merge ${DRONE_COMMIT_SHA}
-  - git fetch --tags
-  when:
-    event:
-      exclude:
-      - ""
+  pull: always
+  image: autonomy/drone-git:latest
 
 - name: machined
   image: autonomy/build-container:latest

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -59,23 +59,8 @@ local volumes = {
 // the master branch, causing improper clones when promoting a pull request.
 local clone = {
   name: "clone",
-  image: build_container,
-  commands: [
-    "git config --global user.email talos@talos.dev",
-    "git config --global user.name talos",
-    "git init",
-    "git remote add origin ${DRONE_REMOTE_URL}",
-    "git fetch origin +refs/heads/${DRONE_COMMIT_BRANCH}:",
-    "git checkout ${DRONE_COMMIT_BRANCH}",
-    "git fetch origin ${DRONE_COMMIT_REF}:",
-    "git merge ${DRONE_COMMIT_SHA}",
-    "git fetch --tags",
-  ],
-  when: {
-    event: {
-      exclude: [""],
-    },
-  },
+  image: "autonomy/drone-git:latest",
+  pull: "always",
 };
 
 // This provides the docker service.


### PR DESCRIPTION
In order to use promotion against pull requests to trigger things like
E2E, we need to update the default clone logic. The issue is that a
promotion is assumed to be ran against a build that has been merged. In
our case, we need to promote builds that are not necessarily merged.