### PR TITLE
refactor: improve metal platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,7 @@ COPY hack/containerd.toml /etc/containerd-system.toml
 RUN touch /rootfs/etc/resolv.conf
 RUN touch /rootfs/etc/hosts
 RUN touch /rootfs/etc/os-release
-RUN mkdir -pv /rootfs/{boot,usr/local/share}
+RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt}
 RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni,usr/libexec/kubernetes}
 RUN ln -s /etc/ssl /rootfs/etc/pki
 RUN ln -s /etc/ssl /rootfs/usr/share/ca-certificates

--- a/internal/pkg/runtime/initializer/metal/metal.go
+++ b/internal/pkg/runtime/initializer/metal/metal.go
@@ -5,6 +5,7 @@
 package metal
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/talos-systems/talos/internal/pkg/event"
@@ -29,14 +30,16 @@ func (b *Metal) Initialize(platform platform.Platform, install machine.Install) 
 
 	mountpoints, err = owned.MountPointsFromLabels()
 	if err != nil {
-		// if install.Image() == "" {
-		// 	install.Image() = fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, version.Tag)
-		// }
+		if install.Image() == "" {
+			return errors.New("an install image is required")
+		}
+
 		if err = installer.Install(install.Image(), install.Disk(), strings.ToLower(platform.Name())); err != nil {
 			return err
 		}
 
 		event.Bus().Notify(event.Event{Type: event.Reboot})
+
 		// Prevent the task from returning to prevent the next phase from
 		// running.
 		select {}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -158,9 +158,8 @@ const (
 	// ConfigPath is the path to the downloaded config.
 	ConfigPath = "/run/config.yaml"
 
-	// UserDataCIData is the volume label for NoCloud cloud-init.
-	// See https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html#datasource-nocloud.
-	UserDataCIData = "cidata"
+	// MetalConfigISOLabel is the volume label for ISO based configuration.
+	MetalConfigISOLabel = "metal-iso"
 
 	// ConfigGuestInfo is the name of the VMware guestinfo config strategy.
 	ConfigGuestInfo = "guestinfo"


### PR DESCRIPTION
This brings in a few minor improvements to the metal platform. The first
is to use talos.config=metal-iso to indicate that the machine's config
can be found in an ISO image. The second is a fix to ensure that /mnt
exists.

This adds support for creating more than one node using the qemu-boot.sh
script.