### PR TITLE
chore: update golangci-lint to 19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.18.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.19.1
 RUN cd $(mktemp -d) \
     && go mod init tmp \
     && go get mvdan.cc/gofumpt/gofumports \

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -266,7 +266,6 @@ func (c *Client) CopyOut(ctx context.Context, rootPath string) (io.Reader, <-cha
 		defer close(errCh)
 
 		for {
-
 			data, err := stream.Recv()
 			if err != nil {
 				if err == io.EOF || status.Code(err) == codes.Canceled {

--- a/hack/golang/golangci-lint.yaml
+++ b/hack/golang/golangci-lint.yaml
@@ -109,6 +109,7 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - funlen
+    - godox
   disable-all: false
   fast: false
 

--- a/internal/app/machined/pkg/system/runner/cri/runner.go
+++ b/internal/app/machined/pkg/system/runner/cri/runner.go
@@ -67,7 +67,6 @@ func (c *criRunner) Close() error {
 		}
 
 		c.podSandboxID = ""
-
 	}
 
 	if c.client == nil {

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -274,7 +274,6 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 				}
 			}
 		}()
-
 	}
 
 	// when service run finishes, cancel context, this is important if service

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -24,7 +24,6 @@ func (n *NetConf) OverlayUserData(data *userdata.UserData) error {
 
 	for link, opts := range *n {
 		for _, device := range data.Networking.OS.Devices {
-
 			device := device
 			if link.Name != device.Interface {
 				continue
@@ -50,7 +49,6 @@ func (n *NetConf) OverlayUserData(data *userdata.UserData) error {
 			if device.MTU != 0 {
 				(*n)[link] = append(opts, nic.WithMTU(uint32(device.MTU)))
 			}
-
 		}
 	}
 

--- a/internal/app/networkd/pkg/reg/reg.go
+++ b/internal/app/networkd/pkg/reg/reg.go
@@ -46,7 +46,6 @@ func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (reply *netwo
 	routes := []*networkapi.Route{}
 
 	for _, rMesg := range list {
-
 		ifaceData, err := r.Networkd.Conn.LinkByIndex(int(rMesg.Attributes.OutIface))
 		if err != nil {
 			log.Printf("failed to get interface details for interface index %d: %v", rMesg.Attributes.OutIface, err)
@@ -67,7 +66,6 @@ func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (reply *netwo
 			Protocol:    networkapi.RouteProtocol(rMesg.Protocol),
 			Flags:       rMesg.Flags,
 		})
-
 	}
 	return &networkapi.RoutesReply{
 		Routes: routes,

--- a/internal/pkg/containers/containerd/containerd.go
+++ b/internal/pkg/containers/containerd/containerd.go
@@ -213,7 +213,6 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 				}
 			}
 		}
-
 	}
 
 	// Typically on actual application containers inside the pod/sandbox

--- a/pkg/userdata/download/download.go
+++ b/pkg/userdata/download/download.go
@@ -105,7 +105,6 @@ func Download(udURL string, opts ...Option) (data *userdata.UserData, err error)
 
 	var dataBytes []byte
 	for attempt := 0; attempt < dlOpts.Retries; attempt++ {
-
 		dataBytes, err = download(req)
 		if err != nil {
 			log.Printf("download failed: %+v", err)
@@ -148,7 +147,6 @@ func Download(udURL string, opts ...Option) (data *userdata.UserData, err error)
 			return data, fmt.Errorf("unmarshal v0 user data: %s", err.Error())
 		}
 		return data, data.Validate()
-
 	}
 
 	return data, fmt.Errorf("failed to download userdata from: %s", u.String())


### PR DESCRIPTION
New linter `whitespace` checks for extra empty lines, I fixed quite a
few of those.

`godox` complains about `TODO:` in comments, but I had to disable it as
we have tons of these.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>