### PR TITLE
chore: upgrade conformange image

### DIFF
--- a/hack/test/conformance.sh
+++ b/hack/test/conformance.sh
@@ -26,6 +26,6 @@ e2e_run "set -eou pipefail
             --skip-preflight \
             --plugin e2e \
             --plugin-env e2e.E2E_USE_GO_RUNNER=true \
-            --kube-conformance-image-version v1.16.0-beta.0
+            --kube-conformance-image-version v1.16.0-rc.2
          results=\$(sonobuoy retrieve --kubeconfig ${KUBECONFIG})
          sonobuoy e2e --kubeconfig ${KUBECONFIG} \$results"


### PR DESCRIPTION
This upgrade the kube-conformance image used by sonobouy to
v1.16.0-rc.2.