### PR TITLE
refactor: use control plane endpoint instead of master IPs

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -109,7 +109,7 @@ func create() (err error) {
 		ips[i] = fmt.Sprintf(baseNetwork, i+2)
 	}
 
-	input, err := generate.NewInput(clusterName, ips, kubernetesVersion)
+	input, err := generate.NewInput(clusterName, ips[0], kubernetesVersion)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/internal/phase/services/post_boot.go
+++ b/internal/app/machined/internal/phase/services/post_boot.go
@@ -35,7 +35,7 @@ func (task *LabelNodeAsMaster) standard(args *phase.RuntimeArgs) (err error) {
 		return nil
 	}
 
-	endpoint := net.ParseIP(args.Config().Cluster().IPs()[0])
+	endpoint := net.ParseIP(args.Config().Cluster().Endpoint())
 
 	h, err := kubernetes.NewTemporaryClientFromPKI(args.Config().Cluster().CA().Crt, args.Config().Cluster().CA().Key, endpoint.String(), "6443")
 	if err != nil {

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -120,22 +120,15 @@ func generateAssets(config config.Configurator) (err error) {
 
 	apiServers := []*url.URL{}
 
-	for _, ip := range config.Cluster().IPs() {
+	for _, endpoint := range []string{"https://" + config.Cluster().Endpoint() + ":6443", "https://127.0.0.1:6443"} {
 		var u *url.URL
 
-		if u, err = url.Parse("https://" + ip + ":6443"); err != nil {
+		if u, err = url.Parse(endpoint); err != nil {
 			return err
 		}
 
 		apiServers = append(apiServers, u)
 	}
-
-	u, err := url.Parse("https://127.0.0.1:6443")
-	if err != nil {
-		return err
-	}
-
-	apiServers = append(apiServers, u)
 
 	_, podCIDR, err := net.ParseCIDR(config.Cluster().Network().PodCIDR())
 	if err != nil {

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -297,7 +297,7 @@ func addMember(endpoints, addrs []string) (*clientv3.MemberAddResponse, error) {
 }
 
 func buildInitialCluster(config config.Configurator, name, ip string) (initial string, err error) {
-	endpoint := stdlibnet.ParseIP(config.Cluster().IPs()[0])
+	endpoint := stdlibnet.ParseIP(config.Cluster().Endpoint())
 
 	h, err := kubernetes.NewTemporaryClientFromPKI(config.Cluster().CA().Crt, config.Cluster().CA().Key, endpoint.String(), "6443")
 	if err != nil {

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -69,7 +69,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, config config.Configurator) error
 		BootstrapTokenID     string
 		BootstrapTokenSecret string
 	}{
-		Server:               "https://" + config.Cluster().IPs()[0] + ":6443",
+		Server:               "https://" + config.Cluster().Endpoint() + ":6443",
 		CACert:               base64.StdEncoding.EncodeToString(config.Cluster().CA().Crt),
 		BootstrapTokenID:     config.Cluster().Token().ID(),
 		BootstrapTokenSecret: config.Cluster().Token().Secret(),

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -13,7 +13,7 @@ import (
 // related options.
 type Cluster interface {
 	Version() string
-	IPs() []string
+	Endpoint() string
 	Token() Token
 	CertSANs() []string
 	SetCertSANs([]string)

--- a/pkg/config/types/v1alpha1/cluster_config.go
+++ b/pkg/config/types/v1alpha1/cluster_config.go
@@ -37,8 +37,6 @@ type ControlPlaneConfig struct {
 	// port number.  It is optional and if not supplied, the IP address of the
 	// first master node will be used.
 	Endpoint string `yaml:"endpoint,omitempty"`
-
-	IPs []string `yaml:"ips"`
 }
 
 // APIServerConfig represents kube apiserver config vals
@@ -79,9 +77,9 @@ func (c *ClusterConfig) Version() string {
 	return c.ControlPlane.Version
 }
 
-// IPs implements the Configurator interface.
-func (c *ClusterConfig) IPs() []string {
-	return c.ControlPlane.IPs
+// Endpoint implements the Configurator interface.
+func (c *ClusterConfig) Endpoint() string {
+	return c.ControlPlane.Endpoint
 }
 
 // CertSANs implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -18,13 +18,18 @@ func controlPlaneUd(in *Input) (string, error) {
 		MachineCertSANs: []string{"127.0.0.1", "::1"},
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
+		MachineInstall: &v1alpha1.InstallConfig{
+			InstallDisk:       in.InstallDisk,
+			InstallImage:      in.InstallImage,
+			InstallBootloader: true,
+		},
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
 		BootstrapToken: in.KubeadmTokens.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
-			Version: in.KubernetesVersion,
-			IPs:     in.MasterIPs,
+			Version:  in.KubernetesVersion,
+			Endpoint: in.ControlPlaneEndpoint,
 		},
 		EtcdConfig: &v1alpha1.EtcdConfig{
 			RootCA: in.Certs.Etcd,

--- a/pkg/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/config/types/v1alpha1/generate/generate_test.go
@@ -27,7 +27,7 @@ func TestGenerateSuite(t *testing.T) {
 
 func (suite *GenerateSuite) SetupSuite() {
 	var err error
-	suite.input, err = genv1alpha1.NewInput("test", []string{"10.0.1.5", "10.0.1.6", "10.0.1.7"}, constants.DefaultKubernetesVersion)
+	suite.input, err = genv1alpha1.NewInput("test", "10.0.1.5", constants.DefaultKubernetesVersion)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -18,6 +18,11 @@ func initUd(in *Input) (string, error) {
 		MachineCA:       in.Certs.OS,
 		MachineCertSANs: []string{"127.0.0.1", "::1"},
 		MachineToken:    in.TrustdInfo.Token,
+		MachineInstall: &v1alpha1.InstallConfig{
+			InstallDisk:       in.InstallDisk,
+			InstallImage:      in.InstallImage,
+			InstallBootloader: true,
+		},
 	}
 
 	certSANs := in.GetAPIServerSANs()
@@ -27,7 +32,6 @@ func initUd(in *Input) (string, error) {
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Version:  in.KubernetesVersion,
 			Endpoint: in.ControlPlaneEndpoint,
-			IPs:      in.MasterIPs,
 		},
 		APIServer: &v1alpha1.APIServerConfig{
 			CertSANs: certSANs,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -18,14 +18,19 @@ func workerUd(in *Input) (string, error) {
 		MachineCertSANs: []string{"127.0.0.1", "::1"},
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
+		MachineInstall: &v1alpha1.InstallConfig{
+			InstallDisk:       in.InstallDisk,
+			InstallImage:      in.InstallImage,
+			InstallBootloader: true,
+		},
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
 		ClusterCA:      &x509.PEMEncodedCertificateAndKey{Crt: in.Certs.K8s.Crt},
 		BootstrapToken: in.KubeadmTokens.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
-			Version: in.KubernetesVersion,
-			IPs:     in.MasterIPs,
+			Version:  in.KubernetesVersion,
+			Endpoint: in.ControlPlaneEndpoint,
 		},
 		ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
 			DNSDomain:     in.ServiceDomain,


### PR DESCRIPTION
Since we no longer have the static IP requirement, we can update all
references to the "master IPs" to use the control plane endpoint.

This adds support for creating more than one node using the qemu-boot.sh
script.