### PR TITLE
chore: remove invalid TODO

### DIFF
--- a/internal/pkg/cis/cis.go
+++ b/internal/pkg/cis/cis.go
@@ -40,8 +40,6 @@ resources:
 `
 
 // EnforceAuditingRequirements enforces CIS requirements for auditing.
-// TODO(andrewrynhard): Enable audit-log-maxbackup.
-// TODO(andrewrynhard): Enable audit-log-maxsize.
 func EnforceAuditingRequirements(cfg *kubeadmapi.ClusterConfiguration) error {
 	if err := ioutil.WriteFile("/etc/kubernetes/audit-policy.yaml", []byte(auditPolicy), 0400); err != nil {
 		return err

--- a/internal/pkg/installer/manifest/manifest.go
+++ b/internal/pkg/installer/manifest/manifest.go
@@ -20,25 +20,11 @@ import (
 	"github.com/talos-systems/talos/pkg/blockdevice/table/gpt/partition"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/userdata"
-	"github.com/talos-systems/talos/pkg/version"
 )
 
 const (
 	// DefaultSizeBootDevice is the default size of the boot partition.
-	// TODO(andrewrynhard): We should inspect the sizes of the artifacts and dynamically set the boot partition's size.
 	DefaultSizeBootDevice = 512 * 1000 * 1000
-)
-
-var (
-	// DefaultURLBase is the base URL for all default artifacts.
-	// TODO(andrewrynhard): We need to setup infrastructure for publishing artifacts and not depend on GitHub.
-	DefaultURLBase = "https://github.com/talos-systems/talos/releases/download/" + version.Tag
-
-	// DefaultKernelURL is the URL to the kernel.
-	DefaultKernelURL = DefaultURLBase + "/vmlinuz"
-
-	// DefaultInitramfsURL is the URL to the initramfs.
-	DefaultInitramfsURL = DefaultURLBase + "/initramfs.xz"
 )
 
 // Manifest represents the instructions for preparing all block devices


### PR DESCRIPTION
This TODO no longer applies. We have setteled on a fixed boot size. This
also removes variables no longer needed.