### PR TITLE
fix: use talos.config instead of talos.userdata

### DIFF
--- a/docs/content/guides/metal.md
+++ b/docs/content/guides/metal.md
@@ -22,7 +22,7 @@ This will generate 5 files - `master-{1,2,3}.yaml`, `worker.yaml`, and `taloscon
 The master and worker config files contain just enough config to bootstrap your cluster, and can be further customized as necessary.
 
 These config files should be supplied as machine userdata or some internally accessible url so they can be downloaded during machine bootup.
-When specifying a remote location to download userdata from, the kernel parameter `talos.userdata=http://myurl.com`.
+When specifying a remote location to download userdata from, the kernel parameter `talos.config=http://myurl.com`.
 
 An iPXE server such as [coreos/Matchbox](https://github.com/poseidon/matchbox) is recommended.
 
@@ -30,7 +30,7 @@ An iPXE server such as [coreos/Matchbox](https://github.com/poseidon/matchbox) i
 
 The following is the list of related kernel commandline parameters:
 
-- `talos.userdata` (required) the HTTP(S) URL at which the machine data can be found
+- `talos.config` (required) the HTTP(S) URL at which the machine data can be found
 - `talos.platform` (required) should be 'metal' for bare-metal installs
 
 Talos also enforces some minimum requirements from the KSPP (kernel self-protection project):

--- a/docs/content/guides/xen.md
+++ b/docs/content/guides/xen.md
@@ -36,7 +36,7 @@ kernel = "/var/lib/xen/talos/vmlinuz"
 ramdisk = "/var/lib/xen/talos/initramfs.xz"
 disk = [ 'phy:/dev/sdb,xvda,w', ]
 vif = [ 'mac=52:54:00:A8:4C:E1,bridge=xenbr0,model=e1000', ]
-extra = "consoleblank=0 console=hvc0 console=tty0 console=ttyS0,9600 talos.platform=metal talos.userdata=http://${IP}:8080/master.yaml"
+extra = "consoleblank=0 console=hvc0 console=tty0 console=ttyS0,9600 talos.platform=metal talos.config=http://${IP}:8080/master.yaml"
 ```
 
 {{% note %}}`http://${IP}:8080/master.yaml` should be reachable by the VM and contain a valid master configuration file.{{% /note %}}
@@ -76,7 +76,7 @@ kernel = "/var/lib/xen/talos/vmlinuz"
 ramdisk = "/var/lib/xen/talos/initramfs.xz"
 disk = [ 'phy:/dev/sdc,xvda,w', ]
 vif = [ 'mac=52:54:00:B9:5D:F2,bridge=xenbr0,model=e1000', ]
-extra = "consoleblank=0 console=hvc0 console=tty0 console=ttyS0,9600 talos.platform=metal talos.userdata=http://${IP}:8080/worker.yaml"
+extra = "consoleblank=0 console=hvc0 console=tty0 console=ttyS0,9600 talos.platform=metal talos.config=http://${IP}:8080/worker.yaml"
 ```
 
 {{% note %}}`http://${IP}:8080/worker.yaml` should be reachable by the VM and contain a valid worker configuration file.{{% /note %}}

--- a/hack/dev/qemu-boot.sh
+++ b/hack/dev/qemu-boot.sh
@@ -39,6 +39,6 @@ qemu-system-x86_64 \
     -device virtio-net,netdev=talos \
     -nographic \
     -serial mon:stdio \
-    -append "talos.platform=metal page_poison=1 slub_debug=P slab_nomerge pti=on random.trust_cpu=on printk.devkmsg=on earlyprintk=serial,tty0,keep console=tty0 talos.userdata=${MACHINE_CONFIG}" \
+    -append "talos.platform=metal page_poison=1 slub_debug=P slab_nomerge pti=on random.trust_cpu=on printk.devkmsg=on earlyprintk=serial,tty0,keep console=tty0 talos.config=${MACHINE_CONFIG}" \
     -kernel ${KERNEL} \
     -initrd ${INITRD}

--- a/hack/installer/entrypoint.sh
+++ b/hack/installer/entrypoint.sh
@@ -97,7 +97,7 @@ case "$1" in
           ;;
         u )
           TALOS_CONFIG=${OPTARG}
-          echo "Using kernel parameter talos.userdata=${TALOS_CONFIG}"
+          echo "Using kernel parameter talos.config=${TALOS_CONFIG}"
           ;;
         \? )
           echo "Invalid Option: -${OPTARG}" 1>&2


### PR DESCRIPTION
The new kernel parameter talos.config should be used instead of
tallos.userdata.