### PR TITLE
fix: enable slub_debug=P

### DIFF
--- a/hack/dev/qemu-boot.sh
+++ b/hack/dev/qemu-boot.sh
@@ -37,7 +37,6 @@ qemu-system-x86_64 \
     -device virtio-net,netdev=talos \
     -nographic \
     -serial mon:stdio \
-    -no-reboot \
-    -append "talos.platform=metal page_poison=1 slab_nomerge pti=on random.trust_cpu=on printk.devkmsg=on earlyprintk=serial,tty0,keep console=tty0 talos.userdata=${MACHINE_CONFIG}" \
+    -append "talos.platform=metal page_poison=1 slub_debug=P slab_nomerge pti=on random.trust_cpu=on printk.devkmsg=on earlyprintk=serial,tty0,keep console=tty0 talos.userdata=${MACHINE_CONFIG}" \
     -kernel ${KERNEL} \
     -initrd ${INITRD}

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -146,9 +146,9 @@ func NewCmdline(parameters string) *Cmdline {
 // AppendDefaults add the Talos default kernel commandline options to the existing set
 func (c *Cmdline) AppendDefaults() {
 	c.Append("page_poison", "1")
+	c.Append("slub_debug", "P")
 	c.Append("slab_nomerge", "")
 	c.Append("pti", "on")
-	// TODO(andrewrynhard): Add slub_debug=P. See https://github.com/talos-systems/talos/pull/157.
 	c.Append("consoleblank", "0")
 	// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
 	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.

--- a/internal/pkg/kernel/kspp/kspp.go
+++ b/internal/pkg/kernel/kspp/kspp.go
@@ -14,10 +14,10 @@ import (
 var (
 	// RequiredKSPPKernelParameters is the set of kernel parameters required to
 	// satisfy the KSPP.
-	// # TODO(andrewrynhard): Add slub_debug=P. See https://github.com/talos-systems/talos/pull/157.
 	RequiredKSPPKernelParameters = kernel.Parameters{
 		kernel.NewParameter("page_poison").Append("1"),
 		kernel.NewParameter("slab_nomerge").Append(""),
+		kernel.NewParameter("slub_debug").Append("P"),
 		kernel.NewParameter("pti").Append("on"),
 	}
 )


### PR DESCRIPTION
This is the last KSPP kernel parameter we need to be compliant with KSPP
guidelines.