### PR TITLE
chore: fix AWS image dependency

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2754,12 +2754,6 @@ steps:
   commands:
   - make image-aws
   environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: aws_access_key_id
-    AWS_DEFAULT_REGION: us-west-2
-    AWS_PUBLISH_REGIONS: us-west-2,us-east-1,us-east-2,us-west-1,eu-central-1
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: aws_secret_access_key
     BINDIR: /usr/local/bin
     BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
   volumes:
@@ -2769,11 +2763,8 @@ steps:
     path: /dev
   - name: tmp
     path: /tmp
-  when:
-    event:
-    - tag
   depends_on:
-  - push
+  - installer
 
 - name: iso
   image: autonomy/build-container:latest

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -332,7 +332,6 @@ local ami_trigger = {
 
 local kernel = Step('kernel');
 local iso = Step('iso', depends_on=[installer]);
-local image_aws = Step('image-aws', depends_on=[push], environment=aws_env_vars) + ami_trigger;
 
 // TODO(andrewrynhard): We should run E2E tests on a release.
 local release = {


### PR DESCRIPTION
We no longer need to wait for the installer image to be pushed before
creating the AWS image.