### PR TITLE
feat(osd): Add ntpd client

### DIFF
--- a/cmd/osctl/cmd/time.go
+++ b/cmd/osctl/cmd/time.go
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
+	"github.com/talos-systems/talos/internal/app/ntpd/proto"
+)
+
+// timeCmd represents the time command
+var timeCmd = &cobra.Command{
+	Use:   "time [--check server]",
+	Short: "Gets current server time",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		setupClient(func(c *client.Client) {
+			server, err := cmd.Flags().GetString("check")
+			if err != nil {
+				helpers.Fatalf("failed to parse check flag: %v", err)
+			}
+
+			var output *proto.TimeReply
+			if server == "" {
+				output, err = c.Time(globalCtx)
+				if err != nil {
+					helpers.Fatalf("error fetching time: %s", err)
+				}
+			} else {
+				output, err = c.TimeCheck(globalCtx, server)
+				if err != nil {
+					helpers.Fatalf("error fetching time: %s", err)
+				}
+			}
+
+			var localtime, remotetime time.Time
+			localtime, err = ptypes.Timestamp(output.Localtime)
+			if err != nil {
+				helpers.Fatalf("error parsing local time: %s", err)
+			}
+			remotetime, err = ptypes.Timestamp(output.Remotetime)
+			if err != nil {
+				helpers.Fatalf("error parsing remote time: %s", err)
+			}
+
+			fmt.Printf("NTP Server: %s\n", output.Server)
+			fmt.Printf("Local time: %s\n", localtime)
+			fmt.Printf("Remote time: %s\n", remotetime)
+		})
+	},
+}
+
+func init() {
+	timeCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
+	timeCmd.Flags().StringP("check", "c", "pool.ntp.org", "checks server time against specified ntp server")
+	rootCmd.AddCommand(timeCmd)
+}

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	initproto "github.com/talos-systems/talos/internal/app/machined/proto"
+	ntpdproto "github.com/talos-systems/talos/internal/app/ntpd/proto"
 	"github.com/talos-systems/talos/internal/app/osd/proto"
 	"github.com/talos-systems/talos/pkg/net"
 	"github.com/talos-systems/talos/pkg/proc"
@@ -43,6 +44,7 @@ type Client struct {
 	conn       *grpc.ClientConn
 	client     proto.OSDClient
 	initClient initproto.InitClient
+	ntpdClient ntpdproto.NtpdClient
 }
 
 // NewDefaultClientCredentials initializes ClientCredentials using default paths
@@ -115,6 +117,7 @@ func NewClient(port int, clientcreds *Credentials) (c *Client, err error) {
 
 	c.client = proto.NewOSDClient(c.conn)
 	c.initClient = initproto.NewInitClient(c.conn)
+	c.ntpdClient = ntpdproto.NewNtpdClient(c.conn)
 
 	return c, nil
 }
@@ -336,4 +339,24 @@ func (c *Client) Stop(ctx context.Context, id string) (string, error) {
 	}
 
 	return r.Resp, nil
+}
+
+// Time returns the time
+func (c *Client) Time(ctx context.Context) (*ntpdproto.TimeReply, error) {
+	r, err := c.ntpdClient.Time(ctx, &empty.Empty{})
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// TimeCheck returns the time compared to the specified ntp server
+func (c *Client) TimeCheck(ctx context.Context, server string) (*ntpdproto.TimeReply, error) {
+	r, err := c.ntpdClient.TimeCheck(ctx, &ntpdproto.TimeRequest{Server: server})
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -8,6 +8,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
@@ -63,8 +65,14 @@ func (n *NTPd) Runner(data *userdata.UserData) (runner.Runner, error) {
 		ProcessArgs: []string{"/ntpd", "--userdata=" + constants.UserDataPath},
 	}
 
+	// Ensure socket dir exists
+	if err := os.MkdirAll(filepath.Dir(constants.NtpdSocketPath), os.ModeDir); err != nil {
+		return nil, err
+	}
+
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: constants.UserDataPath, Source: constants.UserDataPath, Options: []string{"rbind", "ro"}},
+		{Type: "bind", Destination: filepath.Dir(constants.NtpdSocketPath), Source: filepath.Dir(constants.NtpdSocketPath), Options: []string{"rbind", "rw"}},
 	}
 
 	env := []string{}

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -78,6 +78,7 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/var/log", Source: "/var/log", Options: []string{"rbind", "rw"}},
 		{Type: "bind", Destination: filepath.Dir(constants.InitSocketPath), Source: filepath.Dir(constants.InitSocketPath), Options: []string{"rbind", "rw"}},
