### PR TITLE
chore: fix location of Go build cache mount for unit-tests-race

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -310,7 +310,7 @@ COPY --from=base /go/pkg/mod /go/pkg/mod
 WORKDIR /src
 ENV GO111MODULE on
 ARG TESTPKGS
-RUN --mount=type=cache,target=/.cache/go-build go test -v -race ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build go test -v -race ${TESTPKGS}
 
 # The lint target performs linting on the source code.
 


### PR DESCRIPTION
This step is based on `golang` image, so `GOCACHE` is set in a bit of a
different way.

No big deal, but should speed up subsequent runs a bit.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>