### PR TITLE
feat: discover control plane endpoints via Kubernetes

### DIFF
--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	stdlibnet "net"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -22,11 +23,15 @@ import (
 	"github.com/talos-systems/talos/pkg/userdata"
 )
 
-var dataPath *string
+var (
+	dataPath  *string
+	endpoints *string
+)
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 	dataPath = flag.String("userdata", "", "the path to the user data")
+	endpoints = flag.String("endpoints", "", "the IPs of the control plane nodes")
 	flag.Parse()
 }
 
@@ -58,7 +63,7 @@ func main() {
 	}
 
 	var provider tls.CertificateProvider
-	provider, err = tls.NewRemoteRenewingFileCertificateProvider(data.Services.Trustd.Token, data.Services.Trustd.Endpoints, constants.TrustdPort, hostname, ips)
+	provider, err = tls.NewRemoteRenewingFileCertificateProvider(data.Services.Trustd.Token, strings.Split(*endpoints, ","), constants.TrustdPort, hostname, ips)
 	if err != nil {
 		log.Fatalf("failed to create remote certificate provider: %+v", err)
 	}


### PR DESCRIPTION
This change allows for discovery of the control plane IPs. The
motivation behind this is to remove the static IP requirement. The
endpoints are discovered by machined, and passed into OSD as arguments
in order to avoid the need to mount /var/lib/kubelet/pki.