### PR TITLE
fix(machined): limit max stderr output, use pkg/cmd consistently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace github.com/jsimonetti/rtnetlink => github.com/bradbeam/rtnetlink v0.0.0-
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c
+	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/beevik/ntp v0.2.0
 	github.com/containerd/cgroups v0.0.0-20190328223300-4994991857f9
 	github.com/containerd/containerd v1.2.7

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=

--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -7,12 +7,12 @@ package services
 import (
 	"context"
 	"fmt"
-	"os/exec"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/pkg/cmd"
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
@@ -27,12 +27,11 @@ func (c *Udevd) ID(data *userdata.UserData) string {
 
 // PreFunc implements the Service interface.
 func (c *Udevd) PreFunc(ctx context.Context, data *userdata.UserData) error {
-	cmd := exec.Command(
+	return cmd.Run(
 		"/sbin/udevadm",
 		"hwdb",
 		"--update",
 	)
-	return cmd.Run()
 }
 
 // PostFunc implements the Service interface.

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -5,24 +5,30 @@
 package cmd
 
 import (
-	"bytes"
 	"os/exec"
 
+	"github.com/armon/circbuf"
 	"github.com/pkg/errors"
 )
+
+// MaxStderrLen is maximum length of stderr output captured for error message
+const MaxStderrLen = 4096
 
 // Run executes a command.
 func Run(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+	stderr, err := circbuf.NewBuffer(MaxStderrLen)
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = stderr
 
-	if err := cmd.Start(); err != nil {
+	if err = cmd.Start(); err != nil {
 		return errors.Errorf("%s: %s", err, stderr.String())
 	}
 
-	if err := cmd.Wait(); err != nil {
+	if err = cmd.Wait(); err != nil {
 		return errors.Errorf("%s: %s", err, stderr.String())
 	}
 


### PR DESCRIPTION
Use circular buffer instead of (unlimited) `bytes.Buffer` to limit
amount of stderr output captured. If command being run produces too much
output on stderr, this might consume too much RAM.

Use `pkg/cmd` to run command in `udevd` service. This should allow
easier udevd integration.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>