### PR TITLE
feat: allow network interface to be ignored

### DIFF
--- a/internal/app/machined/internal/phase/network/network.go
+++ b/internal/app/machined/internal/phase/network/network.go
@@ -59,6 +59,10 @@ func (task *UserDefinedNetwork) runtime(platform platform.Platform, data *userda
 			return err
 		}
 
+		if iface.IsIgnored() {
+			continue
+		}
+
 		netIfaces = append(netIfaces, iface)
 	}
 

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -59,6 +59,10 @@ func main() {
 			log.Fatal(err)
 		}
 
+		if iface.IsIgnored() {
+			continue
+		}
+
 		netIfaces = append(netIfaces, iface)
 	}
 

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -30,6 +30,11 @@ func (n *NetConf) OverlayUserData(data *userdata.UserData) error {
 				continue
 			}
 
+			if device.Ignore {
+				(*n)[link] = append(opts, nic.WithIgnore())
+				continue
+			}
+
 			// Configure Addressing
 			if device.DHCP {
 				d := &address.DHCP{NetIf: link}

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
+	"github.com/talos-systems/talos/internal/pkg/kernel"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // TODO: Probably should put together some map here
@@ -26,12 +28,21 @@ const (
 // NetworkInterface provides an abstract configuration representation for a
 // network interface
 type NetworkInterface struct {
+	Ignore        bool
 	Name          string
 	Type          int
 	MTU           uint32
 	Index         uint32
 	SubInterfaces []string
 	AddressMethod []address.Addressing
+}
+
+// IsIgnored checks the network interface to see if it should be ignored and not configured
+func (n *NetworkInterface) IsIgnored() bool {
+	if n.Ignore || kernel.ProcCmdline().Get(constants.KernelParamNetworkInterfaceIgnore).Contains(n.Name) {
+		return true
+	}
+	return false
 }
 
 // Create returns a NetworkInterface with all of the given setter options

--- a/internal/app/networkd/pkg/nic/options.go
+++ b/internal/app/networkd/pkg/nic/options.go
@@ -22,6 +22,14 @@ func defaultOptions() *NetworkInterface {
 	}
 }
 
+// WithIgnore indicates that the interface should not be processed by talos.
+func WithIgnore() Option {
+	return func(n *NetworkInterface) (err error) {
+		n.Ignore = true
+		return
+	}
+}
+
 // WithName sets the name of the interface to the given name.
 func WithName(o string) Option {
 	return func(n *NetworkInterface) (err error) {

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -82,6 +82,10 @@ func (v *Parameter) First() *string {
 
 // Get attempts to get a string from a value's internal representation.
 func (v *Parameter) Get(idx int) *string {
+	if v == nil {
+		return nil
+	}
+
 	if len(v.values) > idx {
 		return &v.values[idx]
 	}
@@ -91,6 +95,10 @@ func (v *Parameter) Get(idx int) *string {
 
 // Contains returns a boolean indicating the existence of a value.
 func (v *Parameter) Contains(s string) (ok bool) {
+	if v == nil {
+		return ok
+	}
+
 	for _, value := range v.values {
 		if ok = s == value; ok {
 			return ok

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,6 +29,9 @@ const (
 	// initial interface used to bootstrap the node
 	KernelParamDefaultInterface = "talos.interface"
 
+	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos
+	KernelParamNetworkInterfaceIgnore = "talos.network.interface.ignore"
+
 	// KernelCurrentRoot is the kernel parameter name for specifying the
 	// current root partition.
 	KernelCurrentRoot = "talos.root"

--- a/pkg/userdata/networking.go
+++ b/pkg/userdata/networking.go
@@ -18,10 +18,13 @@ import (
 type Device struct {
 	Interface string  `yaml:"interface"`
 	CIDR      string  `yaml:"cidr"`
-	DHCP      bool    `yaml:"dhcp"`
 	Routes    []Route `yaml:"routes"`
 	Bond      *Bond   `yaml:"bond"`
 	MTU       int     `yaml:"mtu"`
+	DHCP      bool    `yaml:"dhcp"`
+
+	// Ignore indicates that the device should be ignored by any talos setup routines
+	Ignore bool `yaml:"ignore"`
 }
 
 // NetworkDeviceCheck defines the function type for checks
@@ -30,6 +33,10 @@ type NetworkDeviceCheck func(*Device) error
 // Validate triggers the specified validation checks to run
 func (d *Device) Validate(checks ...NetworkDeviceCheck) error {
 	var result *multierror.Error
+
+	if d.Ignore {
+		return result.ErrorOrNil()
+	}
 
 	for _, check := range checks {
 		result = multierror.Append(result, check(d))


### PR DESCRIPTION
Added a property to userdata to allow a network interface to be ignored,
such that Talos will perform no operations on it (including DHCP).

Also added kernel commandline parameter (talos.network.interface.ignore)
to specify a network interface should be ignored.

Fixes #1124

Signed-off-by: Seán C McCord <ulexus@gmail.com>