### PR TITLE
feat: Allow hostname to be specified in userdata

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/etc/etc.go
+++ b/internal/app/machined/internal/phase/rootfs/etc/etc.go
@@ -14,8 +14,6 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
-	"github.com/talos-systems/talos/internal/pkg/kernel"
-	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/version"
 
 	"golang.org/x/sys/unix"
@@ -40,18 +38,16 @@ BUG_REPORT_URL="https://github.com/talos-systems/talos/issues"
 `
 
 // Hosts renders a valid /etc/hosts file and writes it to disk.
-func Hosts() (err error) {
-	var h *string
-	if h = kernel.ProcCmdline().Get(constants.KernelParamHostname).First(); h != nil {
-		if err = unix.Sethostname([]byte(*h)); err != nil {
-			return err
-		}
-	}
+func Hosts(hostname string) (err error) {
 
 	ip := ip()
 
-	var hostname string
-	if hostname, err = os.Hostname(); err != nil {
+	// If no hostname, set it to `talos-<ip>`, talos-1-2-3-4
+	if hostname == "" {
+		hostname = fmt.Sprintf("%s-%s", "talos", strings.ReplaceAll(ip, ".", "-"))
+	}
+
+	if err = unix.Sethostname([]byte(hostname)); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/internal/phase/rootfs/network_configuration.go
+++ b/internal/app/machined/internal/phase/rootfs/network_configuration.go
@@ -31,11 +31,6 @@ func (task *NetworkConfiguration) RuntimeFunc(mode runtime.Mode) phase.RuntimeFu
 }
 
 func (task *NetworkConfiguration) runtime(platform platform.Platform, data *userdata.UserData) (err error) {
-	// Create /etc/hosts.
-	if err = etc.Hosts(); err != nil {
-		return err
-	}
-
 	// Create /etc/resolv.conf.
 	if err = etc.ResolvConf(); err != nil {
 		return err

--- a/internal/app/machined/internal/platform/googlecloud/googlecloud.go
+++ b/internal/app/machined/internal/platform/googlecloud/googlecloud.go
@@ -8,7 +8,6 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
-	"github.com/talos-systems/talos/internal/pkg/network"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -27,26 +26,7 @@ func (gc *GoogleCloud) Name() string {
 
 // UserData implements the platform.Platform interface.
 func (gc *GoogleCloud) UserData() (data *userdata.UserData, err error) {
-	ud, err := userdata.Download(GCUserDataEndpoint, userdata.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
-	if err != nil {
-		return nil, err
-	}
-
-	if ud.Networking == nil {
-		ud.Networking = &userdata.Networking{
-			OS: &userdata.OSNet{
-				Devices: []userdata.Device{
-					{
-						Interface: network.DefaultInterface,
-						DHCP:      true,
-						MTU:       1460,
-					},
-				},
-			},
-		}
-	}
-
-	return ud, nil
+	return userdata.Download(GCUserDataEndpoint, userdata.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
 }
 
 // Initialize implements the platform.Platform interface and handles additional system setup.

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -78,7 +78,9 @@ type Networking struct {
 
 // OSNet represents the network interfaces present on the host
 type OSNet struct {
-	Devices []Device `yaml:"devices"`
+	Devices    []Device `yaml:"devices"`
+	Hostname   string   `yaml:"hostname"`
+	Domainname string   `yaml:"domainname"`
 }
 
 // File represents a file to write to disk.


### PR DESCRIPTION
This sets up the ability to define hostname via userdata. I dont expect
this will get used publicly much, but provides a mechanism to convey
the hostname from various sources internally.

This also fixes the hostname retrieval from metadata services in azure.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>