### PR TITLE
feat: mount /sys/fs/bpf

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/mount_bpffs.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_bpffs.go
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package rootfs
+
+import (
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
+	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
+	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager"
+	"github.com/talos-systems/talos/internal/pkg/mount/manager/bpffs"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+// MountBPFFS represents the MountBPFFS task.
+type MountBPFFS struct{}
+
+// NewMountBPFFSTask initializes and returns an MountBPFFS task.
+func NewMountBPFFSTask() phase.Task {
+	return &MountBPFFS{}
+}
+
+// RuntimeFunc returns the runtime function.
+func (task *MountBPFFS) RuntimeFunc(mode runtime.Mode) phase.RuntimeFunc {
+	switch mode {
+	case runtime.Standard:
+		return task.runtime
+	default:
+		return nil
+	}
+}
+
+func (task *MountBPFFS) runtime(platform platform.Platform, data *userdata.UserData) (err error) {
+	var mountpoints *mount.Points
+	mountpoints, err = bpffs.MountPoints()
+	if err != nil {
+		return err
+	}
+
+	m := manager.NewManager(mountpoints)
+	if err = m.MountAll(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
@@ -5,7 +5,6 @@
 package rootfs
 
 import (
-	// "github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path"

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -49,6 +49,7 @@ func run() (err error) {
 			"system requirements",
 			security.NewSecurityTask(),
 			rootfs.NewSystemDirectoryTask(),
+			rootfs.NewMountBPFFSTask(),
 			rootfs.NewMountCgroupsTask(),
 			rootfs.NewMountSubDevicesTask(),
 			sysctls.NewSysctlsTask(),

--- a/internal/pkg/mount/manager/bpffs/bpffs.go
+++ b/internal/pkg/mount/manager/bpffs/bpffs.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package bpffs
+
+import (
+	"github.com/talos-systems/talos/internal/pkg/mount"
+)
+
+// MountPoints returns the cgroup mount points
+func MountPoints() (mountpoints *mount.Points, err error) {
+	base := "/sys/fs/bpf"
+	bpf := mount.NewMountPoints()
+	bpf.Set("bpf", mount.NewMountPoint("bpffs", base, "bpf", 0, ""))
+
+	return bpf, nil
+}

--- a/internal/pkg/mount/manager/bpffs/bpffs_test.go
+++ b/internal/pkg/mount/manager/bpffs/bpffs_test.go
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package bpffs_test
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	// added for accurate coverage estimation
+	//
+	// please remove it once any unit-test is added
+	// for this package
+}


### PR DESCRIPTION
The BPF filesystem is required to pin BPF objects.

Fixes #1044.