### PR TITLE
feat: add standardized command runner

### DIFF
--- a/internal/pkg/installer/bootloader/syslinux/syslinux.go
+++ b/internal/pkg/installer/bootloader/syslinux/syslinux.go
@@ -9,11 +9,11 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"text/template"
 
 	"github.com/pkg/errors"
+	"github.com/talos-systems/talos/pkg/cmd"
 )
 
 const syslinuxCfgTpl = `DEFAULT {{ .Default }}
@@ -111,7 +111,7 @@ func Install(base string, config interface{}) (err error) {
 		}
 	}
 
-	if err = cmd("extlinux", "--install", filepath.Dir(paths[0])); err != nil {
+	if err = cmd.Run("extlinux", "--install", filepath.Dir(paths[0])); err != nil {
 		return errors.Wrap(err, "failed to install extlinux")
 	}
 
@@ -157,14 +157,4 @@ func WriteSyslinuxCfg(base, path string, syslinuxcfg *Cfg) (err error) {
 	}
 
 	return nil
-}
-
-func cmd(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
-	err := cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	return cmd.Wait()
 }

--- a/pkg/blockdevice/filesystem/vfat/vfat.go
+++ b/pkg/blockdevice/filesystem/vfat/vfat.go
@@ -5,7 +5,7 @@
 package vfat
 
 import (
-	"os/exec"
+	"github.com/talos-systems/talos/pkg/cmd"
 )
 
 // MakeFS creates a VFAT filesystem on the specified partition.
@@ -20,15 +20,5 @@ func MakeFS(partname string, setters ...Option) error {
 
 	args = append(args, partname)
 
-	return cmd("mkfs.vfat", args...)
-}
-
-func cmd(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
-	err := cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	return cmd.Wait()
+	return cmd.Run("mkfs.vfat", args...)
 }

--- a/pkg/blockdevice/filesystem/xfs/xfs.go
+++ b/pkg/blockdevice/filesystem/xfs/xfs.go
@@ -6,13 +6,13 @@
 package xfs
 
 import (
-	"os/exec"
+	"github.com/talos-systems/talos/pkg/cmd"
 )
 
 // GrowFS expands a XFS filesystem to the maximum possible. The partition
 // MUST be mounted, or this will fail.
 func GrowFS(partname string) error {
-	return cmd("xfs_growfs", "-d", partname)
+	return cmd.Run("xfs_growfs", "-d", partname)
 }
 
 // MakeFS creates a XFS filesystem on the specified partition.
@@ -32,14 +32,5 @@ func MakeFS(partname string, setters ...Option) error {
 
 	args = append(args, partname)
 
-	return cmd("mkfs.xfs", args...)
-}
-
-func cmd(name string, args ...string) error {
-	cmd := exec.Command(name, args...)
-	err := cmd.Start()
-	if err != nil {
-		return err
-	}
-	return cmd.Wait()
+	return cmd.Run("mkfs.xfs", args...)
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cmd
+
+import (
+	"bytes"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+// Run executes a command.
+func Run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return errors.Errorf("%s: %s", err, stderr.String())
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return errors.Errorf("%s: %s", err, stderr.String())
+	}
+
+	return nil
+}

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type CmdSuite struct {
+	suite.Suite
+}
+
+func TestCmdSuite(t *testing.T) {
+	suite.Run(t, new(CmdSuite))
+}
+
+func (suite *CmdSuite) TestRun() {
+	type args struct {
+		name string
+		args []string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		errString string
+	}{
+		{
+			"true",
+			args{
+				"true",
+				[]string{},
+			},
+			false,
+			"",
+		},
+		{
+			"false",
+			args{
+				"badcommand",
+				[]string{},
+			},
+			true,
+			"exec: \"badcommand\": executable file not found in $PATH: ",
+		},
+	}
+	for _, t := range tests {
+		println(t.name)
+		err := Run(t.args.name, t.args.args...)
+		if t.wantErr {
+			suite.Assert().Error(err)
+			suite.Assert().Equal(err.Error(), t.errString)
+		} else {
+			suite.Assert().NoError(err)
+		}
+	}
+}


### PR DESCRIPTION
This adds a command runner function that can be used everywhere we need
to exec a binary. It adds addtional logic around error handling that
will allow for viewing errors in the case of a failed command.