### PR TITLE
chore: make TestContainerdSuite/TestRunTwice more robust

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -140,8 +140,10 @@ func (suite *ContainerdSuite) TestRunSuccess() {
 }
 
 func (suite *ContainerdSuite) TestRunTwice() {
+	const ID = "runtwice"
+
 	r := containerdrunner.NewRunner(&userdata.UserData{}, &runner.Args{
-		ID:          "runtwice",
+		ID:          ID,
 		ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
 	},
 		runner.WithLogPath(suite.tmpDir),
@@ -161,7 +163,12 @@ func (suite *ContainerdSuite) TestRunTwice() {
 		suite.Assert().NoError(r.Stop())
 
 		// TODO: workaround containerd (?) bug: https://github.com/docker/for-linux/issues/643
-		time.Sleep(100 * time.Millisecond)
+		for i := 0; i < 100; i++ {
+			time.Sleep(100 * time.Millisecond)
+			if _, err := os.Stat("/containerd-shim/" + containerdNamespace + "/" + ID + "/shim.sock"); err != nil && os.IsNotExist(err) {
+				break
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #1010

Wait for containerd shim socket to be removed before running container
second time.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>