### PR TITLE
fix: move to per-platform console setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,9 @@ image-aws:
 		-n aws \
 		-r \
 		-p aws \
-		-u none
+		-u none \
+		-e console=tty1 \
+		-e console=ttyS0
 	@tar -C $(PWD)/build -czf $(PWD)/build/aws.tar.gz aws.raw
 	@rm -rf $(PWD)/build/aws.raw
 
@@ -175,6 +177,8 @@ image-azure:
 		-r \
 		-p azure \
 		-u none \
+		-e console=ttyS0,115200n8 \
+		-e earlyprintk=ttyS0,115200 \
 		-e rootdelay=300
 	@docker run --rm -v $(PWD)/build:/out $(DOCKER_ARGS) \
 		--entrypoint qemu-img \
@@ -195,7 +199,8 @@ image-gcp:
 		-n disk \
 		-r \
 		-p gcp \
-		-u none
+		-u none \
+		-e console=ttyS0
 	@tar -C $(PWD)/build -czf $(PWD)/build/gcp.tar.gz disk.raw
 	@rm -rf $(PWD)/build/disk.raw
 

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -156,17 +156,6 @@ func (c *Cmdline) AppendDefaults() {
 	c.Append("random.trust_cpu", "on")
 	// Disable rate limited printk
 	c.Append("printk.devkmsg", "on")
-	// Enable early kernel message logging
-	c.Append("earlyprintk", "ttyS0,115200")
-	// NB: We make console=tty0 the last device on the list since the last
-	// device will be used when you open /dev/console.
-	// AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedKernels.html
-	// VMWare: https://kb.vmware.com/s/article/2009269
-	// GCP: https://cloud.google.com/compute/docs/instances/interacting-with-serial-console
-	// Azure: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic#general-linux-system-requirements
-	c.Append("console", "tty0")
-	c.Append("console", "tty1")
-	c.Append("console", "ttyS0,115200n8")
 }
 
 // Get gets a kernel parameter.


### PR DESCRIPTION
This PR will make sure that each platform gets the console settings it
needs by setting them as extra flags in the makefile. This should ensure
that we have console logs flowing properly for each cloud.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>