### PR TITLE
feat: move node certificate to tmpfs

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -176,7 +176,7 @@ const (
 	RootfsAsset = "rootfs.sqsh"
 
 	// NodeCertFile is the filename where the current Talos Node Certificate may be found
-	NodeCertFile = "/var/talos-node.crt"
+	NodeCertFile = "/run/system/talos-node.crt"
 
 	// NodeCertRenewalInterval is the default interval at which Talos Node Certifications should be renewed
 	NodeCertRenewalInterval = 24 * time.Hour


### PR DESCRIPTION
This ensures that node certificates are ephemeral by storing them in a
tmpfs.