### PR TITLE
feat(proxyd): Add gRPC server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,15 @@ RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
 WORKDIR /machined
 COPY ./internal/app/machined/proto ./proto
 RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+WORKDIR /proxyd
+COPY ./internal/app/proxyd/proto ./proto
+RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
 
 FROM scratch AS generate
 COPY --from=generate-build /osd/proto/api.pb.go /internal/app/osd/proto/
 COPY --from=generate-build /trustd/proto/api.pb.go /internal/app/trustd/proto/
 COPY --from=generate-build /machined/proto/api.pb.go /internal/app/machined/proto/
+COPY --from=generate-build /proxyd/proto/api.pb.go /internal/app/proxyd/proto/
 
 # The base target provides a container that can be used to build all Talos
 # assets.

--- a/internal/app/proxyd/internal/reg/reg.go
+++ b/internal/app/proxyd/internal/reg/reg.go
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
+	"github.com/talos-systems/talos/internal/app/proxyd/proto"
+	"google.golang.org/grpc"
+)
+
+// Registrator is the concrete type that implements the factory.Registrator and
+// proto.Init interfaces.
+type Registrator struct {
+	Proxyd *frontend.ReverseProxy
+}
+
+// NewRegistrator builds new Registrator instance
+func NewRegistrator(proxy *frontend.ReverseProxy) *Registrator {
+	return &Registrator{
+		Proxyd: proxy,
+	}
+}
+
+// Register implements the factory.Registrator interface.
+func (r *Registrator) Register(s *grpc.Server) {
+	proto.RegisterProxydServer(s, r)
+}
+
+// Backends exposes the internal state of backends in proxyd
+func (r *Registrator) Backends(ctx context.Context, in *empty.Empty) (reply *proto.BackendsReply, err error) {
+	reply = &proto.BackendsReply{}
+	for _, be := range r.Proxyd.Backends() {
+		protobe := &proto.Backend{
+			Id:          be.UID,
+			Addr:        be.Addr,
+			Connections: be.Connections,
+		}
+		reply.Backends = append(reply.Backends, protobe)
+	}
+
+	return reply, err
+}

--- a/internal/app/proxyd/internal/reg/reg_test.go
+++ b/internal/app/proxyd/internal/reg/reg_test.go
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/proxyd/internal/frontend"
+	"github.com/talos-systems/talos/internal/app/proxyd/proto"
+	"github.com/talos-systems/talos/pkg/grpc/factory"
+	"google.golang.org/grpc"
+)
+
+type ProxydSuite struct {
+	suite.Suite
+}
+
+func TestProxydSuite(t *testing.T) {
+	// Hide all our state transition messages
+	log.SetOutput(ioutil.Discard)
+	suite.Run(t, new(ProxydSuite))
+}
+
+func (suite *ProxydSuite) TestBackends() {
+	testBackend := "127.0.0.1"
+	// Create reverse proxy
+	_, cancel := context.WithCancel(context.Background())
+	r, err := frontend.NewReverseProxy([]string{}, cancel)
+	suite.Assert().NoError(err)
+
+	r.AddBackend("bootstrap-1", testBackend)
+	defer r.Shutdown()
+
+	// Create gRPC server
+	api := NewRegistrator(r)
+	server := factory.NewServer(api)
+	listener, err := fakeProxydRPC()
+	suite.Assert().NoError(err)
+
+	defer server.Stop()
+	// nolint: errcheck
+	defer os.Remove(listener.Addr().String())
+
+	// nolint: errcheck
+	go server.Serve(listener)
+
+	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	suite.Assert().NoError(err)
+	pClient := proto.NewProxydClient(conn)
+
+	resp, err := pClient.Backends(context.Background(), &empty.Empty{})
+	suite.Assert().NoError(err)
+	suite.Assert().Equal(resp.Backends[0].Addr, testBackend)
+	log.Println(resp)
+
+}
+
+func fakeProxydRPC() (net.Listener, error) {
+	tmpfile, err := ioutil.TempFile("", "proxyd")
+	if err != nil {
+		return nil, err
+	}
+
+	return factory.NewListener(
+		factory.Network("unix"),
+		factory.SocketPath(tmpfile.Name()),
+	)
+}

--- a/internal/app/proxyd/proto/api.proto
+++ b/internal/app/proxyd/proto/api.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package proto;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+// The Init service definition.
+service Proxyd {
+  rpc Backends(google.protobuf.Empty) returns (BackendsReply) {}
+}
+
+// The response message containing the proxyd backend status.
+message BackendsReply {
+	repeated Backend backends = 1;
+}
+
+// Backend represents the proxyd backend
+message Backend {
+  string id = 1;
+  string addr = 2;
+  uint32 connections = 3;
+}
+

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -145,6 +145,9 @@ const (
 	// InitSocketPath is the path to file socket of init API
 	InitSocketPath = "/run/system/init/init.sock"
 
+	// ProxydSocketPath is the path to file socket of proxyd API
+	ProxydSocketPath = "/run/system/proxyd/proxyd.sock"
+
 	// KernelAsset defines a well known name for our kernel filename
 	KernelAsset = "vmlinuz"
 


### PR DESCRIPTION
Part of the API refactor; this introduces a gRPC server for proxyd
to expose some of the internal state.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>