### PR TITLE
chore: apply manifests when init node is ready

### DIFF
--- a/hack/test/e2e-integration.sh
+++ b/hack/test/e2e-integration.sh
@@ -47,6 +47,21 @@ e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
 		   sleep 10
 		 done"
 
+## Wait for the init node to report in
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+     until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -l node-role.kubernetes.io/master='' -o json | jq '.items | length' | grep 1 >/dev/null
+	 do
+	   if  [[ \$(date +%s) -gt \$timeout ]]
+	   then
+	     exit 1
+	   fi
+	   kubectl get nodes -o wide
+	   sleep 5
+	 done"
+
+##  Apply psp and flannel
+e2e_run "KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
+
 ##  Wait for nodes to check in
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
 		 until KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -o json | jq '.items | length' | grep ${NUM_NODES} >/dev/null
@@ -58,9 +73,6 @@ e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
 		   KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl get nodes -o wide
 		   sleep 10
 		 done"
-
-##  Apply psp and flannel
-e2e_run "KUBECONFIG=${KUBECONFIG}-${PLATFORM}-capi kubectl apply -f /manifests/psp.yaml -f /manifests/flannel.yaml"
 
 ## Wait for kube-proxy up
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))


### PR DESCRIPTION
If we wait for all masters to check in before applying the PSP, we run
the risk of kube-proxy failing to start for a long period of time.