### PR TITLE
feat: Allow spec of canonical controlplane addr

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -125,7 +125,7 @@ var configAddCmd = &cobra.Command{
 
 // configGenerateCmd represents the config generate command.
 var configGenerateCmd = &cobra.Command{
-	Use:   "generate",
+	Use:   "generate <clusterName> <master-1-IP,master-2-IP,master-3-IP>",
 	Short: "Generate a set of configuration files",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -211,6 +211,7 @@ func genV1Userdata(args []string) {
 		helpers.Fatalf("failed to generate PKI and tokens: %v", err)
 	}
 	input.AdditionalSubjectAltNames = additionalSANs
+	input.ControlPlaneEndpoint = canonicalControlplaneEndpoint
 
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -281,7 +282,8 @@ func init() {
 	configAddCmd.Flags().StringVar(&ca, "ca", "", "the path to the CA certificate")
 	configAddCmd.Flags().StringVar(&crt, "crt", "", "the path to the certificate")
 	configAddCmd.Flags().StringVar(&key, "key", "", "the path to the key")
-	configGenerateCmd.Flags().StringSliceVar(&additionalSANs, "additionalSANs", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
+	configGenerateCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
+	configGenerateCmd.Flags().StringVar(&canonicalControlplaneEndpoint, "controlplane-endpoint", "", "the canonical controlplane endpoint (IP or DNS name) and optional port (defaults to 6443)")
 	configGenerateCmd.Flags().StringVar(&genVersion, "version", "v0", "desired machine config version to generate")
 	helpers.Should(configGenerateCmd.Flags().MarkDeprecated("version", "the v0 version of machine config will be removed in the next version of Talos"))
 	helpers.Should(configAddCmd.MarkFlagRequired("ca"))

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -19,21 +19,22 @@ import (
 )
 
 var (
-	ca             string
-	crt            string
-	additionalSANs []string
-	csr            string
-	hours          int
-	ip             string
-	key            string
-	kubernetes     bool
-	useCRI         bool
-	name           string
-	organization   string
-	rsa            bool
-	talosconfig    string
-	target         string
-	userdataFile   string
+	ca                            string
+	crt                           string
+	additionalSANs                []string
+	canonicalControlplaneEndpoint string
+	csr                           string
+	hours                         int
+	ip                            string
+	key                           string
+	kubernetes                    bool
+	useCRI                        bool
+	name                          string
+	organization                  string
+	rsa                           bool
+	talosconfig                   string
+	target                        string
+	userdataFile                  string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/pkg/userdata/generate/controlplane.go
+++ b/pkg/userdata/generate/controlplane.go
@@ -28,7 +28,7 @@ services:
         bootstrapToken:
           token: '{{ .KubeadmTokens.BootstrapToken }}'
           unsafeSkipCAVerification: true
-          apiServerEndpoint: "{{ .GetControlPlaneEndpoint "6443" }}"
+          apiServerEndpoint: "{{ .GetAPIServerEndpoint "6443" }}"
       nodeRegistration:
         taints: []
         kubeletExtraArgs:

--- a/pkg/userdata/generate/generate.go
+++ b/pkg/userdata/generate/generate.go
@@ -78,8 +78,13 @@ func (i *Input) Endpoints() (out string) {
 	return
 }
 
-// GetControlPlaneEndpoint returns the formatted host:port of the first master node
-func (i *Input) GetControlPlaneEndpoint(port string) string {
+// GetControlPlaneEndpoint returns the formatted host:port of the canonical controlplane address, defaulting to the first master IP
+func (i *Input) GetControlPlaneEndpoint() string {
+	return tnet.FormatAddress(i.MasterIPs[0])
+}
+
+// GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
+func (i *Input) GetAPIServerEndpoint(port string) string {
 
 	if i == nil || len(i.MasterIPs) < 1 {
 		panic("cannot GetControlPlaneEndpoint without any Master IPs")

--- a/pkg/userdata/generate/generate_test.go
+++ b/pkg/userdata/generate/generate_test.go
@@ -95,47 +95,47 @@ func (suite *GenerateSuite) TestGenerateTalosconfigSuccess() {
 	suite.Require().NoError(err)
 }
 
-func (suite *GenerateSuite) TestGetControlPlaneEndpoint() {
-	ep := input.GetControlPlaneEndpoint("6443")
+func (suite *GenerateSuite) TestGetAPIServerEndpoint() {
+	ep := input.GetAPIServerEndpoint("6443")
 	suite.Require().Equal(input.MasterIPs[0]+":6443", ep)
 
-	ep = input.GetControlPlaneEndpoint("443")
+	ep = input.GetAPIServerEndpoint("443")
 	suite.Require().Equal(input.MasterIPs[0]+":443", ep)
 
-	ep = inputv6.GetControlPlaneEndpoint("6443")
+	ep = inputv6.GetAPIServerEndpoint("6443")
 	suite.Require().Equal(fmt.Sprintf("[%s]:6443", inputv6.MasterIPs[0]), ep)
 
-	ep = input.GetControlPlaneEndpoint("")
+	ep = input.GetAPIServerEndpoint("")
 	suite.Require().Equal(input.MasterIPs[0], ep)
 
-	ep = inputv6.GetControlPlaneEndpoint("")
+	ep = inputv6.GetAPIServerEndpoint("")
 	suite.Require().Equal(fmt.Sprintf("[%s]", inputv6.MasterIPs[0]), ep)
 
 	inputv6.IP = net.ParseIP("2001:db8::1")
 	inputv6.Index = 0
 	suite.Require().Equal(
 		fmt.Sprintf("[%s]", inputv6.MasterIPs[0]),
-		inputv6.GetControlPlaneEndpoint(""),
+		inputv6.GetAPIServerEndpoint(""),
 	)
 
 	inputv6.IP = net.ParseIP("2001:db8::2")
 	inputv6.Index = 1
 	suite.Require().Equal(
 		fmt.Sprintf("[%s]", inputv6.MasterIPs[0]),
-		inputv6.GetControlPlaneEndpoint(""),
+		inputv6.GetAPIServerEndpoint(""),
 	)
 
 	inputv6.IP = net.ParseIP("2001:db8::3")
 	inputv6.Index = 2
 	suite.Require().Equal(
 		fmt.Sprintf("[%s]", inputv6.MasterIPs[1]),
-		inputv6.GetControlPlaneEndpoint(""),
+		inputv6.GetAPIServerEndpoint(""),
 	)
 
 	inputv6.IP = net.ParseIP("2001:db8::d")
 	inputv6.Index = 0
 	suite.Require().Equal(
 		fmt.Sprintf("[%s]", inputv6.MasterIPs[0]),
-		inputv6.GetControlPlaneEndpoint(""),
+		inputv6.GetAPIServerEndpoint(""),
 	)
 }

--- a/pkg/userdata/generate/init.go
+++ b/pkg/userdata/generate/init.go
@@ -35,7 +35,7 @@ services:
       kind: ClusterConfiguration
       clusterName: {{ .ClusterName }}
       kubernetesVersion: {{ .KubernetesVersion }}
-      controlPlaneEndpoint: "{{ .GetControlPlaneEndpoint "443" }}"
+      controlPlaneEndpoint: "{{ .GetControlPlaneEndpoint }}"
       apiServer:
         certSANs: [ {{ range $i,$addr := .GetAPIServerSANs }}{{if $i}},{{end}}"{{$addr}}"{{end}} ]
         extraArgs:

--- a/pkg/userdata/generate/join.go
+++ b/pkg/userdata/generate/join.go
@@ -18,7 +18,7 @@ services:
         bootstrapToken:
           token: '{{ .KubeadmTokens.BootstrapToken }}'
           unsafeSkipCAVerification: true
-          apiServerEndpoint: "{{ .GetControlPlaneEndpoint "443" }}"
+          apiServerEndpoint: "{{ .GetAPIServerEndpoint "443" }}"
       nodeRegistration:
         taints: []
         kubeletExtraArgs:

--- a/pkg/userdata/generate/talosconfig.go
+++ b/pkg/userdata/generate/talosconfig.go
@@ -12,7 +12,7 @@ func Talosconfig(in *Input) (string, error) {
 const talosconfigTempl = `context: {{ .ClusterName }}
 contexts:
   {{ .ClusterName }}:
-    target: "{{ .GetControlPlaneEndpoint "" }}"
+    target: "{{ .GetAPIServerEndpoint "" }}"
     ca: {{ .Certs.OsCert }}
     crt: {{ .Certs.AdminCert }}
     key: {{ .Certs.AdminKey }}

--- a/pkg/userdata/v1/cluster_config.go
+++ b/pkg/userdata/v1/cluster_config.go
@@ -19,6 +19,13 @@ type ClusterConfig struct {
 
 // ControlPlaneConfig represents control plane config vals
 type ControlPlaneConfig struct {
+
+	// Endpoint is the canonical controlplane endpoint, which can be an IP
+	// address or a DNS hostname, is single-valued, and may optionally include a
+	// port number.  It is optional and if not supplied, the IP address of the
+	// first master node will be used.
+	Endpoint string `yaml:"endpoint,omitempty"`
+
 	IPs   []string `yaml:"ips"`
 	Index int      `yaml:"index,omitempty"`
 }

--- a/pkg/userdata/v1/generate/init.go
+++ b/pkg/userdata/v1/generate/init.go
@@ -27,8 +27,9 @@ func initUd(in *Input) (string, error) {
 	cluster := &v1.ClusterConfig{
 		ClusterName: in.ClusterName,
 		ControlPlane: &v1.ControlPlaneConfig{
-			IPs:   in.MasterIPs,
-			Index: in.Index,
+			Endpoint: in.ControlPlaneEndpoint,
+			IPs:      in.MasterIPs,
+			Index:    in.Index,
 		},
 		APIServer: &v1.APIServerConfig{
 			CertSANs: certSANs,

--- a/pkg/userdata/v1/generate/talosconfig.go
+++ b/pkg/userdata/v1/generate/talosconfig.go
@@ -17,7 +17,7 @@ func Talosconfig(in *Input) (string, error) {
 const talosconfigTempl = `context: {{ .ClusterName }}
 contexts:
   {{ .ClusterName }}:
-    target: {{ index .MasterIPs 0 }}
+    target: "{{ .GetAPIServerEndpoint "" }}"
     ca: {{ .Certs.OsCert }}
     crt: {{ .Certs.AdminCert }}
     key: {{ .Certs.AdminKey }}


### PR DESCRIPTION
Broke the binding between the discrete IP addresses of the control plane
elements and the ControlPlaneEndpoint.  This allows the specification of
a canonical controlplane address which may optionally be a DNS name.

Fixes #1131

Signed-off-by: Seán C McCord <ulexus@gmail.com>