### PR TITLE
fix: update platform task to set hostname and cert SANs

### DIFF
--- a/internal/app/machined/internal/phase/platform/platform.go
+++ b/internal/app/machined/internal/phase/platform/platform.go
@@ -33,26 +33,27 @@ func (task *Platform) runtime(args *phase.RuntimeArgs) (err error) {
 		return err
 	}
 
-	_, err = args.Platform().Hostname()
+	hostname, err := args.Platform().Hostname()
 	if err != nil {
 		return err
 	}
 
-	// if hostname != nil {
-	// 	data.Networking.OS.Hostname = string(hostname)
-	// }
+	if hostname != nil {
+		args.Config().Machine().Network().SetHostname(string(hostname))
+	}
 
-	// // Attempt to identify external addresses assigned to the instance via platform
-	// // metadata
-	// addrs, err := platform.ExternalIPs()
-	// if err != nil {
-	// 	return err
-	// }
+	addrs, err := args.Platform().ExternalIPs()
+	if err != nil {
+		return err
+	}
 
-	// // And add them to our cert SANs for trustd
-	// for _, addr := range addrs {
-	// 	data.Services.Trustd.CertSANs = append(data.Services.Trustd.CertSANs, addr.String())
-	// }
+	sans := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		sans = append(sans, addr.String())
+	}
+
+	args.Config().Machine().Security().SetCertSANs(sans)
+	args.Config().Cluster().SetCertSANs(sans)
 
 	return nil
 }

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -16,6 +16,7 @@ type Cluster interface {
 	IPs() []string
 	Token() Token
 	CertSANs() []string
+	SetCertSANs([]string)
 	CA() *x509.PEMEncodedCertificateAndKey
 	AESCBCEncryptionSecret() string
 	Config(machine.Type) (string, error)

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -53,6 +53,7 @@ type Security interface {
 	CA() *x509.PEMEncodedCertificateAndKey
 	Token() string
 	CertSANs() []string
+	SetCertSANs([]string)
 }
 
 // Network defines the requirements for a config that pertains to network

--- a/pkg/config/types/v1alpha1/cluster_config.go
+++ b/pkg/config/types/v1alpha1/cluster_config.go
@@ -89,6 +89,15 @@ func (c *ClusterConfig) CertSANs() []string {
 	return c.APIServer.CertSANs
 }
 
+// SetCertSANs implements the Configurator interface.
+func (c *ClusterConfig) SetCertSANs(sans []string) {
+	if c.APIServer == nil {
+		c.APIServer = &APIServerConfig{}
+	}
+
+	c.APIServer.CertSANs = sans
+}
+
 // CA implements the Configurator interface.
 func (c *ClusterConfig) CA() *x509.PEMEncodedCertificateAndKey {
 	return c.ClusterCA

--- a/pkg/config/types/v1alpha1/machine_config.go
+++ b/pkg/config/types/v1alpha1/machine_config.go
@@ -105,6 +105,11 @@ func (m *MachineConfig) CertSANs() []string {
 	return m.MachineCertSANs
 }
 
+// SetCertSANs implements the Configurator interface.
+func (m *MachineConfig) SetCertSANs(sans []string) {
+	m.MachineCertSANs = sans
+}
+
 // ExtraMounts implements the Configurator interface.
 func (m *MachineConfig) ExtraMounts() []specs.Mount {
 	return nil


### PR DESCRIPTION
This adds a setter for the certificate SANs and sets the hostname based
on info from the platform.