### PR TITLE
fix(gpt) Fix partition naming to be >8 characters

### DIFF
--- a/pkg/blockdevice/table/gpt/partition/partition.go
+++ b/pkg/blockdevice/table/gpt/partition/partition.go
@@ -177,20 +177,5 @@ func (prt *Partition) Fields() []*serde.Field {
 				return nil
 			},
 		},
-		{
-			Offset: 72,
-			Length: 56,
-			DeserializerFunc: func(offset, length uint32, new []byte, opts interface{}) ([]byte, error) {
-				data := make([]byte, length)
-				copy(data, prt.TrailingBytes)
-
-				return data, nil
-			},
-			SerializerFunc: func(contents []byte, opts interface{}) error {
-				prt.TrailingBytes = contents
-
-				return nil
-			},
-		},
 	}
 }


### PR DESCRIPTION
There was a bug in the offset calculation for the last field (offset at 72 instead of 128 )
that caused a truncation of the partition name field to only allow for 8 characters/16 bytes
( utf-16 = 2bytes/character ). This last field isnt part of the gpt spec, so we are dropping it.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>