### PR TITLE
feat: write audit policy instead of using trustd

### DIFF
--- a/internal/app/machined/pkg/system/services/kubeadm/kubeadm.go
+++ b/internal/app/machined/pkg/system/services/kubeadm/kubeadm.go
@@ -231,7 +231,6 @@ func WritePKIFiles(data *userdata.UserData) (err error) {
 // be synced via trustd from other nodes
 func RequiredFiles() []string {
 	return []string{
-		constants.AuditPolicyPathInitramfs,
 		constants.KubeadmCACert,
 		constants.KubeadmCAKey,
 		constants.KubeadmSACert,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -124,8 +124,8 @@ const (
 	// VMwareGuestInfoUserDataKey is the guestinfo key used to provide a user data file.
 	VMwareGuestInfoUserDataKey = "talos.userdata"
 
-	// AuditPolicyPathInitramfs is the path to the audit-policy.yaml relative to initramfs.
-	AuditPolicyPathInitramfs = "/etc/kubernetes/audit-policy.yaml"
+	// AuditPolicyPath is the path to the audit-policy.yaml relative to initramfs.
+	AuditPolicyPath = "/etc/kubernetes/audit-policy.yaml"
 
 	// EncryptionConfigInitramfsPath is the path to the EncryptionConfig relative to initramfs.
 	EncryptionConfigInitramfsPath = "/etc/kubernetes/encryptionconfig.yaml"


### PR DESCRIPTION
This changes the controlplane logic to write the audit policy to disk
from a common template instead of using trustd to distribute it.