### PR TITLE
fix: ignore case in install platform check

### DIFF
--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"log"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -41,8 +42,8 @@ var installCmd = &cobra.Command{
 
 		platform, err := platform.NewPlatform()
 		if err == nil {
-			if platform.Name() != platformArg {
-				log.Println("platform mismatch")
+			if strings.ToLower(platform.Name()) != strings.ToLower(platformArg) {
+				log.Printf("platform mismatch (%s != %s)", platform.Name(), platformArg)
 			} else {
 				var b []byte
 				b, err = platform.Configuration()


### PR DESCRIPTION
Because `platform.Name()` returns the capitalized name but the baremetal
platform kernel commandline option expects the lowercase 'metal', we
ignore the case of the platform when doing the platform match checking
in `ostctl install`.

Fixes #1249

Signed-off-by: Seán C McCord <ulexus@gmail.com>