### PR TITLE
feat: allow specifcation of full url for endpoint

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -109,7 +109,7 @@ func create() (err error) {
 		ips[i] = fmt.Sprintf(baseNetwork, i+2)
 	}
 
-	input, err := generate.NewInput(clusterName, ips[0], kubernetesVersion)
+	input, err := generate.NewInput(clusterName, "https://"+ips[0]+":6443", kubernetesVersion)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 replace github.com/jsimonetti/rtnetlink => github.com/bradbeam/rtnetlink v0.0.0-20190820045831-7b9ca088b93d
 
-replace github.com/kubernetes-incubator/bootkube => github.com/andrewrynhard/bootkube v0.14.1-0.20191009160759-890e418c7b1d
+replace github.com/kubernetes-incubator/bootkube => github.com/andrewrynhard/bootkube v0.14.1-0.20191015145817-ac01e28e2840
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/andrewrynhard/bootkube v0.14.1-0.20191009160759-890e418c7b1d h1:7gdwp0BLA9iylhbWsKEfyZIbc4ywWE09XX5YPo4cH4I=
-github.com/andrewrynhard/bootkube v0.14.1-0.20191009160759-890e418c7b1d/go.mod h1:oTqoeN0SnkWpS325wZYrKYVIawqpdkr6iZMlA0iYdUE=
+github.com/andrewrynhard/bootkube v0.14.1-0.20191015145817-ac01e28e2840 h1:GNpqxJ1Rog7uOx36u2rBGt56EmfBmqKNsGre74q1mVY=
+github.com/andrewrynhard/bootkube v0.14.1-0.20191015145817-ac01e28e2840/go.mod h1:oTqoeN0SnkWpS325wZYrKYVIawqpdkr6iZMlA0iYdUE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/internal/app/machined/internal/phase/services/post_boot.go
+++ b/internal/app/machined/internal/phase/services/post_boot.go
@@ -6,7 +6,6 @@ package services
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"time"
 
@@ -35,9 +34,12 @@ func (task *LabelNodeAsMaster) standard(r runtime.Runtime) (err error) {
 		return nil
 	}
 
