### PR TITLE
fix: use /var/log for default log path

### DIFF
--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -61,7 +61,7 @@ func DefaultOptions() *Options {
 	return &Options{
 		Env:                     []string{},
 		Namespace:               "system",
-		LogPath:                 "/run",
+		LogPath:                 "/var/log",
 		GracefulShutdownTimeout: 10 * time.Second,
 		ContainerdAddress:       constants.ContainerdAddress,
 	}

--- a/internal/app/machined/pkg/system/services/machined_api.go
+++ b/internal/app/machined/pkg/system/services/machined_api.go
@@ -45,5 +45,5 @@ func (c *MachinedAPI) DependsOn(data *userdata.UserData) []string {
 
 // Runner implements the Service interface.
 func (c *MachinedAPI) Runner(data *userdata.UserData) (runner.Runner, error) {
-	return goroutine.NewRunner(data, "machined-api", api.NewService().Main), nil
+	return goroutine.NewRunner(data, "machined-api", api.NewService().Main, runner.WithLogPath("/run")), nil
 }

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -75,6 +75,7 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		{Type: "bind", Destination: constants.UserDataPath, Source: constants.UserDataPath, Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: constants.ContainerdAddress, Source: constants.ContainerdAddress, Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/run/system", Source: "/run/system", Options: []string{"bind", "ro"}},
+		{Type: "bind", Destination: "/var/log", Source: "/var/log", Options: []string{"bind", "ro"}},
 	}
 
 	env := []string{}

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -75,6 +75,7 @@ func (c *SystemContainerd) Runner(data *userdata.UserData) (runner.Runner, error
 		data,
 		args,
 		runner.WithEnv(env),
+		runner.WithLogPath("/run"),
 	),
 		restart.WithType(restart.Forever),
 	), nil


### PR DESCRIPTION
This moves the default log path to /var/log. An expection is made for
machined-api and system-containerd since they must have zero
dependencies on the ephemeral disk. In the case of machined-api, we
cannot stop the service since it is required to perform an upgrade. As
for system-containerd, it starts before any ephemeral disk is mounted so
we will fail to start the service since /var/log is a read-only file system.