### PR TITLE
chore: make ntpd depend on networkd

### DIFF
--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -55,7 +55,7 @@ func (n *NTPd) Condition(data *userdata.UserData) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (n *NTPd) DependsOn(data *userdata.UserData) []string {
-	return []string{"system-containerd"}
+	return []string{"system-containerd", "networkd"}
 }
 
 func (n *NTPd) Runner(data *userdata.UserData) (runner.Runner, error) {


### PR DESCRIPTION
As ntpd relies on outbound networking, it makes sense to wait for
networkd.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>