### PR TITLE
fix: increase retries for DHCP

### DIFF
--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -151,7 +151,10 @@ func (d *DHCP) discover() (*dhcpv4.DHCPv4, error) {
 
 	// TODO expose this ( nclient4.WithDebugLogger() ) with some
 	// debug logging option
-	cli, err := nclient4.New(d.NetIf.Name, nclient4.WithTimeout(2*time.Second))
+	cli, err := nclient4.New(d.NetIf.Name,
+		nclient4.WithTimeout(2*time.Second),
+		nclient4.WithRetry(5),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Increased retry count to 6 for DHCP.  In my testing, this worked
reliably in my setup, where the default (3) did not.

Ultimately, this should probably be configurable from the userdata.
Instead, this just makes it work for me.

Fixes #1099

Signed-off-by: Seán C McCord <ulexus@gmail.com>