### PR TITLE
fix: catch panics in boot go routine

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -106,6 +106,8 @@ func main() {
 
 	// Start the boot sequence in a go routine so that we can list for events.
 	go func() {
+		defer recovery()
+		log.Println(err)
 		if err := seq.Boot(); err != nil {
 			panic(errors.Wrap(err, "boot failed"))
 		}


### PR DESCRIPTION
The builtin recover func is scoped to the current go routine, and since
our boot sequence is kicked off in its' own go routine, we were failing
to recover from panics.