-	endpoint := net.ParseIP(r.Config().Cluster().Endpoint())
-
-	h, err := kubernetes.NewTemporaryClientFromPKI(r.Config().Cluster().CA().Crt, r.Config().Cluster().CA().Key, endpoint.String(), "6443")
+	h, err := kubernetes.NewTemporaryClientFromPKI(
+		r.Config().Cluster().CA().Crt,
+		r.Config().Cluster().CA().Key,
+		r.Config().Cluster().Endpoint().Hostname(),
+		r.Config().Cluster().Endpoint().Port(),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -119,18 +119,6 @@ func generateAssets(config runtime.Configurator) (err error) {
 		return err
 	}
 
-	apiServers := []*url.URL{}
-
-	for _, endpoint := range []string{"https://" + config.Cluster().Endpoint() + ":6443", "https://127.0.0.1:6443"} {
-		var u *url.URL
-
-		if u, err = url.Parse(endpoint); err != nil {
-			return err
-		}
-
-		apiServers = append(apiServers, u)
-	}
-
 	_, podCIDR, err := net.ParseCIDR(config.Cluster().Network().PodCIDR())
 	if err != nil {
 		return err
@@ -141,7 +129,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 		return err
 	}
 
-	altNames := altNamesFromURLs(apiServers)
+	altNames := altNamesFromURLs([]*url.URL{config.Cluster().Endpoint()})
 
 	block, _ = pem.Decode(config.Cluster().CA().Crt)
 	if block == nil {
@@ -181,7 +169,8 @@ func generateAssets(config runtime.Configurator) (err error) {
 		EtcdClientKey:          key,
 		EtcdServers:            []*url.URL{etcdServer},
 		EtcdUseTLS:             true,
-		APIServers:             apiServers,
+		ControlPlaneEndpoint:   config.Cluster().Endpoint(),
+		LocalAPIServerPort:     config.Cluster().LocalAPIServerPort(),
 		APIServiceIP:           apiServiceIP,
 		DNSServiceIP:           dnsServiceIP,
 		PodCIDR:                podCIDR,

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -297,9 +297,12 @@ func addMember(endpoints, addrs []string) (*clientv3.MemberAddResponse, error) {
 }
 
 func buildInitialCluster(config runtime.Configurator, name, ip string) (initial string, err error) {
-	endpoint := stdlibnet.ParseIP(config.Cluster().Endpoint())
-
-	h, err := kubernetes.NewTemporaryClientFromPKI(config.Cluster().CA().Crt, config.Cluster().CA().Key, endpoint.String(), "6443")
+	h, err := kubernetes.NewTemporaryClientFromPKI(
+		config.Cluster().CA().Crt,
+		config.Cluster().CA().Key,
+		config.Cluster().Endpoint().Hostname(),
+		config.Cluster().Endpoint().Port(),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -68,7 +68,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, config runtime.Configurator) erro
 		BootstrapTokenID     string
 		BootstrapTokenSecret string
 	}{
-		Server:               "https://" + config.Cluster().Endpoint() + ":6443",
+		Server:               config.Cluster().Endpoint().String(),
 		CACert:               base64.StdEncoding.EncodeToString(config.Cluster().CA().Crt),
 		BootstrapTokenID:     config.Cluster().Token().ID(),
 		BootstrapTokenSecret: config.Cluster().Token().Secret(),

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -5,6 +5,8 @@
 package cluster
 
 import (
+	"net/url"
+
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
@@ -13,7 +15,7 @@ import (
 // related options.
 type Cluster interface {
 	Version() string
-	Endpoint() string
+	Endpoint() *url.URL
 	Token() Token
 	CertSANs() []string
 	SetCertSANs([]string)
@@ -22,6 +24,7 @@ type Cluster interface {
 	Config(machine.Type) (string, error)
 	Etcd() Etcd
 	Network() Network
+	LocalAPIServerPort() int
 }
 
 // Network defines the requirements for a config that pertains to cluster

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -5,6 +5,8 @@
 package generate
 
 import (
+	"net/url"
+
 	yaml "gopkg.in/yaml.v2"
 
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
@@ -25,11 +27,16 @@ func controlPlaneUd(in *Input) (string, error) {
 		},
 	}
 
+	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
+	if err != nil {
+		return "", err
+	}
+
 	cluster := &v1alpha1.ClusterConfig{
 		BootstrapToken: in.KubeadmTokens.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Version:  in.KubernetesVersion,
-			Endpoint: in.ControlPlaneEndpoint,
+			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		EtcdConfig: &v1alpha1.EtcdConfig{
 			RootCA: in.Certs.Etcd,

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -13,6 +13,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"net"
+	"net/url"
 	"time"
 
 	"github.com/talos-systems/talos/internal/pkg/cis"
@@ -123,7 +124,15 @@ func (i *Input) GetControlPlaneEndpoint() string {
 // GetAPIServerSANs returns the formatted list of Subject Alt Name addresses for the API Server
 func (i *Input) GetAPIServerSANs() []string {
 	list := []string{"127.0.0.1", "::1"}
-	list = append(list, i.ControlPlaneEndpoint)
+
+	endpointURL, err := url.Parse(i.ControlPlaneEndpoint)
+	if err == nil {
+		host, _, err := net.SplitHostPort(endpointURL.Host)
+		if err == nil {
+			list = append(list, host)
+		}
+	}
+
 	list = append(list, i.AdditionalSubjectAltNames...)
 
 	return list

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -5,6 +5,8 @@
 package generate
 
 import (
+	"net/url"
+
 	yaml "gopkg.in/yaml.v2"
 
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
@@ -27,11 +29,16 @@ func initUd(in *Input) (string, error) {
 
 	certSANs := in.GetAPIServerSANs()
 
+	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
+	if err != nil {
+		return "", err
+	}
+
 	cluster := &v1alpha1.ClusterConfig{
 		ClusterName: in.ClusterName,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Version:  in.KubernetesVersion,
-			Endpoint: in.ControlPlaneEndpoint,
+			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		APIServer: &v1alpha1.APIServerConfig{
 			CertSANs: certSANs,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -5,6 +5,8 @@
 package generate
 
 import (
+	"net/url"
+
 	yaml "gopkg.in/yaml.v2"
 
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
@@ -25,12 +27,17 @@ func workerUd(in *Input) (string, error) {
 		},
 	}
 
+	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
+	if err != nil {
+		return "", err
+	}
+
 	cluster := &v1alpha1.ClusterConfig{
 		ClusterCA:      &x509.PEMEncodedCertificateAndKey{Crt: in.Certs.K8s.Crt},
 		BootstrapToken: in.KubeadmTokens.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Version:  in.KubernetesVersion,
-			Endpoint: in.ControlPlaneEndpoint,
+			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
 			DNSDomain:     in.ServiceDomain,

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -114,7 +114,7 @@ func NewTemporaryClientFromPKI(caCrt, caKey []byte, endpoint, port string) (help
 		return nil, fmt.Errorf("failed to create certificate from CSR: %w", err)
 	}
 
-	h, err := NewClientFromPKI(caCrt, crt.X509CertificatePEM, key.KeyPEM, endpoint, "6443")
+	h, err := NewClientFromPKI(caCrt, crt.X509CertificatePEM, key.KeyPEM, endpoint, port)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}


### PR DESCRIPTION
This PR moves to using the full URL for endpoint instead of trying to
hardcode 6443 in various places like we were doing.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>