### PR TITLE
chore: enable floating IP creation in e2e tests

### DIFF
--- a/hack/test/manifests/azure-cluster.yaml
+++ b/hack/test/manifests/azure-cluster.yaml
@@ -16,11 +16,13 @@ spec:
     value:
       apiVersion: talosproviderconfig/v1alpha1
       kind: TalosClusterProviderSpec
-      masters:
-        ips:
-          - 23.99.218.95
-          - 23.99.220.43
-          - 23.99.225.139
+      platform:
+        config: |-
+          resourcegroup: "talos"
+          location: "centralus"
+        type: azure
+      controlplane:
+        count: 3
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine

--- a/hack/test/manifests/gce-cluster.yaml
+++ b/hack/test/manifests/gce-cluster.yaml
@@ -16,11 +16,13 @@ spec:
     value:
       apiVersion: talosproviderconfig/v1alpha1
       kind: TalosClusterProviderSpec
-      masters:
-        ips:
-          - 35.208.196.229
-          - 35.208.64.45
-          - 35.208.118.119
+      platform:
+        config: |-
+          region: "us-central1"
+          project: "talos-testbed"
+        type: gce
+      controlplane:
+        count: 3
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine


### PR DESCRIPTION
This PR will edit the manifests for e2e so that we can take advantage of https://github.com/talos-systems/cluster-api-provider-talos/pull/47

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>