### PR TITLE
fix: use localhost for osd endpoint on masters

### DIFF
--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -76,7 +76,7 @@ func (o *OSD) DependsOn(config config.Configurator) []string {
 func (o *OSD) Runner(config config.Configurator) (runner.Runner, error) {
 	image := "talos/osd"
 
-	endpoints := config.Cluster().IPs()
+	endpoints := []string{"127.0.0.1"}
 
 	if config.Machine().Type() == machine.Worker {
 		opts := []retry.Option{retry.WithUnits(3 * time.Second), retry.WithJitter(time.Second)}


### PR DESCRIPTION
This PR will fix a bug where osd fails to start when the instances are
behind a load balancer (only one LB IP specified in machine config). For
masters, osd should be able to look to localhost anyways, and workers
will still gather the endpoints via kubernetes node lookups.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>