### PR TITLE
chore: add version label to installer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -292,6 +292,7 @@ COPY --from=initramfs /initramfs.xz /usr/install/initramfs.xz
 COPY --from=osctl-linux-build /osctl-linux-amd64 /bin/osctl
 ARG TAG
 ENV VERSION ${TAG}
+LABEL "alpha.talos.io/version"="${VERSION}"
 ENTRYPOINT ["entrypoint.sh"]
 
 # The test target performs tests on the source code.


### PR DESCRIPTION
This adds a label to the installer image that indicates the version. We
can build automation around this in a number of different ways, but one
of the use cases we have immediately is to use this label to determine
which version of Talos is at a given channel. For example, if we were to
implement an "edge" channel, we could periodically check for an image
with the tag "edge" and use the version label to determine if a node is
running the current version of edge. Even if we don't use the labels for our
channel implementation, its' still useful information to have.