### PR TITLE
fix(networkd): Fix hostname retrieval

### DIFF
--- a/internal/app/networkd/pkg/address/address.go
+++ b/internal/app/networkd/pkg/address/address.go
@@ -16,18 +16,19 @@ import (
 // addressing configuration. Currently dhcp(v4) and static methods are
 // supported.
 type Addressing interface {
-	Name() string
-	Discover(context.Context) error
 	Address() *net.IPNet
-	Mask() net.IPMask
-	MTU() uint32
-	TTL() time.Duration
+	Discover(context.Context) error
 	Family() int
-	Scope() uint8
-	Routes() []*Route
-	Resolvers() []net.IP
 	Hostname() string
 	Link() *net.Interface
+	MTU() uint32
+	Mask() net.IPMask
+	Name() string
+	Resolvers() []net.IP
+	Routes() []*Route
+	Scope() uint8
+	TTL() time.Duration
+	Valid() bool
 }
 
 // Route is a representation of a network route

--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -87,6 +87,11 @@ func (d *DHCP) Scope() uint8 {
 	return unix.RT_SCOPE_UNIVERSE
 }
 
+// Valid denotes if this address method should be used.
+func (d *DHCP) Valid() bool {
+	return d.Ack != nil
+}
+
 // Routes aggregates all Routers and ClasslessStaticRoutes retrieved from
 // the DHCP offer.
 // rfc3442:

--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -102,3 +102,8 @@ func (s *Static) Hostname() string {
 func (s Static) Link() *net.Interface {
 	return s.NetIf
 }
+
+// Valid denotes if this address method should be used.
+func (s *Static) Valid() bool {
+	return true
+}

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -98,6 +98,10 @@ func (n *Networkd) Configure(ifaces ...*nic.NetworkInterface) error {
 				continue
 			}
 
+			if !method.Valid() {
+				continue
+			}
+
 			// Aggregate a list of DNS servers/resolvers
 			resolvers = append(resolvers, method.Resolvers()...)
 		}
@@ -219,6 +223,9 @@ func (n *Networkd) configureInterface(method address.Addressing) error {
 func (n *Networkd) Hostname(ifaces ...*nic.NetworkInterface) string {
 	for _, iface := range ifaces {
 		for _, method := range iface.AddressMethod {
+			if !method.Valid() {
+				continue
+			}
 			if method.Hostname() != "" {
 				return method.Hostname()
 			}


### PR DESCRIPTION
If multiple interfaces exist on a node, but the first interface was unsuccessful
in getting a dhcp response, we would seg fault when trying to retrieve the hostname
for that interface. This was due to d.Ack being nil and us having no guard around it

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>