### PR TITLE
feat: add aescbcEncryptionSecret field to machine config

### DIFF
--- a/docs/proposals/20190708-MachineConfig.md
+++ b/docs/proposals/20190708-MachineConfig.md
@@ -27,12 +27,12 @@ security:
     ca:
       crt: "{{ .Certs.K8sCert }}"
       key: "{{ .Certs.K8sKey }}"
+    aescbcEncryptionSecret: "{{ .KubeadmTokens.AESCBCEncryptionSecret }}"
 services:
   init:
     cni: flannel
   kubeadm:
     initToken: {{ .InitToken }}
-    certificateKey: '{{ .KubeadmTokens.CertKey }}'
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta1
       kind: InitConfiguration

--- a/pkg/userdata/generate/controlplane.go
+++ b/pkg/userdata/generate/controlplane.go
@@ -15,11 +15,11 @@ security:
     ca:
       crt: "{{ .Certs.K8sCert }}"
       key: "{{ .Certs.K8sKey }}"
+    aescbcEncryptionSecret: "{{ .KubeadmTokens.AESCBCEncryptionSecret }}"
 services:
   init:
     cni: flannel
   kubeadm:
-    certificateKey: '{{ .KubeadmTokens.CertKey }}'
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta2
       kind: JoinConfiguration

--- a/pkg/userdata/generate/generate.go
+++ b/pkg/userdata/generate/generate.go
@@ -17,6 +17,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/talos-systems/talos/internal/pkg/cis"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	tnet "github.com/talos-systems/talos/pkg/net"
@@ -124,8 +125,8 @@ type Certs struct {
 
 // KubeadmTokens holds the senesitve kubeadm data.
 type KubeadmTokens struct {
-	BootstrapToken string
-	CertKey        string
+	BootstrapToken         string
+	AESCBCEncryptionSecret string
 }
 
 // TrustdInfo holds the trustd credentials.
@@ -217,9 +218,7 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 		return nil, err
 	}
 
-	// TODO: Can be dropped
-	// Gen kubeadm cert key
-	kubeadmCertKey, err := randBytes(26)
+	aescbcEncryptionSecret, err := cis.CreateEncryptionToken()
 	if err != nil {
 		return nil, err
 	}
@@ -231,8 +230,8 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 	}
 
 	kubeadmTokens := &KubeadmTokens{
-		BootstrapToken: kubeadmBootstrapToken,
-		CertKey:        kubeadmCertKey,
+		BootstrapToken:         kubeadmBootstrapToken,
+		AESCBCEncryptionSecret: aescbcEncryptionSecret,
 	}
 
 	trustdInfo := &TrustdInfo{

--- a/pkg/userdata/generate/init.go
+++ b/pkg/userdata/generate/init.go
@@ -15,11 +15,11 @@ security:
     ca:
       crt: "{{ .Certs.K8sCert }}"
       key: "{{ .Certs.K8sKey }}"
+    aescbcEncryptionSecret: {{ .KubeadmTokens.AESCBCEncryptionSecret }}
 services:
   init:
     cni: flannel
   kubeadm:
-    certificateKey: '{{ .KubeadmTokens.CertKey }}'
     configuration: |
       apiVersion: kubeadm.k8s.io/v1beta2
       kind: InitConfiguration

--- a/pkg/userdata/kubernetes_security.go
+++ b/pkg/userdata/kubernetes_security.go
@@ -13,10 +13,11 @@ import (
 // KubernetesSecurity represents the set of security options specific to
 // Kubernetes.
 type KubernetesSecurity struct {
-	CA         *x509.PEMEncodedCertificateAndKey `yaml:"ca"`
-	SA         *x509.PEMEncodedCertificateAndKey `yaml:"sa"`
-	FrontProxy *x509.PEMEncodedCertificateAndKey `yaml:"frontproxy"`
-	Etcd       *x509.PEMEncodedCertificateAndKey `yaml:"etcd"`
+	CA                     *x509.PEMEncodedCertificateAndKey `yaml:"ca"`
+	SA                     *x509.PEMEncodedCertificateAndKey `yaml:"sa"`
+	FrontProxy             *x509.PEMEncodedCertificateAndKey `yaml:"frontproxy"`
+	Etcd                   *x509.PEMEncodedCertificateAndKey `yaml:"etcd"`
+	AESCBCEncryptionSecret string                            `yaml:"aescbcEncryptionSecret"`
 }
 
 // KubernetesSecurityCheck defines the function type for checks

--- a/pkg/userdata/translate/translate_v1alpha1.go
+++ b/pkg/userdata/translate/translate_v1alpha1.go
@@ -180,6 +180,7 @@ func translateV1Alpha1Init(nc *v1alpha1.NodeConfig, ud *userdata.UserData) error
 			Crt: kubeCert,
 			Key: kubeKey,
 		},
+		AESCBCEncryptionSecret: nc.Cluster.AESCBCEncryptionSecret,
 	}
 
 	ud.Services.Trustd.CertSANs = []string{nc.Cluster.ControlPlane.IPs[nc.Cluster.ControlPlane.Index], "127.0.0.1", "::1"}
