### PR TITLE
chore: Improve error messages if there is a network config overlap

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -117,7 +117,7 @@ func create() (err error) {
 	fmt.Println("creating network", clusterName)
 
 	if _, err = createNetwork(cli); err != nil {
-		return err
+		return errors.Wrap(err, " A cluster might already exist, run \"osctl cluster destroy\" to permanently delete the existing cluster, and try again.")
 	}
 
 	// Create the master nodes.


### PR DESCRIPTION
Fixes #1251 
It can be cleared the next steps for a new user.

Signed-off-by: u5surf <u5.horie@gmail.com>