### PR TITLE
feat: add retry package

### DIFF
--- a/pkg/blockdevice/probe/probe.go
+++ b/pkg/blockdevice/probe/probe.go
@@ -22,6 +22,7 @@ import (
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/iso9660"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/vfat"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/xfs"
+	"github.com/talos-systems/talos/pkg/retry"
 
 	"golang.org/x/sys/unix"
 )
@@ -64,17 +65,18 @@ func FileSystem(path string) (sb filesystem.SuperBlocker, err error) {
 	// Sleep for up to 5s to wait for kernel to create the necessary device files.
 	// If we dont sleep this becomes racy in that the device file does not exist
 	// and it will fail to open.
-	for i := 0; i <= 100; i++ {
+	err = retry.Constant(5*time.Second, retry.WithUnits((50 * time.Millisecond))).Retry(func() error {
 		if f, err = os.OpenFile(path, os.O_RDONLY|unix.O_CLOEXEC, os.ModeDevice); err != nil {
 			if os.IsNotExist(err) {
-				time.Sleep(50 * time.Millisecond)
-				continue
+				return retry.ExpectedError(err)
 			}
-
-			return nil, err
+			return retry.UnexpectedError(err)
 		}
 
-		break
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	// nolint: errcheck

--- a/pkg/retry/constant.go
+++ b/pkg/retry/constant.go
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package retry
+
+import (
+	"time"
+)
+
+type constantRetryer struct {
+	retryer
+}
+
+// ConstantTicker represents a ticker with a constant algorithm.
+type ConstantTicker struct {
+	ticker
+}
+
+// Constant initializes and returns a constant Retryer.
+func Constant(duration time.Duration, setters ...Option) Retryer {
+	opts := NewDefaultOptions(setters...)
+
+	return constantRetryer{
+		retryer: retryer{
+			duration: duration,
+			options:  opts,
+		},
+	}
+}
+
+// NewConstantTicker is a ticker that sends the time on a channel using a
+// constant algorithm.
+func NewConstantTicker(opts *Options) *ConstantTicker {
+	l := &ConstantTicker{
+		ticker: ticker{
+			C:       make(chan time.Time, 1),
+			options: opts,
+			s:       make(chan struct{}, 1),
+		},
+	}
+
+	return l
+}
+
+// Retry implements the Retryer interface.
+func (c constantRetryer) Retry(f RetryableFunc) error {
+	tick := NewConstantTicker(c.options)
+	defer tick.Stop()
+
+	return retry(f, c.duration, tick)
+}
+
+// Tick implements the Ticker interface.
+func (c ConstantTicker) Tick() time.Duration {
+	return c.options.Units + c.Jitter()
+}

--- a/pkg/retry/constant_test.go
+++ b/pkg/retry/constant_test.go
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// nolint: dupl
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// nolint: scopelint
+func Test_constantRetryer_Retry(t *testing.T) {
+	type fields struct {
+		retryer retryer
+	}
+
+	type args struct {
+		f RetryableFunc
+	}
+
+	count := 0
+
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		expectedCount int
+		wantErr       bool
+	}{
+		{
+			name: "test expected number of retries",
+			fields: fields{
+				retryer: retryer{
+					duration: 2 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       true,
+		},
+		{
+			name: "test expected number of retries with units",
+			fields: fields{
+				retryer: retryer{
+					duration: 2 * time.Second,
+					options:  NewDefaultOptions(WithUnits(500 * time.Millisecond)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 4,
+			wantErr:       true,
+		},
+		{
+			name: "test unexpected error",
+			fields: fields{
+				retryer: retryer{
+					duration: 2 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return UnexpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 1,
+			wantErr:       true,
+		},
+		{
+			name: "test conditional unexpected error",
+			fields: fields{
+				retryer: retryer{
+					duration: 10 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					if count == 2 {
+						return UnexpectedError(fmt.Errorf("unexpected"))
+					}
+					return ExpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       true,
+		},
+		{
+			name: "test conditional no error",
+			fields: fields{
+				retryer: retryer{
+					duration: 10 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					if count == 2 {
+						return nil
+					}
+					return ExpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       false,
+		},
+		{
+			name: "no error",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					return nil
+				},
+			},
+			expectedCount: 0,
+			wantErr:       false,
+		},
+		{
+			name: "test timeout",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(WithUnits(10 * time.Second)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 1,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := constantRetryer{
+				retryer: tt.fields.retryer,
+			}
+			count = 0
+			if err := e.Retry(tt.args.f); (err != nil) != tt.wantErr {
+				t.Errorf("constantRetryer.Retry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if count != tt.expectedCount {
+				t.Errorf("expected count of %d, got %d", tt.expectedCount, count)
+			}
+		})
+	}
+}

--- a/pkg/retry/exponential.go
+++ b/pkg/retry/exponential.go
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package retry
+
+import (
+	"math"
+	"time"
+)
+
+type exponentialRetryer struct {
+	retryer
+}
+
+// ExponentialTicker represents a ticker with a truncated exponential algorithm.
+// Please see https://en.wikipedia.org/wiki/Exponential_backoff for details on
+// the algorithm.
+type ExponentialTicker struct {
+	ticker
+
+	c float64
+}
+
+// Exponential initializes and returns a truncated exponential Retryer.
+func Exponential(duration time.Duration, setters ...Option) Retryer {
+	opts := NewDefaultOptions(setters...)
+
+	return exponentialRetryer{
+		retryer: retryer{
+			duration: duration,
+			options:  opts,
+		},
+	}
+}
+
+// NewExponentialTicker is a ticker that sends the time on a channel using a
+// truncated exponential algorithm.
+func NewExponentialTicker(opts *Options) *ExponentialTicker {
+	e := &ExponentialTicker{
+		ticker: ticker{
+			C:       make(chan time.Time, 1),
+			options: opts,
+			s:       make(chan struct{}, 1),
+		},
+		c: 1.0,
+	}
+
+	return e
+}
+
+// Retry implements the Retryer interface.
+func (e exponentialRetryer) Retry(f RetryableFunc) error {
+	tick := NewExponentialTicker(e.options)
+	defer tick.Stop()
+
+	return retry(f, e.duration, tick)
+}
+
+// Tick implements the Ticker interface.
+func (e *ExponentialTicker) Tick() time.Duration {
+	d := time.Duration((math.Pow(2, e.c)-1)/2)*e.options.Units + e.Jitter()
+	e.c++
+
+	return d
+}

--- a/pkg/retry/exponential_test.go
+++ b/pkg/retry/exponential_test.go
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// nolint: dupl
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// nolint: scopelint
+func Test_exponentialRetryer_Retry(t *testing.T) {
+	type fields struct {
+		retryer retryer
+	}
+
+	type args struct {
+		f RetryableFunc
+	}
+
+	count := 0
+
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		expectedCount int
+		wantErr       bool
+	}{
+		{
+			name: "test expected number of retries",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(WithUnits(100 * time.Millisecond)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 4,
+			wantErr:       true,
+		},
+		{
+			name: "test expected number of retries with units",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(WithUnits(50 * time.Millisecond)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 5,
+			wantErr:       true,
+		},
+		{
+			name: "test unexpected error",
+			fields: fields{
+				retryer: retryer{
+					duration: 2 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return UnexpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 1,
+			wantErr:       true,
+		},
+		{
+			name: "test conditional unexpected error",
+			fields: fields{
+				retryer: retryer{
+					duration: 10 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					if count == 2 {
+						return UnexpectedError(fmt.Errorf("unexpected"))
+					}
+					return ExpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       true,
+		},
+		{
+			name: "test conditional no error",
+			fields: fields{
+				retryer: retryer{
+					duration: 10 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					if count == 2 {
+						return nil
+					}
+					return ExpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       false,
+		},
+		{
+			name: "no error",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					return nil
+				},
+			},
+			expectedCount: 0,
+			wantErr:       false,
+		},
+		{
+			name: "test timeout",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(WithUnits(10 * time.Second)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := exponentialRetryer{
+				retryer: tt.fields.retryer,
+			}
+			count = 0
+			if err := e.Retry(tt.args.f); (err != nil) != tt.wantErr {
+				t.Errorf("exponentialRetryer.Retry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if count != tt.expectedCount {
+				t.Errorf("expected count of %d, got %d", tt.expectedCount, count)
+			}
+		})
+	}
+}

--- a/pkg/retry/linear.go
+++ b/pkg/retry/linear.go
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package retry
+
+import (
+	"time"
+)
+
+type linearRetryer struct {
+	retryer
+}
+
+// LinearTicker represents a ticker with a linear algorithm.
+type LinearTicker struct {
+	ticker
+
+	c int
+}
+
+// Linear initializes and returns a linear Retryer.
+func Linear(duration time.Duration, setters ...Option) Retryer {
+	opts := NewDefaultOptions(setters...)
+
+	return linearRetryer{
+		retryer: retryer{
+			duration: duration,
+			options:  opts,
+		},
+	}
+}
+
+// NewLinearTicker is a ticker that sends the time on a channel using a
+// linear algorithm.
+func NewLinearTicker(opts *Options) *LinearTicker {
+	l := &LinearTicker{
+		ticker: ticker{
+			C:       make(chan time.Time, 1),
+			options: opts,
+			s:       make(chan struct{}, 1),
+		},
+		c: 1,
+	}
+
+	return l
+}
+
+// Retry implements the Retryer interface.
+func (l linearRetryer) Retry(f RetryableFunc) error {
+	tick := NewLinearTicker(l.options)
+	defer tick.Stop()
+
+	return retry(f, l.duration, tick)
+}
+
+// Tick implements the Ticker interface.
+func (l *LinearTicker) Tick() time.Duration {
+	d := time.Duration(l.c)*l.options.Units + l.Jitter()
+	l.c++
+
+	return d
+}

--- a/pkg/retry/linear_test.go
+++ b/pkg/retry/linear_test.go
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// nolint: dupl
+package retry
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// nolint: scopelint
+func Test_linearRetryer_Retry(t *testing.T) {
+	type fields struct {
+		retryer retryer
+	}
+
+	type args struct {
+		f RetryableFunc
+	}
+
+	count := 0
+
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		expectedCount int
+		wantErr       bool
+	}{
+		{
+			name: "test expected number of retries",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(WithUnits(100 * time.Millisecond)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 4,
+			wantErr:       true,
+		},
+		{
+			name: "test expected number of retries with units",
+			fields: fields{
+				retryer: retryer{
+					duration: 2 * time.Second,
+					options:  NewDefaultOptions(WithUnits(50 * time.Millisecond)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 9,
+			wantErr:       true,
+		},
+		{
+			name: "test unexpected error",
+			fields: fields{
+				retryer: retryer{
+					duration: 2 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return UnexpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 1,
+			wantErr:       true,
+		},
+		{
+			name: "test conditional unexpected error",
+			fields: fields{
+				retryer: retryer{
+					duration: 10 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					if count == 1 {
+						return UnexpectedError(fmt.Errorf("unexpected"))
+					}
+					return ExpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 1,
+			wantErr:       true,
+		},
+		{
+			name: "test conditional no error",
+			fields: fields{
+				retryer: retryer{
+					duration: 10 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					if count == 2 {
+						return nil
+					}
+					return ExpectedError(fmt.Errorf("unexpected"))
+				},
+			},
+			expectedCount: 2,
+			wantErr:       false,
+		},
+		{
+			name: "no error",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(),
+				},
+			},
+			args: args{
+				f: func() error {
+					return nil
+				},
+			},
+			expectedCount: 0,
+			wantErr:       false,
+		},
+		{
+			name: "test timeout",
+			fields: fields{
+				retryer: retryer{
+					duration: 1 * time.Second,
+					options:  NewDefaultOptions(WithUnits(10 * time.Second)),
+				},
+			},
+			args: args{
+				f: func() error {
+					count++
+					return ExpectedError(fmt.Errorf("expected"))
+				},
+			},
+			expectedCount: 1,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := linearRetryer{
+				retryer: tt.fields.retryer,
+			}
+			count = 0
+			if err := l.Retry(tt.args.f); (err != nil) != tt.wantErr {
+				t.Errorf("linearRetryer.Retry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if count != tt.expectedCount {
+				t.Errorf("expected count of %d, got %d", tt.expectedCount, count)
+			}
+		})
+	}
+}

--- a/pkg/retry/options.go
+++ b/pkg/retry/options.go
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package retry
+
+import "time"
+
+// Options is the functional options struct.
+type Options struct {
+	Units  time.Duration
+	Jitter time.Duration
+}
+
+// Option is the functional option func.
+type Option func(*Options)
+
+// WithUnits is a functional option for setting the units of the ticker.
+func WithUnits(o time.Duration) Option {
+	return func(args *Options) {
+		args.Units = o
+	}
+}
+
+// WithJitter is a functional option for setting the jitter flag.
+func WithJitter(o time.Duration) Option {
+	return func(args *Options) {
+		args.Jitter = o
+	}
+}
+
+// NewDefaultOptions initializes a Options struct with default values.
+func NewDefaultOptions(setters ...Option) *Options {
+	opts := &Options{
+		Units:  time.Second,
+		Jitter: time.Duration(0),
+	}
+
+	for _, setter := range setters {
+		setter(opts)
+	}
+
+	return opts
+}

--- a/pkg/retry/options_test.go
+++ b/pkg/retry/options_test.go
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package retry
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// nolint: scopelint
+func TestNewDefaultOptions(t *testing.T) {
+	type args struct {
+		setters []Option
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *Options
+	}{
+		{
+			name: "with options",
+			args: args{
+				setters: []Option{WithUnits(time.Millisecond)},
+			},
+			want: &Options{
+				Units: time.Millisecond,
+			},
+		},
+		{
+			name: "default",
+			args: args{
+				setters: []Option{},
+			},
+			want: &Options{
+				Units: time.Second,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewDefaultOptions(tt.args.setters...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewDefaultOptions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package retry
+
+import (
+	"math/rand"
+	"time"
+)
+
+// RetryableFunc represents a function that can be retried.
+type RetryableFunc func() error
+
+// Retryer defines the requirements for retrying a function.
+type Retryer interface {
+	Retry(RetryableFunc) error
+}
+
+// Ticker defines the requirements for providing a clock to the retry logic.
+type Ticker interface {
+	Tick() time.Duration
+	StopChan() <-chan struct{}
+	Stop()
+}
+
+// TimeoutError represents a timeout error.
+type TimeoutError struct{}
+
+func (TimeoutError) Error() string {
+	return "timeout"
+}
+
+// IsTimeout reutrns if the provided error is a timeout error.
+func IsTimeout(err error) bool {
+	_, ok := err.(TimeoutError)
+
+	return ok
+}
+
+type expectedError struct{ error }
+
+type unexpectedError struct{ error }
+
+type retryer struct {
+	duration time.Duration
+	options  *Options
+}
+
+type ticker struct {
+	C       chan time.Time
+	options *Options
+	rand    *rand.Rand
+	s       chan struct{}
+}
+
+func (t ticker) Jitter() time.Duration {
+	if int(t.options.Jitter) == 0 {
+		return time.Duration(0)
+	}
+
+	if t.rand == nil {
+		t.rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+	}
+
+	return time.Duration(t.rand.Int63n(int64(t.options.Jitter)))
+}
+
+func (t ticker) StopChan() <-chan struct{} {
+	return t.s
+}
+
+func (t ticker) Stop() {
+	t.s <- struct{}{}
+}
+
+// ExpectedError error represents an error that is expected by the retrying
+// function. This error is ignored.
+func ExpectedError(err error) error {
+	return expectedError{err}
+}
+
+// UnexpectedError error represents an error that is unexpected by the retrying
+// function. This error is fatal.
+func UnexpectedError(err error) error {
+	return unexpectedError{err}
+}
+
+func retry(f RetryableFunc, d time.Duration, t Ticker) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	// We run the func first to avoid having to wait for the next tick.
+	if err := f(); err != nil {
+		if _, ok := err.(unexpectedError); ok {
+			return err
+		}
+	} else {
+		return nil
+	}
+
+	for {
+		select {
+		case <-timer.C:
+			return TimeoutError{}
+		case <-t.StopChan():
+			return nil
+		case <-time.After(t.Tick()):
+		}
+
+		if err := f(); err != nil {
+			switch err.(type) {
+			case expectedError:
+				continue
+			case unexpectedError:
+				return err
+			}
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
This package provides a consistent way for us to retry arbitrary logic.
It provides the following backoff algorithms:

- exponential
- linear
- constant