### PR TITLE
fix: leave etcd when upgrading control plane node

### DIFF
--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -148,6 +148,7 @@ func (d *Sequencer) Upgrade(req *proto.UpgradeRequest) error {
 		phase.NewPhase(
 			"cordon and drain node",
 			kubernetes.NewCordonAndDrainTask(),
+			upgrade.NewLeaveEtcdTask(),
 		),
 		phase.NewPhase(
 			"stop services",


### PR DESCRIPTION
We need to remove the current node from etcd when upgrading.