### PR TITLE
fix(machined): Fix hostname value when retrieving from cloud providers

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/hostname.go
+++ b/internal/app/machined/internal/phase/rootfs/hostname.go
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package rootfs
+
+import (
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase/rootfs/etc"
+	"github.com/talos-systems/talos/internal/app/machined/internal/platform"
+	"github.com/talos-systems/talos/internal/app/machined/internal/runtime"
+	"github.com/talos-systems/talos/pkg/userdata"
+)
+
+// Hostname represents the Hostname task.
+type Hostname struct{}
+
+// NewHostnameTask initializes and returns an Hostname task.
+func NewHostnameTask() phase.Task {
+	return &Hostname{}
+}
+
+// RuntimeFunc returns the runtime function.
+func (task *Hostname) RuntimeFunc(mode runtime.Mode) phase.RuntimeFunc {
+	switch mode {
+	case runtime.Container:
+		return nil
+	default:
+		return task.runtime
+	}
+}
+
+func (task *Hostname) runtime(platform platform.Platform, data *userdata.UserData) (err error) {
+	// Sets the hostname
+	return etc.Hosts(data.Networking.OS.Hostname)
+}

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -92,6 +92,7 @@ func (d *Sequencer) Boot() error {
 		phase.NewPhase(
 			"save userdata",
 			userdatatask.NewSaveUserDataTask(),
+			rootfs.NewHostnameTask(),
 		),
 		phase.NewPhase(
 			"start services",


### PR DESCRIPTION
There was an issue where the hostname was getting set too early in the boot. This caused
the hostnam retrieved from platform.Hostname() to be ignored.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>