### PR TITLE
chore: move interface type assertion to unit-tests

### DIFF
--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -108,8 +107,3 @@ func (c *Containerd) HealthFunc(*userdata.UserData) health.Check {
 func (c *Containerd) HealthSettings(*userdata.UserData) *health.Settings {
 	return &health.DefaultSettings
 }
-
-// Verify healthchecked interface
-var (
-	_ system.HealthcheckedService = &Containerd{}
-)

--- a/internal/app/machined/pkg/system/services/containerd_test.go
+++ b/internal/app/machined/pkg/system/services/containerd_test.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestContainerdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Containerd))
+}

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/cni"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -167,8 +166,3 @@ func (k *Kubelet) HealthSettings(*userdata.UserData) *health.Settings {
 
 	return &settings
 }
-
-// Verify healthchecked interface
-var (
-	_ system.HealthcheckedService = &Kubelet{}
-)

--- a/internal/app/machined/pkg/system/services/kubelet_test.go
+++ b/internal/app/machined/pkg/system/services/kubelet_test.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestKubeletInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Kubelet))
+}

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -106,9 +105,3 @@ func (n *NTPd) APIStartAllowed(data *userdata.UserData) bool {
 func (n *NTPd) APIRestartAllowed(data *userdata.UserData) bool {
 	return true
 }
-
-// Verify interfaces
-var (
-	_ system.APIStartableService   = &NTPd{}
-	_ system.APIRestartableService = &NTPd{}
-)

--- a/internal/app/machined/pkg/system/services/ntpd_test.go
+++ b/internal/app/machined/pkg/system/services/ntpd_test.go
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestNTPdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.APIStartableService)(nil), new(services.NTPd))
+	assert.Implements(t, (*system.APIRestartableService)(nil), new(services.NTPd))
+}

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -115,8 +114,3 @@ func (o *OSD) HealthFunc(*userdata.UserData) health.Check {
 func (o *OSD) HealthSettings(*userdata.UserData) *health.Settings {
 	return &health.DefaultSettings
 }
-
-// Verify healthchecked interface
-var (
-	_ system.HealthcheckedService = &OSD{}
-)

--- a/internal/app/machined/pkg/system/services/osd_test.go
+++ b/internal/app/machined/pkg/system/services/osd_test.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestOSDInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.OSD))
+}

--- a/internal/app/machined/pkg/system/services/proxyd.go
+++ b/internal/app/machined/pkg/system/services/proxyd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -123,10 +122,3 @@ func (p *Proxyd) APIStartAllowed(data *userdata.UserData) bool {
 func (p *Proxyd) APIRestartAllowed(data *userdata.UserData) bool {
 	return true
 }
-
-// Verify interfaces
-var (
-	_ system.APIStartableService   = &Proxyd{}
-	_ system.APIRestartableService = &Proxyd{}
-	_ system.HealthcheckedService  = &Proxyd{}
-)

--- a/internal/app/machined/pkg/system/services/proxyd_test.go
+++ b/internal/app/machined/pkg/system/services/proxyd_test.go
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestProxydInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Proxyd))
+	assert.Implements(t, (*system.APIStartableService)(nil), new(services.Proxyd))
+	assert.Implements(t, (*system.APIRestartableService)(nil), new(services.Proxyd))
+}

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -108,8 +107,3 @@ func (c *SystemContainerd) HealthFunc(*userdata.UserData) health.Check {
 func (c *SystemContainerd) HealthSettings(*userdata.UserData) *health.Settings {
 	return &health.DefaultSettings
 }
-
-// Verify healthchecked interface
-var (
-	_ system.HealthcheckedService = &SystemContainerd{}
-)

--- a/internal/app/machined/pkg/system/services/system-containerd_test.go
+++ b/internal/app/machined/pkg/system/services/system-containerd_test.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestSystemContainerdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.SystemContainerd))
+}

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -14,7 +14,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -112,8 +111,3 @@ func (t *Trustd) HealthFunc(*userdata.UserData) health.Check {
 func (t *Trustd) HealthSettings(*userdata.UserData) *health.Settings {
 	return &health.DefaultSettings
 }
-
-// Verify healthchecked interface
-var (
-	_ system.HealthcheckedService = &Trustd{}
-)

--- a/internal/app/machined/pkg/system/services/trustd_test.go
+++ b/internal/app/machined/pkg/system/services/trustd_test.go
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestTrustdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Trustd))
+}

--- a/internal/app/machined/pkg/system/services/udevd_trigger.go
+++ b/internal/app/machined/pkg/system/services/udevd_trigger.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
@@ -85,10 +84,3 @@ func (c *UdevdTrigger) APIStopAllowed(data *userdata.UserData) bool {
 func (c *UdevdTrigger) APIRestartAllowed(data *userdata.UserData) bool {
 	return true
 }
-
-// Verify interfaces
-var (
-	_ system.APIStartableService   = &UdevdTrigger{}
-	_ system.APIRestartableService = &UdevdTrigger{}
-	_ system.APIStoppableService   = &UdevdTrigger{}
-)

--- a/internal/app/machined/pkg/system/services/udevd_trigger_test.go
+++ b/internal/app/machined/pkg/system/services/udevd_trigger_test.go
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestUdevdTriggerInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.APIStoppableService)(nil), new(services.UdevdTrigger))
+	assert.Implements(t, (*system.APIStartableService)(nil), new(services.UdevdTrigger))
+	assert.Implements(t, (*system.APIRestartableService)(nil), new(services.UdevdTrigger))
+}


### PR DESCRIPTION
This moves optional interface checks to unit-tests, removing type checks
via global variable assignment.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>