### PR TITLE
chore: bump golangci-lint to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.20.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.21.0
 RUN cd $(mktemp -d) \
     && go mod init tmp \
     && go get mvdan.cc/gofumpt/gofumports \


### PR DESCRIPTION
This release comes with support for caching lint results. It should
allow for speed ups when some packages don't change between the runs, so
cached information about packages might be used instead of running
linter collect phase on the package.

In my non-scientific test:

1. Fresh: 40s
2. One file change: 15s

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>