### PR TITLE
feat: default docker based cluster to 1 master

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -355,7 +355,7 @@ func init() {
 	clusterUpCmd.Flags().StringVar(&nodeImage, "image", "docker.io/autonomy/talos:"+version.Tag, "the image to use")
 	clusterUpCmd.Flags().StringVar(&networkMTU, "mtu", "1500", "MTU of the docker bridge network")
 	clusterUpCmd.Flags().IntVar(&workers, "workers", 1, "the number of workers to create")
-	clusterUpCmd.Flags().IntVar(&masters, "masters", 3, "the number of masters to create")
+	clusterUpCmd.Flags().IntVar(&masters, "masters", 1, "the number of masters to create")
 	clusterUpCmd.Flags().StringVar(&clusterCpus, "cpus", "1.5", "the share of CPUs as fraction (each container)")
 	clusterUpCmd.Flags().IntVar(&clusterMemory, "memory", 1024, "the limit on memory usage in MB (each container)")
 	clusterUpCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")

--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -40,7 +40,7 @@ run() {
          k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"
 }
 
-${LOCALOSCTL} cluster create --name integration --image ${TALOS_IMG} --mtu 1440 --cpus 4.0
+${LOCALOSCTL} cluster create --name integration --image ${TALOS_IMG} --masters=3 --mtu 1440 --cpus 4.0
 ${LOCALOSCTL} config target 10.5.0.2
 
 # ## Wait for the init node to report in


### PR DESCRIPTION
The goal with the docker based cluster is to provide developers with an
easy way to run Kubernetes on their local machines. Most of the time,
they won't need more than 1 master. This defaults cluster creation to 1
master.