### PR TITLE
    feat(networkd): Add grpc endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,10 @@ RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
 WORKDIR /ntpd
 COPY ./internal/app/ntpd/proto ./proto
 RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+WORKDIR /networkd
+COPY ./internal/app/networkd/proto ./proto
+RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+
 
 FROM scratch AS generate
 COPY --from=generate-build /osd/proto/api.pb.go /internal/app/osd/proto/
@@ -51,6 +55,7 @@ COPY --from=generate-build /trustd/proto/api.pb.go /internal/app/trustd/proto/
 COPY --from=generate-build /machined/proto/api.pb.go /internal/app/machined/proto/
 COPY --from=generate-build /proxyd/proto/api.pb.go /internal/app/proxyd/proto/
 COPY --from=generate-build /ntpd/proto/api.pb.go /internal/app/ntpd/proto/
+COPY --from=generate-build /networkd/proto/api.pb.go /internal/app/networkd/proto/
 
 # The base target provides a container that can be used to build all Talos
 # assets.

--- a/cmd/osctl/cmd/interfaces.go
+++ b/cmd/osctl/cmd/interfaces.go
@@ -16,10 +16,10 @@ import (
 	"github.com/talos-systems/talos/internal/app/networkd/proto"
 )
 
-// routesCmd represents the net routes command
-var routesCmd = &cobra.Command{
-	Use:   "routes",
-	Short: "List network routes",
+// interfacesCmd represents the net interfaces command
+var interfacesCmd = &cobra.Command{
+	Use:   "interfaces",
+	Short: "List network interfaces",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 0 {
@@ -28,26 +28,28 @@ var routesCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			reply, err := c.Routes(globalCtx)
+			reply, err := c.Interfaces(globalCtx)
 			if err != nil {
-				helpers.Fatalf("error getting routes: %s", err)
+				helpers.Fatalf("error getting interfaces: %s", err)
 			}
 
-			routesRender(reply)
+			intersRender(reply)
 		})
 	},
 }
 
-func routesRender(reply *proto.RoutesReply) {
+func intersRender(reply *proto.InterfacesReply) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "INTERFACE\tDESTINATION\tGATEWAY\tMETRIC")
-	for _, r := range reply.Routes {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%d\n", r.Interface, r.Destination, r.Gateway, r.Metric)
+	fmt.Fprintln(w, "INDEX\tNAME\tMAC\tMTU\tADDRESS")
+	for _, r := range reply.Interfaces {
+		for _, addr := range r.Ipaddress {
+			fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\n", r.Index, r.Name, r.Hardwareaddr, r.Mtu, addr)
+		}
 	}
 	helpers.Should(w.Flush())
 }
 
 func init() {
-	routesCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
-	rootCmd.AddCommand(routesCmd)
+	interfacesCmd.Flags().StringVarP(&target, "target", "t", "", "target the specificed node")
+	rootCmd.AddCommand(interfacesCmd)
 }

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	initproto "github.com/talos-systems/talos/internal/app/machined/proto"
+	networkdproto "github.com/talos-systems/talos/internal/app/networkd/proto"
 	ntpdproto "github.com/talos-systems/talos/internal/app/ntpd/proto"
 	"github.com/talos-systems/talos/internal/app/osd/proto"
 	"github.com/talos-systems/talos/pkg/net"
