### PR TITLE
chore: bump golangci-lint to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.18.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.20.0
 RUN cd $(mktemp -d) \
     && go mod init tmp \
     && go get mvdan.cc/gofumpt/gofumports \

--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -42,7 +42,7 @@ var installCmd = &cobra.Command{
 
 		platform, err := platform.NewPlatform()
 		if err == nil {
-			if strings.ToLower(platform.Name()) != strings.ToLower(platformArg) {
+			if !strings.EqualFold(platform.Name(), platformArg) {
 				log.Printf("platform mismatch (%s != %s)", platform.Name(), platformArg)
 			} else {
 				var b []byte

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -266,7 +266,6 @@ func (c *Client) CopyOut(ctx context.Context, rootPath string) (io.Reader, <-cha
 		defer close(errCh)
 
 		for {
-
 			data, err := stream.Recv()
 			if err != nil {
 				if err == io.EOF || status.Code(err) == codes.Canceled {

--- a/hack/golang/golangci-lint.yaml
+++ b/hack/golang/golangci-lint.yaml
@@ -109,6 +109,9 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - funlen
+    - wsl
+    - godox
+    - gocognit
   disable-all: false
   fast: false
 
@@ -117,7 +120,8 @@ issues:
   # But independently from this option we use default exclude patterns,
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
-  exclude: []
+  exclude:
+    - ^ST1000  # ST1000: package comment should be of the form "Package services ..." (stylecheck)
 
   exclude-rules:
     - path: cmd/osctl/cmd

--- a/internal/app/machined/pkg/system/runner/cri/runner.go
+++ b/internal/app/machined/pkg/system/runner/cri/runner.go
@@ -66,7 +66,6 @@ func (c *criRunner) Close() error {
 		}
 
 		c.podSandboxID = ""
-
 	}
 
 	if c.client == nil {

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -274,7 +274,6 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 				}
 			}
 		}()
-
 	}
 
 	// when service run finishes, cancel context, this is important if service

--- a/internal/app/networkd/pkg/reg/reg.go
+++ b/internal/app/networkd/pkg/reg/reg.go
@@ -46,7 +46,6 @@ func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (reply *netwo
 	routes := []*networkapi.Route{}
 
 	for _, rMesg := range list {
-
 		ifaceData, err := r.Networkd.Conn.LinkByIndex(int(rMesg.Attributes.OutIface))
 		if err != nil {
 			log.Printf("failed to get interface details for interface index %d: %v", rMesg.Attributes.OutIface, err)
@@ -67,8 +66,8 @@ func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (reply *netwo
 			Protocol:    networkapi.RouteProtocol(rMesg.Protocol),
 			Flags:       rMesg.Flags,
 		})
-
 	}
+
 	return &networkapi.RoutesReply{
 		Routes: routes,
 	}, nil

--- a/internal/pkg/containers/containerd/containerd.go
+++ b/internal/pkg/containers/containerd/containerd.go
@@ -213,7 +213,6 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 				}
 			}
 		}
-
 	}
 
 	// Typically on actual application containers inside the pod/sandbox

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -245,6 +245,7 @@ const (
 )
 
 // See https://linux.die.net/man/3/klogctl
+//nolint: stylecheck
 const (
 	// SYSLOG_ACTION_SIZE_BUFFER is a named type argument to klogctl.
 	// nolint: golint


### PR DESCRIPTION
Memory usage reduced around 8-10x: now it stays stable at 1GB.

I disabled some of the new linters, and one rule which is violated a
lot.

I might make sense to go back and enable `wsl` fixing all the issues
(leaving that for another PR).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>