### PR TITLE
refactor(ntpd): Improvements to the robustness of ntp

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -27,6 +27,7 @@ policies:
           - kernel
           - machined
           - networkd
+          - ntpd
           - proxyd
           - osctl
           - osd

--- a/internal/app/ntpd/pkg/ntp/ntp.go
+++ b/internal/app/ntpd/pkg/ntp/ntp.go
@@ -5,93 +5,110 @@
 package ntp
 
 import (
-	"errors"
+	"fmt"
 	"log"
 	"math/rand"
 	"syscall"
 	"time"
 
 	"github.com/beevik/ntp"
-)
-
-// https://access.redhat.com/solutions/39194
-// Using the above as reference for setting min/max
-const (
-	MaxPoll = 1000
-	MinPoll = 20
+	"github.com/hashicorp/go-multierror"
 )
 
 // NTP contains a server address
-// and the most recent response from a query
 type NTP struct {
-	Server   string
-	Response *ntp.Response
+	Server  string
+	MinPoll time.Duration
+	MaxPoll time.Duration
+	Retry   int
 }
 
 // NewNTPClient instantiates a new ntp client for the
 // specified server
-func NewNTPClient(server string) *NTP {
-	return &NTP{Server: server}
+func NewNTPClient(opts ...Option) (*NTP, error) {
+	ntp := defaultOptions()
+
+	var result *multierror.Error
+	for _, setter := range opts {
+		result = multierror.Append(setter(ntp))
+	}
+
+	return ntp, result.ErrorOrNil()
 }
 
 // Daemon runs the control loop for query and set time
 // We dont ever want the daemon to stop, so we only log
 // errors
 func (n *NTP) Daemon() (err error) {
-	rando := rand.New(rand.NewSource(time.Now().UnixNano()))
-	ticker := time.NewTicker(time.Duration(rando.Intn(MaxPoll)+MinPoll) * time.Second)
 
 	// Do an initial hard set of time to ensure clock skew isnt too far off
 	var resp *ntp.Response
-	resp, err = n.Query()
-	if err != nil {
+	if resp, err = n.Query(); err != nil {
 		log.Printf("error querying %s for time, %s", n.Server, err)
 		return err
 	}
-	n.Response = resp
 
-	if err = n.SetTime(resp); err != nil {
+	if err = setTime(resp.Time); err != nil {
 		return err
 	}
 
+	var randSleep time.Duration
 	for {
-		<-ticker.C
-		// Set some variance with how frequently we poll ntp servers
-		resp, err = n.Query()
-		if err != nil {
+		// Set some variance with how frequently we poll ntp servers.
+		// This is based on rand(MaxPoll) + MinPoll so we wait at least
+		// MinPoll.
+		randSleep = time.Duration(rand.Intn(int(n.MaxPoll.Seconds()))) * time.Second
+		time.Sleep(randSleep + n.MinPoll)
+
+		if resp, err = n.Query(); err != nil {
 			// As long as we set initial time, we'll treat
 			// subsequent errors as nonfatal
 			log.Printf("error querying %s for time, %s", n.Server, err)
 			continue
 		}
-		n.Response = resp
 
-		if err = n.SetTime(resp); err != nil {
+		if err = adjustTime(resp.ClockOffset); err != nil {
 			log.Printf("failed to set time, %s", err)
 			continue
 		}
-		ticker = time.NewTicker(time.Duration(rando.Intn(MaxPoll)+MinPoll) * time.Second)
 	}
 }
 
-// Query polls the ntp server to get back a response
-// and saves it for later use
+// Query polls the ntp server and verifies a successful response.
 func (n *NTP) Query() (*ntp.Response, error) {
-	return ntp.Query(n.Server)
-}
 
-// SetTime sets the system time based on the query response
-func (n *NTP) SetTime(resp *ntp.Response) error {
-	// Not sure if this is the right thing to do
-	if resp == nil {
-		return errors.New("not a valid ntp response")
+	for i := 0; i < n.Retry; i++ {
+		resp, err := ntp.Query(n.Server)
+		if err != nil {
+			time.Sleep(time.Duration(i) * n.MinPoll)
+			continue
+		}
+
+		if err := resp.Validate(); err != nil {
+			time.Sleep(time.Duration(i) * n.MinPoll)
+			continue
+		}
+
+		return resp, nil
 	}
 
-	timeval := syscall.NsecToTimeval(resp.Time.UnixNano())
-	return syscall.Settimeofday(&timeval)
+	return nil, fmt.Errorf("failed to get a response back from ntp server after %d retries", n.Retry)
 }
 
 // GetTime returns the current system time
 func (n *NTP) GetTime() time.Time {
 	return time.Now()
+}
+
+// SetTime sets the system time based on the query response
+func setTime(adjustedTime time.Time) error {
+	log.Printf("setting time to %s", adjustedTime)
+
+	timeval := syscall.NsecToTimeval(adjustedTime.UnixNano())
+	return syscall.Settimeofday(&timeval)
+}
+
+// adjustTime adds an offset to the current time
+func adjustTime(offset time.Duration) error {
+	return setTime(time.Now().Add(offset))
 }

--- a/internal/app/ntpd/pkg/ntp/ntpd_test.go
+++ b/internal/app/ntpd/pkg/ntp/ntpd_test.go
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package ntp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type NtpSuite struct {
+	suite.Suite
+}
+
+func TestNtpSuite(t *testing.T) {
+	suite.Run(t, new(NtpSuite))
+}
+
+func (suite *NtpSuite) TestQuery() {
+	testServer := "time.cloudflare.com"
+	// Create ntp client
+	n, err := NewNTPClient(WithServer(testServer))
+	suite.Assert().NoError(err)
+
+	_, err = n.Query()
+	suite.Assert().NoError(err)
+}

--- a/internal/app/ntpd/pkg/ntp/options.go
+++ b/internal/app/ntpd/pkg/ntp/options.go
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package ntp
+
+import (
+	"fmt"
+	"time"
+)
+
+// Option allows for the configuration of the ntp client
+type Option func(*NTP) error
+
+const (
+	// MaxPoll is the 'recommended' interval for querying a time server
+	MaxPoll = 1024
+	// MinPoll is the minimum time allowed for a client to query a time server
+	MinPoll = 4
+)
+
+func defaultOptions() *NTP {
+	// defaults for minpoll + maxpoll
+	// http://www.ntp.org/ntpfaq/NTP-s-algo.htm#AEN2082
+	return &NTP{
+		Server:  "pool.ntp.org",
+		MaxPoll: MaxPoll * time.Second,
+		MinPoll: 64 * time.Second,
+		Retry:   3,
+	}
+}
+
+// WithServer configures the ntp client to use the specified server
+func WithServer(o string) Option {
+	return func(n *NTP) (err error) {
+		n.Server = o
+		return err
+	}
+}
+
+// WithMaxPoll configures the ntp client MaxPoll interval
+func WithMaxPoll(o int) Option {
+	return func(n *NTP) (err error) {
+		// TODO add in constraints around min/max values from ntp doc
+		if o > MaxPoll {
+			return fmt.Errorf("MaxPoll(%d) is larger than maximum allowed value(%d)", o, MaxPoll)
+		}
+		n.MaxPoll = time.Duration(o) * time.Second
+		return err
+	}
+}
+
+// WithMinPoll configures the ntp client MinPoll interval
+func WithMinPoll(o int) Option {
+	return func(n *NTP) (err error) {
+		if o < MinPoll {
+			return fmt.Errorf("MinPoll(%d) is smaller than minimum allowed value(%d)", o, MinPoll)
+		}
+		n.MinPoll = time.Duration(o) * time.Second
+		return err
+	}
+}
+
+// WithRetry configures the ntp client maximum number of retries
+func WithRetry(o int) Option {
+	return func(n *NTP) (err error) {
+		n.Retry = o
+		return err
+	}
+}

--- a/internal/app/ntpd/pkg/reg/reg.go
+++ b/internal/app/ntpd/pkg/reg/reg.go
@@ -47,7 +47,11 @@ func (r *Registrator) Time(ctx context.Context, in *empty.Empty) (reply *proto.T
 // TimeCheck issues a query to the specified ntp server and displays the results
 func (r *Registrator) TimeCheck(ctx context.Context, in *proto.TimeRequest) (reply *proto.TimeReply, err error) {
 	reply = &proto.TimeReply{}
-	tc := ntp.NewNTPClient(in.Server)
+	tc, err := ntp.NewNTPClient(ntp.WithServer(in.Server))
+	if err != nil {
+		return reply, err
+	}
+
 	rt, err := tc.Query()
 	if err != nil {
 		return reply, err

--- a/internal/app/ntpd/pkg/reg/reg_test.go
+++ b/internal/app/ntpd/pkg/reg/reg_test.go
@@ -33,7 +33,8 @@ func TestNtpdSuite(t *testing.T) {
 func (suite *NtpdSuite) TestTime() {
 	testServer := "time.cloudflare.com"
 	// Create ntp client
-	n := ntp.NewNTPClient(testServer)
+	n, err := ntp.NewNTPClient(ntp.WithServer(testServer))
+	suite.Assert().NoError(err)
 
 	// Create gRPC server
 	api := NewRegistrator(n)
@@ -63,7 +64,8 @@ func (suite *NtpdSuite) TestTimeCheck() {
 	// Create ntp client with bogus server
 	// so we can check that we explicitly check the time of the
 	// specified server ( testserver )
-	n := ntp.NewNTPClient("127.0.0.1")
+	n, err := ntp.NewNTPClient(ntp.WithServer("127.0.0.1"))
+	suite.Assert().NoError(err)
 
 	// Create gRPC server
 	api := NewRegistrator(n)


### PR DESCRIPTION
- Use the Validate method to ensure we get an appropriate time back
- Hard set the clock initially, adjust clock by offsets afterwards
- Introduce functional opts to configure ntp client
- Add additional test coverage

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>