### PR TITLE
chore: update sonobuoy for conformance tests

### DIFF
--- a/hack/test/e2e-runner.sh
+++ b/hack/test/e2e-runner.sh
@@ -18,7 +18,7 @@ export CAPT_VERSION="0.1.0-alpha.2"
 export PROVIDER_COMPONENTS="https://github.com/talos-systems/cluster-api-provider-talos/releases/download/v${CAPT_VERSION}/provider-components.yaml"
 export KUSTOMIZE_VERSION="1.0.11"
 export KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64"
-export SONOBUOY_VERSION="0.15.4"
+export SONOBUOY_VERSION="0.16.1"
 export SONOBUOY_URL="https://github.com/heptio/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
 export CAPI_NS="cluster-api-provider-talos-system"
 


### PR DESCRIPTION
This PR updates the sonobuoy version. We're currently running
conformance tests with 0.15.x

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>