@@ -287,6 +288,10 @@ func translateV1Alpha1ControlPlane(nc *v1alpha1.NodeConfig, ud *userdata.UserDat
 	}
 	ud.Services.Trustd.CertSANs = []string{nc.Cluster.ControlPlane.IPs[nc.Cluster.ControlPlane.Index], "127.0.0.1", "::1"}
 	ud.Services.Kubeadm.ControlPlane = true
+
+	ud.Security.Kubernetes = &userdata.KubernetesSecurity{
+		AESCBCEncryptionSecret: nc.Cluster.AESCBCEncryptionSecret,
+	}
 
 	// Craft a control plane kubeadm config
 	controlPlaneConfig := &kubeadm.JoinConfiguration{

--- a/pkg/userdata/v1alpha1/cluster_config.go
+++ b/pkg/userdata/v1alpha1/cluster_config.go
@@ -6,15 +6,16 @@ package v1alpha1
 
 // ClusterConfig reperesents the cluster-wide config values
 type ClusterConfig struct {
-	ControlPlane      *ControlPlaneConfig      `yaml:"controlPlane"`
-	ClusterName       string                   `yaml:"clusterName,omitempty"`
-	Network           *ClusterNetworkConfig    `yaml:"network,omitempty"`
-	Token             string                   `yaml:"token,omitempty"`
-	CA                *ClusterCAConfig         `yaml:"ca,omitempty"`
-	APIServer         *APIServerConfig         `yaml:"apiServer,omitempty"`
-	ControllerManager *ControllerManagerConfig `yaml:"controllerManager,omitempty"`
-	Scheduler         *SchedulerConfig         `yaml:"scheduler,omitempty"`
-	Etcd              *EtcdConfig              `yaml:"etcd,omitempty"`
+	ControlPlane           *ControlPlaneConfig      `yaml:"controlPlane"`
+	ClusterName            string                   `yaml:"clusterName,omitempty"`
+	Network                *ClusterNetworkConfig    `yaml:"network,omitempty"`
+	Token                  string                   `yaml:"token,omitempty"`
+	AESCBCEncryptionSecret string                   `yaml:"aescbcEncryptionSecret"`
+	CA                     *ClusterCAConfig         `yaml:"ca,omitempty"`
+	APIServer              *APIServerConfig         `yaml:"apiServer,omitempty"`
+	ControllerManager      *ControllerManagerConfig `yaml:"controllerManager,omitempty"`
+	Scheduler              *SchedulerConfig         `yaml:"scheduler,omitempty"`
+	Etcd                   *EtcdConfig              `yaml:"etcd,omitempty"`
 }
 
 // ControlPlaneConfig represents control plane config vals

--- a/pkg/userdata/v1alpha1/generate/controlplane.go
+++ b/pkg/userdata/v1alpha1/generate/controlplane.go
@@ -28,6 +28,7 @@ func controlPlaneUd(in *Input) (string, error) {
 			IPs:   in.MasterIPs,
 			Index: in.Index,
 		},
+		AESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,
 	}
 
 	ud := v1alpha1.NodeConfig{

--- a/pkg/userdata/v1alpha1/generate/generate.go
+++ b/pkg/userdata/v1alpha1/generate/generate.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/talos-systems/talos/internal/pkg/cis"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	tnet "github.com/talos-systems/talos/pkg/net"
@@ -137,8 +138,8 @@ type Certs struct {
 
 // KubeadmTokens holds the senesitve kubeadm data.
 type KubeadmTokens struct {
-	BootstrapToken string
-	CertKey        string
+	BootstrapToken         string
+	AESCBCEncryptionSecret string
 }
 
 // TrustdInfo holds the trustd credentials.
@@ -230,9 +231,7 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 		return nil, err
 	}
 
-	// TODO: Can be dropped
-	// Gen kubeadm cert key
-	kubeadmCertKey, err := randBytes(26)
+	aescbcEncryptionSecret, err := cis.CreateEncryptionToken()
 	if err != nil {
 		return nil, err
 	}
@@ -244,8 +243,8 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 	}
 
 	kubeadmTokens := &KubeadmTokens{
-		BootstrapToken: kubeadmBootstrapToken,
-		CertKey:        kubeadmCertKey,
+		BootstrapToken:         kubeadmBootstrapToken,
+		AESCBCEncryptionSecret: aescbcEncryptionSecret,
 	}
 
 	trustdInfo := &TrustdInfo{

--- a/pkg/userdata/v1alpha1/generate/init.go
+++ b/pkg/userdata/v1alpha1/generate/init.go
@@ -46,7 +46,8 @@ func initUd(in *Input) (string, error) {
 			Crt: in.Certs.K8sCert,
 			Key: in.Certs.K8sKey,
 		},
-		Token: in.KubeadmTokens.BootstrapToken,
+		Token:                  in.KubeadmTokens.BootstrapToken,
+		AESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,
 	}
 
 	ud := v1alpha1.NodeConfig{


### PR DESCRIPTION
This change allows us to generate the EncryptionConfig on each
controlplane node. The benefit is that we no longer need to distibute
the EncryptionConfig via trustd.