### PR TITLE
chore: Disable rate limited kmessage

### DIFF
--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -24,6 +24,8 @@ func NewDefaultCmdline() *Cmdline {
 	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
 	cmdline.Append("nvme_core.io_timeout", "4294967295")
 	cmdline.Append("random.trust_cpu", "on")
+	// Disable rate limited printk
+	cmdline.Append("printk.devkmsg", "on")
 	// Enable early kernel message logging
 	cmdline.Append("earlyprintk", "ttyS0,115200")
 	// NB: We make console=tty0 the last device on the list since the last


### PR DESCRIPTION
This should allow for better troubleshooting during early boot/startup

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>