### PR TITLE
fix(machined): add nil checks to metal initializer

### DIFF
--- a/internal/app/machined/internal/runtime/initializer/metal/metal.go
+++ b/internal/app/machined/internal/runtime/initializer/metal/metal.go
@@ -5,6 +5,7 @@
 package metal
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -25,6 +26,12 @@ type Metal struct{}
 
 // Initialize implements the Initializer interface.
 func (b *Metal) Initialize(platform platform.Platform, data *userdata.UserData) (err error) {
+	if data == nil {
+		return errors.New("no userdata")
+	}
+	if data.Install == nil {
+		return errors.New("userdata has no install section")
+	}
 	// Attempt to discover a previous installation
 	// An err case should only happen if no partitions
 	// with matching labels were found


### PR DESCRIPTION
Check that the userdata has an Install section before trying to use it

Fixes #1186

Signed-off-by: Seán C McCord <ulexus@gmail.com>