### PR TITLE
[wip] feat: generate and use v1 machine configs

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -24,7 +24,7 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/cmd/cluster/pkg/node"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/pkg/userdata/generate"
+	"github.com/talos-systems/talos/pkg/userdata/v1/generate"
 	"github.com/talos-systems/talos/pkg/version"
 )
 

--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"github.com/talos-systems/talos/pkg/userdata/generate"
+	"github.com/talos-systems/talos/pkg/userdata/v1/generate"
 )
 
 // Request represents the set of options available for configuring a node.

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -6,6 +6,7 @@ package cmd
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -17,10 +18,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
-	"github.com/talos-systems/talos/pkg/userdata"
-	"github.com/talos-systems/talos/pkg/userdata/generate"
+	udv0 "github.com/talos-systems/talos/pkg/userdata"
+	udgenv0 "github.com/talos-systems/talos/pkg/userdata/generate"
+	udgenv1 "github.com/talos-systems/talos/pkg/userdata/v1/generate"
 	"gopkg.in/yaml.v2"
 )
+
+var generateVersion string
 
 // configCmd represents the config command.
 var configCmd = &cobra.Command{
@@ -127,64 +131,147 @@ var configGenerateCmd = &cobra.Command{
 		if len(args) != 2 {
 			log.Fatal("expected a cluster name and comma delimited list of IP addresses")
 		}
-		input, err := generate.NewInput(args[0], strings.Split(args[1], ","))
-		if err != nil {
-			helpers.Fatalf("failed to generate PKI and tokens: %v", err)
+
+		var err error
+		switch generateVersion {
+		case "v0":
+			err = genV0(args)
+		case "v1":
+			err = genV1(args)
+		default:
+			err = errors.New("failed to determine version of machine config to generate")
 		}
 		input.AdditionalSubjectAltNames = additionalSANs
 
-		workingDir, err := os.Getwd()
 		if err != nil {
-			helpers.Fatalf("failed to fetch current working dir: %v", err)
+			helpers.Fatalf("Failed to generate configs: %v", err)
 		}
 
-		var udType generate.Type
-		for idx, master := range strings.Split(args[1], ",") {
-			input.Index = idx
-			input.IP = net.ParseIP(master)
-			if input.Index == 0 {
-				udType = generate.TypeInit
-			} else {
-				udType = generate.TypeControlPlane
-			}
-
-			if err = writeUserdata(input, udType, "master-"+strconv.Itoa(idx+1)); err != nil {
-				helpers.Fatalf("failed to generate userdata for %s: %v", "master-"+strconv.Itoa(idx+1), err)
-			}
-			fmt.Println("created file", workingDir+"/master-"+strconv.Itoa(idx+1)+".yaml")
-		}
-		input.IP = nil
-
-		if err = writeUserdata(input, generate.TypeJoin, "worker"); err != nil {
-			helpers.Fatalf("failed to generate userdata for %s: %v", "worker", err)
-		}
-		fmt.Println("created file", workingDir+"/worker.yaml")
-
-		data, err := generate.Talosconfig(input)
-		if err != nil {
-			helpers.Fatalf("failed to generate talosconfig: %v", err)
-		}
-		if err = ioutil.WriteFile("talosconfig", []byte(data), 0644); err != nil {
-			helpers.Fatalf("%v", err)
-		}
-		fmt.Println("created file", workingDir+"/talosconfig")
 	},
 }
 
-func writeUserdata(input *generate.Input, t generate.Type, name string) (err error) {
-	var data string
-	data, err = generate.Userdata(t, input)
+func genV0(args []string) error {
+	input, err := udgenv0.NewInput(args[0], strings.Split(args[1], ","))
 	if err != nil {
 		return err
 	}
-	ud := &userdata.UserData{}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	var udType udgenv0.Type
+	for idx, master := range strings.Split(args[1], ",") {
+		input.Index = idx
+		input.IP = net.ParseIP(master)
+		if input.Index == 0 {
+			udType = udgenv0.TypeInit
+		} else {
+			udType = udgenv0.TypeControlPlane
+		}
+
+		if err = writeUserdataV0(input, udType, "master-"+strconv.Itoa(idx+1)); err != nil {
+			return err
+		}
+		fmt.Println("created file", workingDir+"/master-"+strconv.Itoa(idx+1)+".yaml")
+	}
+	input.IP = nil
+
+	if err = writeUserdataV0(input, udgenv0.TypeJoin, "worker"); err != nil {
+		return err
+	}
+	fmt.Println("created file", workingDir+"/worker.yaml")
+
+	data, err := udgenv0.Talosconfig(input)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile("talosconfig", []byte(data), 0644); err != nil {
+		return err
+	}
+	fmt.Println("created file", workingDir+"/talosconfig")
+	return nil
+}
+
+func writeUserdataV0(input *udgenv0.Input, t udgenv0.Type, name string) (err error) {
+	var data string
+	data, err = udgenv0.Userdata(t, input)
+	if err != nil {
+		return err
+	}
+	ud := &udv0.UserData{}
 	if err = yaml.Unmarshal([]byte(data), ud); err != nil {
 		return err
 	}
 	if err = ud.Validate(); err != nil {
 		return err
-
 	}
+	if err = ioutil.WriteFile(strings.ToLower(name)+".yaml", []byte(data), 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func genV1(args []string) error {
+	input, err := udgenv1.NewInput(args[0], strings.Split(args[1], ","))
+	if err != nil {
+		return err
+	}
+
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	var udType udgenv1.Type
+	for idx, master := range strings.Split(args[1], ",") {
+		input.Index = idx
+		input.IP = net.ParseIP(master)
+		if input.Index == 0 {
+			udType = udgenv1.TypeInit
+		} else {
+			udType = udgenv1.TypeControlPlane
+		}
+
+		if err = writeUserdataV1(input, udType, "master-"+strconv.Itoa(idx+1)); err != nil {
+			return err
+		}
+		fmt.Println("created file", workingDir+"/master-"+strconv.Itoa(idx+1)+".yaml")
+	}
+	input.IP = nil
+
+	if err = writeUserdataV1(input, udgenv1.TypeJoin, "worker"); err != nil {
+		return err
+	}
+	fmt.Println("created file", workingDir+"/worker.yaml")
+
+	data, err := udgenv1.Talosconfig(input)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile("talosconfig", []byte(data), 0644); err != nil {
+		return err
+	}
+	fmt.Println("created file", workingDir+"/talosconfig")
+	return nil
+}
+
+func writeUserdataV1(input *udgenv1.Input, t udgenv1.Type, name string) (err error) {
+	var data string
+	data, err = udgenv1.Userdata(t, input)
+	if err != nil {
+		return err
+	}
+
+	translated, err := udv0.TranslateV1(data)
+	if err != nil {
+		return err
+	}
+	if err = translated.Validate(); err != nil {
+		return err
+	}
+
 	if err = ioutil.WriteFile(strings.ToLower(name)+".yaml", []byte(data), 0644); err != nil {
 		return err
 	}
@@ -197,6 +284,7 @@ func init() {
 	configAddCmd.Flags().StringVar(&crt, "crt", "", "the path to the certificate")
 	configAddCmd.Flags().StringVar(&key, "key", "", "the path to the key")
 	configGenerateCmd.Flags().StringSliceVar(&additionalSANs, "additionalSANs", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
+	configGenerateCmd.Flags().StringVar(&generateVersion, "genversion", "v0", "version of machine configs to generate")
 	helpers.Should(configAddCmd.MarkFlagRequired("ca"))
 	helpers.Should(configAddCmd.MarkFlagRequired("crt"))
 	helpers.Should(configAddCmd.MarkFlagRequired("key"))

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,8 @@ require (
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v0.0.0
 	k8s.io/cri-api v0.0.0
+	k8s.io/kube-proxy v0.0.0
+	k8s.io/kubelet v0.0.0
 	k8s.io/kubernetes v1.16.0-alpha.3
 	k8s.io/utils v0.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -671,6 +671,7 @@ k8s.io/kube-scheduler v0.0.0-20190807222621-642e553af6d6/go.mod h1:qOY5SXVe6zci9
 k8s.io/kubectl v0.0.0-20190807223350-296b7feb3712/go.mod h1:th05yqI6+fyolVgqKdowab+e7tV/sgTirr9nTHHppDc=
 k8s.io/kubelet v0.0.0-20190807222527-c75499879fd7 h1:P4TUfI5QLIB1YmZBnXjhNgE7B+csw7pxI5F/LJzcqnA=
 k8s.io/kubelet v0.0.0-20190807222527-c75499879fd7/go.mod h1:jp9H2PTFrv8oj46GAEst2ddr4utu7Db13P1gSv1qeTI=
+k8s.io/kubernetes v1.15.3 h1:PqAKiWeebLJQT2/sqTmeezrd2ApvznBVscDt1rBkcV4=
 k8s.io/kubernetes v1.16.0-alpha.3 h1:3rrB9Ua/qQ6RR2gkPa2dPLGe9r6Xc9y/aR0Ly1pzX7Q=
 k8s.io/kubernetes v1.16.0-alpha.3/go.mod h1:xUROzQTxEBX+J/AUDQDoDjFvyi6Mbm09p6B8FAVOwd0=
 k8s.io/legacy-cloud-providers v0.0.0-20190807223058-bf918bc72210/go.mod h1:XyGXlmfhJhmVBmAB/d9hd59wF0Cp5bHtVFs/dtgjPSM=

--- a/internal/app/machined/internal/phase/userdata/save_userdata.go
+++ b/internal/app/machined/internal/phase/userdata/save_userdata.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
@@ -32,12 +33,11 @@ func (task *SaveUserData) RuntimeFunc(mode runtime.Mode) phase.RuntimeFunc {
 
 func (task *SaveUserData) runtime(platform platform.Platform, data *userdata.UserData) (err error) {
 	if _, err = os.Stat(constants.UserDataPath); os.IsNotExist(err) {
-		log.Println("saving userdata to disk")
 
 		var dataBytes []byte
 		dataBytes, err = yaml.Marshal(data)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to marshal")
 		}
 
 		if err = ioutil.WriteFile(constants.UserDataPath, dataBytes, 0400); err != nil {

--- a/internal/app/machined/internal/platform/container/container.go
+++ b/internal/app/machined/internal/platform/container/container.go
@@ -11,8 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
 	"github.com/talos-systems/talos/pkg/userdata"
-
-	"gopkg.in/yaml.v2"
 )
 
 // Container is a platform for installing Talos via an Container image.
@@ -33,11 +31,10 @@ func (c *Container) UserData() (data *userdata.UserData, err error) {
 	if decoded, err = base64.StdEncoding.DecodeString(s); err != nil {
 		return nil, err
 	}
-	data = &userdata.UserData{}
-	if err = yaml.Unmarshal(decoded, data); err != nil {
+	data, err = userdata.TranslateV1(string(decoded))
+	if err != nil {
 		return nil, err
 	}
-
 	return data, nil
 }
 

--- a/internal/app/machined/pkg/system/services/kubeadm/kubeadm_test.go
+++ b/internal/app/machined/pkg/system/services/kubeadm/kubeadm_test.go
@@ -45,31 +45,36 @@ func genUD() (ud *userdata.UserData, err error) {
 	return ud, err
 }
 
-func (suite *KubeadmSuite) TestWriteJoinConfig() {
+func (suite *KubeadmSuite) TestEditJoinConfig() {
 	data, err := genUD()
 	suite.Assert().NoError(err)
 
 	// testConfig is an initConfig
-	_, err = writeJoinConfig(data)
+	err = editJoinConfig(data)
 	suite.Assert().Error(err)
 
 	data, err = data.Upgrade()
 	suite.Assert().NoError(err)
-	_, err = writeJoinConfig(data)
+
+	err = editJoinConfig(data)
 	suite.Assert().NoError(err)
 }
 
-func (suite *KubeadmSuite) TestWriteInitConfig() {
+func (suite *KubeadmSuite) TestEditInitConfig() {
 	// Cant test this atm because we run through cis hardening
 	// which automatically generates additional assets in
 	// hardcoded locations
 	data, err := genUD()
 	suite.Assert().NoError(err)
 
+	err = editInitConfig(data)
+	suite.Assert().NoError(err)
+
 	data, err = data.Upgrade()
 	suite.Assert().NoError(err)
+
 	// upgraded config is an joinConfig
-	_, err = writeInitConfig(data)
+	err = editInitConfig(data)
 	suite.Assert().Error(err)
 }
 
@@ -143,7 +148,7 @@ services:
     initToken: d306cd08-a02e-11e9-ae96-acde48001122
     certificateKey: 'dnwrwn05vd2lyghvflnk93nwie'
     configuration: |
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: InitConfiguration
       bootstrapTokens:
       - token: 'gcwogs.kflpeg7yievuh1kq'
@@ -153,7 +158,7 @@ services:
         kubeletExtraArgs:
           node-labels: ""
       ---
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: ClusterConfiguration
       clusterName: cluster.local
       kubernetesVersion: v1.15.0

--- a/internal/pkg/cis/cis.go
+++ b/internal/pkg/cis/cis.go
@@ -15,7 +15,7 @@ import (
 	"github.com/talos-systems/talos/pkg/constants"
 
 	v1 "k8s.io/api/core/v1"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 )
 
 const disabled = "false"
@@ -42,7 +42,7 @@ resources:
 // EnforceAuditingRequirements enforces CIS requirements for auditing.
 // TODO(andrewrynhard): Enable audit-log-maxbackup.
 // TODO(andrewrynhard): Enable audit-log-maxsize.
-func EnforceAuditingRequirements(cfg *kubeadmapi.InitConfiguration) error {
+func EnforceAuditingRequirements(cfg *kubeadmapi.ClusterConfiguration) error {
 	if err := ioutil.WriteFile("/etc/kubernetes/audit-policy.yaml", []byte(auditPolicy), 0400); err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func CreateEncryptionToken() error {
 }
 
 // EnforceSecretRequirements enforces CIS requirements for secrets.
-func EnforceSecretRequirements(cfg *kubeadmapi.InitConfiguration) error {
+func EnforceSecretRequirements(cfg *kubeadmapi.ClusterConfiguration) error {
 	cfg.APIServer.ExtraArgs["experimental-encryption-provider-config"] = constants.EncryptionConfigRootfsPath
 	vol := kubeadmapi.HostPathMount{
 		Name:      "encryptionconfig",
@@ -107,7 +107,7 @@ func EnforceSecretRequirements(cfg *kubeadmapi.InitConfiguration) error {
 }
 
 // EnforceTLSRequirements enforces CIS requirements for TLS.
-func EnforceTLSRequirements(cfg *kubeadmapi.InitConfiguration) error {
+func EnforceTLSRequirements(cfg *kubeadmapi.ClusterConfiguration) error {
 	// nolint: lll
 	cfg.APIServer.ExtraArgs["tls-cipher-suites"] = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
 
@@ -118,7 +118,7 @@ func EnforceTLSRequirements(cfg *kubeadmapi.InitConfiguration) error {
 // TODO(andrewrynhard): Include any extra user specified plugins.
 // TODO(andrewrynhard): Enable EventRateLimit.
 // TODO(andrewrynhard): Enable AlwaysPullImages (See https://github.com/kubernetes/kubernetes/issues/64333).
-func EnforceAdmissionPluginsRequirements(cfg *kubeadmapi.InitConfiguration) error {
+func EnforceAdmissionPluginsRequirements(cfg *kubeadmapi.ClusterConfiguration) error {
 	// nolint: lll
 	cfg.APIServer.ExtraArgs["enable-admission-plugins"] = "PodSecurityPolicy,NamespaceLifecycle,ServiceAccount,NodeRestriction,LimitRanger,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota"
 
@@ -128,7 +128,7 @@ func EnforceAdmissionPluginsRequirements(cfg *kubeadmapi.InitConfiguration) erro
 // EnforceExtraRequirements enforces miscellaneous CIS requirements.
 // TODO(andrewrynhard): Enable anonymous-auth, see https://github.com/kubernetes/kubeadm/issues/798.
 // TODO(andrewrynhard): Enable kubelet-certificate-authority, see https://github.com/kubernetes/kubeadm/issues/118#issuecomment-407202481.
-func EnforceExtraRequirements(cfg *kubeadmapi.InitConfiguration) error {
+func EnforceExtraRequirements(cfg *kubeadmapi.ClusterConfiguration) error {
 	cfg.APIServer.ExtraArgs["profiling"] = disabled
 	cfg.ControllerManager.ExtraArgs["profiling"] = disabled
 	cfg.Scheduler.ExtraArgs["profiling"] = disabled
@@ -139,7 +139,7 @@ func EnforceExtraRequirements(cfg *kubeadmapi.InitConfiguration) error {
 }
 
 // EnforceMasterRequirements enforces the CIS requirements for master nodes.
-func EnforceMasterRequirements(cfg *kubeadmapi.InitConfiguration, generateSecret bool) error {
+func EnforceMasterRequirements(cfg *kubeadmapi.ClusterConfiguration, generateSecret bool) error {
 	ensureFieldsAreNotNil(cfg)
 
 	if err := EnforceAuditingRequirements(cfg); err != nil {
@@ -171,7 +171,7 @@ func EnforceWorkerRequirements(cfg *kubeadmapi.JoinConfiguration) error {
 	return nil
 }
 
-func ensureFieldsAreNotNil(cfg *kubeadmapi.InitConfiguration) {
+func ensureFieldsAreNotNil(cfg *kubeadmapi.ClusterConfiguration) {
 	if cfg.APIServer.ExtraArgs == nil {
 		cfg.APIServer.ExtraArgs = make(map[string]string)
 	}

--- a/internal/pkg/installer/manifest/manifest_test.go
+++ b/internal/pkg/installer/manifest/manifest_test.go
@@ -119,7 +119,7 @@ services:
   kubeadm:
     certificateKey: 'test'
     configuration: |
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: InitConfiguration
       localAPIEndpoint:
         bindPort: 6443
@@ -127,7 +127,7 @@ services:
       - token: '1qbsj9.3oz5hsk6grdfp98b'
         ttl: 0s
       ---
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: ClusterConfiguration
       clusterName: test
       kubernetesVersion: v1.16.0-alpha.3

--- a/pkg/crypto/x509/x509.go
+++ b/pkg/crypto/x509/x509.go
@@ -306,7 +306,7 @@ func NewCertificateFromCSR(ca *x509.Certificate, key *ecdsa.PrivateKey, csr *x50
 func NewCertificateFromCSRBytes(ca, key, csr []byte, setters ...Option) (crt *Certificate, err error) {
 	caPemBlock, _ := pem.Decode(ca)
 	if caPemBlock == nil {
-		return nil, fmt.Errorf("decode PEM: %v", err)
+		return nil, fmt.Errorf("decode CA PEM: %v", err)
 	}
 	caCrt, err := x509.ParseCertificate(caPemBlock.Bytes)
 	if err != nil {
@@ -314,7 +314,7 @@ func NewCertificateFromCSRBytes(ca, key, csr []byte, setters ...Option) (crt *Ce
 	}
 	keyPemBlock, _ := pem.Decode(key)
 	if keyPemBlock == nil {
-		return nil, fmt.Errorf("decode PEM: %v", err)
+		return nil, fmt.Errorf("decode key PEM: %v", err)
 	}
 	caKey, err := x509.ParseECPrivateKey(keyPemBlock.Bytes)
 	if err != nil {

--- a/pkg/userdata/generate/controlplane.go
+++ b/pkg/userdata/generate/controlplane.go
@@ -21,7 +21,7 @@ services:
   kubeadm:
     certificateKey: '{{ .KubeadmTokens.CertKey }}'
     configuration: |
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: JoinConfiguration
       controlPlane: {}
       discovery:

--- a/pkg/userdata/generate/generate.go
+++ b/pkg/userdata/generate/generate.go
@@ -197,7 +197,7 @@ func isIPv6(addrs ...string) bool {
 
 // NewInput generates the sensitive data required to generate all userdata
 // types.
-// nolint: gocyclo
+// nolint: dupl,gocyclo
 func NewInput(clustername string, masterIPs []string) (input *Input, err error) {
 
 	var loopbackIP, podNet, serviceNet string

--- a/pkg/userdata/generate/init.go
+++ b/pkg/userdata/generate/init.go
@@ -22,7 +22,7 @@ services:
     initToken: {{ .InitToken }}
     certificateKey: '{{ .KubeadmTokens.CertKey }}'
     configuration: |
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: InitConfiguration
       bootstrapTokens:
       - token: '{{ .KubeadmTokens.BootstrapToken }}'
@@ -32,7 +32,7 @@ services:
         kubeletExtraArgs:
           node-labels: ""
       ---
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: ClusterConfiguration
       clusterName: {{ .ClusterName }}
       kubernetesVersion: {{ .KubernetesVersion }}

--- a/pkg/userdata/generate/join.go
+++ b/pkg/userdata/generate/join.go
@@ -12,7 +12,7 @@ services:
     cni: flannel
   kubeadm:
     configuration: |
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: JoinConfiguration
       discovery:
         bootstrapToken:

--- a/pkg/userdata/kubeadm.go
+++ b/pkg/userdata/kubeadm.go
@@ -5,15 +5,16 @@
 package userdata
 
 import (
+	"bytes"
 	"errors"
 
 	"github.com/talos-systems/talos/pkg/userdata/token"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
+	kubeadmv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+	kubeletconfigv1beta1scheme "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1"
+	kubeproxyconfigv1alpha1scheme "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1"
 )
 
 // Kubeadm describes the set of configuration options available for kubeadm.
@@ -21,8 +22,13 @@ type Kubeadm struct {
 	CommonServiceOptions `yaml:",inline"`
 
 	// ConfigurationStr is converted to Configuration and back in Marshal/UnmarshalYAML
-	Configuration    runtime.Object `yaml:"-"`
-	ConfigurationStr string         `yaml:"configuration"`
+	InitConfiguration      runtime.Object `yaml:"-"`
+	ClusterConfiguration   runtime.Object `yaml:"-"`
+	JoinConfiguration      runtime.Object `yaml:"-"`
+	KubeletConfiguration   runtime.Object `yaml:"-"`
+	KubeProxyConfiguration runtime.Object `yaml:"-"`
+
+	ConfigurationStr string `yaml:"configuration"`
 
 	ExtraArgs             []string     `yaml:"extraArgs,omitempty"`
 	CertificateKey        string       `yaml:"certificateKey,omitempty"`
@@ -33,12 +39,48 @@ type Kubeadm struct {
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (kdm *Kubeadm) MarshalYAML() (interface{}, error) {
-	b, err := configutil.MarshalKubeadmConfigObject(kdm.Configuration)
-	if err != nil {
-		return nil, err
+
+	// Encode init and cluster configs
+	encodedObjs := [][]byte{}
+	for _, obj := range []runtime.Object{kdm.InitConfiguration, kdm.ClusterConfiguration, kdm.JoinConfiguration} {
+		if obj == nil {
+			continue
+		}
+		encoded, err := kubeadmutil.MarshalToYamlForCodecs(obj, kubeadmv1beta2.SchemeGroupVersion, kubeadmscheme.Codecs)
+		if err != nil {
+			return nil, err
+		}
+		encodedObjs = append(encodedObjs, encoded)
 	}
 
-	kdm.ConfigurationStr = string(b)
+	// Encode proxy config
+	if kdm.KubeProxyConfiguration != nil {
+		err := kubeproxyconfigv1alpha1scheme.AddToScheme(kubeadmscheme.Scheme)
+		if err != nil {
+			return nil, err
+		}
+		encoded, err := kubeadmutil.MarshalToYamlForCodecs(kdm.KubeProxyConfiguration, kubeproxyconfigv1alpha1scheme.SchemeGroupVersion, kubeadmscheme.Codecs)
+		if err != nil {
+			return nil, err
+		}
+		encodedObjs = append(encodedObjs, encoded)
+	}
+
+	// Encode kubelet config
+	if kdm.KubeletConfiguration != nil {
+		err := kubeletconfigv1beta1scheme.AddToScheme(kubeadmscheme.Scheme)
+		if err != nil {
+			return nil, err
+		}
+		encoded, err := kubeadmutil.MarshalToYamlForCodecs(kdm.KubeletConfiguration, kubeletconfigv1beta1scheme.SchemeGroupVersion, kubeadmscheme.Codecs)
+		if err != nil {
+			return nil, err
+		}
+		encodedObjs = append(encodedObjs, encoded)
+	}
+
+	kubeadmConfig := bytes.Join(encodedObjs, []byte("---\n"))
+	kdm.ConfigurationStr = string(kubeadmConfig)
 
 	type KubeadmAlias Kubeadm
 
@@ -56,42 +98,62 @@ func (kdm *Kubeadm) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	b := []byte(kdm.ConfigurationStr)
 
-	gvks, err := kubeadmutil.GroupVersionKindsFromBytes(b)
-	if err != nil {
-		return err
-	}
+	splitConfig := bytes.Split(b, []byte("---\n"))
 
-	switch {
-	case kubeadmutil.GroupVersionKindsHasInitConfiguration(gvks...):
-		// Since the ClusterConfiguration is embedded in the InitConfiguration
-		// struct, it is required to (un)marshal it a special way. The kubeadm
-		// API exposes one function (MarshalKubeadmConfigObject) to handle the
-		// marshaling, but does not yet have that convenience for
-		// unmarshaling.
-		cfg, err := configutil.BytesToInitConfiguration(b)
+	// Range through each config doc, determine kind, set kubeadm struct val
+	for _, config := range splitConfig {
+		gvks, err := kubeadmutil.GroupVersionKindsFromBytes(config)
 		if err != nil {
 			return err
 		}
-		if err := configutil.SetInitDynamicDefaults(cfg); err != nil {
-			return err
-		}
-		kdm.Configuration = cfg
-		kdm.controlPlane = true
-	case kubeadmutil.GroupVersionKindsHasJoinConfiguration(gvks...):
-		cfg, err := kubeadmutil.UnmarshalFromYamlForCodecs(b, kubeadmapi.SchemeGroupVersion, kubeadmscheme.Codecs)
-		if err != nil {
-			return err
-		}
-		kdm.Configuration = cfg
-		joinCfg, ok := cfg.(*kubeadm.JoinConfiguration)
-		if !ok {
-			return errors.New("expected JoinConfiguration")
-		}
-		if err := configutil.SetJoinDynamicDefaults(joinCfg); err != nil {
-			return err
-		}
-		if joinCfg.ControlPlane != nil {
+
+		switch {
+		case kubeadmutil.GroupVersionKindsHasKind(gvks, "InitConfiguration"):
+			cfg, err := kubeadmutil.UnmarshalFromYamlForCodecs(config, kubeadmv1beta2.SchemeGroupVersion, kubeadmscheme.Codecs)
+			if err != nil {
+				return err
+			}
+			kdm.InitConfiguration = cfg
 			kdm.controlPlane = true
+		case kubeadmutil.GroupVersionKindsHasKind(gvks, "JoinConfiguration"):
+			cfg, err := kubeadmutil.UnmarshalFromYamlForCodecs(config, kubeadmv1beta2.SchemeGroupVersion, kubeadmscheme.Codecs)
+			if err != nil {
+				return err
+			}
+			joinCfg, ok := cfg.(*kubeadmv1beta2.JoinConfiguration)
+			if !ok {
+				return errors.New("expected JoinConfiguration")
+			}
+			if joinCfg.ControlPlane != nil {
+				kdm.controlPlane = true
+			}
+			kdm.JoinConfiguration = cfg
+		case kubeadmutil.GroupVersionKindsHasKind(gvks, "ClusterConfiguration"):
+			cfg, err := kubeadmutil.UnmarshalFromYamlForCodecs(config, kubeadmv1beta2.SchemeGroupVersion, kubeadmscheme.Codecs)
+			if err != nil {
+				return err
+			}
+			kdm.ClusterConfiguration = cfg
+		case kubeadmutil.GroupVersionKindsHasKind(gvks, "KubeletConfiguration"):
+			err := kubeletconfigv1beta1scheme.AddToScheme(kubeadmscheme.Scheme)
+			if err != nil {
+				return err
+			}
+			cfg, err := kubeadmutil.UnmarshalFromYamlForCodecs(config, kubeletconfigv1beta1scheme.SchemeGroupVersion, kubeadmscheme.Codecs)
+			if err != nil {
+				return err
+			}
+			kdm.KubeletConfiguration = cfg
+		case kubeadmutil.GroupVersionKindsHasKind(gvks, "KubeProxyConfiguration"):
+			err := kubeproxyconfigv1alpha1scheme.AddToScheme(kubeadmscheme.Scheme)
+			if err != nil {
+				return err
+			}
+			cfg, err := kubeadmutil.UnmarshalFromYamlForCodecs(config, kubeproxyconfigv1alpha1scheme.SchemeGroupVersion, kubeadmscheme.Codecs)
+			if err != nil {
+				return err
+			}
+			kdm.KubeProxyConfiguration = cfg
 		}
 	}
 

--- a/pkg/userdata/translator.go
+++ b/pkg/userdata/translator.go
@@ -1,0 +1,277 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package userdata
+
+import (
+	"encoding/base64"
+	"strings"
+	"time"
+
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
+	v1 "github.com/talos-systems/talos/pkg/userdata/v1"
+	yaml "gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeletConfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	proxyConfig "k8s.io/kubernetes/pkg/proxy/apis/config"
+)
+
+// TranslateV1 takes a v1 NodeConfig and translates it to a UserData struct
+func TranslateV1(ncString string) (*UserData, error) {
+	nc := &v1.NodeConfig{}
+
+	err := yaml.Unmarshal([]byte(ncString), nc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Lay down the absolute minimum for all node types
+	ud := &UserData{
+		Version:  "v1",
+		Debug:    true,
+		Security: &Security{},
+		Services: &Services{
+			Init: &Init{
+				CNI: "flannel",
+			},
+			Kubeadm: &Kubeadm{},
+			Trustd: &Trustd{
+				Token:     nc.Machine.Token,
+				Endpoints: nc.Cluster.ControlPlane.IPs,
+			},
+		},
+	}
+
+	if nc.Machine.Install != nil {
+		translateV1Install(nc, ud)
+	}
+
+	switch nc.Machine.Type {
+	case "init":
+
+		err = translateV1Init(nc, ud)
+		if err != nil {
+			return nil, err
+		}
+
+	case "controlplane":
+		err = translateV1ControlPlane(nc, ud)
+		if err != nil {
+			return nil, err
+		}
+
+	case "worker":
+		translateV1Worker(nc, ud)
+	}
+	return ud, nil
+}
+
+func translateV1Install(nc *v1.NodeConfig, ud *UserData) {
+
+	ud.Install = &Install{
+		Wipe:  nc.Machine.Install.Wipe,
+		Force: nc.Machine.Install.Force,
+	}
+
+	if nc.Machine.Install.Boot != nil {
+		ud.Install.Boot = &BootDevice{
+			InstallDevice: InstallDevice{
+				Device: nc.Machine.Install.Boot.InstallDevice.Device,
+				Size:   nc.Machine.Install.Boot.InstallDevice.Size,
+			},
+			Kernel:    nc.Machine.Install.Boot.Kernel,
+			Initramfs: nc.Machine.Install.Boot.Initramfs,
+		}
+	}
+
+	if nc.Machine.Install.Ephemeral != nil {
+		ud.Install.Ephemeral = &InstallDevice{
+			Device: nc.Machine.Install.Ephemeral.Device,
+			Size:   nc.Machine.Install.Ephemeral.Size,
+		}
+	}
+
+	if nc.Machine.Install.ExtraDevices != nil {
+		ud.Install.ExtraDevices = []*ExtraDevice{}
+		for _, device := range nc.Machine.Install.ExtraDevices {
+			ed := &ExtraDevice{
+				Device:     device.Device,
+				Partitions: []*ExtraDevicePartition{},
+			}
+
+			for _, partition := range device.Partitions {
+				partToAppend := &ExtraDevicePartition{
+					Size:       partition.Size,
+					MountPoint: partition.MountPoint,
+				}
+				ed.Partitions = append(ed.Partitions, partToAppend)
+			}
+			ud.Install.ExtraDevices = append(ud.Install.ExtraDevices, ed)
+		}
+	}
+
+	if nc.Machine.Install.ExtraKernelArgs != nil {
+		ud.Install.ExtraKernelArgs = nc.Machine.Install.ExtraKernelArgs
+	}
+}
+
+func translateV1Init(nc *v1.NodeConfig, ud *UserData) error {
+	// Convert and decode certs back to byte slices
+	osCert, err := base64.StdEncoding.DecodeString(nc.Machine.CA.Crt)
+	if err != nil {
+		return err
+	}
+	osKey, err := base64.StdEncoding.DecodeString(nc.Machine.CA.Key)
+	if err != nil {
+		return err
+	}
+
+	kubeCert, err := base64.StdEncoding.DecodeString(nc.Cluster.CA.Crt)
+	if err != nil {
+		return err
+	}
+	kubeKey, err := base64.StdEncoding.DecodeString(nc.Cluster.CA.Key)
+	if err != nil {
+		return err
+	}
+
+	// Inject certs and SANs
+	ud.Security.OS = &OSSecurity{
+		CA: &x509.PEMEncodedCertificateAndKey{
+			Crt: osCert,
+			Key: osKey,
+		},
+	}
+	ud.Security.Kubernetes = &KubernetesSecurity{
+		CA: &x509.PEMEncodedCertificateAndKey{
+			Crt: kubeCert,
+			Key: kubeKey,
+		},
+	}
+
+	ud.Services.Trustd.CertSANs = []string{nc.Cluster.ControlPlane.IPs[nc.Cluster.ControlPlane.Index], "127.0.0.1", "::1"}
+
+	ud.Services.Kubeadm.Token = nc.Cluster.InitToken
+	ud.Services.Kubeadm.controlPlane = true
+
+	kubeadmToken := strings.Split(nc.Cluster.Token, ".")
+
+	// Craft an init kubeadm config
+	ud.Services.Kubeadm.Configuration = &kubeadm.InitConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InitConfiguration",
+			APIVersion: "kubeadm.k8s.io/v1beta2",
+		},
+		BootstrapTokens: []kubeadm.BootstrapToken{
+			{
+				Token: &kubeadm.BootstrapTokenString{
+					ID:     kubeadmToken[0],
+					Secret: kubeadmToken[1],
+				},
+				TTL: &metav1.Duration{
+					Duration: time.Duration(0),
+				},
+			},
+		},
+		NodeRegistration: kubeadm.NodeRegistrationOptions{
+			KubeletExtraArgs: nc.Machine.Kubelet.ExtraArgs,
+		},
+		ClusterConfiguration: kubeadm.ClusterConfiguration{
+			ComponentConfigs: kubeadm.ComponentConfigs{
+				Kubelet: &kubeletConfig.KubeletConfiguration{
+					FeatureGates: map[string]bool{
+						"ExperimentalCriticalPodAnnotation": true,
+					},
+				},
+				KubeProxy: &proxyConfig.KubeProxyConfiguration{
+					Mode: proxyConfig.ProxyModeIPVS,
+					IPVS: proxyConfig.KubeProxyIPVSConfiguration{
+						Scheduler: "lc",
+					},
+				},
+			},
+			ClusterName:          nc.Cluster.ClusterName,
+			KubernetesVersion:    constants.KubernetesVersion,
+			ControlPlaneEndpoint: nc.Cluster.ControlPlane.IPs[0] + ":443",
+			Networking: kubeadm.Networking{
+				DNSDomain:     nc.Cluster.Network.DNSDomain,
+				PodSubnet:     nc.Cluster.Network.PodSubnet[0],
+				ServiceSubnet: nc.Cluster.Network.ServiceSubnet[0],
+			},
+			APIServer: kubeadm.APIServer{
+				ControlPlaneComponent: kubeadm.ControlPlaneComponent{
+					ExtraArgs: nc.Cluster.APIServer.ExtraArgs,
+				},
+				CertSANs: append(nc.Cluster.ControlPlane.IPs, "127.0.0.1", "::1"),
+				TimeoutForControlPlane: &metav1.Duration{
+					Duration: time.Duration(0),
+				},
+			},
+			ControllerManager: kubeadm.ControlPlaneComponent{
+				ExtraArgs: nc.Cluster.ControllerManager.ExtraArgs,
+			},
+			Scheduler: kubeadm.ControlPlaneComponent{
+				ExtraArgs: nc.Cluster.Scheduler.ExtraArgs,
+			},
+		},
+	}
+	return nil
+}
+
+func translateV1ControlPlane(nc *v1.NodeConfig, ud *UserData) error {
+	// Convert and decode certs back to byte slices
+	osCert, err := base64.StdEncoding.DecodeString(nc.Machine.CA.Crt)
+	if err != nil {
+		return err
+	}
+	osKey, err := base64.StdEncoding.DecodeString(nc.Machine.CA.Key)
+	if err != nil {
+		return err
+	}
+
+	// Inject certs and SANs
+	ud.Security.OS = &OSSecurity{
+		CA: &x509.PEMEncodedCertificateAndKey{
+			Crt: osCert,
+			Key: osKey,
+		},
+	}
+	ud.Services.Trustd.CertSANs = []string{nc.Cluster.ControlPlane.IPs[nc.Cluster.ControlPlane.Index], "127.0.0.1", "::1"}
+	ud.Services.Kubeadm.controlPlane = true
+
+	// Craft a control plane kubeadm config
+	ud.Services.Kubeadm.Configuration = &kubeadm.JoinConfiguration{
+		ControlPlane: &kubeadm.JoinControlPlane{},
+		Discovery: kubeadm.Discovery{
+			BootstrapToken: &kubeadm.BootstrapTokenDiscovery{
+				Token:                    nc.Cluster.Token,
+				APIServerEndpoint:        nc.Cluster.ControlPlane.IPs[nc.Cluster.ControlPlane.Index-1] + ":6443",
+				UnsafeSkipCAVerification: true,
+			},
+		},
+		NodeRegistration: kubeadm.NodeRegistrationOptions{
+			KubeletExtraArgs: nc.Machine.Kubelet.ExtraArgs,
+		},
+	}
+
+	return nil
+}
+
+func translateV1Worker(nc *v1.NodeConfig, ud *UserData) {
+	//Craft a worker kubeadm config
+	ud.Services.Kubeadm.Configuration = &kubeadm.JoinConfiguration{
+		Discovery: kubeadm.Discovery{
+			BootstrapToken: &kubeadm.BootstrapTokenDiscovery{
+				Token:                    nc.Cluster.Token,
+				APIServerEndpoint:        nc.Cluster.ControlPlane.IPs[0] + ":443",
+				UnsafeSkipCAVerification: true,
+			},
+		},
+		NodeRegistration: kubeadm.NodeRegistrationOptions{
+			KubeletExtraArgs: nc.Machine.Kubelet.ExtraArgs,
+		},
+	}
+}

--- a/pkg/userdata/translator_test.go
+++ b/pkg/userdata/translator_test.go
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package userdata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type translatorSuite struct {
+	suite.Suite
+}
+
+func TestTranslatorSuite(t *testing.T) {
+	suite.Run(t, new(translatorSuite))
+}
+
+func (suite *translatorSuite) TestTranslation() {
+	ud, err := TranslateV1(testV1Config)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(string(ud.Version), "v1")
+	err = ud.Validate()
+	suite.Require().NoError(err)
+}

--- a/pkg/userdata/userdata_test.go
+++ b/pkg/userdata/userdata_test.go
@@ -179,7 +179,7 @@ services:
     initToken: 528d1ad6-3485-49ad-94cd-0f44a35877ac
     certificateKey: 'test'
     configuration: |
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: InitConfiguration
       localAPIEndpoint:
         bindPort: 6443
@@ -187,7 +187,7 @@ services:
       - token: '1qbsj9.3oz5hsk6grdfp98b'
         ttl: 0s
       ---
-      apiVersion: kubeadm.k8s.io/v1beta1
+      apiVersion: kubeadm.k8s.io/v1beta2
       kind: ClusterConfiguration
       clusterName: test
       kubernetesVersion: v1.16.0-alpha.3

--- a/pkg/userdata/v1/cluster_config.go
+++ b/pkg/userdata/v1/cluster_config.go
@@ -1,0 +1,59 @@
+package v1
+
+import "github.com/talos-systems/talos/pkg/userdata/token"
+
+// ClusterConfig reperesents the cluster-wide config values
+type ClusterConfig struct {
+	ControlPlane      *ControlPlaneConfig      `yaml:"controlPlane"`
+	ClusterName       string                   `yaml:"clusterName,omitempty"`
+	Network           *ClusterNetworkConfig    `yaml:"network,omitempty"`
+	Token             string                   `yaml:"token,omitempty"`
+	InitToken         *token.Token             `yaml:"initToken,omitempty"`
+	CA                *ClusterCAConfig         `yaml:"ca,omitempty"`
+	APIServer         *APIServerConfig         `yaml:"apiServer,omitempty"`
+	ControllerManager *ControllerManagerConfig `yaml:"controllerManager,omitempty"`
+	Scheduler         *SchedulerConfig         `yaml:"scheduler,omitempty"`
+	Etcd              *EtcdConfig              `yaml:"etcd,omitempty"`
+}
+
+// ControlPlaneConfig represents control plane config vals
+type ControlPlaneConfig struct {
+	IPs   []string `yaml:"ips"`
+	Index int      `yaml:"index,omitempty"`
+}
+
+// APIServerConfig represents kube apiserver config vals
+type APIServerConfig struct {
+	Image     string            `yaml:"image,omitempty"`
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// ControllerManagerConfig represents kube controller manager config vals
+type ControllerManagerConfig struct {
+	Image     string            `yaml:"image,omitempty"`
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// SchedulerConfig represents kube scheduler config vals
+type SchedulerConfig struct {
+	Image     string            `yaml:"image,omitempty"`
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// EtcdConfig represents etcd config vals
+type EtcdConfig struct {
+	Image string `yaml:"image,omitempty"`
+}
+
+// ClusterNetworkConfig represents kube networking config vals
+type ClusterNetworkConfig struct {
+	DNSDomain     string   `yaml:"dnsDomain"`
+	PodSubnet     []string `yaml:"podSubnets"`
+	ServiceSubnet []string `yaml:"serviceSubnets"`
+}
+
+// ClusterCAConfig represents kube cert config vals
+type ClusterCAConfig struct {
+	Crt string `yaml:"crt"`
+	Key string `yaml:"key"`
+}

--- a/pkg/userdata/v1/errors.go
+++ b/pkg/userdata/v1/errors.go
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package v1 provides user-facing v1 machine configs
+// nolint: dupl
+package v1
+
+import "errors"
+
+var (
+	// General
+
+	// ErrRequiredSection denotes a section is required
+	ErrRequiredSection = errors.New("required userdata section")
+	// ErrInvalidVersion denotes that the config file version is invalid
+	ErrInvalidVersion = errors.New("invalid config version")
+
+	// Security
+
+	// ErrInvalidCert denotes that the certificate specified is invalid
+	ErrInvalidCert = errors.New("certificate is invalid")
+	// ErrInvalidCertType denotes that the certificate type is invalid
+	ErrInvalidCertType = errors.New("certificate type is invalid")
+
+	// Services
+
+	// ErrUnsupportedCNI denotes that the specified CNI is invalid
+	ErrUnsupportedCNI = errors.New("unsupported CNI driver")
+	// ErrInvalidTrustdToken denotes that a trustd token has not been specified
+	ErrInvalidTrustdToken = errors.New("trustd token is invalid")
+
+	// Networking
+
+	// ErrBadAddressing denotes that an incorrect combination of network
+	// address methods have been specified
+	ErrBadAddressing = errors.New("invalid network device addressing method")
+	// ErrInvalidAddress denotes that a bad address was provided
+	ErrInvalidAddress = errors.New("invalid network address")
+)

--- a/pkg/userdata/v1/generate/controlplane.go
+++ b/pkg/userdata/v1/generate/controlplane.go
@@ -23,6 +23,7 @@ func controlPlaneUd(in *Input) (string, error) {
 	}
 
 	cluster := &v1.ClusterConfig{
+		Token: in.KubeadmTokens.BootstrapToken,
 		ControlPlane: &v1.ControlPlaneConfig{
 			IPs:   in.MasterIPs,
 			Index: in.Index,

--- a/pkg/userdata/v1/generate/controlplane.go
+++ b/pkg/userdata/v1/generate/controlplane.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package generate
+
+import (
+	v1 "github.com/talos-systems/talos/pkg/userdata/v1"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func controlPlaneUd(in *Input) (string, error) {
+
+	machine := &v1.MachineConfig{
+		Type:  "controlplane",
+		Token: in.TrustdInfo.Token,
+		CA: &v1.MachineCAConfig{
+			Crt: in.Certs.OsCert,
+			Key: in.Certs.OsKey,
+		},
+		Kubelet: &v1.KubeletConfig{},
+		Network: &v1.NetworkConfig{},
+	}
+
+	cluster := &v1.ClusterConfig{
+		ControlPlane: &v1.ControlPlaneConfig{
+			IPs:   in.MasterIPs,
+			Index: in.Index,
+		},
+	}
+
+	ud := v1.NodeConfig{
+		Version: "v1",
+		Machine: machine,
+		Cluster: cluster,
+	}
+
+	udMarshal, err := yaml.Marshal(ud)
+	if err != nil {
+		return "", err
+	}
+
+	return string(udMarshal), nil
+}

--- a/pkg/userdata/v1/generate/generate.go
+++ b/pkg/userdata/v1/generate/generate.go
@@ -1,0 +1,279 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package generate
+
+import (
+	"bufio"
+	"crypto/rand"
+	stdlibx509 "crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
+	"github.com/talos-systems/talos/pkg/userdata/token"
+)
+
+// CertStrings holds the string representation of a certificate and key.
+type CertStrings struct {
+	Crt string
+	Key string
+}
+
+// Input holds info about certs, ips, and node type.
+type Input struct {
+	Certs             *Certs
+	MasterIPs         []string
+	Index             int
+	ClusterName       string
+	ServiceDomain     string
+	PodNet            []string
+	ServiceNet        []string
+	Endpoints         string
+	KubernetesVersion string
+	KubeadmTokens     *KubeadmTokens
+	TrustdInfo        *TrustdInfo
+	InitToken         *token.Token
+	IP                net.IP
+}
+
+// Certs holds the base64 encoded keys and certificates.
+type Certs struct {
+	AdminCert string
+	AdminKey  string
+	OsCert    string
+	OsKey     string
+	K8sCert   string
+	K8sKey    string
+}
+
+// KubeadmTokens holds the senesitve kubeadm data.
+type KubeadmTokens struct {
+	BootstrapToken string
+	CertKey        string
+}
+
+// TrustdInfo holds the trustd credentials.
+type TrustdInfo struct {
+	Token string
+}
+
+// randBytes returns a random string consisting of the characters in
+// validBootstrapTokenChars, with the length customized by the parameter
+func randBytes(length int) (string, error) {
+
+	// validBootstrapTokenChars defines the characters a bootstrap token can consist of
+	const validBootstrapTokenChars = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+	// len("0123456789abcdefghijklmnopqrstuvwxyz") = 36 which doesn't evenly divide
+	// the possible values of a byte: 256 mod 36 = 4. Discard any random bytes we
+	// read that are >= 252 so the bytes we evenly divide the character set.
+	const maxByteValue = 252
+
+	var (
+		b     byte
+		err   error
+		token = make([]byte, length)
+	)
+
+	reader := bufio.NewReaderSize(rand.Reader, length*2)
+	for i := range token {
+		for {
+			if b, err = reader.ReadByte(); err != nil {
+				return "", err
+			}
+			if b < maxByteValue {
+				break
+			}
+		}
+		token[i] = validBootstrapTokenChars[int(b)%len(validBootstrapTokenChars)]
+	}
+
+	return string(token), err
+}
+
+//genToken will generate a token of the format abc.123 (like kubeadm/trustd), where the length of the first string (before the dot)
+//and length of the second string (after dot) are specified as inputs
+func genToken(lenFirst int, lenSecond int) (string, error) {
+
+	var err error
+	var tokenTemp = make([]string, 2)
+
+	tokenTemp[0], err = randBytes(lenFirst)
+	if err != nil {
+		return "", err
+	}
+	tokenTemp[1], err = randBytes(lenSecond)
+	if err != nil {
+		return "", err
+	}
+
+	return tokenTemp[0] + "." + tokenTemp[1], nil
+}
+
+// NewInput generates the sensitive data required to generate all userdata
+// types.
+// nolint: gocyclo
+func NewInput(clustername string, masterIPs []string) (input *Input, err error) {
+
+	//Gen trustd token strings
+	kubeadmBootstrapToken, err := genToken(6, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	//TODO: Can be dropped
+	//Gen kubeadm cert key
+	kubeadmCertKey, err := randBytes(26)
+	if err != nil {
+		return nil, err
+	}
+
+	//Gen trustd token strings
+	trustdToken, err := genToken(6, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeadmTokens := &KubeadmTokens{
+		BootstrapToken: kubeadmBootstrapToken,
+		CertKey:        kubeadmCertKey,
+	}
+
+	trustdInfo := &TrustdInfo{
+		Token: trustdToken,
+	}
+
+	// Generate Kubernetes CA.
+	opts := []x509.Option{x509.RSA(true), x509.Organization("talos-k8s")}
+	k8sCert, err := x509.NewSelfSignedCertificateAuthority(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate Talos CA.
+	opts = []x509.Option{x509.RSA(false), x509.Organization("talos-os")}
+	osCert, err := x509.NewSelfSignedCertificateAuthority(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the init token
+	tok, err := token.NewToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate the admin talosconfig.
+	adminKey, err := x509.NewKey()
+	if err != nil {
+		return nil, err
+	}
+	pemBlock, _ := pem.Decode(adminKey.KeyPEM)
+	if pemBlock == nil {
+		return nil, errors.New("failed to decode admin key pem")
+	}
+	adminKeyEC, err := stdlibx509.ParseECPrivateKey(pemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	ips := []net.IP{net.ParseIP("127.0.0.1")}
+	opts = []x509.Option{x509.IPAddresses(ips)}
+	csr, err := x509.NewCertificateSigningRequest(adminKeyEC, opts...)
+	if err != nil {
+		return nil, err
+	}
+	csrPemBlock, _ := pem.Decode(csr.X509CertificateRequestPEM)
+	if csrPemBlock == nil {
+		return nil, errors.New("failed to decode csr pem")
+	}
+	ccsr, err := stdlibx509.ParseCertificateRequest(csrPemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	caPemBlock, _ := pem.Decode(osCert.CrtPEM)
+	if caPemBlock == nil {
+		return nil, errors.New("failed to decode ca cert pem")
+	}
+	caCrt, err := stdlibx509.ParseCertificate(caPemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	caKeyPemBlock, _ := pem.Decode(osCert.KeyPEM)
+	if caKeyPemBlock == nil {
+		return nil, errors.New("failed to decode ca key pem")
+	}
+	caKey, err := stdlibx509.ParseECPrivateKey(caKeyPemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	adminCrt, err := x509.NewCertificateFromCSR(caCrt, caKey, ccsr)
+	if err != nil {
+		return nil, err
+	}
+
+	certs := &Certs{
+		AdminCert: base64.StdEncoding.EncodeToString(adminCrt.X509CertificatePEM),
+		AdminKey:  base64.StdEncoding.EncodeToString(adminKey.KeyPEM),
+		OsCert:    base64.StdEncoding.EncodeToString(osCert.CrtPEM),
+		OsKey:     base64.StdEncoding.EncodeToString(osCert.KeyPEM),
+		K8sCert:   base64.StdEncoding.EncodeToString(k8sCert.CrtPEM),
+		K8sKey:    base64.StdEncoding.EncodeToString(k8sCert.KeyPEM),
+	}
+
+	input = &Input{
+		Certs:             certs,
+		MasterIPs:         masterIPs,
+		PodNet:            []string{"10.244.0.0/16"},
+		ServiceNet:        []string{"10.96.0.0/12"},
+		ServiceDomain:     "cluster.local",
+		ClusterName:       clustername,
+		Endpoints:         strings.Join(masterIPs, ", "),
+		KubernetesVersion: constants.KubernetesVersion,
+		KubeadmTokens:     kubeadmTokens,
+		TrustdInfo:        trustdInfo,
+		InitToken:         tok,
+	}
+
+	return input, nil
+}
+
+// Type represents a userdata type.
+type Type int
+
+const (
+	// TypeInit indicates a userdata type should correspond to the kubeadm
+	// InitConfiguration type.
+	TypeInit Type = iota
+	// TypeControlPlane indicates a userdata type should correspond to the
+	// kubeadm JoinConfiguration type that has the ControlPlane field
+	// defined.
+	TypeControlPlane
+	// TypeJoin indicates a userdata type should correspond to the kubeadm
+	// JoinConfiguration type.
+	TypeJoin
+)
+
+// Sring returns the string representation of Type.
+func (t Type) String() string {
+	return [...]string{"Init", "ControlPlane", "Join"}[t]
+}
+
+// Userdata returns the talos userdata for a given node type.
+func Userdata(t Type, in *Input) (string, error) {
+	switch t {
+	case TypeInit:
+		return initUd(in)
+	case TypeControlPlane:
+		return controlPlaneUd(in)
+	case TypeJoin:
+		return workerUd(in)
+	default:
+	}
+	return "", errors.New("failed to determine userdata type to generate")
+}

--- a/pkg/userdata/v1/generate/generate.go
+++ b/pkg/userdata/v1/generate/generate.go
@@ -11,13 +11,26 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"net"
-	"strings"
 
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
+	tnet "github.com/talos-systems/talos/pkg/net"
 	"github.com/talos-systems/talos/pkg/userdata/token"
 )
+
+// DefaultIPv4PodNet is the network to be used for kubernetes Pods when using IPv4-based master nodes
+const DefaultIPv4PodNet = "10.244.0.0/16"
+
+// DefaultIPv4ServiceNet is the network to be used for kubernetes Services when using IPv4-based master nodes
+const DefaultIPv4ServiceNet = "10.96.0.0/12"
+
+// DefaultIPv6PodNet is the network to be used for kubernetes Pods when using IPv6-based master nodes
+const DefaultIPv6PodNet = "fc00:db8:10::/56"
+
+// DefaultIPv6ServiceNet is the network to be used for kubernetes Services when using IPv6-based master nodes
+const DefaultIPv6ServiceNet = "fc00:db8:20::/112"
 
 // CertStrings holds the string representation of a certificate and key.
 type CertStrings struct {
@@ -27,19 +40,72 @@ type CertStrings struct {
 
 // Input holds info about certs, ips, and node type.
 type Input struct {
-	Certs             *Certs
-	MasterIPs         []string
-	Index             int
+	Certs                     *Certs
+	MasterIPs                 []string
+	AdditionalSubjectAltNames []string
+
 	ClusterName       string
 	ServiceDomain     string
 	PodNet            []string
 	ServiceNet        []string
-	Endpoints         string
 	KubernetesVersion string
 	KubeadmTokens     *KubeadmTokens
 	TrustdInfo        *TrustdInfo
 	InitToken         *token.Token
-	IP                net.IP
+
+	//
+	// Runtime variables
+	//
+
+	// Index is the index of the current master
+	Index int
+
+	// IP is the IP address of the current master
+	IP net.IP
+}
+
+// Endpoints returns the formatted set of Master IP addresses
+func (i *Input) Endpoints() (out string) {
+	if i == nil || len(i.MasterIPs) < 1 {
+		panic("cannot Endpoints without any Master IPs")
+	}
+	for index, addr := range i.MasterIPs {
+		if index > 0 {
+			out += ", "
+		}
+		out += fmt.Sprintf(`"%s"`, addr)
+	}
+	return
+}
+
+// GetControlPlaneEndpoint returns the formatted host:port of the first master node
+func (i *Input) GetControlPlaneEndpoint(port string) string {
+
+	if i == nil || len(i.MasterIPs) < 1 {
+		panic("cannot GetControlPlaneEndpoint without any Master IPs")
+	}
+
+	// Each master after the first should reference the next-lower master index.
+	// Thus, master-2 references master-1 and master-3 references master-2.
+	refMaster := 0
+	if i.Index > 1 {
+		refMaster = i.Index - 1
+	}
+
+	if port == "" {
+		return tnet.FormatAddress(i.MasterIPs[refMaster])
+	}
+	return net.JoinHostPort(i.MasterIPs[refMaster], port)
+}
+
+// GetAPIServerSANs returns the formatted list of Subject Alt Name addresses for the API Server
+func (i *Input) GetAPIServerSANs() []string {
+
+	var list = []string{"127.0.0.1", "::1"}
+	list = append(list, i.MasterIPs...)
+	list = append(list, i.AdditionalSubjectAltNames...)
+
+	return list
 }
 
 // Certs holds the base64 encoded keys and certificates.
@@ -116,10 +182,33 @@ func genToken(lenFirst int, lenSecond int) (string, error) {
 	return tokenTemp[0] + "." + tokenTemp[1], nil
 }
 
+func isIPv6(addrs ...string) bool {
+	for _, a := range addrs {
+		if ip := net.ParseIP(a); ip != nil {
+			if ip.To4() == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // NewInput generates the sensitive data required to generate all userdata
 // types.
-// nolint: gocyclo
+// nolint: dupl,gocyclo
 func NewInput(clustername string, masterIPs []string) (input *Input, err error) {
+
+	var loopbackIP, podNet, serviceNet string
+
+	if isIPv6(masterIPs...) {
+		loopbackIP = "::1"
+		podNet = DefaultIPv6PodNet
+		serviceNet = DefaultIPv6ServiceNet
+	} else {
+		loopbackIP = "127.0.0.1"
+		podNet = DefaultIPv4PodNet
+		serviceNet = DefaultIPv4ServiceNet
+	}
 
 	//Gen trustd token strings
 	kubeadmBootstrapToken, err := genToken(6, 16)
@@ -182,7 +271,7 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 	if err != nil {
 		return nil, err
 	}
-	ips := []net.IP{net.ParseIP("127.0.0.1")}
+	ips := []net.IP{net.ParseIP(loopbackIP)}
 	opts = []x509.Option{x509.IPAddresses(ips)}
 	csr, err := x509.NewCertificateSigningRequest(adminKeyEC, opts...)
 	if err != nil {
@@ -229,11 +318,10 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 	input = &Input{
 		Certs:             certs,
 		MasterIPs:         masterIPs,
-		PodNet:            []string{"10.244.0.0/16"},
-		ServiceNet:        []string{"10.96.0.0/12"},
+		PodNet:            []string{podNet},
+		ServiceNet:        []string{serviceNet},
 		ServiceDomain:     "cluster.local",
 		ClusterName:       clustername,
-		Endpoints:         strings.Join(masterIPs, ", "),
 		KubernetesVersion: constants.KubernetesVersion,
 		KubeadmTokens:     kubeadmTokens,
 		TrustdInfo:        trustdInfo,

--- a/pkg/userdata/v1/generate/generate_test.go
+++ b/pkg/userdata/v1/generate/generate_test.go
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package generate_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	v1 "github.com/talos-systems/talos/pkg/userdata/v1"
+	udgenv1 "github.com/talos-systems/talos/pkg/userdata/v1/generate"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	input *udgenv1.Input
+)
+
+type GenerateSuite struct {
+	suite.Suite
+}
+
+func TestGenerateSuite(t *testing.T) {
+	suite.Run(t, new(GenerateSuite))
+}
+
+func (suite *GenerateSuite) SetupSuite() {
+	var err error
+	input, err = udgenv1.NewInput("test", []string{"10.0.1.5", "10.0.1.6", "10.0.1.7"})
+	suite.Require().NoError(err)
+}
+
+func (suite *GenerateSuite) TestGenerateInitSuccess() {
+	input.IP = net.ParseIP("10.0.1.5")
+	dataString, err := udgenv1.Userdata(udgenv1.TypeInit, input)
+	suite.Require().NoError(err)
+	data := &v1.NodeConfig{}
+	err = yaml.Unmarshal([]byte(dataString), data)
+	suite.Require().NoError(err)
+}
+
+func (suite *GenerateSuite) TestGenerateControlPlaneSuccess() {
+	input.IP = net.ParseIP("10.0.1.6")
+	dataString, err := udgenv1.Userdata(udgenv1.TypeControlPlane, input)
+	suite.Require().NoError(err)
+	data := &v1.NodeConfig{}
+	err = yaml.Unmarshal([]byte(dataString), data)
+	suite.Require().NoError(err)
+}
+
+func (suite *GenerateSuite) TestGenerateWorkerSuccess() {
+	dataString, err := udgenv1.Userdata(udgenv1.TypeJoin, input)
+	suite.Require().NoError(err)
+	data := &v1.NodeConfig{}
+	err = yaml.Unmarshal([]byte(dataString), data)
+	suite.Require().NoError(err)
+}
+
+func (suite *GenerateSuite) TestGenerateTalosconfigSuccess() {
+	_, err := udgenv1.Talosconfig(input)
+	suite.Require().NoError(err)
+}

--- a/pkg/userdata/v1/generate/init.go
+++ b/pkg/userdata/v1/generate/init.go
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package generate
+
+import (
+	v1 "github.com/talos-systems/talos/pkg/userdata/v1"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func initUd(in *Input) (string, error) {
+
+	machine := &v1.MachineConfig{
+		Type:    "init",
+		Kubelet: &v1.KubeletConfig{},
+		Network: &v1.NetworkConfig{},
+		CA: &v1.MachineCAConfig{
+			Crt: in.Certs.OsCert,
+			Key: in.Certs.OsKey,
+		},
+		Token: in.TrustdInfo.Token,
+	}
+
+	cluster := &v1.ClusterConfig{
+		ClusterName: in.ClusterName,
+		ControlPlane: &v1.ControlPlaneConfig{
+			IPs:   in.MasterIPs,
+			Index: in.Index,
+		},
+		APIServer:         &v1.APIServerConfig{},
+		ControllerManager: &v1.ControllerManagerConfig{},
+		Scheduler:         &v1.SchedulerConfig{},
+		Etcd:              &v1.EtcdConfig{},
+		Network: &v1.ClusterNetworkConfig{
+			DNSDomain:     in.ServiceDomain,
+			PodSubnet:     in.PodNet,
+			ServiceSubnet: in.ServiceNet,
+		},
+		CA: &v1.ClusterCAConfig{
+			Crt: in.Certs.K8sCert,
+			Key: in.Certs.K8sKey,
+		},
+		Token:     in.KubeadmTokens.BootstrapToken,
+		InitToken: in.InitToken,
+	}
+
+	ud := v1.NodeConfig{
+		Version: "v1",
+		Machine: machine,
+		Cluster: cluster,
+	}
+
+	udMarshal, err := yaml.Marshal(ud)
+	if err != nil {
+		return "", err
+	}
+
+	return string(udMarshal), nil
+}

--- a/pkg/userdata/v1/generate/join.go
+++ b/pkg/userdata/v1/generate/join.go
@@ -19,6 +19,7 @@ func workerUd(in *Input) (string, error) {
 	}
 
 	cluster := &v1.ClusterConfig{
+		Token: in.KubeadmTokens.BootstrapToken,
 		ControlPlane: &v1.ControlPlaneConfig{
 			IPs: in.MasterIPs,
 		},

--- a/pkg/userdata/v1/generate/join.go
+++ b/pkg/userdata/v1/generate/join.go
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package generate
+
+import (
+	v1 "github.com/talos-systems/talos/pkg/userdata/v1"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func workerUd(in *Input) (string, error) {
+
+	machine := &v1.MachineConfig{
+		Type:    "worker",
+		Token:   in.TrustdInfo.Token,
+		Kubelet: &v1.KubeletConfig{},
+		Network: &v1.NetworkConfig{},
+	}
+
+	cluster := &v1.ClusterConfig{
+		ControlPlane: &v1.ControlPlaneConfig{
+			IPs: in.MasterIPs,
+		},
+	}
+
+	ud := v1.NodeConfig{
+		Version: "v1",
+		Machine: machine,
+		Cluster: cluster,
+	}
+
+	udMarshal, err := yaml.Marshal(ud)
+	if err != nil {
+		return "", err
+	}
+
+	return string(udMarshal), nil
+}

--- a/pkg/userdata/v1/generate/talosconfig.go
+++ b/pkg/userdata/v1/generate/talosconfig.go
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package generate
+
+import (
+	"bytes"
+	"html/template"
+)
+
+// Talosconfig returns the talos admin Talos config.
+func Talosconfig(in *Input) (string, error) {
+	return renderTemplate(in, talosconfigTempl)
+}
+
+const talosconfigTempl = `context: {{ .ClusterName }}
+contexts:
+  {{ .ClusterName }}:
+    target: {{ index .MasterIPs 0 }}
+    ca: {{ .Certs.OsCert }}
+    crt: {{ .Certs.AdminCert }}
+    key: {{ .Certs.AdminKey }}
+`
+
+// renderTemplate will output a templated string.
+func renderTemplate(in *Input, udTemplate string) (string, error) {
+	// So we can have a simple add func
+	funcs := template.FuncMap{"add": add}
+
+	templ := template.Must(template.New("udTemplate").Funcs(funcs).Parse(udTemplate))
+	var buf bytes.Buffer
+	if err := templ.Execute(&buf, in); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func add(a, b int) int {
+	return a + b
+}

--- a/pkg/userdata/v1/install.go
+++ b/pkg/userdata/v1/install.go
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package v1 provides user-facing v1 machine configs
+//nolint: dupl
+package v1
+
+// Install represents the installation options for preparing a node.
+type Install struct {
+	Boot            *BootDevice    `yaml:"boot,omitempty"`
+	Ephemeral       *InstallDevice `yaml:"ephemeral,omitempty"`
+	ExtraDevices    []*ExtraDevice `yaml:"extraDevices,omitempty"`
+	ExtraKernelArgs []string       `yaml:"extraKernelArgs,omitempty"`
+	Wipe            bool           `yaml:"wipe"`
+	Force           bool           `yaml:"force"`
+}
+
+// BootDevice represents the install options specific to the boot partition.
+type BootDevice struct {
+	InstallDevice `yaml:",inline"`
+
+	Kernel    string `yaml:"kernel"`
+	Initramfs string `yaml:"initramfs"`
+}
+
+// RootDevice represents the install options specific to the root partition.
+type RootDevice struct {
+	InstallDevice `yaml:",inline"`
+
+	Rootfs string `yaml:"rootfs"`
+}
+
+// InstallDevice represents the specific directions for each partition.
+type InstallDevice struct {
+	Device string `yaml:"device,omitempty"`
+	Size   uint   `yaml:"size,omitempty"`
+}
+
+// ExtraDevice represents the options available for partitioning, formatting,
+// and mounting extra disks.
+type ExtraDevice struct {
+	Device     string                  `yaml:"device,omitempty"`
+	Partitions []*ExtraDevicePartition `yaml:"partitions,omitempty"`
+}
+
+// ExtraDevicePartition represents the options for a device partition.
+type ExtraDevicePartition struct {
+	Size       uint   `yaml:"size,omitempty"`
+	MountPoint string `yaml:"mountpoint,omitempty"`
+}

--- a/pkg/userdata/v1/machine_config.go
+++ b/pkg/userdata/v1/machine_config.go
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package v1
+
+// MachineConfig reperesents the machine-specific config values
+type MachineConfig struct {
+	Type    string           `yaml:"type"`
+	Token   string           `yaml:"token"`
+	CA      *MachineCAConfig `yaml:"ca,omitempty"`
+	Kubelet *KubeletConfig   `yaml:"kubelet,omitempty"`
+	Network *NetworkConfig   `yaml:"network,omitempty"`
+	Install *Install         `yaml:"install,omitempty"`
+}
+
+// KubeletConfig reperesents the kubelet config values
+type KubeletConfig struct {
+	Image     string            `yaml:"image,omitempty"`
+	ExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// NetworkConfig reperesents the machine's networking config values
+type NetworkConfig struct {
+	Hostname   string    `yaml:"hostname,omitempty"`
+	Interfaces []*Device `yaml:"interfaces,omitempty"`
+}
+
+// MachineCAConfig reperesents the machine's talos cert config values
+type MachineCAConfig struct {
+	Crt string `yaml:"crt,omitempty"`
+	Key string `yaml:"key,omitempty"`
+}

--- a/pkg/userdata/v1/networking.go
+++ b/pkg/userdata/v1/networking.go
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Package userdata provides internal representation of machine configs
+// Package v1 provides user-facing v1 machine configs
 // nolint: dupl
-package userdata
+package v1
 
 import (
 	"net"
@@ -15,6 +15,7 @@ import (
 )
 
 // Device represents a network interface
+// nolint: dupl
 type Device struct {
 	Interface string  `yaml:"interface"`
 	CIDR      string  `yaml:"cidr"`
@@ -25,9 +26,11 @@ type Device struct {
 }
 
 // NetworkDeviceCheck defines the function type for checks
+// nolint: dupl
 type NetworkDeviceCheck func(*Device) error
 
 // Validate triggers the specified validation checks to run
+// nolint: dupl
 func (d *Device) Validate(checks ...NetworkDeviceCheck) error {
 	var result *multierror.Error
 
@@ -39,6 +42,7 @@ func (d *Device) Validate(checks ...NetworkDeviceCheck) error {
 }
 
 // CheckDeviceInterface ensures that the interface has been specified
+// nolint: dupl
 func CheckDeviceInterface() NetworkDeviceCheck {
 	return func(d *Device) error {
 		var result *multierror.Error
@@ -53,6 +57,7 @@ func CheckDeviceInterface() NetworkDeviceCheck {
 
 // CheckDeviceAddressing ensures that an appropriate addressing method
 // has been specified
+// nolint: dupl
 func CheckDeviceAddressing() NetworkDeviceCheck {
 	return func(d *Device) error {
 		var result *multierror.Error
@@ -79,6 +84,7 @@ func CheckDeviceAddressing() NetworkDeviceCheck {
 }
 
 // CheckDeviceRoutes ensures that the specified routes are valid
+// nolint: dupl
 func CheckDeviceRoutes() NetworkDeviceCheck {
 	return func(d *Device) error {
 		var result *multierror.Error
@@ -102,6 +108,7 @@ func CheckDeviceRoutes() NetworkDeviceCheck {
 
 // Bond contains the various options for configuring a
 // bonded interface
+// nolint: dupl
 type Bond struct {
 	Mode       string   `yaml:"mode"`
 	HashPolicy string   `yaml:"hashpolicy"`
@@ -110,6 +117,7 @@ type Bond struct {
 }
 
 // Route represents a network route
+// nolint: dupl
 type Route struct {
 	Network string `yaml:"network"`
 	Gateway string `yaml:"gateway"`

--- a/pkg/userdata/v1/node_config.go
+++ b/pkg/userdata/v1/node_config.go
@@ -1,0 +1,8 @@
+package v1
+
+// NodeConfig holds the full representation of the node config
+type NodeConfig struct {
+	Version string
+	Machine *MachineConfig
+	Cluster *ClusterConfig
+}


### PR DESCRIPTION
This currently just creates the v1 machine configs (and v0) with osctl config generate. WIP, since I need to flesh out the translation between the new machine configs and the expected internal struct. Just pushing it up for the weekend. Also currently looks horrendous b/c there's a bunch of files moving around.

This PR will implement the v1 machine config proposal. This will allow
for a streamlined config for talos nodes.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>