### PR TITLE
feat: Discover platform external addresses

### DIFF
--- a/internal/pkg/platform/azure/azure.go
+++ b/internal/pkg/platform/azure/azure.go
@@ -7,6 +7,7 @@ package azure
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -74,4 +75,9 @@ func (a *Azure) Hostname() (hostname []byte, err error) {
 	}
 
 	return ioutil.ReadAll(resp.Body)
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (a *Azure) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
 }

--- a/internal/pkg/platform/container/container.go
+++ b/internal/pkg/platform/container/container.go
@@ -6,6 +6,7 @@ package container
 
 import (
 	"encoding/base64"
+	"net"
 	"os"
 
 	"github.com/pkg/errors"
@@ -52,4 +53,9 @@ func (c *Container) Mode() runtime.Mode {
 // Hostname implements the platform.Platform interface.
 func (c *Container) Hostname() (hostname []byte, err error) {
 	return nil, nil
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (c *Container) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
 }

--- a/internal/pkg/platform/gcp/gcp.go
+++ b/internal/pkg/platform/gcp/gcp.go
@@ -5,14 +5,24 @@
 package gcp
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/talos-systems/talos/pkg/userdata/download"
 )
 
+// Ref: https://cloud.google.com/compute/docs/storing-retrieving-metadata
+// ex, curl -H "Metadata-Flavor: Google" 'http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/?recursive=true'
 const (
 	// GCUserDataEndpoint is the local metadata endpoint inside of DO
 	GCUserDataEndpoint = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/user-data"
+	// GCExternalIPEndpoint displays all external addresses associated with the instance
+	GCExternalIPEndpoint = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/?recursive=true"
 )
 
 // GCP is the concrete type that implements the platform.Platform interface.
@@ -35,5 +45,56 @@ func (gc *GCP) Mode() runtime.Mode {
 
 // Hostname implements the platform.Platform interface.
 func (gc *GCP) Hostname() (hostname []byte, err error) {
+	// curl -Lv -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/name
 	return nil, nil
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (gc *GCP) ExternalIPs() (addrs []net.IP, err error) {
+	var (
+		body []byte
+		req  *http.Request
+		resp *http.Response
+	)
+
+	if req, err = http.NewRequest("GET", GCExternalIPEndpoint, nil); err != nil {
+		return
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+
+	client := &http.Client{}
+	if resp, err = client.Do(req); err != nil {
+		return
+	}
+
+	// nolint: errcheck
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return addrs, fmt.Errorf("failed to retrieve external addresses for instance")
+	}
+
+	type metadata []struct {
+		AccessConfigs []struct {
+			ExternalIP string `json:"externalIp"`
+		} `json:"accessConfigs"`
+	}
+
+	if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		return
+	}
+
+	m := metadata{}
+	if err = json.Unmarshal(body, &m); err != nil {
+		return
+	}
+
+	for _, networkInterface := range m {
+		for _, accessConfig := range networkInterface.AccessConfigs {
+			addrs = append(addrs, net.ParseIP(accessConfig.ExternalIP))
+		}
+	}
+
+	return addrs, err
 }

--- a/internal/pkg/platform/gcp/gcp_test.go
+++ b/internal/pkg/platform/gcp/gcp_test.go
@@ -12,3 +12,73 @@ func TestEmpty(t *testing.T) {
 	// please remove it once any unit-test is added
 	// for this package
 }
+
+// TODO use this mock data for tests
+/*
+brad@instance-1:~$ curl -H "Metadata-Flavor: Google" 'http://169.254.169.254/computeMetadata/v1/instance/?recursive=true' | jq '.'
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  1825  100  1825    0     0   285k      0 --:--:-- --:--:-- --:--:--  297k
+{
+  "attributes": {
+    "ssh-keys": ""
+  },
+  "cpuPlatform": "Intel Haswell",
+  "description": "",
+  "disks": [
+    {
+      "deviceName": "instance-1",
+      "index": 0,
+      "mode": "READ_WRITE",
+      "type": "PERSISTENT"
+    }
+  ],
+  "guestAttributes": {},
+  "hostname": "instance-1.c.talos-testbed.internal",
+  "id": 7413733082653629000,
+  "image": "projects/debian-cloud/global/images/debian-9-stretch-v20190916",
+  "licenses": [
+    {
+      "id": "1000205"
+    }
+  ],
+  "machineType": "projects/381598048798/machineTypes/f1-micro",
+  "maintenanceEvent": "NONE",
+  "name": "instance-1",
+  "networkInterfaces": [
+    {
+      "accessConfigs": [
+        {
+          "externalIp": "35.239.151.17",
+          "type": "ONE_TO_ONE_NAT"
+        }
+      ],
+      "dnsServers": [
+        "169.254.169.254"
+      ],
+      "forwardedIps": [],
+      "gateway": "10.128.0.1",
+      "ip": "10.128.15.237",
+      "ipAliases": [],
+      "mac": "42:01:0a:80:0f:ed",
+      "mtu": 1460,
+      "network": "projects/381598048798/networks/default",
+      "subnetmask": "255.255.240.0",
+      "targetInstanceIps": []
+    }
+  ],
+  "preempted": "FALSE",
+  "remainingCpuTime": -1,
+  "scheduling": {
+    "automaticRestart": "TRUE",
+    "onHostMaintenance": "MIGRATE",
+    "preemptible": "FALSE"
+  },
+  "serviceAccounts": {},
+  "tags": [],
+  "virtualClock": {
+    "driftToken": "0"
+  },
+  "zone": "projects/381598048798/zones/us-central1-f"
+}
+*/

--- a/internal/pkg/platform/iso/iso.go
+++ b/internal/pkg/platform/iso/iso.go
@@ -5,6 +5,8 @@
 package iso
 
 import (
+	"net"
+
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/userdata"
@@ -47,4 +49,9 @@ func (i *ISO) Mode() runtime.Mode {
 // Hostname implements the platform.Platform interface.
 func (i *ISO) Hostname() (hostname []byte, err error) {
 	return nil, nil
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (i *ISO) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
 }

--- a/internal/pkg/platform/metal/metal.go
+++ b/internal/pkg/platform/metal/metal.go
@@ -6,6 +6,7 @@ package metal
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
 
@@ -80,4 +81,9 @@ func (b *Metal) Mode() runtime.Mode {
 // Hostname implements the platform.Platform interface.
 func (b *Metal) Hostname() (hostname []byte, err error) {
 	return nil, nil
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (b *Metal) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
 }

--- a/internal/pkg/platform/packet/packet.go
+++ b/internal/pkg/platform/packet/packet.go
@@ -5,6 +5,8 @@
 package packet
 
 import (
+	"net"
+
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/userdata"
 	"github.com/talos-systems/talos/pkg/userdata/download"
@@ -36,4 +38,9 @@ func (p *Packet) Mode() runtime.Mode {
 // Hostname implements the platform.Platform interface.
 func (p *Packet) Hostname() (hostname []byte, err error) {
 	return nil, nil
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (p *Packet) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
 }

--- a/internal/pkg/platform/platform.go
+++ b/internal/pkg/platform/platform.go
@@ -5,6 +5,7 @@
 package platform
 
 import (
+	"net"
 	"os"
 
 	"github.com/pkg/errors"
@@ -29,6 +30,7 @@ type Platform interface {
 	UserData() (*userdata.UserData, error)
 	Mode() runtime.Mode
 	Hostname() ([]byte, error)
+	ExternalIPs() ([]net.IP, error)
 }
 
 // NewPlatform is a helper func for discovering the current platform.

--- a/internal/pkg/platform/vmware/vmware.go
+++ b/internal/pkg/platform/vmware/vmware.go
@@ -7,6 +7,7 @@ package vmware
 import (
 	"encoding/base64"
 	"fmt"
+	"net"
 
 	"github.com/vmware/vmw-guestinfo/rpcvmx"
 	"github.com/vmware/vmw-guestinfo/vmcheck"
@@ -75,4 +76,9 @@ func (vmw *VMware) Mode() runtime.Mode {
 // Hostname implements the platform.Platform interface.
 func (vmw *VMware) Hostname() (hostname []byte, err error) {
 	return nil, nil
+}
+
+// ExternalIPs provides any external addresses assigned to the instance
+func (vmw *VMware) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
 }


### PR DESCRIPTION
This introduces the functionality for discovering external addresses configured on an intance.
This allows us to automatically append these external addresses to our certificate SANs so we can
access the machines from these addresses without having to know about them ahead of time.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>