### PR TITLE
feat: output cluster network info for all node types

### DIFF
--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -29,6 +29,11 @@ func controlPlaneUd(in *Input) (string, error) {
 		EtcdConfig: &v1alpha1.EtcdConfig{
 			RootCA: in.Certs.Etcd,
 		},
+		ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
+			DNSDomain:     in.ServiceDomain,
+			PodSubnet:     in.PodNet,
+			ServiceSubnet: in.ServiceNet,
+		},
 		ClusterCA:                     in.Certs.K8s,
 		CertificateKey:                in.KubeadmTokens.CertificateKey,
 		ClusterAESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -27,6 +27,11 @@ func workerUd(in *Input) (string, error) {
 			Version: in.KubernetesVersion,
 			IPs:     in.MasterIPs,
 		},
+		ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
+			DNSDomain:     in.ServiceDomain,
+			PodSubnet:     in.PodNet,
+			ServiceSubnet: in.ServiceNet,
+		},
 	}
 
 	ud := v1alpha1.Config{


### PR DESCRIPTION
This PR will push the cluster network node configs for all nodes. This
is needed so that non-init nodes can know the service address range to
use for determining the IP of services like coredns.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>