### PR TITLE
fix(machined): Remove host mounts for specific CNI providers

### DIFF
--- a/internal/app/machined/internal/cni/cni.go
+++ b/internal/app/machined/internal/cni/cni.go
@@ -6,8 +6,6 @@ package cni
 
 import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -17,18 +15,6 @@ func Mounts(data *userdata.UserData) ([]specs.Mount, error) {
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: "/etc/cni", Source: "/etc/cni", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/opt/cni", Source: "/opt/cni", Options: []string{"rbind", "rshared", "rw"}},
-	}
-
-	switch data.Services.Init.CNI {
-	case constants.CNICalico:
-		calicoMounts := []specs.Mount{
-			{Type: "bind", Destination: "/var/lib/calico", Source: "/var/lib/calico", Options: []string{"rbind", "rshared", "rw"}},
-		}
-		mounts = append(mounts, calicoMounts...)
-	case constants.CNIFlannel:
-		// Nothing to do.
-	default:
-		return nil, errors.Errorf("unknown CNI %s", data.Services.Init.CNI)
 	}
 
 	return mounts, nil


### PR DESCRIPTION
We shouldnt need these anymore

Fixes #1046 

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>