@@ -41,10 +42,11 @@ type Credentials struct {
 // Client implements the proto.OSDClient interface. It serves as the
 // concrete type with the required methods.
 type Client struct {
-	conn       *grpc.ClientConn
-	client     proto.OSDClient
-	initClient initproto.InitClient
-	ntpdClient ntpdproto.NtpdClient
+	conn           *grpc.ClientConn
+	client         proto.OSDClient
+	initClient     initproto.InitClient
+	ntpdClient     ntpdproto.NtpdClient
+	networkdClient networkdproto.NetworkdClient
 }
 
 // NewDefaultClientCredentials initializes ClientCredentials using default paths
@@ -118,6 +120,7 @@ func NewClient(port int, clientcreds *Credentials) (c *Client, err error) {
 	c.client = proto.NewOSDClient(c.conn)
 	c.initClient = initproto.NewInitClient(c.conn)
 	c.ntpdClient = ntpdproto.NewNtpdClient(c.conn)
+	c.networkdClient = networkdproto.NewNetworkdClient(c.conn)
 
 	return c, nil
 }
@@ -211,9 +214,15 @@ func (c *Client) Version(ctx context.Context) ([]byte, error) {
 	return data.Bytes, nil
 }
 
-// Routes implements the proto.OSDClient interface.
-func (c *Client) Routes(ctx context.Context) (reply *proto.RoutesReply, err error) {
-	reply, err = c.client.Routes(ctx, &empty.Empty{})
+// Routes implements the networkdproto.NetworkdClient interface.
+func (c *Client) Routes(ctx context.Context) (reply *networkdproto.RoutesReply, err error) {
+	reply, err = c.networkdClient.Routes(ctx, &empty.Empty{})
+	return
+}
+
+// Interfaces implements the proto.OSDClient interface.
+func (c *Client) Interfaces(ctx context.Context) (reply *networkdproto.InterfacesReply, err error) {
+	reply, err = c.networkdClient.Interfaces(ctx, &empty.Empty{})
 	return
 }
 

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -8,6 +8,8 @@ package services
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
@@ -63,10 +65,16 @@ func (n *Networkd) Runner(data *userdata.UserData) (runner.Runner, error) {
 		ProcessArgs: []string{"/networkd"},
 	}
 
+	// Ensure socket dir exists
+	if err := os.MkdirAll(filepath.Dir(constants.NetworkdSocketPath), os.ModeDir); err != nil {
+		return nil, err
+	}
+
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: constants.UserDataPath, Source: constants.UserDataPath, Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: "/etc/resolv.conf", Source: "/etc/resolv.conf", Options: []string{"rbind", "rw"}},
 		{Type: "bind", Destination: "/etc/hosts", Source: "/etc/hosts", Options: []string{"rbind", "rw"}},
+		{Type: "bind", Destination: filepath.Dir(constants.NetworkdSocketPath), Source: filepath.Dir(constants.NetworkdSocketPath), Options: []string{"rbind", "rw"}},
 	}
 
 	env := []string{}

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -79,6 +79,7 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		{Type: "bind", Destination: "/var/log", Source: "/var/log", Options: []string{"rbind", "rw"}},
 		{Type: "bind", Destination: filepath.Dir(constants.InitSocketPath), Source: filepath.Dir(constants.InitSocketPath), Options: []string{"rbind", "rw"}},
 		{Type: "bind", Destination: filepath.Dir(constants.NtpdSocketPath), Source: filepath.Dir(constants.NtpdSocketPath), Options: []string{"rbind", "rw"}},
+		{Type: "bind", Destination: filepath.Dir(constants.NetworkdSocketPath), Source: filepath.Dir(constants.NetworkdSocketPath), Options: []string{"rbind", "rw"}},
 	}
 
 	env := []string{}

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/internal/app/networkd/pkg/reg"
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -71,5 +74,12 @@ func main() {
 
 	log.Println("starting renewal watcher")
 	// handle dhcp renewal
-	nwd.Renew(netIfaces...)
+	go nwd.Renew(netIfaces...)
+
+	log.Fatalf("%+v", factory.ListenAndServe(
+		reg.NewRegistrator(nwd),
+		factory.Network("unix"),
+		factory.SocketPath(constants.NetworkdSocketPath),
+	),
+	)
 }

