### PR TITLE
fix: set target if specified on command line

### DIFF
--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -104,6 +104,9 @@ func setupClient(action func(*client.Client)) {
 	if err != nil {
 		helpers.Fatalf("error getting client credentials: %s", err)
 	}
+	if target != "" {
+		t = target
+	}
 	c, err := client.NewClient(creds, t, constants.OsdPort)
 	if err != nil {
 		helpers.Fatalf("error constructing client: %s", err)


### PR DESCRIPTION
This overrides the target defined in the config if a target is
specified on the command line.