+		{Type: "bind", Destination: filepath.Dir(constants.NtpdSocketPath), Source: filepath.Dir(constants.NtpdSocketPath), Options: []string{"rbind", "rw"}},
 	}
 
 	env := []string{}

--- a/internal/app/osd/internal/reg/ntp_client.go
+++ b/internal/app/osd/internal/reg/ntp_client.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/talos-systems/talos/internal/app/ntpd/proto"
+	"github.com/talos-systems/talos/pkg/constants"
+	"google.golang.org/grpc"
+)
+
+// NtpdClient is a gRPC client for init service API
+type NtpdClient struct {
+	proto.NtpdClient
+}
+
+// NewNtpdClient initializes new client and connects to ntpd
+func NewNtpdClient() (*NtpdClient, error) {
+	conn, err := grpc.Dial("unix:"+constants.NtpdSocketPath,
+		grpc.WithInsecure(),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &NtpdClient{
+		NtpdClient: proto.NewNtpdClient(conn),
+	}, nil
+}
+
+// Time issues a query to the configured ntp server and displays the results
+func (c *NtpdClient) Time(ctx context.Context, in *empty.Empty) (*proto.TimeReply, error) {
+	return c.NtpdClient.Time(ctx, in)
+}
+
+// TimeCheck issues a query to the specified ntp server and displays the results
+func (c *NtpdClient) TimeCheck(ctx context.Context, in *proto.TimeRequest) (*proto.TimeReply, error) {
+	return c.NtpdClient.TimeCheck(ctx, in)
+}

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 
 	initproto "github.com/talos-systems/talos/internal/app/machined/proto"
+	ntpdproto "github.com/talos-systems/talos/internal/app/ntpd/proto"
 	"github.com/talos-systems/talos/internal/app/osd/proto"
 	"github.com/talos-systems/talos/internal/pkg/containers"
 	"github.com/talos-systems/talos/internal/pkg/containers/containerd"
@@ -42,6 +43,7 @@ import (
 type Registrator struct {
 	// every Init service API is proxied via OSD
 	*InitServiceClient
+	*NtpdClient
 
 	Data *userdata.UserData
 }
@@ -50,6 +52,7 @@ type Registrator struct {
 func (r *Registrator) Register(s *grpc.Server) {
 	proto.RegisterOSDServer(s, r)
 	initproto.RegisterInitServer(s, r)
+	ntpdproto.RegisterNtpdServer(s, r)
 }
 
 // Kubeconfig implements the proto.OSDServer interface. The admin kubeconfig is

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -56,11 +56,17 @@ func main() {
 		log.Fatalf("init client: %v", err)
 	}
 
+	ntpdClient, err := reg.NewNtpdClient()
+	if err != nil {
+		log.Fatalf("ntp client: %v", err)
+	}
+
 	log.Println("Starting osd")
 	err = factory.ListenAndServe(
 		&reg.Registrator{
 			Data:              data,
 			InitServiceClient: initClient,
+			NtpdClient:        ntpdClient,
 		},
 		factory.Port(constants.OsdPort),
 		factory.ServerOptions(


### PR DESCRIPTION
Allows us to access ntp api

```
[16:43:50] $ ./build/osctl-darwin-amd64 time --check time.cloudflare.com; ./build/osctl-darwin-amd64 time
NTP Server: time.cloudflare.com
Local time: 2019-08-21 21:44:14.5179364 +0000 UTC
Remote time: 2019-08-21 21:44:14.474403077 +0000 UTC
NTP Server: pool.ntp.org
Local time: 2019-08-21 21:44:14.9037713 +0000 UTC
Remote time: 2019-08-21 21:44:14.814032015 +0000 UTC
```

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>