### PR TITLE
fix: use ntp client constructor

### DIFF
--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -54,7 +54,12 @@ func main() {
 		server = data.Services.NTPd.Server
 	}
 
-	n := &ntp.NTP{Server: server}
+	n, err := ntp.NewNTPClient(
+		ntp.WithServer(server),
+	)
+	if err != nil {
+		log.Fatalf("failed to create ntp client: %v", err)
+	}
 
 	log.Println("Starting ntpd")
 	errch := make(chan error)


### PR DESCRIPTION
Uses NTP client constructor so that defaults are appropriately used.

Fixes #1126

Signed-off-by: Seán C McCord <ulexus@gmail.com>