### PR TITLE
chore: update provider-components for capi v0.1.9

### DIFF
--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -79,4 +79,3 @@ run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
        kubectl get nodes -o wide -l node-role.kubernetes.io/master=''
        sleep 5
      done"
-

--- a/hack/test/manifests/provider-components.yaml
+++ b/hack/test/manifests/provider-components.yaml
@@ -252,6 +252,8 @@ spec:
   names:
     kind: Cluster
     plural: clusters
+    shortNames:
+    - cl
   scope: Namespaced
   subresources:
     status: {}
@@ -387,6 +389,8 @@ spec:
   names:
     kind: MachineClass
     plural: machineclasses
+    shortNames:
+    - mc
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -428,6 +432,8 @@ spec:
   names:
     kind: MachineDeployment
     plural: machinedeployments
+    shortNames:
+    - md
   scope: Namespaced
   subresources:
     scale:
@@ -495,6 +501,9 @@ spec:
                     = RollingUpdate.
                   properties:
                     maxSurge:
+                      anyOf:
+                      - type: string
+                      - type: integer
                       description: 'The maximum number of machines that can be scheduled
                         above the desired number of machines. Value can be an absolute
                         number (ex: 5) or a percentage of desired machines (ex: 10%).
@@ -507,10 +516,10 @@ spec:
                         new MachineSet can be scaled up further, ensuring that total
                         number of machines running at any time during the update is
                         at most 130% of desired machines.'
-                      oneOf:
+                    maxUnavailable:
+                      anyOf:
                       - type: string
                       - type: integer
-                    maxUnavailable:
                       description: 'The maximum number of machines that can be unavailable
                         during the update. Value can be an absolute number (ex: 5)
                         or a percentage of desired machines (ex: 10%). Absolute number
@@ -522,9 +531,6 @@ spec:
                         down further, followed by scaling up the new MachineSet, ensuring
                         that the total number of machines available at all times during
                         the update is at least 70% of desired machines.'
-                      oneOf:
-                      - type: string
-                      - type: integer
                   type: object
                 type:
                   description: Type of deployment. Currently the only supported strategy
@@ -706,6 +712,8 @@ spec:
   names:
     kind: Machine
     plural: machines
+    shortNames:
+    - ma
   scope: Namespaced
   subresources:
     status: {}
@@ -944,6 +952,8 @@ spec:
   names:
     kind: MachineSet
     plural: machinesets
+    shortNames:
+    - ms
   scope: Namespaced
   subresources:
     scale:
@@ -1185,6 +1195,7 @@ rules:
   - list
   - watch
   - create
+  - patch
 - apiGroups:
   - cluster.k8s.io
   resources:
@@ -1260,6 +1271,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1313,7 +1332,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: gcr.io/k8s-cluster-api/cluster-api-controller:0.1.1
+        image: us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.1.9
         name: manager
         resources:
           limits:


### PR DESCRIPTION
This PR updates our e2e tests with the provider-components file that's
generated by our capi v0.1.9 update.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>