### PR TITLE
fix: set packet and metal platform mode to metal

### DIFF
--- a/internal/pkg/runtime/platform/metal/metal.go
+++ b/internal/pkg/runtime/platform/metal/metal.go
@@ -53,7 +53,7 @@ func (b *Metal) Hostname() (hostname []byte, err error) {
 
 // Mode implements the platform.Platform interface.
 func (b *Metal) Mode() runtime.Mode {
-	return runtime.Cloud
+	return runtime.Metal
 }
 
 // ExternalIPs provides any external addresses assigned to the instance

--- a/internal/pkg/runtime/platform/packet/packet.go
+++ b/internal/pkg/runtime/platform/packet/packet.go
@@ -31,7 +31,7 @@ func (p *Packet) Configuration() ([]byte, error) {
 
 // Mode implements the platform.Platform interface.
 func (p *Packet) Mode() runtime.Mode {
-	return runtime.Cloud
+	return runtime.Metal
 }
 
 // Hostname implements the platform.Platform interface.


### PR DESCRIPTION
The packet and metal platforms were erroneously set to cloud mode. This
sets them to metal.