### PR TITLE
fix: log system services to /run/system/log

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/var_directories.go
+++ b/internal/app/machined/internal/phase/rootfs/var_directories.go
@@ -27,7 +27,7 @@ func (task *VarDirectories) RuntimeFunc(mode runtime.Mode) phase.RuntimeFunc {
 }
 
 func (task *VarDirectories) runtime(platform platform.Platform, data *userdata.UserData) (err error) {
-	for _, p := range []string{"/var/log", "/var/lib/kubelet", "/var/log/pods"} {
+	for _, p := range []string{"/var/log/pods", "/var/lib/kubelet"} {
 		if err = os.MkdirAll(p, 0700); err != nil {
 			return err
 		}

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -61,7 +61,7 @@ func DefaultOptions() *Options {
 	return &Options{
 		Env:                     []string{},
 		Namespace:               "system",
-		LogPath:                 "/var/log",
+		LogPath:                 constants.DefaultLogPath,
 		GracefulShutdownTimeout: 10 * time.Second,
 		ContainerdAddress:       constants.ContainerdAddress,
 	}

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -55,7 +55,7 @@ func (o *OSD) Condition(data *userdata.UserData) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *OSD) DependsOn(data *userdata.UserData) []string {
-	return []string{"system-containerd"}
+	return []string{"system-containerd", "containerd"}
 }
 
 func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
@@ -74,8 +74,8 @@ func (o *OSD) Runner(data *userdata.UserData) (runner.Runner, error) {
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: constants.UserDataPath, Source: constants.UserDataPath, Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: constants.ContainerdAddress, Source: constants.ContainerdAddress, Options: []string{"bind", "ro"}},
-		{Type: "bind", Destination: "/run/system", Source: "/run/system", Options: []string{"bind", "ro"}},
-		{Type: "bind", Destination: "/var/log", Source: "/var/log", Options: []string{"bind", "ro"}},
+		{Type: "bind", Destination: constants.SystemRunPath, Source: constants.SystemRunPath, Options: []string{"bind", "ro"}},
+		{Type: "bind", Destination: "/var/log/pods", Source: "/var/log/pods", Options: []string{"bind", "ro"}},
 	}
 
 	env := []string{}

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -212,13 +212,7 @@ func (r *Registrator) Logs(req *proto.LogsRequest, l proto.OSD_LogsServer) (err 
 
 	switch {
 	case req.Namespace == "system" || req.Id == "kubelet" || req.Id == "kubeadm":
-		// TODO(andrewrynhard): This is a dirty hack. We should expose this at
-		// the service level.
-		base := "/var/log"
-		if req.Id == "machined-api" || req.Id == "system-containerd" {
-			base = "/run"
-		}
-		filename := filepath.Join(base, filepath.Base(req.Id)+".log")
+		filename := filepath.Join(constants.DefaultLogPath, filepath.Base(req.Id)+".log")
 		var file *os.File
 		file, err = os.OpenFile(filename, os.O_RDONLY, 0)
 		if err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -143,22 +143,22 @@ const (
 	SystemContainerdNamespace = "system"
 
 	// SystemContainerdAddress is the path to the system containerd socket.
-	SystemContainerdAddress = "/run/system/containerd/containerd.sock"
+	SystemContainerdAddress = SystemRunPath + "/containerd/containerd.sock"
 
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 
 	// InitSocketPath is the path to file socket of init API
-	InitSocketPath = "/run/system/init/init.sock"
+	InitSocketPath = SystemRunPath + "/init/init.sock"
 
 	// ProxydSocketPath is the path to file socket of proxyd API
-	ProxydSocketPath = "/run/system/proxyd/proxyd.sock"
+	ProxydSocketPath = SystemRunPath + "/proxyd/proxyd.sock"
 
 	// NtpdSocketPath is the path to file socket of proxyd API
-	NtpdSocketPath = "/run/system/ntpd/ntpd.sock"
+	NtpdSocketPath = SystemRunPath + "/ntpd/ntpd.sock"
 
 	// NetworkdSocketPath is the path to file socket of proxyd API
-	NetworkdSocketPath = "/run/system/networkd/networkd.sock"
+	NetworkdSocketPath = SystemRunPath + "/networkd/networkd.sock"
 
 	// KernelAsset defines a well known name for our kernel filename
 	KernelAsset = "vmlinuz"
@@ -176,7 +176,7 @@ const (
 	RootfsAsset = "rootfs.sqsh"
 
 	// NodeCertFile is the filename where the current Talos Node Certificate may be found
-	NodeCertFile = "/run/system/talos-node.crt"
+	NodeCertFile = SystemRunPath + "/talos-node.crt"
 
 	// NodeCertRenewalInterval is the default interval at which Talos Node Certifications should be renewed
 	NodeCertRenewalInterval = 24 * time.Hour
@@ -185,9 +185,16 @@ const (
 	// directories.
 	SystemVarPath = "/var/system"
 
+	// SystemRunPath is the path to write temporary runtime system related files
+	// and directories.
+	SystemRunPath = "/run/system"
+
 	// DefaultInstallerImageRepository is the default container repository for
 	// the installer.
 	DefaultInstallerImageRepository = "docker.io/autonomy/installer"
+
+	// DefaultLogPath is the default path to the log storage directory.
+	DefaultLogPath = SystemRunPath + "/log"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Writing system logs to /var/log breaks upgrades. The system disk unmount
fails with EBUSY. For now we can log to /run/system/log to avoid this.