### PR TITLE
feat(osd): Enable hitting multiple OSD endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN curl -sfL https://github.com/uber/prototool/releases/download/v1.8.0/prototo
 
 FROM scratch AS build
 COPY --from=tools / /
+COPY --from=autonomy/protoc-gen-proxy:a87401e /protoc-gen-proxy /toolchain/bin/protoc-gen-proxy
 SHELL ["/toolchain/bin/bash", "-c"]
 ENV PATH /toolchain/bin:/toolchain/go/bin
 ENV GO111MODULE on
@@ -36,7 +37,8 @@ WORKDIR /src
 FROM build AS generate-build
 WORKDIR /osd
 COPY ./api/os ./proto
-RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+# Generate additional grpc functionality only for OSD
+RUN protoc -I./proto --plugin=proxy --proxy_out=plugins=grpc+proxy:proto proto/api.proto
 WORKDIR /trustd
 COPY ./api/security ./proto
 RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto

--- a/api/os/api.proto
+++ b/api/os/api.proto
@@ -13,29 +13,33 @@ import "google/protobuf/empty.proto";
 //
 // OS Service also implements all the API of Init Service
 service OS {
-  rpc Dmesg(google.protobuf.Empty) returns (Data);
-  rpc Kubeconfig(google.protobuf.Empty) returns (Data);
-  rpc Logs(LogsRequest) returns (stream Data);
   rpc Containers(ContainersRequest) returns (ContainersReply);
+  rpc Dmesg(google.protobuf.Empty) returns (DataReply);
+  rpc Kubeconfig(google.protobuf.Empty) returns (DataReply);
+  rpc Logs(LogsRequest) returns (stream Data);
+  rpc Processes(google.protobuf.Empty) returns (ProcessesReply);
   rpc Restart(RestartRequest) returns (RestartReply);
   rpc Stats(StatsRequest) returns (StatsReply);
-  rpc Processes(google.protobuf.Empty) returns (ProcessesReply);
 }
 
+// Common metadata message nested in all reply message types
+message NodeMetadata {
+  string hostname = 1;
+}
+
+// rpc Containers
+
+// The request message containing the containerd namespace.
 enum ContainerDriver {
   CONTAINERD = 0;
   CRI = 1;
 }
 
-// The request message containing the containerd namespace.
 message ContainersRequest {
   string namespace = 1;
   // driver might be default "containerd" or "cri"
   ContainerDriver driver = 2;
 }
