### PR TITLE
fix: Use correct names for kubelet config

### DIFF
--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -149,7 +149,7 @@ func (k *Kubelet) Runner(config config.Configurator) (runner.Runner, error) {
 			"/hyperkube",
 			"kubelet",
 			"--bootstrap-kubeconfig=" + constants.KubeletBootstrapKubeconfig,
-			"--kubeconfig=/etc/kubernetes/kubeconfig-kubelet",
+			"--kubeconfig=" + constants.KubeletKubeconfig,
 			"--container-runtime=remote",
 			"--container-runtime-endpoint=unix://" + constants.ContainerdAddress,
 			"--anonymous-auth=false",

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -56,7 +56,7 @@ func (o *OSD) PostFunc(config config.Configurator) (err error) {
 // Condition implements the Service interface.
 func (o *OSD) Condition(config config.Configurator) conditions.Condition {
 	if config.Machine().Type() == machine.Worker {
-		return conditions.WaitForFileToExist("/etc/kubernetes/kubelet.conf")
+		return conditions.WaitForFileToExist(constants.KubeletKubeconfig)
 	}
 
 	return nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -140,6 +140,9 @@ const (
 	// AdminKubeconfig is the generated admin kubeconfig.
 	AdminKubeconfig = "/etc/kubernetes/kubeconfig"
 
+	// KubeletKubeconfig is the generated kubeconfig for kubelet.
+	KubeletKubeconfig = "/etc/kubernetes/kubeconfig-kubelet"
+
 	// DefaultEtcdVersion is the default target version of etcd.
 	DefaultEtcdVersion = "3.3.15-0"
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -38,11 +38,9 @@ type Helper struct {
 
 // NewHelper initializes and returns a Helper.
 func NewHelper() (helper *Helper, err error) {
-	kubeconfig := "/etc/kubernetes/kubelet.conf"
-
 	var config *restclient.Config
 
-	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err = clientcmd.BuildConfigFromFlags("", constants.KubeletKubeconfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With the change to bootkube, kubelet.conf has changed names and is now kubelet-kubeconfig.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>