### PR TITLE
fix: Make updating cert sans an append operation

### DIFF
--- a/pkg/config/types/v1alpha1/cluster_config.go
+++ b/pkg/config/types/v1alpha1/cluster_config.go
@@ -95,7 +95,7 @@ func (c *ClusterConfig) SetCertSANs(sans []string) {
 		c.APIServer = &APIServerConfig{}
 	}
 
-	c.APIServer.CertSANs = sans
+	c.APIServer.CertSANs = append(c.APIServer.CertSANs, sans...)
 }
 
 // CA implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/machine_config.go
+++ b/pkg/config/types/v1alpha1/machine_config.go
@@ -107,7 +107,7 @@ func (m *MachineConfig) CertSANs() []string {
 
 // SetCertSANs implements the Configurator interface.
 func (m *MachineConfig) SetCertSANs(sans []string) {
-	m.MachineCertSANs = sans
+	m.MachineCertSANs = append(m.MachineCertSANs, sans...)
 }
 
 // ExtraMounts implements the Configurator interface.


### PR DESCRIPTION
This updates any discovered CertSANs to be appended to the list provided by userdata.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>