### PR TITLE
fix: set default install image

### DIFF
--- a/internal/app/machined/internal/runtime/initializer/metal/metal.go
+++ b/internal/app/machined/internal/runtime/initializer/metal/metal.go
@@ -5,6 +5,7 @@
 package metal
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 // Metal represents an initializer that performs a full installation to a
@@ -46,6 +48,9 @@ func (b *Metal) Initialize(platform platform.Platform, data *userdata.UserData) 
 	var mountpoints *mount.Points
 	mountpoints, err = owned.MountPointsFromLabels()
 	if err != nil {
+		if data.Install.Image == "" {
+			data.Install.Image = fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, version.Tag)
+		}
 		if err = install.Install(data.Install.Image, data.Install.Disk, strings.ToLower(platform.Name())); err != nil {
 			return err
 		}

--- a/internal/pkg/installer/manifest/verify.go
+++ b/internal/pkg/installer/manifest/verify.go
@@ -5,13 +5,10 @@
 package manifest
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"github.com/talos-systems/talos/pkg/version"
 )
 
 // VerifyDataDevice verifies the supplied data device options.
@@ -49,10 +46,6 @@ func VerifyBootDevice(data *userdata.UserData) (err error) {
 		// because VerifyDataDevice should have been called first in
 		// in the chain, but we verify again just in case.
 		return errors.New("missing disk")
-	}
-
-	if data.Install.Image == "" {
-		data.Install.Image = fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, version.Tag)
 	}
 
 	if !data.Install.Force {


### PR DESCRIPTION
This sets the default install image just before installation. It was
erroneously placed in the boot verification.