### PR TITLE
fix: update bootkube fork to fix pod-checkpointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 replace github.com/jsimonetti/rtnetlink => github.com/bradbeam/rtnetlink v0.0.0-20190820045831-7b9ca088b93d
 
-replace github.com/kubernetes-incubator/bootkube => github.com/andrewrynhard/bootkube v0.14.1-0.20191007145809-5429871965af
+replace github.com/kubernetes-incubator/bootkube => github.com/andrewrynhard/bootkube v0.14.1-0.20191008231328-95aa44e9be5c
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/andrewrynhard/bootkube v0.14.1-0.20191007145809-5429871965af h1:lkRiiIBHcb7tCdM86Wsl17Uuj1dJUq3gyFNmwPRCdRE=
-github.com/andrewrynhard/bootkube v0.14.1-0.20191007145809-5429871965af/go.mod h1:oTqoeN0SnkWpS325wZYrKYVIawqpdkr6iZMlA0iYdUE=
+github.com/andrewrynhard/bootkube v0.14.1-0.20191008231328-95aa44e9be5c h1:9TcdzsFzcyn8VTKWilH51qknwly4IPPgheK3b/eCa4I=
+github.com/andrewrynhard/bootkube v0.14.1-0.20191008231328-95aa44e9be5c/go.mod h1:oTqoeN0SnkWpS325wZYrKYVIawqpdkr6iZMlA0iYdUE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/internal/app/machined/internal/bootkube/bootkube.go
+++ b/internal/app/machined/internal/bootkube/bootkube.go
@@ -25,7 +25,7 @@ func NewService() *Service {
 // Main is the entrypoint for bootkube.
 func (s *Service) Main(ctx context.Context, config config.Configurator, logWriter io.Writer) error {
 	defaultRequiredPods := []string{
-		// "kube-system/pod-checkpointer",
+		"kube-system/pod-checkpointer",
 		"kube-system/kube-apiserver",
 		"kube-system/kube-scheduler",
 		"kube-system/kube-controller-manager",


### PR DESCRIPTION
This brings in an updated version of our fork so that pod-checkpointer
will run properly.