-
-// The response message containing the requested containers.
-message ContainersReply { repeated Container containers = 1; }
 
 // The response message containing the requested containers.
 message Container {
@@ -48,36 +52,34 @@ message Container {
   string name = 7;
 }
 
-// The request message containing the containerd namespace.
-message StatsRequest {
-  string namespace = 1;
-  // driver might be default "containerd" or "cri"
-  ContainerDriver driver = 2;
+// The response message containing the requested containers.
+message ContainerResponse {
+  NodeMetadata metadata = 1;
+  repeated Container containers = 2;
 }
 
-// The response message containing the requested stats.
-message StatsReply { repeated Stat stats = 1; }
-
-// The response message containing the requested stat.
-message Stat {
-  string namespace = 1;
-  string id = 2;
-  uint64 memory_usage = 4;
-  uint64 cpu_usage = 5;
-  string pod_id = 6;
-  string name = 7;
+message ContainersReply {
+  repeated ContainerResponse response = 1;
 }
 
-// The request message containing the process to restart.
-message RestartRequest {
-  string namespace = 1;
-  string id = 2;
-  // driver might be default "containerd" or "cri"
-  ContainerDriver driver = 3;
+// rpc dmesg
+// rpc kubeconfig
+
+// The response message containing the requested logs.
+message Data {
+  bytes bytes = 1;
 }
 
-// The response message containing the restart status.
-message RestartReply {}
+message DataResponse {
+  NodeMetadata metadata = 1;
+  Data bytes = 2;
+}
+
+message DataReply {
+  repeated DataResponse response = 1;
+}
+
+// rpc logs
 
 // The request message containing the process name.
 message LogsRequest {
@@ -87,12 +89,17 @@ message LogsRequest {
   ContainerDriver driver = 3;
 }
 
-// The response message containing the requested logs.
-message Data { bytes bytes = 1; }
-
+// rpc processes
 message ProcessesRequest {}
 
-message ProcessesReply { repeated Process processes = 1; }
+message ProcessesReply {
+  repeated ProcessResponse response = 1;
+}
+
+message ProcessResponse {
+  NodeMetadata metadata = 1;
+  repeated Process processes = 2;
+}
 
 message Process {
   int32 pid = 1;
@@ -106,3 +113,51 @@ message Process {
   string executable = 9;
   string args = 10;
 }
+
+// rpc restart
+// The request message containing the process to restart.
+message RestartRequest {
+  string namespace = 1;
+  string id = 2;
+  // driver might be default "containerd" or "cri"
+  ContainerDriver driver = 3;
+}
+
+message RestartResponse {
+  NodeMetadata metadata = 1;
+}
+
+// The response message containing the restart status.
+message RestartReply {
+  repeated RestartResponse response = 1;
+}
+
+// rpc stats
+
+// The request message containing the containerd namespace.
+message StatsRequest {
+  string namespace = 1;
+  // driver might be default "containerd" or "cri"
+  ContainerDriver driver = 2;
+}
+
+// The response message containing the requested stats.
+message StatsResponse {
+  NodeMetadata metadata = 1;
+  repeated Stat stats = 2;
+}
+
+message StatsReply {
+  repeated StatsResponse response = 1;
+}
+
+// The response message containing the requested stat.
+message Stat {
+  string namespace = 1;
+  string id = 2;
+  uint64 memory_usage = 4;
+  uint64 cpu_usage = 5;
+  string pod_id = 6;
+  string name = 7;
+}
+

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -42,11 +42,6 @@ var configTargetCmd = &cobra.Command{
 	Short: "Set the target for the current context",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			helpers.Should(cmd.Usage())
-			os.Exit(1)
-		}
-		target = args[0]
 		c, err := config.Open(talosconfig)
 		if err != nil {
 			helpers.Fatalf("error reading config: %s", err)
@@ -54,7 +49,8 @@ var configTargetCmd = &cobra.Command{
 		if c.Context == "" {
 			helpers.Fatalf("no context is set")
 		}
-		c.Contexts[c.Context].Target = target
+
+		c.Contexts[c.Context].Target = args[0]
 		if err := c.Save(talosconfig); err != nil {
 			helpers.Fatalf("error writing config: %s", err)
 		}

--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -5,9 +5,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
@@ -25,13 +27,20 @@ var dmesgCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			msg, err := c.Dmesg(globalCtx)
+			md := metadata.New(make(map[string]string))
+			md.Set("targets", target...)
+			reply, err := c.Dmesg(metadata.NewOutgoingContext(globalCtx, md))
 			if err != nil {
 				helpers.Fatalf("error getting dmesg: %s", err)
 			}
 
-			_, err = os.Stdout.Write(msg)
-			helpers.Should(err)
+			for _, resp := range reply.Response {
+				if len(reply.Response) > 1 {
+					fmt.Println(resp.Metadata.Hostname)
+				}
+				_, err = os.Stdout.Write(resp.Bytes.Bytes)
+				helpers.Should(err)
+			}
 		})
 	},
 }

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -34,7 +34,7 @@ var (
 	organization                  string
 	rsa                           bool
 	talosconfig                   string
-	target                        string
+	target                        []string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -96,7 +96,7 @@ func Execute() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&talosconfig, "talosconfig", defaultTalosConfig, "The path to the Talos configuration file")
-	rootCmd.PersistentFlags().StringVarP(&target, "target", "t", "", "target the specificed node")
+	rootCmd.PersistentFlags().StringSliceVarP(&target, "target", "t", []string{}, "target the specificed node")
 
 	if err := rootCmd.Execute(); err != nil {
 		helpers.Fatalf("%s", err)
@@ -108,10 +108,6 @@ func setupClient(action func(*client.Client)) {
 	t, creds, err := client.NewClientTargetAndCredentialsFromConfig(talosconfig)
 	if err != nil {
 		helpers.Fatalf("error getting client credentials: %s", err)
-	}
-
-	if target != "" {
-		t = target
 	}
 
 	c, err := client.NewClient(creds, t, constants.OsdPort)

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -145,13 +145,8 @@ func (c *Client) Close() error {
 }
 
 // Kubeconfig implements the proto.OSClient interface.
-func (c *Client) Kubeconfig(ctx context.Context) ([]byte, error) {
-	r, err := c.client.Kubeconfig(ctx, &empty.Empty{})
-	if err != nil {
-		return nil, err
-	}
-
-	return r.Bytes, nil
+func (c *Client) Kubeconfig(ctx context.Context) (*osapi.DataReply, error) {
+	return c.client.Kubeconfig(ctx, &empty.Empty{})
 }
 
 // Stats implements the proto.OSClient interface.
@@ -204,13 +199,8 @@ func (c *Client) Shutdown(ctx context.Context) (err error) {
 }
 
 // Dmesg implements the proto.OSClient interface.
-func (c *Client) Dmesg(ctx context.Context) ([]byte, error) {
-	data, err := c.client.Dmesg(ctx, &empty.Empty{})
-	if err != nil {
-		return nil, err
-	}
-
-	return data.Bytes, nil
+func (c *Client) Dmesg(ctx context.Context) (*osapi.DataReply, error) {
+	return c.client.Dmesg(ctx, &empty.Empty{})
 }
 
 // Logs implements the proto.OSClient interface.

--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -91,6 +91,7 @@ run "kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true pod -l k8s-ap
 # Wait for DNS addon to report ready
 run "kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true pod -l k8s-app=kube-dns -n kube-system"
 
-run "osctl -t 10.5.0.2 service etcd | grep Running"
-run "osctl -t 10.5.0.3 service etcd | grep Running"
-run "osctl -t 10.5.0.4 service etcd | grep Running"
+run "osctl config target 10.5.0.2 && osctl -t 10.5.0.2 service etcd | grep Running"
+run "osctl config target 10.5.0.3 && osctl -t 10.5.0.3 service etcd | grep Running"
+run "osctl config target 10.5.0.4 && osctl -t 10.5.0.4 service etcd | grep Running"
+run "osctl --target 10.5.0.2,10.5.0.3,10.5.0.4,10.5.0.5 containers | grep osd"

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -52,14 +52,18 @@ func (r *Registrator) Register(s *grpc.Server) {
 }
 
 // Kubeconfig implements the osapi.OSDServer interface.
-func (r *Registrator) Kubeconfig(ctx context.Context, in *empty.Empty) (data *osapi.Data, err error) {
+func (r *Registrator) Kubeconfig(ctx context.Context, in *empty.Empty) (data *osapi.DataReply, err error) {
 	fileBytes, err := ioutil.ReadFile(constants.AdminKubeconfig)
 	if err != nil {
 		return
 	}
 
-	data = &osapi.Data{
-		Bytes: fileBytes,
+	data = &osapi.DataReply{
+		Response: []*osapi.DataResponse{
+			{
+				Bytes: &osapi.Data{Bytes: fileBytes},
+			},
+		},
 	}
 
 	return data, err
@@ -101,7 +105,15 @@ func (r *Registrator) Containers(ctx context.Context, in *osapi.ContainersReques
 		}
 	}
 
-	return &osapi.ContainersReply{Containers: containers}, nil
+	reply = &osapi.ContainersReply{
+		Response: []*osapi.ContainerResponse{
+			{
+				Containers: containers,
+			},
+		},
+	}
+
+	return reply, nil
 }
 
 // Stats implements the osapi.OSDServer interface.
@@ -145,7 +157,13 @@ func (r *Registrator) Stats(ctx context.Context, in *osapi.StatsRequest) (reply 
 		}
 	}
 
-	reply = &osapi.StatsReply{Stats: stats}
+	reply = &osapi.StatsReply{
+		Response: []*osapi.StatsResponse{
+			{
+				Stats: stats,
+			},
+		},
+	}
 
 	return reply, nil
 }
@@ -180,7 +198,7 @@ func (r *Registrator) Restart(ctx context.Context, in *osapi.RestartRequest) (*o
 // to read from the ring buffer at /proc/kmsg by taking the
 // SYSLOG_ACTION_READ_ALL action. This action reads all messages remaining in
 // the ring buffer non-destructively.
-func (r *Registrator) Dmesg(ctx context.Context, in *empty.Empty) (data *osapi.Data, err error) {
+func (r *Registrator) Dmesg(ctx context.Context, in *empty.Empty) (data *osapi.DataReply, err error) {
 	// Return the size of the kernel ring buffer
 	size, err := unix.Klogctl(constants.SYSLOG_ACTION_SIZE_BUFFER, nil)
 	if err != nil {
@@ -194,7 +212,13 @@ func (r *Registrator) Dmesg(ctx context.Context, in *empty.Empty) (data *osapi.D
 		return
 	}
 
-	data = &osapi.Data{Bytes: buf[:n]}
+	data = &osapi.DataReply{
+		Response: []*osapi.DataResponse{
+			{
+				Bytes: &osapi.Data{Bytes: buf[:n]},
+			},
+		},
+	}
 
 	return data, err
 }
@@ -296,7 +320,13 @@ func (r *Registrator) Processes(ctx context.Context, in *empty.Empty) (reply *os
 		processes = append(processes, p)
 	}
 
-	reply = &osapi.ProcessesReply{Processes: processes}
+	reply = &osapi.ProcessesReply{
+		Response: []*osapi.ProcessResponse{
+			{
+				Processes: processes,
+			},
+		},
+	}
 
 	return reply, nil
 }


### PR DESCRIPTION
This enables the ability to specify additional <talos> endpoints to connect to
to pull back data.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>