### PR TITLE
chore: Make installer script more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ base: buildkitd
 generate: buildkitd
 	$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-    --output type=local,dest=./ \
+		--output type=local,dest=./ \
 		--opt target=$@ \
 		$(COMMON_ARGS)
 
@@ -124,7 +124,7 @@ generate: buildkitd
 kernel: buildkitd
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-    --output type=local,dest=build \
+		--output type=local,dest=build \
 		--opt target=$@ \
 		$(COMMON_ARGS)
 	@-rm -rf ./build/modules
@@ -133,7 +133,7 @@ kernel: buildkitd
 initramfs: buildkitd
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-    --output type=local,dest=build \
+		--output type=local,dest=build \
 		--opt target=$@ \
 		$(COMMON_ARGS)
 
@@ -191,7 +191,14 @@ push-image-azure:
 
 .PHONY: image-gce
 image-gce:
-	@docker run --rm -v /dev:/dev -v $(PWD)/build:/out --privileged $(DOCKER_ARGS) autonomy/installer:$(TAG) install -n disk -r -p googlecloud -u none
+	@docker run --rm -v /dev:/dev -v $(PWD)/build:/out \
+		--privileged $(DOCKER_ARGS) \
+		autonomy/installer:$(TAG) \
+		install \
+		-n disk \
+		-r \
+		-p googlecloud \
+		-u none
 	@tar -C $(PWD)/build -czf $(PWD)/build/gce.tar.gz disk.raw
 	@rm -rf $(PWD)/build/disk.raw
 
@@ -263,7 +270,7 @@ markdownlint: buildkitd
 osctl-linux: buildkitd
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-    --output type=local,dest=build \
+		--output type=local,dest=build \
 		--opt target=$@ \
 		$(COMMON_ARGS)
 
@@ -271,7 +278,7 @@ osctl-linux: buildkitd
 osctl-darwin: buildkitd
 	@$(BINDIR)/buildctl --addr $(BUILDKIT_HOST) \
 		build \
-    --output type=local,dest=build \
+		--output type=local,dest=build \
 		--opt target=$@ \
 		$(COMMON_ARGS)
 

--- a/hack/installer/entrypoint.sh
+++ b/hack/installer/entrypoint.sh
@@ -20,11 +20,10 @@ function setup_raw_device(){
     rm ${TALOS_RAW}
   fi
   dd if=/dev/zero of="${TALOS_RAW}" bs=1M count=0 seek=544
-  DEVICE=$(losetup -f)
   # NB: Since we use BLKRRPART to tell the kernel to re-read the partition
   # table, it is required to create a partitioned loop device. The BLKRRPART
   # command is meaningful only for partitionable devices.
-  losetup -P ${DEVICE} ${TALOS_RAW}
+  DEVICE=$(losetup --find --partscan --nooverlap --show ${TALOS_RAW})
   printf "done\n"
 }
 


### PR DESCRIPTION
Adds some functionality to help prevent collisions.

- Run `losetup -f <attach>` to atomically provision the next loopback
  device with a file
- Creates a tempfile for default and test named raw images to prevent
  overlap


Signed-off-by: Brad Beam <brad.beam@talos-systems.com>