### PR TITLE
fix: set default node identity cert to expire in 10 years

### DIFF
--- a/internal/app/machined/internal/phase/userdata/pki.go
+++ b/internal/app/machined/internal/phase/userdata/pki.go
@@ -6,6 +6,7 @@ package userdata
 
 import (
 	"log"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -38,8 +39,11 @@ func (task *PKI) runtime(platform platform.Platform, data *userdata.UserData) (e
 		if csr, err = data.NewIdentityCSR(); err != nil {
 			return err
 		}
+		opts := []x509.Option{
+			x509.NotAfter(time.Now().Add(87600 * time.Hour)),
+		}
 		var crt *x509.Certificate
-		crt, err = x509.NewCertificateFromCSRBytes(data.Security.OS.CA.Crt, data.Security.OS.CA.Key, csr.X509CertificateRequestPEM)
+		crt, err = x509.NewCertificateFromCSRBytes(data.Security.OS.CA.Crt, data.Security.OS.CA.Key, csr.X509CertificateRequestPEM, opts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Since trustd does not rotate its' certificate in v0.2, we must generate
the default node identity certificate to 10 years. This has been fixed
in v0.3, but the implementation is too risky to cherry-pick.