### PR TITLE
chore: format code with gofumpt

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -271,6 +271,7 @@ func ensureImageExists(ctx context.Context, cli *client.Client, image string) er
 
 	return nil
 }
+
 func createNetwork(cli *client.Client) (types.NetworkCreateResponse, error) {
 	options := types.NetworkCreate{
 		Labels: map[string]string{

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -197,7 +197,6 @@ func writeV0Userdata(input *udgenv0.Input, t udgenv0.Type, name string) (err err
 	}
 	if err = ud.Validate(); err != nil {
 		return err
-
 	}
 	if err = ioutil.WriteFile(strings.ToLower(name)+".yaml", []byte(data), 0644); err != nil {
 		return err
@@ -269,7 +268,6 @@ func writeV1Alpha1Userdata(input *udgenv1alpha1.Input, t udgenv1alpha1.Type, nam
 
 	if err = ud.Validate(); err != nil {
 		return err
-
 	}
 	if err = ioutil.WriteFile(strings.ToLower(name)+".yaml", []byte(data), 0644); err != nil {
 		return err

--- a/cmd/osctl/cmd/cp.go
+++ b/cmd/osctl/cmd/cp.go
@@ -134,7 +134,6 @@ captures ownership and permission bits.`,
 					}
 				}
 			}
-
 		})
 	},
 }

--- a/cmd/osctl/cmd/ls.go
+++ b/cmd/osctl/cmd/ls.go
@@ -26,7 +26,6 @@ var lsCmd = &cobra.Command{
 	Short: "Retrieve a directory listing",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		setupClient(func(c *client.Client) {
 			rootDir := "/"
 			if len(args) > 0 {

--- a/cmd/osctl/cmd/ps.go
+++ b/cmd/osctl/cmd/ps.go
@@ -43,7 +43,6 @@ var psCmd = &cobra.Command{
 				driver = proto.ContainerDriver_CRI
 			}
 			reply, err := c.Processes(globalCtx, namespace, driver)
-
 			if err != nil {
 				helpers.Fatalf("error getting process list: %s", err)
 			}

--- a/cmd/osctl/cmd/time.go
+++ b/cmd/osctl/cmd/time.go
@@ -24,7 +24,6 @@ var timeCmd = &cobra.Command{
 	Short: "Gets current server time",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-
 		setupClient(func(c *client.Client) {
 			server, err := cmd.Flags().GetString("check")
 			if err != nil {

--- a/cmd/osctl/cmd/top.go
+++ b/cmd/osctl/cmd/top.go
@@ -72,7 +72,6 @@ func init() {
 
 // nolint: gocyclo
 func topUI(ctx context.Context, c *client.Client) {
-
 	l := widgets.NewParagraph()
 	l.Border = false
 	l.WrapText = false
@@ -82,7 +81,6 @@ func topUI(ctx context.Context, c *client.Client) {
 	var processOutput string
 
 	draw := func() {
-
 		// Attempt to get terminal dimensions
 		// Since we're getting this data on each call
 		// we'll be able to handle terminal window resizing

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -13,9 +13,7 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )
 
-var (
-	upgradeImage string
-)
+var upgradeImage string
 
 // upgradeCmd represents the processes command
 var upgradeCmd = &cobra.Command{

--- a/cmd/osctl/cmd/version.go
+++ b/cmd/osctl/cmd/version.go
@@ -13,9 +13,7 @@ import (
 	"github.com/talos-systems/talos/pkg/version"
 )
 
-var (
-	shortVersion bool
-)
+var shortVersion bool
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{

--- a/internal/app/machined/internal/api/reg/reg.go
+++ b/internal/app/machined/internal/api/reg/reg.go
@@ -172,7 +172,6 @@ func (r *Registrator) CopyOut(req *proto.CopyOutRequest, s proto.Init_CopyOutSer
 
 // LS implements the proto.InitServer interface.
 func (r *Registrator) LS(req *proto.LSRequest, s proto.Init_LSServer) error {
-
 	if req == nil {
 		req = new(proto.LSRequest)
 	}

--- a/internal/app/machined/internal/event/event_test.go
+++ b/internal/app/machined/internal/event/event_test.go
@@ -20,12 +20,12 @@ func (suite *EventSuite) TestBus() {
 	// publish event without subscribers
 	event.Bus().Notify(event.Event{Type: event.Shutdown})
 
-	var subscriber1 = struct {
+	subscriber1 := struct {
 		*event.Embeddable
 	}{
 		&event.Embeddable{},
 	}
-	var subscriber2 = struct {
+	subscriber2 := struct {
 		*event.Embeddable
 	}{
 		&event.Embeddable{},

--- a/internal/app/machined/internal/phase/rootfs/etc/etc.go
+++ b/internal/app/machined/internal/phase/rootfs/etc/etc.go
@@ -39,7 +39,6 @@ BUG_REPORT_URL="https://github.com/talos-systems/talos/issues"
 
 // Hosts renders a valid /etc/hosts file and writes it to disk.
 func Hosts(hostname string) (err error) {
-
 	ip := ip()
 
 	// If no hostname, set it to `talos-<ip>`, talos-1-2-3-4

--- a/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
@@ -26,9 +26,7 @@ const (
 	memoryUseHierarchyPermissions = os.FileMode(400)
 )
 
-var (
-	memoryUseHierarchyContents = []byte(strconv.Itoa(1))
-)
+var memoryUseHierarchyContents = []byte(strconv.Itoa(1))
 
 // MountCgroups represents the MountCgroups task.
 type MountCgroups struct{}

--- a/internal/app/machined/internal/platform/azure/register.go
+++ b/internal/app/machined/internal/platform/azure/register.go
@@ -113,8 +113,8 @@ func reportHealth(gsIncarnation, gsContainerID, gsInstanceID string) (err error)
 		return err
 	}
 	return err
-
 }
+
 func addHeaders(req *http.Request) {
 	req.Header.Add("x-ms-agent-name", "WALinuxAgent")
 	req.Header.Add("x-ms-version", "2015-04-05")

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -111,7 +111,7 @@ func main() {
 		}
 	}()
 
-	var rebootFlag = unix.LINUX_REBOOT_CMD_RESTART
+	rebootFlag := unix.LINUX_REBOOT_CMD_RESTART
 
 	// Wait for an event.
 

--- a/internal/app/machined/pkg/system/conditions/files_test.go
+++ b/internal/app/machined/pkg/system/conditions/files_test.go
@@ -27,7 +27,6 @@ func (suite *FilesSuite) SetupSuite() {
 	var err error
 	suite.tempDir, err = ioutil.TempDir("", "talos")
 	suite.Require().NoError(err)
-
 }
 
 func (suite *FilesSuite) TearDownSuite() {

--- a/internal/app/machined/pkg/system/health/health_test.go
+++ b/internal/app/machined/pkg/system/health/health_test.go
@@ -21,7 +21,7 @@ type CheckSuite struct {
 }
 
 func (suite *CheckSuite) TestHealthy() {
-	var settings = health.Settings{
+	settings := health.Settings{
 		InitialDelay: time.Millisecond,
 		Period:       10 * time.Millisecond,
 		Timeout:      time.Millisecond,
@@ -65,7 +65,7 @@ func (suite *CheckSuite) TestHealthy() {
 }
 
 func (suite *CheckSuite) TestHealthChange() {
-	var settings = health.Settings{
+	settings := health.Settings{
 		InitialDelay: time.Millisecond,
 		Period:       time.Millisecond,
 		Timeout:      time.Millisecond,
@@ -134,7 +134,7 @@ func (suite *CheckSuite) TestHealthChange() {
 }
 
 func (suite *CheckSuite) TestCheckAbort() {
-	var settings = health.Settings{
+	settings := health.Settings{
 		InitialDelay: time.Millisecond,
 		Period:       time.Millisecond,
 		Timeout:      time.Millisecond,
@@ -176,7 +176,7 @@ func (suite *CheckSuite) TestCheckAbort() {
 }
 
 func (suite *CheckSuite) TestInitialState() {
-	var settings = health.Settings{
+	settings := health.Settings{
 		InitialDelay: 5 * time.Minute,
 	}
 

--- a/internal/app/machined/pkg/system/mocks_test.go
+++ b/internal/app/machined/pkg/system/mocks_test.go
@@ -34,6 +34,7 @@ func (m *MockService) ID(*userdata.UserData) string {
 	}
 	return "MockRunner"
 }
+
 func (m *MockService) PreFunc(context.Context, *userdata.UserData) error {
 	return m.preError
 }

--- a/internal/app/machined/pkg/system/runner/containerd/import.go
+++ b/internal/app/machined/pkg/system/runner/containerd/import.go
@@ -80,7 +80,6 @@ func (i *Importer) Import(reqs ...*ImportRequest) error {
 	for _, req := range reqs {
 		go func(errCh chan<- error, r *ImportRequest) {
 			errCh <- func() error {
-
 				tarball, ierr := os.Open(r.Path)
 				if ierr != nil {
 					return errors.Wrapf(ierr, "error opening %v", r.Path)

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -58,7 +58,8 @@ func (c *Containerd) Runner(data *userdata.UserData) (runner.Runner, error) {
 	// Set the process arguments.
 	args := &runner.Args{
 		ID: c.ID(data),
-		ProcessArgs: []string{"/bin/containerd",
+		ProcessArgs: []string{
+			"/bin/containerd",
 			"--address",
 			constants.ContainerdAddress,
 			"--config",

--- a/internal/app/machined/pkg/system/services/kubeadm.go
+++ b/internal/app/machined/pkg/system/services/kubeadm.go
@@ -91,7 +91,6 @@ func (k *Kubeadm) PreFunc(ctx context.Context, data *userdata.UserData) (err err
 	// ( filtered by ones we already have ) and
 	// Get assets from remote nodes
 	for _, fileRequest := range kubeadm.FileSet(kubeadm.RequiredFiles()) {
-
 		// Handle all file requests in parallel
 		go func(ctx context.Context, fileRequest *proto.ReadFileRequest) {
 			defer wg.Done()
@@ -119,7 +118,6 @@ func (k *Kubeadm) PreFunc(ctx context.Context, data *userdata.UserData) (err err
 				// given file
 				kubeadm.WriteTrustdFiles(fileRequest.Path, filecontent)
 			}
-
 		}(ctx, fileRequest)
 	}
 	wg.Wait()

--- a/internal/app/machined/pkg/system/services/kubeadm/kubeadm.go
+++ b/internal/app/machined/pkg/system/services/kubeadm/kubeadm.go
@@ -50,7 +50,6 @@ func PhaseCerts() error {
 }
 
 func editFullInitConfig(data *userdata.UserData) (err error) {
-
 	if data.Services.Kubeadm.InitConfiguration == nil {
 		return errors.New("expected InitConfiguration")
 	}
@@ -78,7 +77,6 @@ func editInitConfig(data *userdata.UserData) (err error) {
 	initConfiguration, ok := data.Services.Kubeadm.InitConfiguration.(*kubeadmv1beta2.InitConfiguration)
 	if !ok {
 		return errors.New("failed InitConfiguration assertion")
-
 	}
 
 	// Hardcodes specific kubeadm config parameters
@@ -94,7 +92,6 @@ func editJoinConfig(data *userdata.UserData) (err error) {
 	joinConfiguration, ok := data.Services.Kubeadm.JoinConfiguration.(*kubeadmv1beta2.JoinConfiguration)
 	if !ok {
 		return errors.New("failed JoinConfiguration assertion")
-
 	}
 
 	joinConfiguration.NodeRegistration.CRISocket = constants.ContainerdAddress
@@ -112,7 +109,6 @@ func editClusterConfig(data *userdata.UserData) (err error) {
 	clusterConfiguration, ok := data.Services.Kubeadm.ClusterConfiguration.(*kubeadmv1beta2.ClusterConfiguration)
 	if !ok {
 		return errors.New("failed ClusterConfiguration assertion")
-
 	}
 
 	// Hardcodes specific kubeadm config parameters
@@ -243,7 +239,6 @@ func RequiredFiles() []string {
 // FileSet compares the list of required files to the ones
 // already present on the node and returns the delta
 func FileSet(files []string) []*proto.ReadFileRequest {
-
 	fileRequests := []*proto.ReadFileRequest{}
 	// Check to see if we already have the file locally
 	for _, file := range files {

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -209,7 +209,6 @@ func (n *Networkd) configureInterface(method address.Addressing) error {
 			default:
 				log.Printf("failed to add address (already exists) %+v to %s: %v", method.Address(), method.Link().Name, err)
 			}
-
 		}
 	}
 

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -48,7 +48,6 @@ func (n *NetworkInterface) IsIgnored() bool {
 // Create returns a NetworkInterface with all of the given setter options
 // applied
 func Create(link *net.Interface, setters ...Option) (*NetworkInterface, error) {
-
 	// Default interface setup
 	iface := defaultOptions()
 

--- a/internal/app/networkd/pkg/reg/reg.go
+++ b/internal/app/networkd/pkg/reg/reg.go
@@ -120,7 +120,7 @@ func (r *Registrator) Interfaces(ctx context.Context, in *empty.Empty) (reply *p
 }
 
 func toCIDR(family uint8, prefix net.IP, prefixLen int) string {
-	var netLen = 32
+	netLen := 32
 	if family == unix.AF_INET6 {
 		netLen = 128
 	}

--- a/internal/app/networkd/pkg/reg/reg_test.go
+++ b/internal/app/networkd/pkg/reg/reg_test.go
@@ -27,7 +27,7 @@ type NetworkdSuite struct {
 
 func TestNetworkdSuite(t *testing.T) {
 	// Hide all our state transition messages
-	//log.SetOutput(ioutil.Discard)
+	// log.SetOutput(ioutil.Discard)
 	suite.Run(t, new(NetworkdSuite))
 }
 

--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -25,9 +25,7 @@ const (
 	DefaultServer = "pool.ntp.org"
 )
 
-var (
-	dataPath *string
-)
+var dataPath *string
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)

--- a/internal/app/ntpd/pkg/ntp/ntp.go
+++ b/internal/app/ntpd/pkg/ntp/ntp.go
@@ -40,7 +40,6 @@ func NewNTPClient(opts ...Option) (*NTP, error) {
 // We dont ever want the daemon to stop, so we only log
 // errors
 func (n *NTP) Daemon() (err error) {
-
 	// Do an initial hard set of time to ensure clock skew isnt too far off
 	var resp *ntp.Response
 	if resp, err = n.Query(); err != nil {
@@ -76,7 +75,6 @@ func (n *NTP) Daemon() (err error) {
 
 // Query polls the ntp server and verifies a successful response.
 func (n *NTP) Query() (*ntp.Response, error) {
-
 	for i := 0; i < n.Retry; i++ {
 		resp, err := ntp.Query(n.Server)
 		if err != nil {

--- a/internal/app/ntpd/pkg/reg/reg_test.go
+++ b/internal/app/ntpd/pkg/reg/reg_test.go
@@ -26,7 +26,7 @@ type NtpdSuite struct {
 
 func TestNtpdSuite(t *testing.T) {
 	// Hide all our state transition messages
-	//log.SetOutput(ioutil.Discard)
+	// log.SetOutput(ioutil.Discard)
 	suite.Run(t, new(NtpdSuite))
 }
 

--- a/internal/app/osd/internal/reg/init_client.go
+++ b/internal/app/osd/internal/reg/init_client.go
@@ -24,7 +24,6 @@ func NewInitServiceClient() (*InitServiceClient, error) {
 	conn, err := grpc.Dial("unix:"+constants.InitSocketPath,
 		grpc.WithInsecure(),
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/osd/internal/reg/networkd_client.go
+++ b/internal/app/osd/internal/reg/networkd_client.go
@@ -23,7 +23,6 @@ func NewNetworkdClient() (*NetworkdClient, error) {
 	conn, err := grpc.Dial("unix:"+constants.NetworkdSocketPath,
 		grpc.WithInsecure(),
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/osd/internal/reg/ntp_client.go
+++ b/internal/app/osd/internal/reg/ntp_client.go
@@ -23,7 +23,6 @@ func NewNtpdClient() (*NtpdClient, error) {
 	conn, err := grpc.Dial("unix:"+constants.NtpdSocketPath,
 		grpc.WithInsecure(),
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -108,7 +108,6 @@ func (r *Registrator) Processes(ctx context.Context, in *proto.ProcessesRequest)
 	}
 
 	return &proto.ProcessesReply{Processes: processes}, nil
-
 }
 
 // Stats implements the proto.OSDServer interface.
@@ -150,7 +149,6 @@ func (r *Registrator) Stats(ctx context.Context, in *proto.StatsRequest) (reply 
 
 			stats = append(stats, stat)
 		}
-
 	}
 
 	reply = &proto.StatsReply{Stats: stats}

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -19,9 +19,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-var (
-	dataPath *string
-)
+var dataPath *string
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)

--- a/internal/app/proxyd/internal/frontend/frontend.go
+++ b/internal/app/proxyd/internal/frontend/frontend.go
@@ -138,7 +138,6 @@ func (r *ReverseProxy) DecrementBackend(uid string) {
 
 // Watch uses the Kubernetes informer API to watch events for the API server.
 func (r *ReverseProxy) Watch(kubeClient kubernetes.Interface) (err error) {
-
 	// Filter for only apiservers
 	labelSelector := labels.FormatLabels(map[string]string{"component": "kube-apiserver"})
 	watchlist := &cache.ListWatch{

--- a/internal/app/proxyd/internal/reg/reg_test.go
+++ b/internal/app/proxyd/internal/reg/reg_test.go
@@ -62,7 +62,6 @@ func (suite *ProxydSuite) TestBackends() {
 	suite.Assert().NoError(err)
 	suite.Assert().Equal(resp.Backends[0].Addr, testBackend)
 	log.Println(resp)
-
 }
 
 func fakeProxydRPC() (net.Listener, error) {

--- a/internal/app/proxyd/main.go
+++ b/internal/app/proxyd/main.go
@@ -22,9 +22,7 @@ import (
 	pkgnet "github.com/talos-systems/talos/pkg/net"
 )
 
-var (
-	dataPath *string
-)
+var dataPath *string
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
@@ -67,7 +65,6 @@ func main() {
 			factory.Network("unix"),
 			factory.SocketPath(constants.ProxydSocketPath),
 		)
-
 	}()
 
 	log.Fatal(<-errch)
@@ -106,5 +103,4 @@ func waitForKube(r *frontend.ReverseProxy) {
 	if err = r.Watch(clientset); err != nil {
 		log.Fatalf("failed to watch kubernetes api server: %v", err)
 	}
-
 }

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -19,9 +19,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-var (
-	dataPath *string
-)
+var dataPath *string
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)

--- a/internal/pkg/containers/containerd/containerd.go
+++ b/internal/pkg/containers/containerd/containerd.go
@@ -284,7 +284,6 @@ func (i *inspector) Container(id string) (*ctrs.Container, error) {
 	}
 
 	return cntr, err
-
 }
 
 // Pods collects information about running pods & containers.

--- a/internal/pkg/containers/cri/cri.go
+++ b/internal/pkg/containers/cri/cri.go
@@ -146,7 +146,6 @@ func (i *inspector) Container(id string) (*ctrs.Container, error) {
 			"io.kubernetes.container.name": name,
 		},
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -201,6 +201,7 @@ func (suite *CRISuite) TestList() {
 	_, err = suite.client.ListImages(suite.ctx, &runtimeapi.ImageFilter{})
 	suite.Require().NoError(err)
 }
+
 func TestCRISuite(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("can't run the test as non-root")

--- a/internal/pkg/cri/images.go
+++ b/internal/pkg/cri/images.go
@@ -34,7 +34,6 @@ func (c *Client) ListImages(ctx context.Context, filter *runtimeapi.ImageFilter)
 	}
 
 	return resp.Images, nil
-
 }
 
 // ImageStatus returns the status of the image.

--- a/internal/pkg/kernel/kspp/kspp.go
+++ b/internal/pkg/kernel/kspp/kspp.go
@@ -11,16 +11,14 @@ import (
 	"github.com/talos-systems/talos/pkg/sysctl"
 )
 
-var (
-	// RequiredKSPPKernelParameters is the set of kernel parameters required to
-	// satisfy the KSPP.
-	RequiredKSPPKernelParameters = kernel.Parameters{
-		kernel.NewParameter("page_poison").Append("1"),
-		kernel.NewParameter("slab_nomerge").Append(""),
-		kernel.NewParameter("slub_debug").Append("P"),
-		kernel.NewParameter("pti").Append("on"),
-	}
-)
+// RequiredKSPPKernelParameters is the set of kernel parameters required to
+// satisfy the KSPP.
+var RequiredKSPPKernelParameters = kernel.Parameters{
+	kernel.NewParameter("page_poison").Append("1"),
+	kernel.NewParameter("slab_nomerge").Append(""),
+	kernel.NewParameter("slub_debug").Append("P"),
+	kernel.NewParameter("pti").Append("on"),
+}
 
 // EnforceKSPPKernelParameters verifies that all required KSPP kernel
 // parameters are present with the right value.

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -135,7 +135,6 @@ func (p *Point) Mount() (err error) {
 	}
 
 	return nil
-
 }
 
 // Unmount attempts to retry an unmount on EBUSY. It will attempt a

--- a/pkg/archiver/walker.go
+++ b/pkg/archiver/walker.go
@@ -99,14 +99,12 @@ func Walker(ctx context.Context, rootPath string, options ...WalkerOption) (<-ch
 
 			return nil
 		})
-
 		if err != nil {
 			select {
 			case <-ctx.Done():
 			case ch <- FileItem{Error: err}:
 			}
 		}
-
 	}()
 
 	return ch, nil

--- a/pkg/archiver/walker_test.go
+++ b/pkg/archiver/walker_test.go
@@ -37,7 +37,8 @@ func (suite *WalkerSuite) TestIterationDir() {
 		"dev", "dev/random",
 		"etc", "etc/certs", "etc/certs/ca.crt", "etc/hostname",
 		"lib", "lib/dynalib.so",
-		"usr", "usr/bin", "usr/bin/cp", "usr/bin/mv"},
+		"usr", "usr/bin", "usr/bin/cp", "usr/bin/mv",
+	},
 		relPaths)
 }
 
@@ -53,7 +54,8 @@ func (suite *WalkerSuite) TestIterationMaxRecurseDepth() {
 	}
 
 	suite.Assert().Equal([]string{
-		".", "dev", "etc", "lib", "usr"},
+		".", "dev", "etc", "lib", "usr",
+	},
 		relPaths)
 }
 

--- a/pkg/blockdevice/table/gpt/header/header.go
+++ b/pkg/blockdevice/table/gpt/header/header.go
@@ -187,7 +187,6 @@ func (hdr *Header) Fields() []*serde.Field {
 				}
 				if o.Primary {
 					binary.LittleEndian.PutUint64(data, hdr.BackupLBA)
-
 				} else {
 					binary.LittleEndian.PutUint64(data, hdr.CurrentLBA)
 				}

--- a/pkg/chunker/file/file_test.go
+++ b/pkg/chunker/file/file_test.go
@@ -95,7 +95,6 @@ func (suite *FileChunkerSuite) TestStreaming() {
 	ctxCancel()
 
 	suite.Require().Equal([]byte("abcdefghijklmno"), <-combinedCh)
-
 }
 
 func (suite *FileChunkerSuite) TestStreamingWithSomeHead() {

--- a/pkg/grpc/factory/factory.go
+++ b/pkg/grpc/factory/factory.go
@@ -134,7 +134,6 @@ func NewListener(setters ...Option) (net.Listener, error) {
 func ListenAndServe(r Registrator, setters ...Option) (err error) {
 	server := NewServer(r, setters...)
 	listener, err := NewListener(setters...)
-
 	if err != nil {
 		return err
 	}

--- a/pkg/grpc/gen/gen.go
+++ b/pkg/grpc/gen/gen.go
@@ -41,7 +41,7 @@ func NewGenerator(data *userdata.UserData, port int) (g *Generator, err error) {
 		conn, err = basic.NewConnection(data.Services.Trustd.Endpoints[i], port, creds)
 		if err != nil {
 			multiError = multierror.Append(multiError, err)
-			//Unable to connect, bail and attempt to contact next endpoint
+			// Unable to connect, bail and attempt to contact next endpoint
 			continue
 		}
 		client := proto.NewTrustdClient(conn)
@@ -51,7 +51,6 @@ func NewGenerator(data *userdata.UserData, port int) (g *Generator, err error) {
 	// We were unable to connect to any trustd endpoint
 	// Return error from last attempt.
 	return nil, multiError.ErrorOrNil()
-
 }
 
 // Certificate implements the proto.TrustdClient interface.

--- a/pkg/grpc/tls/cert.go
+++ b/pkg/grpc/tls/cert.go
@@ -113,7 +113,6 @@ func NewRenewingFileCertificateProvider(ctx context.Context, data *userdata.User
 }
 
 func (p *renewingFileCertificateProvider) loadInitialCert() error {
-
 	// TODO: eventually, we will reverse this priority, and have the override
 	// come from the userdata.  For now, however, we use the local file to
 	// override the userdata, because we _always_ have userdata certs, and the
@@ -134,7 +133,7 @@ func (p *renewingFileCertificateProvider) loadInitialCert() error {
 }
 
 func (p *renewingFileCertificateProvider) manageUpdates(ctx context.Context) {
-	var nextRenewal = constants.NodeCertRenewalInterval
+	nextRenewal := constants.NodeCertRenewalInterval
 
 	for ctx.Err() == nil {
 		if c, _ := p.GetCertificate(nil); c != nil { // nolint: errcheck

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -22,7 +22,6 @@ func IPAddrs() (ips []net.IP, err error) {
 		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
 			if ipnet.IP.To4() != nil {
 				ips = append(ips, ipnet.IP)
-
 			}
 		}
 	}

--- a/pkg/proc/reaper/wait.go
+++ b/pkg/proc/reaper/wait.go
@@ -36,7 +36,6 @@ func WaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, cmd *exec.Cmd) e
 	}
 
 	return err
-
 }
 
 func convertWaitStatus(status syscall.WaitStatus) error {

--- a/pkg/userdata/generate/generate.go
+++ b/pkg/userdata/generate/generate.go
@@ -85,7 +85,6 @@ func (i *Input) GetControlPlaneEndpoint() string {
 
 // GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
 func (i *Input) GetAPIServerEndpoint(port string) string {
-
 	if i == nil || len(i.MasterIPs) < 1 {
 		panic("cannot GetControlPlaneEndpoint without any Master IPs")
 	}
@@ -105,8 +104,7 @@ func (i *Input) GetAPIServerEndpoint(port string) string {
 
 // GetAPIServerSANs returns the formatted list of Subject Alt Name addresses for the API Server
 func (i *Input) GetAPIServerSANs() []string {
-
-	var list = []string{"127.0.0.1", "::1"}
+	list := []string{"127.0.0.1", "::1"}
 	list = append(list, i.MasterIPs...)
 	list = append(list, i.AdditionalSubjectAltNames...)
 
@@ -137,7 +135,6 @@ type TrustdInfo struct {
 // randBytes returns a random string consisting of the characters in
 // validBootstrapTokenChars, with the length customized by the parameter
 func randBytes(length int) (string, error) {
-
 	// validBootstrapTokenChars defines the characters a bootstrap token can consist of
 	const validBootstrapTokenChars = "0123456789abcdefghijklmnopqrstuvwxyz"
 
@@ -168,12 +165,11 @@ func randBytes(length int) (string, error) {
 	return string(token), err
 }
 
-//genToken will generate a token of the format abc.123 (like kubeadm/trustd), where the length of the first string (before the dot)
-//and length of the second string (after dot) are specified as inputs
+// genToken will generate a token of the format abc.123 (like kubeadm/trustd), where the length of the first string (before the dot)
+// and length of the second string (after dot) are specified as inputs
 func genToken(lenFirst int, lenSecond int) (string, error) {
-
 	var err error
-	var tokenTemp = make([]string, 2)
+	tokenTemp := make([]string, 2)
 
 	tokenTemp[0], err = randBytes(lenFirst)
 	if err != nil {
@@ -202,7 +198,6 @@ func isIPv6(addrs ...string) bool {
 // types.
 // nolint: dupl,gocyclo
 func NewInput(clustername string, masterIPs []string) (input *Input, err error) {
-
 	var loopbackIP, podNet, serviceNet string
 
 	if isIPv6(masterIPs...) {
@@ -215,20 +210,20 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 		serviceNet = DefaultIPv4ServiceNet
 	}
 
-	//Gen trustd token strings
+	// Gen trustd token strings
 	kubeadmBootstrapToken, err := genToken(6, 16)
 	if err != nil {
 		return nil, err
 	}
 
-	//TODO: Can be dropped
-	//Gen kubeadm cert key
+	// TODO: Can be dropped
+	// Gen kubeadm cert key
 	kubeadmCertKey, err := randBytes(26)
 	if err != nil {
 		return nil, err
 	}
 
-	//Gen trustd token strings
+	// Gen trustd token strings
 	trustdToken, err := genToken(6, 16)
 	if err != nil {
 		return nil, err

--- a/pkg/userdata/kubeadm.go
+++ b/pkg/userdata/kubeadm.go
@@ -37,7 +37,6 @@ type Kubeadm struct {
 
 // MarshalYAML implements the yaml.Marshaler interface.
 func (kdm *Kubeadm) MarshalYAML() (interface{}, error) {
-
 	// Encode init and cluster configs
 	encodedObjs := [][]byte{}
 	for _, obj := range []runtime.Object{kdm.InitConfiguration, kdm.ClusterConfiguration, kdm.JoinConfiguration} {

--- a/pkg/userdata/kubernetes_security_test.go
+++ b/pkg/userdata/kubernetes_security_test.go
@@ -21,7 +21,6 @@ func (suite *validateSuite) TestValidateKubernetesSecurity() {
 	// Embedding the check in suite.Assert().Equal(true, xerrors.Is had issues )
 	if !xerrors.Is(err.(*multierror.Error).Errors[0], ErrRequiredSection) {
 		suite.T().Errorf("%+v", err)
-
 	}
 
 	kube.CA = &x509.PEMEncodedCertificateAndKey{}

--- a/pkg/userdata/networking_test.go
+++ b/pkg/userdata/networking_test.go
@@ -19,7 +19,6 @@ func (suite *validateSuite) TestValidateDevice() {
 	// Embedding the check in suite.Assert().Equal(true, xerrors.Is had issues )
 	if !xerrors.Is(err.(*multierror.Error).Errors[0], ErrRequiredSection) {
 		suite.T().Errorf("%+v", err)
-
 	}
 
 	dev.Interface = "eth0"

--- a/pkg/userdata/os_security_test.go
+++ b/pkg/userdata/os_security_test.go
@@ -21,7 +21,6 @@ func (suite *validateSuite) TestValidateOSSecurity() {
 	// Embedding the check in suite.Assert().Equal(true, xerrors.Is had issues )
 	if !xerrors.Is(err.(*multierror.Error).Errors[0], ErrRequiredSection) {
 		suite.T().Errorf("%+v", err)
-
 	}
 
 	os.CA = &x509.PEMEncodedCertificateAndKey{}

--- a/pkg/userdata/translate/translate_v1alpha1.go
+++ b/pkg/userdata/translate/translate_v1alpha1.go
@@ -112,11 +112,9 @@ func translateV1Alpha1Network(nc *v1alpha1.NodeConfig, ud *userdata.UserData) {
 
 		ud.Networking.OS.Devices = append(ud.Networking.OS.Devices, d)
 	}
-
 }
 
 func translateV1Alpha1Install(nc *v1alpha1.NodeConfig, ud *userdata.UserData) {
-
 	ud.Install = &userdata.Install{
 		Disk:       nc.Machine.Install.Disk,
 		Image:      nc.Machine.Install.Image,
@@ -314,7 +312,7 @@ func translateV1Alpha1ControlPlane(nc *v1alpha1.NodeConfig, ud *userdata.UserDat
 }
 
 func translateV1Alpha1Worker(nc *v1alpha1.NodeConfig, ud *userdata.UserData) {
-	//Craft a worker kubeadm config
+	// Craft a worker kubeadm config
 	workerConfig := &kubeadm.JoinConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "JoinConfiguration",

--- a/pkg/userdata/v1alpha1/generate/controlplane.go
+++ b/pkg/userdata/v1alpha1/generate/controlplane.go
@@ -10,7 +10,6 @@ import (
 )
 
 func controlPlaneUd(in *Input) (string, error) {
-
 	machine := &v1alpha1.MachineConfig{
 		Type:  "controlplane",
 		Token: in.TrustdInfo.Token,

--- a/pkg/userdata/v1alpha1/generate/generate.go
+++ b/pkg/userdata/v1alpha1/generate/generate.go
@@ -85,7 +85,6 @@ func (i *Input) Endpoints() (out string) {
 
 // GetControlPlaneEndpoint returns the formatted host:port of the canonical controlplane address, defaulting to the first master IP
 func (i *Input) GetControlPlaneEndpoint() string {
-
 	if i == nil || (len(i.MasterIPs) < 1 && i.ControlPlaneEndpoint == "") {
 		panic("cannot GetControlPlaneEndpoint without any Master IPs")
 	}
@@ -99,7 +98,6 @@ func (i *Input) GetControlPlaneEndpoint() string {
 
 // GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
 func (i *Input) GetAPIServerEndpoint(port string) string {
-
 	if i == nil || len(i.MasterIPs) < 1 {
 		panic("cannot GetControlPlaneEndpoint without any Master IPs")
 	}
@@ -119,8 +117,7 @@ func (i *Input) GetAPIServerEndpoint(port string) string {
 
 // GetAPIServerSANs returns the formatted list of Subject Alt Name addresses for the API Server
 func (i *Input) GetAPIServerSANs() []string {
-
-	var list = []string{"127.0.0.1", "::1"}
+	list := []string{"127.0.0.1", "::1"}
 	list = append(list, i.MasterIPs...)
 	list = append(list, i.AdditionalSubjectAltNames...)
 
@@ -151,7 +148,6 @@ type TrustdInfo struct {
 // randBytes returns a random string consisting of the characters in
 // validBootstrapTokenChars, with the length customized by the parameter
 func randBytes(length int) (string, error) {
-
 	// validBootstrapTokenChars defines the characters a bootstrap token can consist of
 	const validBootstrapTokenChars = "0123456789abcdefghijklmnopqrstuvwxyz"
 
@@ -182,12 +178,11 @@ func randBytes(length int) (string, error) {
 	return string(token), err
 }
 
-//genToken will generate a token of the format abc.123 (like kubeadm/trustd), where the length of the first string (before the dot)
-//and length of the second string (after dot) are specified as inputs
+// genToken will generate a token of the format abc.123 (like kubeadm/trustd), where the length of the first string (before the dot)
+// and length of the second string (after dot) are specified as inputs
 func genToken(lenFirst int, lenSecond int) (string, error) {
-
 	var err error
-	var tokenTemp = make([]string, 2)
+	tokenTemp := make([]string, 2)
 
 	tokenTemp[0], err = randBytes(lenFirst)
 	if err != nil {
@@ -216,7 +211,6 @@ func isIPv6(addrs ...string) bool {
 // types.
 // nolint: dupl,gocyclo
 func NewInput(clustername string, masterIPs []string) (input *Input, err error) {
-
 	var loopbackIP, podNet, serviceNet string
 
 	if isIPv6(masterIPs...) {
@@ -229,20 +223,20 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 		serviceNet = DefaultIPv4ServiceNet
 	}
 
-	//Gen trustd token strings
+	// Gen trustd token strings
 	kubeadmBootstrapToken, err := genToken(6, 16)
 	if err != nil {
 		return nil, err
 	}
 
-	//TODO: Can be dropped
-	//Gen kubeadm cert key
+	// TODO: Can be dropped
+	// Gen kubeadm cert key
 	kubeadmCertKey, err := randBytes(26)
 	if err != nil {
 		return nil, err
 	}
 
-	//Gen trustd token strings
+	// Gen trustd token strings
 	trustdToken, err := genToken(6, 16)
 	if err != nil {
 		return nil, err

--- a/pkg/userdata/v1alpha1/generate/generate_test.go
+++ b/pkg/userdata/v1alpha1/generate/generate_test.go
@@ -14,9 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	input *udgenv1alpha1.Input
-)
+var input *udgenv1alpha1.Input
 
 type GenerateSuite struct {
 	suite.Suite

--- a/pkg/userdata/v1alpha1/generate/init.go
+++ b/pkg/userdata/v1alpha1/generate/init.go
@@ -10,7 +10,6 @@ import (
 )
 
 func initUd(in *Input) (string, error) {
-
 	machine := &v1alpha1.MachineConfig{
 		Type:    "init",
 		Kubelet: &v1alpha1.KubeletConfig{},

--- a/pkg/userdata/v1alpha1/generate/join.go
+++ b/pkg/userdata/v1alpha1/generate/join.go
@@ -10,7 +10,6 @@ import (
 )
 
 func workerUd(in *Input) (string, error) {
-
 	machine := &v1alpha1.MachineConfig{
 		Type:    "worker",
 		Token:   in.TrustdInfo.Token,


### PR DESCRIPTION
The gofumpt linter is a stricter drop-in replacement for gofmt. The
rules are ones that I strongly agree with and I think it would be better
if we added this linter instead of nit picking every PR.