### PR TITLE
feat: allow specification of additional API SANs

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -131,6 +131,7 @@ var configGenerateCmd = &cobra.Command{
 		if err != nil {
 			helpers.Fatalf("failed to generate PKI and tokens: %v", err)
 		}
+		input.AdditionalSubjectAltNames = additionalSANs
 
 		workingDir, err := os.Getwd()
 		if err != nil {
@@ -195,6 +196,7 @@ func init() {
 	configAddCmd.Flags().StringVar(&ca, "ca", "", "the path to the CA certificate")
 	configAddCmd.Flags().StringVar(&crt, "crt", "", "the path to the certificate")
 	configAddCmd.Flags().StringVar(&key, "key", "", "the path to the key")
+	configGenerateCmd.Flags().StringSliceVar(&additionalSANs, "additionalSANs", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
 	helpers.Should(configAddCmd.MarkFlagRequired("ca"))
 	helpers.Should(configAddCmd.MarkFlagRequired("crt"))
 	helpers.Should(configAddCmd.MarkFlagRequired("key"))

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -19,20 +19,21 @@ import (
 )
 
 var (
-	ca           string
-	crt          string
-	csr          string
-	hours        int
-	ip           string
-	key          string
-	kubernetes   bool
-	useCRI       bool
-	name         string
-	organization string
-	rsa          bool
-	talosconfig  string
-	target       string
-	userdataFile string
+	ca             string
+	crt            string
+	additionalSANs []string
+	csr            string
+	hours          int
+	ip             string
+	key            string
+	kubernetes     bool
+	useCRI         bool
+	name           string
+	organization   string
+	rsa            bool
+	talosconfig    string
+	target         string
+	userdataFile   string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/pkg/userdata/generate/generate.go
+++ b/pkg/userdata/generate/generate.go
@@ -42,8 +42,9 @@ type CertStrings struct {
 
 // Input holds info about certs, ips, and node type.
 type Input struct {
-	Certs     *Certs
-	MasterIPs []string
+	Certs                     *Certs
+	MasterIPs                 []string
+	AdditionalSubjectAltNames []string
 
 	ClusterName       string
 	ServiceDomain     string
@@ -97,6 +98,16 @@ func (i *Input) GetControlPlaneEndpoint(port string) string {
 		return tnet.FormatAddress(i.MasterIPs[refMaster])
 	}
 	return net.JoinHostPort(i.MasterIPs[refMaster], port)
+}
+
+// GetAPIServerSANs returns the formatted list of Subject Alt Name addresses for the API Server
+func (i *Input) GetAPIServerSANs() []string {
+
+	var list = []string{"127.0.0.1", "::1"}
+	list = append(list, i.MasterIPs...)
+	list = append(list, i.AdditionalSubjectAltNames...)
+
+	return list
 }
 
 // Certs holds the base64 encoded keys and certificates.

--- a/pkg/userdata/generate/init.go
+++ b/pkg/userdata/generate/init.go
@@ -38,7 +38,7 @@ services:
       kubernetesVersion: {{ .KubernetesVersion }}
       controlPlaneEndpoint: "{{ .GetControlPlaneEndpoint "443" }}"
       apiServer:
-        certSANs: [ {{ range $i,$ip := .MasterIPs }}{{if $i}},{{end}}"{{$ip}}"{{end}}, "127.0.0.1", "::1" ]
+        certSANs: [ {{ range $i,$addr := .GetAPIServerSANs }}{{if $i}},{{end}}"{{$addr}}"{{end}} ]
         extraArgs:
           runtime-config: settings.k8s.io/v1alpha1=true
           feature-gates: ExperimentalCriticalPodAnnotation=true


### PR DESCRIPTION
Adds handler for specification of additional subjet alt names (SANs) for
the API Server when generating a new cluster configuration using
`osctl`.

Fixes #800

Signed-off-by: Seán C McCord <ulexus@gmail.com>