### PR TITLE
feat: use kubeadm to distribute Kubernetes PKI

### DIFF
--- a/internal/app/machined/pkg/system/services/kubeadm.go
+++ b/internal/app/machined/pkg/system/services/kubeadm.go
@@ -7,10 +7,8 @@ package services
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
-	"sync"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
@@ -19,7 +17,6 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 
-	securityapi "github.com/talos-systems/talos/api/security"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -50,7 +47,6 @@ func (k *Kubeadm) PreFunc(ctx context.Context, data *userdata.UserData) (err err
 		return err
 	}
 
-	containerdctx := namespaces.WithNamespace(ctx, "k8s.io")
 	client, err := containerdapi.New(constants.ContainerdAddress)
 	if err != nil {
 		return err
@@ -59,69 +55,10 @@ func (k *Kubeadm) PreFunc(ctx context.Context, data *userdata.UserData) (err err
 	defer client.Close()
 
 	// Pull the image and unpack it.
-
+	containerdctx := namespaces.WithNamespace(ctx, "k8s.io")
 	if _, err = client.Pull(containerdctx, constants.KubernetesImage, containerdapi.WithPullUnpack); err != nil {
 		return fmt.Errorf("failed to pull image %q: %v", constants.KubernetesImage, err)
 	}
-
-	// Run kubeadm init phase certs all. This should fill in whatever gaps
-	// we have in the provided certs.
-	if data.Services.Kubeadm.IsBootstrap() {
-		if err = kubeadm.PhaseCerts(); err != nil {
-			return err
-		}
-	}
-
-	if data.Services.Kubeadm.IsWorker() || data.Services.Kubeadm.IsBootstrap() || data.Services.Trustd == nil {
-		log.Println("skipping retrieval of files from peers via trustd")
-		return nil
-	}
-
-	// Initialize trustd peer client connection
-	var trustds []securityapi.SecurityClient
-	if trustds, err = kubeadm.CreateSecurityClients(data); err != nil {
-		return err
-	}
-
-	// Wait for all files to get synced
-	var wg sync.WaitGroup
-	wg.Add(len(kubeadm.FileSet(kubeadm.RequiredFiles())))
-
-	log.Println("retrieving needed files via trustd")
-	// Generate a list of files we need to request
-	// ( filtered by ones we already have ) and
-	// Get assets from remote nodes
-	for _, fileRequest := range kubeadm.FileSet(kubeadm.RequiredFiles()) {
-		// Handle all file requests in parallel
-		go func(ctx context.Context, fileRequest *securityapi.ReadFileRequest) {
-			defer wg.Done()
-
-			trustctx, ctxCancel := context.WithCancel(ctx)
-			defer ctxCancel()
-
-			// Have a single chan shared across all clients
-			// for a given file
-			content := make(chan []byte)
-
-			// kick off a goroutine for each trustd client
-			// to fetch the given file
-			for _, SecurityClient := range trustds {
-				go kubeadm.Download(trustctx, SecurityClient, fileRequest, content)
-			}
-
-			select {
-			case <-trustctx.Done():
-				return
-			case filecontent := <-content:
-				// TODO replace this with proper error handling
-				// nolint: errcheck
-				// read from the content chan to write out the
-				// given file
-				kubeadm.WriteTrustdFiles(fileRequest.Path, filecontent)
-			}
-		}(ctx, fileRequest)
-	}
-	wg.Wait()
 
 	return nil
 }
@@ -134,10 +71,6 @@ func (k *Kubeadm) PostFunc(data *userdata.UserData) error {
 // DependsOn implements the Service interface.
 func (k *Kubeadm) DependsOn(data *userdata.UserData) []string {
 	deps := []string{"containerd", "networkd"}
-
-	if data.Services.Kubeadm.IsControlPlane() {
-		deps = append(deps, "trustd")
-	}
 
 	return deps
 }
@@ -174,6 +107,7 @@ func (k *Kubeadm) Runner(data *userdata.UserData) (runner.Runner, error) {
 			ignore,
 			"--skip-token-print",
 			"--skip-certificate-key-print",
+			"--upload-certs",
 		}
 	case data.Services.Kubeadm.JoinConfiguration != nil:
 		// Worker

--- a/internal/app/machined/pkg/system/services/kubeadm/kubeadm_test.go
+++ b/internal/app/machined/pkg/system/services/kubeadm/kubeadm_test.go
@@ -80,9 +80,6 @@ func (suite *KubeadmSuite) TestEditInitConfig() {
 }
 
 func (suite *KubeadmSuite) TestFileSet() {
-	// Ensure by default we get the expected number of requests
-	suite.Assert().Equal(len(FileSet(RequiredFiles())), len(RequiredFiles()))
-
 	// Make sure if local file exists we dont copy it
 	tmpfile, err := ioutil.TempFile("", "testfileset")
 	suite.Assert().NoError(err)

--- a/internal/pkg/cis/cis.go
+++ b/internal/pkg/cis/cis.go
@@ -70,7 +70,7 @@ func CreateEncryptionToken() (string, error) {
 
 // WriteEncryptionConfigToDisk writes an EncryptionConfig to disk.
 func WriteEncryptionConfigToDisk(aescbcEncryptionSecret string) error {
-	if _, err := os.Stat(constants.EncryptionConfigInitramfsPath); os.IsNotExist(err) {
+	if _, err := os.Stat(constants.EncryptionConfigPath); os.IsNotExist(err) {
 		aux := struct {
 			AESCBCEncryptionSecret string
 		}{
@@ -86,7 +86,7 @@ func WriteEncryptionConfigToDisk(aescbcEncryptionSecret string) error {
 		if err := t.Execute(buf, aux); err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(constants.EncryptionConfigInitramfsPath, buf.Bytes(), 0400); err != nil {
+		if err := ioutil.WriteFile(constants.EncryptionConfigPath, buf.Bytes(), 0400); err != nil {
 			return err
 		}
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -127,8 +127,8 @@ const (
 	// AuditPolicyPath is the path to the audit-policy.yaml relative to initramfs.
 	AuditPolicyPath = "/etc/kubernetes/audit-policy.yaml"
 
-	// EncryptionConfigInitramfsPath is the path to the EncryptionConfig relative to initramfs.
-	EncryptionConfigInitramfsPath = "/etc/kubernetes/encryptionconfig.yaml"
+	// EncryptionConfigPath is the path to the EncryptionConfig relative to initramfs.
+	EncryptionConfigPath = "/etc/kubernetes/encryptionconfig.yaml"
 
 	// EncryptionConfigRootfsPath is the path to the EncryptionConfig relative to rootfs.
 	EncryptionConfigRootfsPath = "/etc/kubernetes/encryptionconfig.yaml"

--- a/pkg/userdata/generate/controlplane.go
+++ b/pkg/userdata/generate/controlplane.go
@@ -29,6 +29,7 @@ services:
           token: '{{ .KubeadmTokens.BootstrapToken }}'
           unsafeSkipCAVerification: true
           apiServerEndpoint: "{{ .GetAPIServerEndpoint "6443" }}"
+      certificateKey: {{ .KubeadmTokens.CertificateKey }}
       nodeRegistration:
         taints: []
         kubeletExtraArgs:

--- a/pkg/userdata/generate/init.go
+++ b/pkg/userdata/generate/init.go
@@ -26,6 +26,7 @@ services:
       bootstrapTokens:
       - token: '{{ .KubeadmTokens.BootstrapToken }}'
         ttl: 0s
+      certificateKey: {{ .KubeadmTokens.CertificateKey }}
       nodeRegistration:
         taints: []
         kubeletExtraArgs:

--- a/pkg/userdata/translate/translate_v1alpha1.go
+++ b/pkg/userdata/translate/translate_v1alpha1.go
@@ -206,6 +206,7 @@ func translateV1Alpha1Init(nc *v1alpha1.NodeConfig, ud *userdata.UserData) error
 				},
 			},
 		},
+		CertificateKey: nc.Cluster.CertificateKey,
 		NodeRegistration: kubeadm.NodeRegistrationOptions{
 			KubeletExtraArgs: nc.Machine.Kubelet.ExtraArgs,
 		},
@@ -299,7 +300,9 @@ func translateV1Alpha1ControlPlane(nc *v1alpha1.NodeConfig, ud *userdata.UserDat
 			Kind:       "JoinConfiguration",
 			APIVersion: "kubeadm.k8s.io/v1beta2",
 		},
-		ControlPlane: &kubeadm.JoinControlPlane{},
+		ControlPlane: &kubeadm.JoinControlPlane{
+			CertificateKey: nc.Cluster.CertificateKey,
+		},
 		Discovery: kubeadm.Discovery{
 			BootstrapToken: &kubeadm.BootstrapTokenDiscovery{
 				Token:                    nc.Cluster.Token,

--- a/pkg/userdata/v1alpha1/cluster_config.go
+++ b/pkg/userdata/v1alpha1/cluster_config.go
@@ -10,6 +10,7 @@ type ClusterConfig struct {
 	ClusterName            string                   `yaml:"clusterName,omitempty"`
 	Network                *ClusterNetworkConfig    `yaml:"network,omitempty"`
 	Token                  string                   `yaml:"token,omitempty"`
+	CertificateKey         string                   `yaml:"certificateKey"`
 	AESCBCEncryptionSecret string                   `yaml:"aescbcEncryptionSecret"`
 	CA                     *ClusterCAConfig         `yaml:"ca,omitempty"`
 	APIServer              *APIServerConfig         `yaml:"apiServer,omitempty"`

--- a/pkg/userdata/v1alpha1/generate/controlplane.go
+++ b/pkg/userdata/v1alpha1/generate/controlplane.go
@@ -28,6 +28,7 @@ func controlPlaneUd(in *Input) (string, error) {
 			IPs:   in.MasterIPs,
 			Index: in.Index,
 		},
+		CertificateKey:         in.KubeadmTokens.CertificateKey,
 		AESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,
 	}
 

--- a/pkg/userdata/v1alpha1/generate/generate.go
+++ b/pkg/userdata/v1alpha1/generate/generate.go
@@ -7,8 +7,10 @@ package generate
 import (
 	"bufio"
 	"crypto/rand"
+	"crypto/sha256"
 	stdlibx509 "crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -140,11 +142,24 @@ type Certs struct {
 type KubeadmTokens struct {
 	BootstrapToken         string
 	AESCBCEncryptionSecret string
+	CertificateKey         string
 }
 
 // TrustdInfo holds the trustd credentials.
 type TrustdInfo struct {
 	Token string
+}
+
+func generateCertificateKey() (string, error) {
+	key, err := randBytes(32)
+	if err != nil {
+		return "", err
+	}
+
+	hashedKey := sha256.Sum256([]byte(key))
+	encoded := hex.EncodeToString(hashedKey[:])
+
+	return encoded, nil
 }
 
 // randBytes returns a random string consisting of the characters in
@@ -231,6 +246,11 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 		return nil, err
 	}
 
+	kubeadmCertificateKey, err := generateCertificateKey()
+	if err != nil {
+		return nil, err
+	}
+
 	aescbcEncryptionSecret, err := cis.CreateEncryptionToken()
 	if err != nil {
 		return nil, err
@@ -245,6 +265,7 @@ func NewInput(clustername string, masterIPs []string) (input *Input, err error) 
 	kubeadmTokens := &KubeadmTokens{
 		BootstrapToken:         kubeadmBootstrapToken,
 		AESCBCEncryptionSecret: aescbcEncryptionSecret,
+		CertificateKey:         kubeadmCertificateKey,
 	}
 
 	trustdInfo := &TrustdInfo{

--- a/pkg/userdata/v1alpha1/generate/init.go
+++ b/pkg/userdata/v1alpha1/generate/init.go
@@ -47,6 +47,7 @@ func initUd(in *Input) (string, error) {
 			Key: in.Certs.K8sKey,
 		},
 		Token:                  in.KubeadmTokens.BootstrapToken,
+		CertificateKey:         in.KubeadmTokens.CertificateKey,
 		AESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,
 	}
 


### PR DESCRIPTION
This removes the trustd-based PKI distribution method in favor of
kubeadm's method.