### PR TITLE
chore: disable go test result cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -310,7 +310,7 @@ COPY --from=base /go/pkg/mod /go/pkg/mod
 WORKDIR /src
 ENV GO111MODULE on
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build go test -v -race ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build go test -v -count 1 -race ${TESTPKGS}
 
 # The lint target performs linting on the source code.
 

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -4,12 +4,12 @@ set -e
 
 perform_tests() {
   echo "Performing tests on $1"
-  go test -v -covermode=atomic -coverprofile=coverage.txt "$1"
+  go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 "$1"
 }
 
 perform_short_tests() {
   echo "Performing short tests on $1"
-  go test -v -short "$1"
+  go test -v -short -count 1 "$1"
 }
 
 case $1 in


### PR DESCRIPTION
Go by default caches unit-tests results via build cache, so if source
code doesn't have any changes, test results are cached on package level.
As our unit-tests are not that pure and depend on the environment, it
would be more helpful to make sure all the unit-tests during each build.

Setting number of test runs to one disable test result cache (but build
cache is still being used).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>