### PR TITLE
chore: upgrade golancgi-lint to 1.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.16.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.18.0
 RUN cd $(mktemp -d) \
     && go mod init tmp \
     && go get mvdan.cc/gofumpt \
@@ -318,6 +318,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go test -v -count 1 -race ${
 
 FROM base AS lint
 COPY hack/golang/golangci-lint.yaml .
+ENV GOGC=50
 RUN --mount=type=cache,target=/.cache/go-build golangci-lint run --config golangci-lint.yaml
 RUN find . -name '*.pb.go' | xargs rm
 RUN FILES="$(gofumpt -l .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumpt -s -w':\n${FILES}"; exit 1)

--- a/hack/golang/golangci-lint.yaml
+++ b/hack/golang/golangci-lint.yaml
@@ -101,6 +101,7 @@ linters:
     - typecheck
     - gochecknoglobals
     - gochecknoinits
+    - funlen
   disable-all: false
   fast: false
 


### PR DESCRIPTION
New linter 'funlen' was disabled as too many functions break the default
limit, but might be considered for the future.

To limit peak memory usage, `GOGC=50` was added to the golangci-lint run
to make Go's garbage collector more aggressive. With this setting peak
seems to be around 8Gb.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>