### PR TITLE
fix(osd): Mount host directory for grpc sockets

### DIFF
--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"path/filepath"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
@@ -75,10 +74,7 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: constants.UserDataPath, Source: constants.UserDataPath, Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: constants.ContainerdAddress, Source: constants.ContainerdAddress, Options: []string{"bind", "ro"}},
-		{Type: "bind", Destination: constants.SystemContainerdAddress, Source: constants.SystemContainerdAddress, Options: []string{"bind", "ro"}},
-		{Type: "bind", Destination: filepath.Dir(constants.InitSocketPath), Source: filepath.Dir(constants.InitSocketPath), Options: []string{"rbind", "rw"}},
-		{Type: "bind", Destination: filepath.Dir(constants.NtpdSocketPath), Source: filepath.Dir(constants.NtpdSocketPath), Options: []string{"rbind", "rw"}},
-		{Type: "bind", Destination: filepath.Dir(constants.NetworkdSocketPath), Source: filepath.Dir(constants.NetworkdSocketPath), Options: []string{"rbind", "rw"}},
+		{Type: "bind", Destination: "/run/system", Source: "/run/system", Options: []string{"bind", "ro"}},
 	}
 
 	env := []string{}


### PR DESCRIPTION
Should prevent broken mounts from occurring when services are restarted.

fixes #1115 

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>