### PR TITLE
chore: fix qemu-boot.sh

### DIFF
--- a/hack/dev/qemu-boot.sh
+++ b/hack/dev/qemu-boot.sh
@@ -8,7 +8,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 case $(uname -s) in
-  LINUX*)
+  Linux*)
     ACCEL=kvm
     ;;
 


### PR DESCRIPTION
Fixes a typo that cased the switch statement to not match Linux
environments.