### PR TITLE
fix: prepend custom options for kernel commandline

### DIFF
--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -42,13 +42,14 @@ var installCmd = &cobra.Command{
 			},
 		}
 
-		cmdline := kernel.NewDefaultCmdline()
+		cmdline := kernel.NewCmdline("")
 		cmdline.Append("initrd", filepath.Join("/", "default", constants.InitramfsAsset))
 		cmdline.Append(constants.KernelParamPlatform, platform)
 		cmdline.Append(constants.KernelParamUserData, endpoint)
 		if err = cmdline.AppendAll(data.Install.ExtraKernelArgs); err != nil {
 			log.Fatal(err)
 		}
+		cmdline.AppendDefaults()
 
 		i, err := installer.NewInstaller(cmdline, data)
 		if err != nil {

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -15,28 +15,7 @@ import (
 // nolint: golint
 func NewDefaultCmdline() *Cmdline {
 	cmdline := NewCmdline("")
-	cmdline.Append("page_poison", "1")
-	cmdline.Append("slab_nomerge", "")
-	cmdline.Append("pti", "on")
-	// TODO(andrewrynhard): Add slub_debug=P. See https://github.com/talos-systems/talos/pull/157.
-	cmdline.Append("consoleblank", "0")
-	// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
-	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
-	cmdline.Append("nvme_core.io_timeout", "4294967295")
-	cmdline.Append("random.trust_cpu", "on")
-	// Disable rate limited printk
-	cmdline.Append("printk.devkmsg", "on")
-	// Enable early kernel message logging
-	cmdline.Append("earlyprintk", "ttyS0,115200")
-	// NB: We make console=tty0 the last device on the list since the last
-	// device will be used when you open /dev/console.
-	// AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedKernels.html
-	// VMWare: https://kb.vmware.com/s/article/2009269
-	// GCP: https://cloud.google.com/compute/docs/instances/interacting-with-serial-console
-	// Azure: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic#general-linux-system-requirements
-	cmdline.Append("console", "tty0")
-	cmdline.Append("console", "tty1")
-	cmdline.Append("console", "ttyS0,115200n8")
+	cmdline.AppendDefaults()
 
 	return cmdline
 }
@@ -162,6 +141,32 @@ func NewCmdline(parameters string) *Cmdline {
 	c := &Cmdline{sync.Mutex{}, parsed}
 
 	return c
+}
+
+// AppendDefaults add the Talos default kernel commandline options to the existing set
+func (c *Cmdline) AppendDefaults() {
+	c.Append("page_poison", "1")
+	c.Append("slab_nomerge", "")
+	c.Append("pti", "on")
+	// TODO(andrewrynhard): Add slub_debug=P. See https://github.com/talos-systems/talos/pull/157.
+	c.Append("consoleblank", "0")
+	// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
+	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
+	c.Append("nvme_core.io_timeout", "4294967295")
+	c.Append("random.trust_cpu", "on")
+	// Disable rate limited printk
+	c.Append("printk.devkmsg", "on")
+	// Enable early kernel message logging
+	c.Append("earlyprintk", "ttyS0,115200")
+	// NB: We make console=tty0 the last device on the list since the last
+	// device will be used when you open /dev/console.
+	// AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedKernels.html
+	// VMWare: https://kb.vmware.com/s/article/2009269
+	// GCP: https://cloud.google.com/compute/docs/instances/interacting-with-serial-console
+	// Azure: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic#general-linux-system-requirements
+	c.Append("console", "tty0")
+	c.Append("console", "tty1")
+	c.Append("console", "ttyS0,115200n8")
 }
 
 // Get gets a kernel parameter.


### PR DESCRIPTION
Added a decomposition option to the kernel.NewDefaultCmdline() so that
the Defaults can be added _after_ constructing a custom commandline.
This is then implemented for `osctl install`.

Fixes #1128

Signed-off-by: Seán C McCord <ulexus@gmail.com>