### PR TITLE
fix: remove basic integration teardown

### DIFF
--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -80,5 +80,3 @@ run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
        sleep 5
      done"
 
-${LOCALOSCTL} cluster destroy --name integration
-


### PR DESCRIPTION
This was breaking e2e testing, as we depend on it for applying CAPI and
launching VMs from there.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>