### PR TITLE
fix: always run networkd

### DIFF
--- a/internal/app/machined/internal/phase/services/start_services.go
+++ b/internal/app/machined/internal/phase/services/start_services.go
@@ -41,11 +41,11 @@ func (task *StartServices) loadSystemServices(args *phase.RuntimeArgs) {
 		&services.MachinedAPI{},
 		&services.Containerd{},
 		&services.OSD{},
+		&services.Networkd{},
 	)
 
 	if args.Platform().Mode() != runtime.Container {
 		svcs.Load(
-			&services.Networkd{},
 			&services.NTPd{},
 			&services.Udevd{},
 			&services.UdevdTrigger{},


### PR DESCRIPTION
Without networkd, the /etc/resolv.conf in containers causes CoreDNS to
fail with "Forwarding loop detected in "." zone." With networkd running,
we overwrite /etc/resolv.conf and avoid this. I'm not sure this is what
we want in the long run, but this will fix things for now.