### PR TITLE
chore: prepare release v0.3.0-alpha.0

### DIFF
--- a/CHANGELOG-0.3.md
+++ b/CHANGELOG-0.3.md
@@ -1,0 +1,18 @@
+# [v0.3.0-alpha.0](https://github.com/andrewrynhard/talos/compare/v0.2.0-rc.0...v0.3.0-alpha.0) (2019-09-24)
+
+
+### Bug Fixes
+
+* **machined:** add nil checks to metal initializer ([1a64ece](https://github.com/andrewrynhard/talos/commit/1a64ece)), closes [#1186](https://github.com/andrewrynhard/talos/issues/1186)
+* add kerenel config required by Cilium ([d4260f6](https://github.com/andrewrynhard/talos/commit/d4260f6))
+* generate CA certificates with 1 year expiration ([fe4fe08](https://github.com/andrewrynhard/talos/commit/fe4fe08))
+* generate CA certificates with 10 year expiration ([70eab14](https://github.com/andrewrynhard/talos/commit/70eab14))
+* set extra kernel args for all platforms ([8f10647](https://github.com/andrewrynhard/talos/commit/8f10647))
+
+
+### Features
+
+* default processes command to one shot ([ead8ce2](https://github.com/andrewrynhard/talos/commit/ead8ce2))
+* return a data structure in version RPC ([9230ff4](https://github.com/andrewrynhard/talos/commit/9230ff4))
+* return a struct for processes RPC ([9ffa064](https://github.com/andrewrynhard/talos/commit/9ffa064))
+* upgrade Kubernetes to v1.16.0 ([82c706a](https://github.com/andrewrynhard/talos/commit/82c706a))


### PR DESCRIPTION
This is the official v0.3.0-alpha.0 release.