### PR TITLE
chore(machined): implement process reaper for PID 1 machined process

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/internal/sequencer"
 	"github.com/talos-systems/talos/internal/app/machined/proto"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/proc/reaper"
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
@@ -85,6 +86,10 @@ func main() {
 	defer close(init.Channel())
 	event.Bus().Register(init)
 	defer event.Bus().Unregister(init)
+
+	// Initialize process reaper.
+	reaper.Run()
+	defer reaper.Shutdown()
 
 	// Ensure rng is seeded.
 	if err = startup.RandSeed(); err != nil {

--- a/internal/app/machined/pkg/system/log/log.go
+++ b/internal/app/machined/pkg/system/log/log.go
@@ -27,14 +27,15 @@ type Log struct {
 
 // New initializes and registers a log for a service.
 func New(name, rootPath string) (*Log, error) {
+	logpath := FormatLogPath(name, rootPath)
+
 	mu.Lock()
-	if l, ok := instance[name]; ok {
+	if l, ok := instance[logpath]; ok {
 		mu.Unlock()
 		return l, nil
 	}
 	mu.Unlock()
 
-	logpath := FormatLogPath(name, rootPath)
 	w, err := os.Create(logpath)
 	if err != nil {
 		return nil, fmt.Errorf("create log file: %s", err.Error())
@@ -47,7 +48,7 @@ func New(name, rootPath string) (*Log, error) {
 	}
 
 	mu.Lock()
-	instance[name] = l
+	instance[l.Path] = l
 	mu.Unlock()
 
 	return l, nil
@@ -61,7 +62,7 @@ func (l *Log) Write(p []byte) (n int, err error) {
 // Close implements io.WriteCloser.
 func (l *Log) Close() error {
 	mu.Lock()
-	delete(instance, l.Name)
+	delete(instance, l.Path)
 	mu.Unlock()
 
 	return l.source.Close()

--- a/pkg/proc/reaper/hunter.go
+++ b/pkg/proc/reaper/hunter.go
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reaper
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+type zombieHunter struct {
+	mu sync.Mutex
+
+	running   bool
+	listeners map[chan<- ProcessInfo]struct{}
+	shutdown  chan struct{}
+}
+
+func (zh *zombieHunter) Run() {
+	zh.mu.Lock()
+	defer zh.mu.Unlock()
+
+	if zh.running {
+		panic("zombie hunter is already running")
+	}
+	zh.running = true
+
+	zh.shutdown = make(chan struct{})
+	zh.listeners = make(map[chan<- ProcessInfo]struct{})
+
+	go zh.run()
+}
+
+func (zh *zombieHunter) Shutdown() {
+	zh.mu.Lock()
+	running := zh.running
+	zh.mu.Unlock()
+
+	if !running {
+		return
+	}
+
+	zh.shutdown <- struct{}{}
+	<-zh.shutdown
+}
+
+func (zh *zombieHunter) Notify(ch chan<- ProcessInfo) bool {
+	zh.mu.Lock()
+	defer zh.mu.Unlock()
+
+	if !zh.running {
+		return false
+	}
+
+	zh.listeners[ch] = struct{}{}
+	return true
+}
+
+func (zh *zombieHunter) Stop(ch chan<- ProcessInfo) {
+	zh.mu.Lock()
+	defer zh.mu.Unlock()
+
+	delete(zh.listeners, ch)
+}
+
+func (zh *zombieHunter) run() {
+	sigCh := make(chan os.Signal, 1)
+
+	signal.Notify(sigCh, syscall.SIGCHLD)
+	defer signal.Stop(sigCh)
+
+	for {
+		// wait for SIGCHLD
+		select {
+		case <-sigCh:
+		case <-zh.shutdown:
+			zh.mu.Lock()
+			zh.running = false
+			zh.mu.Unlock()
+
+			zh.shutdown <- struct{}{}
+			return
+		}
+
+		// reap all the zombies
+		zh.reapLoop()
+	}
+}
+
+// reapLoop processes all the known zombies at the moment
+func (zh *zombieHunter) reapLoop() {
+	for {
+		var (
+			wstatus syscall.WaitStatus
+			pid     int
+			err     error
+		)
+
+		for {
+			// retry EINTR on wait4()
+			pid, err = syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
+			if err != syscall.EINTR {
+				break
+			}
+		}
+
+		if err == syscall.ECHILD || pid == 0 {
+			// no more zombies
+			return
+		}
+
+		if err != nil {
+			log.Printf("zombie reaper error in wait4: %s", err)
+			return
+		}
+
+		zh.send(pid, wstatus)
+	}
+}
+
+// send notification about reaped zombie to all listeners
+func (zh *zombieHunter) send(pid int, wstatus syscall.WaitStatus) {
+	zh.mu.Lock()
+	listeners := make([]chan<- ProcessInfo, 0, len(zh.listeners))
+	for ch := range zh.listeners {
+		listeners = append(listeners, ch)
+	}
+	zh.mu.Unlock()
+
+	notification := ProcessInfo{
+		Pid:    pid,
+		Status: wstatus,
+	}
+
+	for _, listener := range listeners {
+		select {
+		case listener <- notification:
+		default:
+			// drop notifications if listener is not keeping up
+		}
+	}
+}

--- a/pkg/proc/reaper/reaper.go
+++ b/pkg/proc/reaper/reaper.go
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Package reaper implements zombie process reaper with notifications.
+package reaper
+
+import "syscall"
+
+// Run launches loop for the zombie process reaper.
+func Run() {
+	hunter.Run()
+}
+
+// Shutdown stops the process reaper.
+func Shutdown() {
+	hunter.Shutdown()
+}
+
+// ProcessInfo describes reaped zombie process.
+type ProcessInfo struct {
+	Pid    int
+	Status syscall.WaitStatus
+}
+
+// Notify causes reaper to deliver notifications about reaped zombies.
+//
+// If Notify returns false, reaper is not running, and Notify does nothing.
+func Notify(ch chan<- ProcessInfo) bool {
+	return hunter.Notify(ch)
+}
+
+// Stop sending notifications to the channel.
+func Stop(ch chan<- ProcessInfo) {
+	hunter.Stop(ch)
+}
+
+// Singleton instance of zombieHunter
+var hunter = &zombieHunter{}

--- a/pkg/proc/reaper/reaper_test.go
+++ b/pkg/proc/reaper/reaper_test.go
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reaper_test
+
+import (
+	"os/exec"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/pkg/proc/reaper"
+)
+
+type ReaperSuite struct {
+	suite.Suite
+}
+
+func (suite *ReaperSuite) SetupSuite() {
+	reaper.Run()
+}
+
+func (suite *ReaperSuite) TearDownSuite() {
+	reaper.Shutdown()
+}
+
+func (suite *ReaperSuite) TestNoActivity() {
+}
+
+func (suite *ReaperSuite) TestNoNotify() {
+	const N = 5
+	commands := make([]*exec.Cmd, N)
+
+	for i := range commands {
+		commands[i] = exec.Command("/bin/sh", "-c", ":")
+		suite.Assert().NoError(commands[i].Start())
+	}
+
+	// let the reaper do the work
+	time.Sleep(time.Second)
+
+	// zombies should have been reaped, so `Wait()` should fail
+	for i := range commands {
+		suite.Assert().EqualError(commands[i].Wait(), "waitid: no child processes")
+	}
+}
+
+//nolint: gocyclo
+func (suite *ReaperSuite) TestNotifyStop() {
+	const N = 5
+	commands := make([]*exec.Cmd, N)
+
+	notifyCh := make([]chan reaper.ProcessInfo, 2)
+	for j := range notifyCh {
+		notifyCh[j] = make(chan reaper.ProcessInfo, N)
+		reaper.Notify(notifyCh[j])
+	}
+
+	expectedPids := make([]int, N)
+
+	for i := range commands {
+		commands[i] = exec.Command("/bin/sh", "-c", ":")
+		suite.Require().NoError(commands[i].Start())
+		expectedPids[i] = commands[i].Process.Pid
+	}
+
+	sort.Ints(expectedPids)
+
+	for _, ch := range notifyCh {
+		gotPids := make([]int, N)
+		for i := range gotPids {
+			info := <-ch
+			suite.T().Log(info)
+			gotPids[i] = info.Pid
+
+			suite.Assert().True(info.Status.Exited())
+			suite.Assert().Equal(0, info.Status.ExitStatus())
+		}
+		sort.Ints(gotPids)
+
+		suite.Assert().Equal(expectedPids, gotPids)
+	}
+
+	// zombies should have been reaped, so `Wait()` should fail
+	for i := range commands {
+		suite.Assert().EqualError(commands[i].Wait(), "waitid: no child processes")
+	}
+
+	for _, ch := range notifyCh {
+		select {
+		case <-ch:
+			suite.Require().Fail("there should be no more notifications in the channel")
+		default:
+		}
+	}
+
+	reaper.Stop(notifyCh[0])
+
+	command := exec.Command("/bin/sh", "-c", ":")
+	suite.Require().NoError(command.Start())
+
+	// notification should come on still active notify channel
+	<-notifyCh[1]
+
+	select {
+	case <-notifyCh[0]:
+		suite.Require().Fail("there should be no notifications after Stop")
+	default:
+	}
+
+	for j := range notifyCh {
+		reaper.Stop(notifyCh[j])
+	}
+}
+
+func (suite *ReaperSuite) TestFailedProcess() {
+	notifyCh := make(chan reaper.ProcessInfo, 1)
+	reaper.Notify(notifyCh)
+	defer reaper.Stop(notifyCh)
+
+	command := exec.Command("/bin/sh", "-c", "exit 3")
+	suite.Require().NoError(command.Start())
+
+	info := <-notifyCh
+
+	suite.Assert().Equal(command.Process.Pid, info.Pid)
+	suite.Assert().True(info.Status.Exited())
+	suite.Assert().Equal(3, info.Status.ExitStatus())
+	suite.Assert().EqualError(command.Wait(), "waitid: no child processes")
+}
+
+func (suite *ReaperSuite) TestWait() {
+	type args struct {
+		name string
+		args []string
+	}
+	tests := []struct {
+		args      args
+		errString string
+	}{
+		{
+			args{
+				"true",
+				[]string{},
+			},
+			"",
+		},
+		{
+			args{
+				"false",
+				[]string{},
+			},
+			"exit status 1",
+		},
+		{
+			args{
+				"/bin/sh",
+				[]string{
+					"-c",
+					"kill -2 $$",
+				},
+			},
+			"signal: interrupt",
+		},
+	}
+
+	notifyCh := make(chan reaper.ProcessInfo, 1)
+	suite.Require().True(reaper.Notify(notifyCh))
+	defer reaper.Stop(notifyCh)
+
+	for _, t := range tests {
+		cmd := exec.Command(t.args.name, t.args.args...)
+		suite.Require().NoError(cmd.Start())
+
+		err := reaper.WaitWrapper(true, notifyCh, cmd)
+		if t.errString == "" {
+			suite.Assert().NoError(err)
+		} else {
+			suite.Assert().EqualError(err, t.errString)
+		}
+	}
+}
+
+func TestReaperSuite(t *testing.T) {
+	suite.Run(t, new(ReaperSuite))
+}

--- a/pkg/proc/reaper/wait.go
+++ b/pkg/proc/reaper/wait.go
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package reaper
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// WaitWrapper emulates os/exec.Command.Wait() when reaper is running.
+//
+// WaitWrapper(true, cmd) should be equivalent to cmd.Wait().
+func WaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, cmd *exec.Cmd) error {
+	if !usingReaper {
+		return cmd.Wait()
+	}
+
+	var info ProcessInfo
+
+	for info = range notifyCh {
+		if info.Pid == cmd.Process.Pid && (info.Status.Exited() || info.Status.Signaled()) {
+			break
+		}
+	}
+
+	err := convertWaitStatus(info.Status)
+
+	// still do cmd.Wait() to release any resources
+	waitErr := cmd.Wait()
+	if err == nil && waitErr != nil && waitErr.Error() != "waitid: no child processes" {
+		err = waitErr
+	}
+
+	return err
+
+}
+
+func convertWaitStatus(status syscall.WaitStatus) error {
+	if status.Signaled() {
+		return errors.Errorf("signal: %s", status.Signal())
+	}
+
+	if status.Exited() && status.ExitStatus() != 0 {
+		return errors.Errorf("exit status %d", status.ExitStatus())
+	}
+
+	return nil
+}


### PR DESCRIPTION
In UNIX, any zombies without parent process get re-parented to process
with PID 1 (usually running init), and PID 1 process should take care of
them (usually simply clean them up). Cleaning up zombies is important,
as they still take kerner resources, and having enormous amount of
zombie processes signifcantly degrades system performance.

For Talos, PID 1 process is machined, and machined itself forks to run
other processes in process runner and `pkg/cmd` one-time commands. Naive
solution of running `wait()` loop doesn't work as it might race with
`Process.Wait()` and clean up zombie which wasn't re-parented which
leads to process execution false failure.

After considering other solutions, we decided to go with the simple
approach: machined runs global zombie process reaper which publishes
information about reaped zombies. Any call to `Process.Wait()` (or
`Command.Wait()` which calls it) should be replaced with listening to
reaper's channel for notifications to catch info about the process which
was created in this call.

There are several changes in this PR:

1. Reaper implementation itself, started from machined.

2. Process runner and `pkg/cmd` can either use regular `Command.Wait()`
or use reaper notifications depending on reaper status (running/not
running). This allows using this code outside of machined.

3. Small bug fixes with process log which was affecting the tests.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>