--- a/internal/app/networkd/pkg/networkd/netlink.go
+++ b/internal/app/networkd/pkg/networkd/netlink.go
@@ -12,13 +12,13 @@ import (
 
 // setMTU sets the link MTU
 func (n *Networkd) setMTU(idx int, mtu uint32) error {
-	msg, err := n.nlConn.Link.Get(uint32(idx))
+	msg, err := n.NlConn.Link.Get(uint32(idx))
 	if err != nil {
 		log.Printf("failed to get link %d\n", idx)
 		return err
 	}
 
-	err = n.nlConn.Link.Set(&rtnetlink.LinkMessage{
+	err = n.NlConn.Link.Set(&rtnetlink.LinkMessage{
 		Family: msg.Family,
 		Type:   msg.Type,
 		Index:  uint32(idx),

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -32,7 +32,7 @@ const (
 // and/or a specified configuration file.
 type Networkd struct {
 	Conn   *rtnl.Conn
-	nlConn *rtnetlink.Conn
+	NlConn *rtnetlink.Conn
 }
 
 // New instantiates a new rtnetlink connection that is used for all subsequent
@@ -51,7 +51,7 @@ func New() (*Networkd, error) {
 		return nil, err
 	}
 
-	return &Networkd{Conn: conn, nlConn: nlConn}, err
+	return &Networkd{Conn: conn, NlConn: nlConn}, err
 }
 
 // Discover enumerates a list of network links on the host and creates a
@@ -231,7 +231,7 @@ func (n *Networkd) Hostname(ifaces ...*nic.NetworkInterface) string {
 // PrintState displays the current links, addresses, and routing table.
 // nolint: gocyclo
 func (n *Networkd) PrintState() {
-	rl, err := n.nlConn.Route.List()
+	rl, err := n.NlConn.Route.List()
 	if err != nil {
 		log.Println(err)
 		return

--- a/internal/app/networkd/pkg/reg/reg.go
+++ b/internal/app/networkd/pkg/reg/reg.go
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+	"log"
+	"net"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
+	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
+	"github.com/talos-systems/talos/internal/app/networkd/proto"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+)
+
+// Registrator is the concrete type that implements the factory.Registrator and
+// proto.Init interfaces.
+type Registrator struct {
+	Networkd *networkd.Networkd
+}
+
+// NewRegistrator builds new Registrator instance.
+func NewRegistrator(n *networkd.Networkd) *Registrator {
+	return &Registrator{
+		Networkd: n,
+	}
+}
+
+// Register implements the factory.Registrator interface.
+func (r *Registrator) Register(s *grpc.Server) {
+	proto.RegisterNetworkdServer(s, r)
+}
+
+// Routes returns the hosts routing table.
+func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (reply *proto.RoutesReply, err error) {
+	list, err := r.Networkd.NlConn.Route.List()
+	if err != nil {
+		return nil, errors.Errorf("failed to get route list: %v", err)
+	}
+
+	routes := []*proto.Route{}
+
+	for _, rMesg := range list {
+
+		ifaceData, err := r.Networkd.Conn.LinkByIndex(int(rMesg.Attributes.OutIface))
+		if err != nil {
+			log.Printf("failed to get interface details for interface index %d: %v", rMesg.Attributes.OutIface, err)
+			// TODO: Remove once we get this sorted on why there's a
+			// failure here
+			log.Printf("%+v", rMesg)
+			continue
+		}
+
+		routes = append(routes, &proto.Route{
+			Interface:   ifaceData.Name,
+			Destination: toCIDR(rMesg.Family, rMesg.Attributes.Dst, int(rMesg.DstLength)),
+			Gateway:     rMesg.Attributes.Gateway.String(),
+			Metric:      rMesg.Attributes.Priority,
+			Scope:       uint32(rMesg.Scope),
+			Source:      toCIDR(rMesg.Family, rMesg.Attributes.Src, int(rMesg.SrcLength)),
+			Family:      proto.AddressFamily(rMesg.Family),
+			Protocol:    proto.RouteProtocol(rMesg.Protocol),
+			Flags:       rMesg.Flags,
+		})
+
+	}
+	return &proto.RoutesReply{
+		Routes: routes,
+	}, nil
+}
+
+// Interfaces returns the hosts network interfaces and addresses.
+func (r *Registrator) Interfaces(ctx context.Context, in *empty.Empty) (reply *proto.InterfacesReply, err error) {
+	var (
+		ifaces  []*net.Interface
+		addrs   []string
+		ifaddrs []*net.IPNet
+	)
+
+	// List out all interfaces/links
+	ifaces, err = r.Networkd.Conn.Links()
+	if err != nil {
+		return reply, err
+	}
+
+	reply = &proto.InterfacesReply{}
+
+	for _, iface := range ifaces {
+		addrs = []string{}
+		// Gather addresses configured on the given interface
+		// both ipv4 and ipv6
+		for _, fam := range []int{unix.AF_INET, unix.AF_INET6} {
+			ifaddrs, err = r.Networkd.Conn.Addrs(iface, fam)
+			if err != nil {
+				return reply, err
+			}
+
+			for _, ifaddr := range ifaddrs {
+				addrs = append(addrs, ifaddr.String())
+			}
+		}
+
+		ifmsg := &proto.Interface{
+			Index:        uint32(iface.Index),
+			Mtu:          uint32(iface.MTU),
+			Name:         iface.Name,
+			Hardwareaddr: iface.HardwareAddr.String(),
+			Flags:        proto.InterfaceFlags(iface.Flags),
+			Ipaddress:    addrs,
+		}
+
+		reply.Interfaces = append(reply.Interfaces, ifmsg)
+	}
+
+	return reply, nil
+}
+
+func toCIDR(family uint8, prefix net.IP, prefixLen int) string {
+	var netLen = 32
+	if family == unix.AF_INET6 {
+		netLen = 128
+	}
+	ipNet := &net.IPNet{
+		IP:   prefix,
+		Mask: net.CIDRMask(prefixLen, netLen),
+	}
+	return ipNet.String()
+}

--- a/internal/app/networkd/pkg/reg/reg_test.go
+++ b/internal/app/networkd/pkg/reg/reg_test.go
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
+	"github.com/talos-systems/talos/internal/app/networkd/proto"
+	"github.com/talos-systems/talos/pkg/grpc/factory"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc"
+)
+
+type NetworkdSuite struct {
+	suite.Suite
+}
+
+func TestNetworkdSuite(t *testing.T) {
+	// Hide all our state transition messages
+	//log.SetOutput(ioutil.Discard)
+	suite.Run(t, new(NetworkdSuite))
+}
+
+// nolint: dupl
+func (suite *NetworkdSuite) TestRoutes() {
+	server, listener := suite.fakeNetworkdRPC()
+
+	// nolint: errcheck
+	defer os.Remove(listener.Addr().String())
+
+	defer server.Stop()
+
+	// nolint: errcheck
+	go server.Serve(listener)
+
+	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	suite.Assert().NoError(err)
+	nClient := proto.NewNetworkdClient(conn)
+
+	resp, err := nClient.Routes(context.Background(), &empty.Empty{})
+	suite.Assert().NoError(err)
+	suite.Assert().Greater(len(resp.Routes), 0)
+}
+
+// nolint: dupl
+func (suite *NetworkdSuite) TestInterfaces() {
+	server, listener := suite.fakeNetworkdRPC()
+
+	// nolint: errcheck
+	defer os.Remove(listener.Addr().String())
+
+	defer server.Stop()
+
+	// nolint: errcheck
+	go server.Serve(listener)
+
+	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	suite.Assert().NoError(err)
+	nClient := proto.NewNetworkdClient(conn)
+
+	resp, err := nClient.Interfaces(context.Background(), &empty.Empty{})
+	suite.Assert().NoError(err)
+	suite.Assert().Greater(len(resp.Interfaces), 0)
+}
+
+func (suite *NetworkdSuite) fakeNetworkdRPC() (*grpc.Server, net.Listener) {
+	// Create networkd instance
+	n, err := networkd.New()
+	suite.Assert().NoError(err)
+
+	// Create gRPC server
+	api := NewRegistrator(n)
+	server := factory.NewServer(api)
+	tmpfile, err := ioutil.TempFile("", "networkd")
+	suite.Assert().NoError(err)
+
+	listener, err := factory.NewListener(
+		factory.Network("unix"),
+		factory.SocketPath(tmpfile.Name()),
+	)
+	suite.Assert().NoError(err)
+
+	return server, listener
+}
+
+func (suite *NetworkdSuite) TestToCIDR() {
+	suite.Assert().Equal(toCIDR(unix.AF_INET, net.ParseIP("192.168.254.0"), 24), "192.168.254.0/24")
+	suite.Assert().Equal(toCIDR(unix.AF_INET6, net.ParseIP("2001:db8::"), 16), "2001:db8::/16")
+}

--- a/internal/app/networkd/proto/api.proto
+++ b/internal/app/networkd/proto/api.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+
+package proto;
+
+import "google/protobuf/empty.proto";
+
+// The Init service definition.
+service Networkd {
+  rpc Routes(google.protobuf.Empty) returns (RoutesReply) {}
+  rpc Interfaces(google.protobuf.Empty) returns(InterfacesReply) {}
+}
+
+enum AddressFamily {
+   option allow_alias = true;
+   AF_UNSPEC = 0x0;
+   AF_INET = 0x2;
+   IPV4 = 0x2;
+   AF_INET6 = 0xa;
+   IPV6 = 0xa;
+}
+
+enum RouteProtocol {
+   RTPROT_UNSPEC = 0;
+   RTPROT_REDIRECT = 1;  // Route installed by ICMP redirects
+   RTPROT_KERNEL = 2;    // Route installed by kernel
+   RTPROT_BOOT = 3;      // Route installed during boot
+   RTPROT_STATIC = 4;    // Route installed by administrator
+   RTPROT_GATED = 8;     // Route installed by gated
+   RTPROT_RA = 9;        // Route installed by router advertisement
+   RTPROT_MRT = 10;      // Route installed by Merit MRT
+   RTPROT_ZEBRA = 11;    // Route installed by Zebra/Quagga
+   RTPROT_BIRD = 12;     // Route installed by Bird
+   RTPROT_DNROUTED = 13; // Route installed by DECnet routing daemon
+   RTPROT_XORP = 14;     // Route installed by XORP
+   RTPROT_NTK = 15;      // Route installed by Netsukuku
+   RTPROT_DHCP = 16;     // Route installed by DHCP
+   RTPROT_MROUTED = 17;  // Route installed by Multicast daemon
+   RTPROT_BABEL = 42;    // Route installed by Babel daemon
+}
+
+enum InterfaceFlags {
+  FlagUnknown = 0;
+	FlagUp = 1;
+  FlagBroadcast = 2;
+  FlagLoopback = 3;
+  FlagPointToPoint = 4;
+  FlagMulticast = 5;
+}
+
+// The response message containing the routes.
+message RoutesReply { repeated Route routes = 1; }
+
+// The response message containing a route.
+message Route {
+
+  // Interface is the interface over which traffic to this destination should be sent
+  string interface = 1;
+
+  // Destination is the network prefix CIDR which this route provides
+  string destination = 2;
+
+  // Gateway is the gateway address to which traffic to this destination should be sent
+  string gateway = 3;
+
+  // Metric is the priority of the route, where lower metrics have higher priorities
+  uint32 metric = 4;
+
+  // Scope desribes the scope of this route
+  uint32 scope = 5;
+
+  // Source is the source prefix CIDR for the route, if one is defined
+  string source = 6;
+
+  // Family is the address family of the route.  Currently, the only options are AF_INET (IPV4) and AF_INET6 (IPV6).
+  AddressFamily family = 7;
+
+  // Protocol is the protocol by which this route came to be in place
+  RouteProtocol protocol = 8;
+
+  // Flags indicate any special flags on the route
+  uint32 flags = 9;
+}
+
+message InterfacesReply { repeated Interface interfaces = 1; }
+
+// Interface represents a net.Interface
+message Interface {
+	uint32 index = 1;
+	uint32 mtu = 2;
+  string name = 3;
+  string hardwareaddr = 4;
+  InterfaceFlags flags = 5;
+  repeated string ipaddress = 6;
+}

--- a/internal/app/osd/internal/reg/networkd_client.go
+++ b/internal/app/osd/internal/reg/networkd_client.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reg // nolint: dupl
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/talos-systems/talos/internal/app/networkd/proto"
+	"github.com/talos-systems/talos/pkg/constants"
+	"google.golang.org/grpc"
+)
+
+// NetworkdClient is a gRPC client for init service API
+type NetworkdClient struct {
+	proto.NetworkdClient
+}
+
+// NewNetworkdClient initializes new client and connects to networkd
+func NewNetworkdClient() (*NetworkdClient, error) {
+	conn, err := grpc.Dial("unix:"+constants.NetworkdSocketPath,
+		grpc.WithInsecure(),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetworkdClient{
+		NetworkdClient: proto.NewNetworkdClient(conn),
+	}, nil
+}
+
+// Routes returns the hosts routing table.
+func (c *NetworkdClient) Routes(ctx context.Context, in *empty.Empty) (*proto.RoutesReply, error) {
+	return c.NetworkdClient.Routes(ctx, in)
+}
+
+// Interfaces returns the hosts network interfaces and addresses.
+func (c *NetworkdClient) Interfaces(ctx context.Context, in *empty.Empty) (*proto.InterfacesReply, error) {
+	return c.NetworkdClient.Interfaces(ctx, in)
+}

--- a/internal/app/osd/internal/reg/ntp_client.go
+++ b/internal/app/osd/internal/reg/ntp_client.go
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package reg
+package reg // nolint: dupl
 
 import (
 	"context"

--- a/internal/app/osd/internal/reg/reg_test.go
+++ b/internal/app/osd/internal/reg/reg_test.go
@@ -3,16 +3,3 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package reg
-
-import (
-	"net"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
-)
-
-func TestToCIDR(t *testing.T) {
-	assert.Equal(t, toCIDR(unix.AF_INET, net.ParseIP("192.168.254.0"), 24), "192.168.254.0/24")
-	assert.Equal(t, toCIDR(unix.AF_INET6, net.ParseIP("2001:db8::"), 16), "2001:db8::/16")
-}

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -61,12 +61,18 @@ func main() {
 		log.Fatalf("ntp client: %v", err)
 	}
 
+	networkdClient, err := reg.NewNetworkdClient()
+	if err != nil {
+		log.Fatalf("networkd client: %v", err)
+	}
+
 	log.Println("Starting osd")
 	err = factory.ListenAndServe(
 		&reg.Registrator{
 			Data:              data,
 			InitServiceClient: initClient,
 			NtpdClient:        ntpdClient,
+			NetworkdClient:    networkdClient,
 		},
 		factory.Port(constants.OsdPort),
 		factory.ServerOptions(

--- a/internal/app/osd/proto/api.proto
+++ b/internal/app/osd/proto/api.proto
@@ -14,7 +14,6 @@ service OSD {
   rpc Logs(LogsRequest) returns (stream Data) {}
   rpc Processes(ProcessesRequest) returns (ProcessesReply) {}
   rpc Restart(RestartRequest) returns (RestartReply) {}
-  rpc Routes(google.protobuf.Empty) returns (RoutesReply) {}
   rpc Stats(StatsRequest) returns (StatsReply) {}
   rpc Top(google.protobuf.Empty) returns (TopReply) {}
   rpc Version(google.protobuf.Empty) returns (Data) {}
@@ -87,68 +86,6 @@ message LogsRequest {
 
 // The response message containing the requested logs.
 message Data { bytes bytes = 1; }
-
-// The response message containing the routes.
-message RoutesReply { repeated Route routes = 1; }
-
-// The response message containing a route.
-message Route {
-
-  // Interface is the interface over which traffic to this destination should be sent
-  string interface = 1;
-
-  // Destination is the network prefix CIDR which this route provides
-  string destination = 2;
-
-  // Gateway is the gateway address to which traffic to this destination should be sent
-  string gateway = 3;
-
-  // Metric is the priority of the route, where lower metrics have higher priorities
-  uint32 metric = 4;
-
-  // Scope desribes the scope of this route
-  uint32 scope = 5;
-
-  // Source is the source prefix CIDR for the route, if one is defined
-  string source = 6;
-
-  // Family is the address family of the route.  Currently, the only options are AF_INET (IPV4) and AF_INET6 (IPV6).
-  AddressFamily family = 7;
-
-  // Protocol is the protocol by which this route came to be in place
-  RouteProtocol protocol = 8;
-
-  // Flags indicate any special flags on the route
-  uint32 flags = 9;
-}
-
-enum AddressFamily {
-   option allow_alias = true;
-   AF_UNSPEC = 0x0;
-   AF_INET = 0x2;
-   IPV4 = 0x2;
-   AF_INET6 = 0xa;
-   IPV6 = 0xa;
-}
-
-enum RouteProtocol {
-   RTPROT_UNSPEC = 0;
-   RTPROT_REDIRECT = 1;  // Route installed by ICMP redirects
-   RTPROT_KERNEL = 2;    // Route installed by kernel
-   RTPROT_BOOT = 3;      // Route installed during boot
-   RTPROT_STATIC = 4;    // Route installed by administrator
-   RTPROT_GATED = 8;     // Route installed by gated
-   RTPROT_RA = 9;        // Route installed by router advertisement
-   RTPROT_MRT = 10;      // Route installed by Merit MRT
-   RTPROT_ZEBRA = 11;    // Route installed by Zebra/Quagga
-   RTPROT_BIRD = 12;     // Route installed by Bird
-   RTPROT_DNROUTED = 13; // Route installed by DECnet routing daemon
-   RTPROT_XORP = 14;     // Route installed by XORP
-   RTPROT_NTK = 15;      // Route installed by Netsukuku
-   RTPROT_DHCP = 16;     // Route installed by DHCP
-   RTPROT_MROUTED = 17;  // Route installed by Multicast daemon
-   RTPROT_BABEL = 42;    // Route installed by Babel daemon
-}
 
 message TopRequest {}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -154,6 +154,9 @@ const (
 	// NtpdSocketPath is the path to file socket of proxyd API
 	NtpdSocketPath = "/run/system/ntpd/ntpd.sock"
 
+	// NetworkdSocketPath is the path to file socket of proxyd API
+	NetworkdSocketPath = "/run/system/networkd/networkd.sock"
+
 	// KernelAsset defines a well known name for our kernel filename
 	KernelAsset = "vmlinuz"
 


### PR DESCRIPTION
Allows us to list routes and interface details. This includes moving routes() from osd to networkd

```
~/go/src/github.com/talos-systems/talos/qemu
[23:42:34] $ ../build/osctl-darwin-amd64 --talosconfig talosconfig routes
INTERFACE   DESTINATION                   GATEWAY      METRIC
eth0        <nil>                         10.254.0.2   0
eth0        10.254.0.0/24                 <nil>        0
eth0        10.254.0.0/32                 <nil>        0
eth0        10.254.0.10/32                <nil>        0
eth0        10.254.0.255/32               <nil>        0
lo          127.0.0.0/32                  <nil>        0
lo          127.0.0.0/8                   <nil>        0
lo          127.0.0.1/32                  <nil>        0
lo          127.255.255.255/32            <nil>        0
lo          ::1/128                       <nil>        0
eth0        fe80::5054:ff:fe12:3456/128   <nil>        0
eth0        fe80::/64                     <nil>        256
eth0        ff00::/8                      <nil>        256
~/go/src/github.com/talos-systems/talos/qemu
[23:42:36] $ ../build/osctl-darwin-amd64 --talosconfig talosconfig interfaces
Index   Name   MAC                 MTU     Address
1       lo     00:00:00:00:00:00   65536   127.0.0.1/8
1       lo     00:00:00:00:00:00   65536   ::1/128
4       eth0   52:54:00:12:34:56   1500    10.254.0.10/24
4       eth0   52:54:00:12:34:56   1500    fe80::5054:ff:fe12:3456/64
```


Signed-off-by: Brad Beam <brad.beam@talos-systems.com>
