### PR TITLE
feat: run dedicated instance of containerd for system services

### DIFF
--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -57,6 +57,7 @@ func NewNode(clusterName string, req *Request) (err error) {
 			"/var/lib/containerd": {},
 			"/var/lib/kubelet":    {},
 			"/etc/cni":            {},
+			"/run":                {},
 		},
 	}
 

--- a/internal/app/machined/internal/phase/services/services.go
+++ b/internal/app/machined/internal/phase/services/services.go
@@ -41,6 +41,7 @@ func (task *Services) startSystemServices(data *userdata.UserData, mode runtime.
 	svcs.Load(
 		&services.MachinedAPI{},
 		&services.Networkd{},
+		&services.SystemContainerd{},
 		&services.Containerd{},
 		&services.Udevd{},
 		&services.OSD{},

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -31,7 +31,8 @@ func (n *NTPd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (n *NTPd) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
+	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
+	return importer.Import(&containerd.ImportRequest{
 		Path: "/usr/images/ntpd.tar",
 		Options: []containerdapi.ImportOpt{
 			containerdapi.WithIndexName("talos/ntpd"),
@@ -51,7 +52,7 @@ func (n *NTPd) Condition(data *userdata.UserData) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (n *NTPd) DependsOn(data *userdata.UserData) []string {
-	return []string{"containerd"}
+	return []string{"system-containerd"}
 }
 
 func (n *NTPd) Runner(data *userdata.UserData) (runner.Runner, error) {
@@ -74,6 +75,7 @@ func (n *NTPd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	return restart.New(containerd.NewRunner(
 		data,
 		&args,
+		runner.WithContainerdAddress(constants.SystemContainerdAddress),
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(

--- a/internal/app/machined/pkg/system/services/proxyd.go
+++ b/internal/app/machined/pkg/system/services/proxyd.go
@@ -34,7 +34,8 @@ func (p *Proxyd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (p *Proxyd) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
+	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
+	return importer.Import(&containerd.ImportRequest{
 		Path: "/usr/images/proxyd.tar",
 		Options: []containerdapi.ImportOpt{
 			containerdapi.WithIndexName("talos/proxyd"),
@@ -54,7 +55,7 @@ func (p *Proxyd) Condition(data *userdata.UserData) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (p *Proxyd) DependsOn(data *userdata.UserData) []string {
-	return []string{"containerd"}
+	return []string{"system-containerd"}
 }
 
 func (p *Proxyd) Runner(data *userdata.UserData) (runner.Runner, error) {
@@ -81,6 +82,7 @@ func (p *Proxyd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	return restart.New(containerd.NewRunner(
 		data,
 		&args,
+		runner.WithContainerdAddress(constants.SystemContainerdAddress),
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+// SystemContainerd implements the Service interface. It serves as the concrete type with
+// the required methods.
+type SystemContainerd struct{}
+
+// ID implements the Service interface.
+func (c *SystemContainerd) ID(data *userdata.UserData) string {
+	return "system-containerd"
+}
+
+// PreFunc implements the Service interface.
+func (c *SystemContainerd) PreFunc(ctx context.Context, data *userdata.UserData) error {
+	return os.MkdirAll(defaults.DefaultRootDir, os.ModeDir)
+}
+
+// PostFunc implements the Service interface.
+func (c *SystemContainerd) PostFunc(data *userdata.UserData) (err error) {
+	return nil
+}
+
+// Condition implements the Service interface.
+func (c *SystemContainerd) Condition(data *userdata.UserData) conditions.Condition {
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (c *SystemContainerd) DependsOn(data *userdata.UserData) []string {
+	return nil
+}
+
+// Runner implements the Service interface.
+func (c *SystemContainerd) Runner(data *userdata.UserData) (runner.Runner, error) {
+	// Set the process arguments.
+	args := &runner.Args{
+		ID: c.ID(data),
+		ProcessArgs: []string{
+			"/bin/containerd",
+			"--address", constants.SystemContainerdAddress,
+			"--state", "/run/system/containerd",
+			"--root", "/run/system/lib/containerd",
+		},
+	}
+
+	env := []string{}
+	for key, val := range data.Env {
+		env = append(env, fmt.Sprintf("%s=%s", key, val))
+	}
+
+	return restart.New(process.NewRunner(
+		data,
+		args,
+		runner.WithEnv(env),
+	),
+		restart.WithType(restart.Forever),
+	), nil
+}
+
+// HealthFunc implements the HealthcheckedService interface
+func (c *SystemContainerd) HealthFunc(*userdata.UserData) health.Check {
+	return func(ctx context.Context) error {
+		client, err := containerd.New(constants.SystemContainerdAddress)
+		if err != nil {
+			return err
+		}
+		// nolint: errcheck
+		defer client.Close()
+
+		resp, err := client.HealthService().Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		if err != nil {
+			return err
+		}
+
+		if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+			return errors.Errorf("unexpected serving status: %d", resp.Status)
+		}
+
+		return nil
+	}
+}
+
+// HealthSettings implements the HealthcheckedService interface
+func (c *SystemContainerd) HealthSettings(*userdata.UserData) *health.Settings {
+	return &health.DefaultSettings
+}
+
+// Verify healthchecked interface
+var (
+	_ system.HealthcheckedService = &SystemContainerd{}
+)

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -34,7 +34,8 @@ func (t *Trustd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (t *Trustd) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	return containerd.Import(constants.SystemContainerdNamespace, &containerd.ImportRequest{
+	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
+	return importer.Import(&containerd.ImportRequest{
 		Path: "/usr/images/trustd.tar",
 		Options: []containerdapi.ImportOpt{
 			containerdapi.WithIndexName("talos/trustd"),
@@ -81,6 +82,7 @@ func (t *Trustd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	return restart.New(containerd.NewRunner(
 		data,
 		&args,
+		runner.WithContainerdAddress(constants.SystemContainerdAddress),
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -327,7 +327,11 @@ func getContainerInspector(ctx context.Context, namespace string, driver proto.C
 		}
 		return cri.NewInspector(ctx)
 	case proto.ContainerDriver_CONTAINERD:
-		return containerd.NewInspector(ctx, namespace)
+		addr := constants.ContainerdAddress
+		if namespace == constants.SystemContainerdNamespace {
+			addr = constants.SystemContainerdAddress
+		}
+		return containerd.NewInspector(ctx, namespace, containerd.WithContainerdAddress(addr))
 	default:
 		return nil, errors.Errorf("unsupported driver %q", driver)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -139,6 +139,9 @@ const (
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"
 
+	// SystemContainerdAddress is the path to the system containerd socket.
+	SystemContainerdAddress = "/run/system/containerd/containerd.sock"
+
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 


### PR DESCRIPTION
In order to facilitate upgrades and resets that are capable of
manipulating the system block device, we need to run an instance of
containerd that has zero dependencies on the disk. We run containerd
purely in memory for running system services.