### PR TITLE
chore: remove custom log paths

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/system_directory.go
+++ b/internal/app/machined/internal/phase/rootfs/system_directory.go
@@ -6,9 +6,11 @@ package rootfs
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // SystemDirectory represents the SystemDirectory task.
@@ -25,5 +27,11 @@ func (task *SystemDirectory) RuntimeFunc(mode runtime.Mode) phase.RuntimeFunc {
 }
 
 func (task *SystemDirectory) runtime(args *phase.RuntimeArgs) (err error) {
-	return os.MkdirAll("/run/system/etc", os.ModeDir)
+	for _, p := range []string{"etc", "log"} {
+		if err = os.MkdirAll(filepath.Join(constants.SystemRunPath, p), 0700); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/app/machined/pkg/system/services/machined_api.go
+++ b/internal/app/machined/pkg/system/services/machined_api.go
@@ -45,5 +45,5 @@ func (c *MachinedAPI) DependsOn(config config.Configurator) []string {
 
 // Runner implements the Service interface.
 func (c *MachinedAPI) Runner(config config.Configurator) (runner.Runner, error) {
-	return goroutine.NewRunner(config, "machined-api", api.NewService().Main, runner.WithLogPath("/run")), nil
+	return goroutine.NewRunner(config, "machined-api", api.NewService().Main), nil
 }

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -74,7 +74,6 @@ func (c *SystemContainerd) Runner(config config.Configurator) (runner.Runner, er
 		config.Debug(),
 		args,
 		runner.WithEnv(env),
-		runner.WithLogPath("/run"),
 	),
 		restart.WithType(restart.Forever),
 	), nil


### PR DESCRIPTION
These services should log to the default system log path.