### PR TITLE
fix: prevent EBUSY when unmounting system disk

### DIFF
--- a/internal/app/machined/internal/phase/kubernetes/tasks.go
+++ b/internal/app/machined/internal/phase/kubernetes/tasks.go
@@ -6,6 +6,7 @@ package kubernetes
 
 import (
 	"context"
+	"log"
 	"syscall"
 
 	"github.com/containerd/containerd"
@@ -59,6 +60,7 @@ func (task *KillKubernetesTasks) standard() (err error) {
 
 	for _, task := range response.Tasks {
 		task := task // https://golang.org/doc/faq#closures_and_goroutines
+		log.Printf("killing task %s", task.ID)
 		g.Go(func() error {
 			if _, err = s.Kill(ctx, &tasks.KillRequest{ContainerID: task.ID, Signal: uint32(syscall.SIGTERM), All: true}); err != nil {
 				return errors.Wrap(err, "error killing task")

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -104,6 +104,12 @@ func (h *Helper) Drain(node string) error {
 	for _, pod := range pods.Items {
 		go func(p corev1.Pod) {
 			defer wg.Done()
+			for _, ref := range p.ObjectMeta.OwnerReferences {
+				if ref.Kind == "DaemonSet" {
+					log.Printf("skipping DaemonSet pod %s\n", p.GetName())
+					return
+				}
+			}
 			if err := h.evict(p, int64(60)); err != nil {
 				log.Printf("WARNING: failed to evict pod: %v", err)
 			}


### PR DESCRIPTION
Reading /proc/mounts while simultaneously unmounting mountpoints
prevents unmounting all submounts under /var. This is due to the fact
that /proc/mounts will change as we perform unmounts, and that causes a
read of the file to become inaccurate. We now read /proc/mounts into
memory to get a snapshot of all submounts under /var, and then we
proceed with unmounting them.

This also adds some additional logging that I found to be useful while
debugging this. It also adds logic to skip of DaemonSet managed pods.