### PR TITLE
chore: re-enable end to end tests

### DIFF
--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -43,14 +43,6 @@ run() {
 ${LOCALOSCTL} cluster create --name integration --image ${TALOS_IMG} --masters=3 --mtu 1440 --cpus 4.0
 ${LOCALOSCTL} config target 10.5.0.2
 
-# ## Wait for the init node to report in
-# run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-#      until kubectl get node master-1 >/dev/null; do
-#        [[ \$(date +%s) -gt \$timeout ]] && exit 1
-#        kubectl get nodes -o wide
-#        sleep 5
-#      done"
-
 ## Wait for bootkube to finish successfully.
 run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
      until osctl service bootkube | grep Finished >/dev/null; do

--- a/hack/test/manifests/aws-cluster.yaml
+++ b/hack/test/manifests/aws-cluster.yaml
@@ -22,6 +22,7 @@ spec:
         type: aws
       controlplane:
         count: 3
+        k8sversion: "1.16.1"
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine

--- a/hack/test/manifests/azure-cluster.yaml
+++ b/hack/test/manifests/azure-cluster.yaml
@@ -23,6 +23,7 @@ spec:
         type: azure
       controlplane:
         count: 3
+        k8sversion: "1.16.1"
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine

--- a/hack/test/manifests/gcp-cluster.yaml
+++ b/hack/test/manifests/gcp-cluster.yaml
@@ -23,6 +23,7 @@ spec:
         type: gce
       controlplane:
         count: 3
+        k8sversion: "1.16.1"
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine


### PR DESCRIPTION
This PR will add the bits necessary to make use of changes to our
v1alpha1 cluster api provider for CI testing. This is needed since we've
had machine config changes.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>