### PR TITLE
refactor: use go 1.13 error wrapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TOOLS ?= autonomy/tools:96cb1b9
 # TODO(andrewrynhard): Move this logic to a shell script.
 BUILDKIT_VERSION ?= v0.6.0
 KUBECTL_VERSION ?= v1.16.0
-GO_VERSION ?= 1.12
+GO_VERSION ?= 1.13
 BUILDKIT_IMAGE ?= moby/buildkit:$(BUILDKIT_VERSION)
 BUILDKIT_HOST ?= tcp://0.0.0.0:1234
 BUILDKIT_CONTAINER_NAME ?= talos-buildkit

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -144,7 +144,7 @@ var configGenerateCmd = &cobra.Command{
 func genV1Alpha1Config(args []string) {
 	input, err := genv1alpha1.NewInput(args[0], args[1], kubernetesVersion)
 	if err != nil {
-		helpers.Fatalf("failed to generate PKI and tokens: %v", err)
+		helpers.Fatalf("failed to generate PKI and tokens: %w", err)
 	}
 
 	input.AdditionalSubjectAltNames = additionalSANs
@@ -155,7 +155,7 @@ func genV1Alpha1Config(args []string) {
 
 	for _, t := range []genv1alpha1.Type{genv1alpha1.TypeInit, genv1alpha1.TypeControlPlane, genv1alpha1.TypeJoin} {
 		if err = writeV1Alpha1Config(input, t, t.String()); err != nil {
-			helpers.Fatalf("failed to generate config for %s: %v", t.String(), err)
+			helpers.Fatalf("failed to generate config for %s: %w", t.String(), err)
 		}
 	}
 
@@ -177,7 +177,7 @@ func genV1Alpha1Config(args []string) {
 	}
 
 	if err = ioutil.WriteFile("talosconfig", data, 0644); err != nil {
-		helpers.Fatalf("%v", err)
+		helpers.Fatalf("%w", err)
 	}
 
 	fmt.Println("created talosconfig")

--- a/cmd/osctl/cmd/ls.go
+++ b/cmd/osctl/cmd/ls.go
@@ -33,15 +33,15 @@ var lsCmd = &cobra.Command{
 			}
 			long, err := cmd.Flags().GetBool("long")
 			if err != nil {
-				helpers.Fatalf("failed to parse long flag: %v", err)
+				helpers.Fatalf("failed to parse long flag: %w", err)
 			}
 			recurse, err := cmd.Flags().GetBool("recurse")
 			if err != nil {
-				helpers.Fatalf("failed to parse recurse flag: %v", err)
+				helpers.Fatalf("failed to parse recurse flag: %w", err)
 			}
 			recursionDepth, err := cmd.Flags().GetInt32("depth")
 			if err != nil {
-				helpers.Fatalf("failed to parse depth flag: %v", err)
+				helpers.Fatalf("failed to parse depth flag: %w", err)
 			}
 
 			stream, err := c.LS(globalCtx, machineapi.LSRequest{

--- a/cmd/osctl/cmd/time.go
+++ b/cmd/osctl/cmd/time.go
@@ -27,7 +27,7 @@ var timeCmd = &cobra.Command{
 		setupClient(func(c *client.Client) {
 			server, err := cmd.Flags().GetString("check")
 			if err != nil {
-				helpers.Fatalf("failed to parse check flag: %v", err)
+				helpers.Fatalf("failed to parse check flag: %w", err)
 			}
 
 			var output *timeapi.TimeReply

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -64,17 +64,17 @@ func NewClientTargetAndCredentialsFromConfig(p string) (target string, creds *Cr
 
 	caBytes, err := base64.StdEncoding.DecodeString(context.CA)
 	if err != nil {
-		return "", nil, fmt.Errorf("error decoding CA: %v", err)
+		return "", nil, fmt.Errorf("error decoding CA: %w", err)
 	}
 
 	crtBytes, err := base64.StdEncoding.DecodeString(context.Crt)
 	if err != nil {
-		return "", nil, fmt.Errorf("error decoding certificate: %v", err)
+		return "", nil, fmt.Errorf("error decoding certificate: %w", err)
 	}
 
 	keyBytes, err := base64.StdEncoding.DecodeString(context.Key)
 	if err != nil {
-		return "", nil, fmt.Errorf("error decoding key: %v", err)
+		return "", nil, fmt.Errorf("error decoding key: %w", err)
 	}
 
 	creds = &Credentials{

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc8 // indirect
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/pborman/uuid v1.2.0 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/procfs v0.0.3
 	github.com/ryanuber/columnize v2.1.0+incompatible
 	github.com/spf13/cobra v0.0.5
@@ -62,7 +61,6 @@ require (
 	golang.org/x/sys v0.0.0-20190825160603-fb81701db80f
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124

--- a/go.sum
+++ b/go.sum
@@ -434,8 +434,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -5,10 +5,11 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
@@ -79,7 +80,7 @@ func main() {
 	defer recovery()
 
 	if err := run(); err != nil {
-		panic(errors.Wrap(err, "early boot failed"))
+		panic(fmt.Errorf("early boot failed: %w", err))
 	}
 
 	// We should never reach this point if things are working as intended.

--- a/internal/app/machined/internal/api/reg/reg.go
+++ b/internal/app/machined/internal/api/reg/reg.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 
@@ -182,7 +181,7 @@ func (r *Registrator) CopyOut(req *machineapi.CopyOutRequest, s machineapi.Machi
 	path = filepath.Clean(path)
 
 	if !filepath.IsAbs(path) {
-		return errors.Errorf("path is not absolute %v", path)
+		return fmt.Errorf("path is not absolute %v", path)
 	}
 
 	pr, pw := io.Pipe()

--- a/internal/app/machined/internal/phase/acpi/acpi.go
+++ b/internal/app/machined/internal/phase/acpi/acpi.go
@@ -5,11 +5,11 @@
 package acpi
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/netlink"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/event"
@@ -59,7 +59,7 @@ func listenForPowerButton() (err error) {
 	if netlink.IsNotExist(err) {
 		// nolint: errcheck
 		conn.Close()
-		return errors.Wrap(err, acpiGenlFamilyName+" not available")
+		return fmt.Errorf(acpiGenlFamilyName+" not available: %w", err)
 	}
 
 	var id uint32

--- a/internal/app/machined/internal/phase/disk/reset.go
+++ b/internal/app/machined/internal/phase/disk/reset.go
@@ -5,7 +5,7 @@
 package disk
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -50,7 +50,7 @@ func (task *ResetDisk) standard() (err error) {
 
 	for _, p := range pt.Partitions() {
 		if err = pt.Delete(p); err != nil {
-			return errors.Wrap(err, "failed to delete partition")
+			return fmt.Errorf("failed to delete partition: %w", err)
 		}
 	}
 

--- a/internal/app/machined/internal/phase/kubernetes/tasks.go
+++ b/internal/app/machined/internal/phase/kubernetes/tasks.go
@@ -6,13 +6,13 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"syscall"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/namespaces"
-	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
@@ -63,14 +63,14 @@ func (task *KillKubernetesTasks) standard() (err error) {
 		log.Printf("killing task %s", task.ID)
 		g.Go(func() error {
 			if _, err = s.Kill(ctx, &tasks.KillRequest{ContainerID: task.ID, Signal: uint32(syscall.SIGTERM), All: true}); err != nil {
-				return errors.Wrap(err, "error killing task")
+				return fmt.Errorf("error killing task: %w", err)
 			}
 			// TODO(andrewrynhard): Send SIGKILL on a timeout threshold.
 			if _, err = s.Wait(ctx, &tasks.WaitRequest{ContainerID: task.ID}); err != nil {
-				return errors.Wrap(err, "error waiting on task")
+				return fmt.Errorf("error waiting on task: %w", err)
 			}
 			if _, err = s.Delete(ctx, &tasks.DeleteTaskRequest{ContainerID: task.ID}); err != nil {
-				return errors.Wrap(err, "error deleting task")
+				return fmt.Errorf("error deleting task: %w", err)
 			}
 
 			return nil

--- a/internal/app/machined/internal/phase/phase.go
+++ b/internal/app/machined/internal/phase/phase.go
@@ -5,12 +5,12 @@
 package phase
 
 import (
+	"fmt"
 	"log"
 	goruntime "runtime"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -57,7 +57,7 @@ func NewRunner(config runtime.Configurator) (*Runner, error) {
 	case runtime.Cloud:
 		// Setup logging to /dev/kmsg.
 		if _, err = kmsg.Setup("[talos]"); err != nil {
-			return nil, errors.Errorf("failed to setup logging to /dev/kmsg: %v", err)
+			return nil, fmt.Errorf("failed to setup logging to /dev/kmsg: %w", err)
 		}
 	}
 
@@ -84,7 +84,7 @@ func (r *RuntimeArgs) Config() runtime.Configurator {
 func (r *Runner) Run() error {
 	for _, phase := range r.phases {
 		if err := r.runPhase(phase); err != nil {
-			return errors.Wrapf(err, "error running phase %q", phase.description)
+			return fmt.Errorf("error running phase %q: %w", phase.description, err)
 		}
 	}
 
@@ -130,7 +130,7 @@ func (r *Runner) runTask(task Task, errCh chan<- error) {
 		if r := recover(); r != nil {
 			buf := make([]byte, 8192)
 			n := goruntime.Stack(buf, false)
-			err = errors.Errorf("panic recovered: %v\n%s", r, string(buf[:n]))
+			err = fmt.Errorf("panic recovered: %v\n%s", r, string(buf[:n]))
 		}
 	}()
 

--- a/internal/app/machined/internal/phase/rootfs/etc/etc.go
+++ b/internal/app/machined/internal/phase/rootfs/etc/etc.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/pkg/version"
 
 	"golang.org/x/sys/unix"
@@ -74,11 +72,11 @@ func Hosts(hostname string) (err error) {
 	}
 
 	if err = ioutil.WriteFile("/run/system/etc/hosts", writer.Bytes(), 0644); err != nil {
-		return fmt.Errorf("write /run/hosts: %v", err)
+		return fmt.Errorf("write /run/hosts: %w", err)
 	}
 
 	if err = unix.Mount("/run/system/etc/hosts", "/etc/hosts", "", unix.MS_BIND, ""); err != nil {
-		return errors.Wrap(err, "failed to create bind mount for /etc/hosts")
+		return fmt.Errorf("failed to create bind mount for /etc/hosts: %w", err)
 	}
 
 	return nil
@@ -99,7 +97,7 @@ func ResolvConf() (err error) {
 	defer f.Close()
 
 	if err = unix.Mount("/run/system/etc/resolv.conf", "/etc/resolv.conf", "", unix.MS_BIND, ""); err != nil {
-		return errors.Wrap(err, "failed to create bind mount for /etc/resolv.conf")
+		return fmt.Errorf("failed to create bind mount for /etc/resolv.conf: %w", err)
 	}
 
 	return nil
@@ -142,11 +140,11 @@ func OSRelease() (err error) {
 	}
 
 	if err = ioutil.WriteFile("/run/system/etc/os-release", writer.Bytes(), 0644); err != nil {
-		return fmt.Errorf("write /run/system/etc/os-release: %v", err)
+		return fmt.Errorf("write /run/system/etc/os-release: %w", err)
 	}
 
 	if err = unix.Mount("/run/system/etc/os-release", "/etc/os-release", "", unix.MS_BIND, ""); err != nil {
-		return errors.Wrap(err, "failed to create bind mount for /etc/os-release")
+		return fmt.Errorf("failed to create bind mount for /etc/os-release: %w", err)
 	}
 
 	return nil

--- a/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_cgroups.go
@@ -5,12 +5,11 @@
 package rootfs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/mount"
@@ -61,7 +60,7 @@ func (task *MountCgroups) runtime(r runtime.Runtime) (err error) {
 	// See https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
 	target := path.Join("/sys/fs/cgroup", memoryCgroup, memoryUseHierarchy)
 	if err = ioutil.WriteFile(target, memoryUseHierarchyContents, memoryUseHierarchyPermissions); err != nil {
-		return errors.Wrap(err, "failed to enable memory hierarchy support")
+		return fmt.Errorf("failed to enable memory hierarchy support: %w", err)
 	}
 
 	return nil

--- a/internal/app/machined/internal/phase/rootfs/mount_sub_devices.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_sub_devices.go
@@ -5,8 +5,6 @@
 package rootfs
 
 import (
-	// "github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"

--- a/internal/app/machined/internal/phase/rootfs/unmount_pod_mounts.go
+++ b/internal/app/machined/internal/phase/rootfs/unmount_pod_mounts.go
@@ -7,11 +7,11 @@ package rootfs
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
@@ -59,7 +59,7 @@ func (task *UnmountPodMounts) standard(r runtime.Runtime) (err error) {
 			log.Printf("unmounting %s\n", mountpoint)
 
 			if err = unix.Unmount(mountpoint, 0); err != nil {
-				return errors.Errorf("error unmounting %s: %v", mountpoint, err)
+				return fmt.Errorf("error unmounting %s: %w", mountpoint, err)
 			}
 		}
 	}

--- a/internal/app/machined/internal/phase/services/post_boot.go
+++ b/internal/app/machined/internal/phase/services/post_boot.go
@@ -5,11 +5,10 @@
 package services
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -57,7 +56,7 @@ func (task *LabelNodeAsMaster) standard(r runtime.Runtime) (err error) {
 	})
 
 	if err != nil {
-		return errors.Wrap(err, "failed to label node as master")
+		return fmt.Errorf("failed to label node as master: %w", err)
 	}
 
 	return nil

--- a/internal/app/machined/internal/phase/sysctls/sysctls.go
+++ b/internal/app/machined/internal/phase/sysctls/sysctls.go
@@ -5,8 +5,9 @@
 package sysctls
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -30,15 +31,15 @@ func (task *Task) runtime(r runtime.Runtime) error {
 	var multiErr *multierror.Error
 
 	if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "net.ipv4.ip_forward", Value: "1"}); err != nil {
-		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "failed to set IPv4 forwarding"))
+		multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set IPv4 forwarding: %w", err))
 	}
 
 	if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "net.ipv6.conf.default.forwarding", Value: "1"}); err != nil {
-		multiErr = multierror.Append(multiErr, errors.Wrap(err, "failed to set IPv6 forwarding"))
+		multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set IPv6 forwarding: %w", err))
 	}
 
 	if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "kernel.pid_max", Value: "262144"}); err != nil {
-		multiErr = multierror.Append(multiErr, errors.Wrap(err, "failed to set pid_max"))
+		multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set pid_max: %w", err))
 	}
 
 	return multiErr.ErrorOrNil()

--- a/internal/app/machined/internal/phase/upgrade/leave_etcd.go
+++ b/internal/app/machined/internal/phase/upgrade/leave_etcd.go
@@ -6,11 +6,10 @@ package upgrade
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -81,7 +80,7 @@ func (task *LeaveEtcd) standard(r runtime.Runtime) (err error) {
 	}
 
 	if id == nil {
-		return errors.Errorf("failed to find %q in list of etcd members", hostname)
+		return fmt.Errorf("failed to find %q in list of etcd members", hostname)
 	}
 
 	log.Println("leaving etcd cluster")

--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -5,9 +5,8 @@
 package upgrade
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
@@ -42,7 +41,7 @@ func (task *Upgrade) standard(r runtime.Runtime) (err error) {
 	// platform name, this should be determined in the installer container.
 	var config *string
 	if config = kernel.ProcCmdline().Get(constants.KernelParamConfig).First(); config == nil {
-		return errors.Errorf("no config option was found")
+		return fmt.Errorf("no config option was found")
 	}
 
 	if err = install.Install(task.ref, task.devname, strings.ToLower(r.Platform().Name())); err != nil {

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -5,7 +5,7 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
@@ -67,12 +67,12 @@ func (d *Sequencer) Boot() error {
 
 	content, err := config.FromFile(constants.ConfigPath)
 	if err != nil {
-		return errors.Wrap(err, "failed to read config")
+		return fmt.Errorf("failed to read config: %w", err)
 	}
 
 	config, err := config.New(content)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse config")
+		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
 	phaserunner, err = phase.NewRunner(config)

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -5,11 +5,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"log"
 	"os"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	machineapi "github.com/talos-systems/talos/api/machine"
@@ -114,7 +115,7 @@ func main() {
 		defer recovery()
 		if err := seq.Boot(); err != nil {
 			log.Println(err)
-			panic(errors.Wrap(err, "boot failed"))
+			panic(fmt.Errorf("boot failed: %w", err))
 		}
 	}()
 
@@ -129,7 +130,7 @@ func main() {
 			fallthrough
 		case event.Reboot:
 			if err := seq.Shutdown(); err != nil {
-				panic(errors.Wrap(err, "shutdown failed"))
+				panic(fmt.Errorf("shutdown failed: %w", err))
 			}
 
 			sync()
@@ -149,7 +150,7 @@ func main() {
 			}
 
 			if err := seq.Upgrade(req); err != nil {
-				panic(errors.Wrap(err, "upgrade failed"))
+				panic(fmt.Errorf("upgrade failed: %w", err))
 			}
 
 			event.Bus().Notify(event.Event{Type: event.Reboot})

--- a/internal/app/machined/pkg/system/mocks_test.go
+++ b/internal/app/machined/pkg/system/mocks_test.go
@@ -6,10 +6,9 @@ package system_test
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"

--- a/internal/app/machined/pkg/system/runner/cri/runner.go
+++ b/internal/app/machined/pkg/system/runner/cri/runner.go
@@ -6,10 +6,10 @@ package cri
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
@@ -109,7 +109,7 @@ func (c *criRunner) findImage(ctx context.Context) error {
 		}
 	}
 
-	return errors.Errorf("container image %q hasn't been found", c.opts.ContainerImage)
+	return fmt.Errorf("container image %q hasn't been found", c.opts.ContainerImage)
 }
 
 // Open prepares the runner.
@@ -256,9 +256,9 @@ WAIT:
 				return nil
 			}
 
-			return errors.Errorf("container exited with code %d (%s)", status.ExitCode, status.Reason)
+			return fmt.Errorf("container exited with code %d (%s)", status.ExitCode, status.Reason)
 		default:
-			return errors.Errorf("container in unexpected state (%d)", status.State)
+			return fmt.Errorf("container in unexpected state (%d)", status.State)
 		}
 	}
 

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
@@ -12,8 +12,6 @@ import (
 	stdlibruntime "runtime"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/log"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -77,7 +75,7 @@ func (r *goroutineRunner) wrappedMain() (err error) {
 		if r := recover(); r != nil {
 			buf := make([]byte, 8192)
 			n := stdlibruntime.Stack(buf, false)
-			err = errors.Errorf("panic in service: %v\n%s", r, string(buf[:n]))
+			err = fmt.Errorf("panic in service: %v\n%s", r, string(buf[:n]))
 		}
 	}()
 
@@ -85,7 +83,7 @@ func (r *goroutineRunner) wrappedMain() (err error) {
 
 	w, err = log.New(r.id, r.opts.LogPath)
 	if err != nil {
-		err = errors.Wrap(err, "service log handler")
+		err = fmt.Errorf("service log handler: %w", err)
 		return
 	}
 	// nolint: errcheck

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
@@ -6,6 +6,7 @@ package goroutine_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"

--- a/internal/app/machined/pkg/system/runner/process/process.go
+++ b/internal/app/machined/pkg/system/runner/process/process.go
@@ -13,8 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	processlogger "github.com/talos-systems/talos/internal/app/machined/pkg/system/log"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -87,7 +85,7 @@ func (p *processRunner) build() (cmd *exec.Cmd, err error) {
 	// Setup logging.
 	w, err := processlogger.New(p.args.ID, p.opts.LogPath)
 	if err != nil {
-		err = fmt.Errorf("service log handler: %v", err)
+		err = fmt.Errorf("service log handler: %w", err)
 		return
 	}
 
@@ -107,7 +105,7 @@ func (p *processRunner) build() (cmd *exec.Cmd, err error) {
 func (p *processRunner) run(eventSink events.Recorder) error {
 	cmd, err := p.build()
 	if err != nil {
-		return errors.Wrap(err, "error building command")
+		return fmt.Errorf("error building command: %w", err)
 	}
 
 	notifyCh := make(chan reaper.ProcessInfo, 8)
@@ -118,7 +116,7 @@ func (p *processRunner) run(eventSink events.Recorder) error {
 	}
 
 	if err = cmd.Start(); err != nil {
-		return errors.Wrap(err, "error starting process")
+		return fmt.Errorf("error starting process: %w", err)
 	}
 
 	eventSink(events.StateRunning, "Process %s started with PID %d", p, cmd.Process.Pid)

--- a/internal/app/machined/pkg/system/runner/restart/restart.go
+++ b/internal/app/machined/pkg/system/runner/restart/restart.go
@@ -136,12 +136,12 @@ func (r *restarter) Run(eventSink events.Recorder) error {
 				return nil
 			}
 
-			eventSink(events.StateWaiting, "Error running %s, going to restart until it succeeds: %s", r.wrappedRunner, err)
+			eventSink(events.StateWaiting, "Error running %s, going to restart until it succeeds: %w", r.wrappedRunner, err)
 		case Forever:
 			if err == nil {
 				eventSink(events.StateWaiting, "Runner %s exited without error, going to restart it", r.wrappedRunner)
 			} else {
-				eventSink(events.StateWaiting, "Error running %v, going to restart forever: %s", r.wrappedRunner, err)
+				eventSink(events.StateWaiting, "Error running %v, going to restart forever: %w", r.wrappedRunner, err)
 			}
 		}
 

--- a/internal/app/machined/pkg/system/service_events.go
+++ b/internal/app/machined/pkg/system/service_events.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 )
 
@@ -33,7 +31,7 @@ func (sc *serviceCondition) Wait(ctx context.Context) error {
 	instance.mu.Unlock()
 
 	if svcrunner == nil {
-		return errors.Errorf("service %q is not registered", sc.service)
+		return fmt.Errorf("service %q is not registered", sc.service)
 	}
 
 	notifyCh := make(chan struct{}, 1)

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
@@ -240,7 +238,7 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 	}
 
 	if err := runnr.Open(ctx); err != nil {
-		return errors.Wrap(err, "error opening runner")
+		return fmt.Errorf("error opening runner: %w", err)
 	}
 
 	// nolint: errcheck
@@ -297,11 +295,11 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 		<-errCh
 
 		if err != nil {
-			return errors.Wrap(err, "error stopping service")
+			return fmt.Errorf("error stopping service: %w", err)
 		}
 	case err := <-errCh:
 		if err != nil {
-			return errors.Wrap(err, "error running service")
+			return fmt.Errorf("error running service: %w", err)
 		}
 	}
 

--- a/internal/app/machined/pkg/system/service_runner_test.go
+++ b/internal/app/machined/pkg/system/service_runner_test.go
@@ -5,10 +5,10 @@
 package system_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/url"
@@ -15,7 +17,6 @@ import (
 
 	"github.com/kubernetes-incubator/bootkube/pkg/asset"
 	"github.com/kubernetes-incubator/bootkube/pkg/tlsutil"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/bootkube"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
@@ -80,7 +81,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	peer, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse client certificate")
+		return fmt.Errorf("failed to parse client certificate: %w", err)
 	}
 
 	caCrt, err := ioutil.ReadFile(constants.KubernetesEtcdCACert)
@@ -95,7 +96,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	ca, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse etcd CA certificate")
+		return fmt.Errorf("failed to parse etcd CA certificate: %w", err)
 	}
 
 	peerKey, err := ioutil.ReadFile(constants.KubernetesEtcdPeerKey)
@@ -110,7 +111,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse client key")
+		return fmt.Errorf("failed to parse client key: %w", err)
 	}
 
 	etcdServer, err := url.Parse("https://127.0.0.1:2379")
@@ -149,7 +150,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	k8sCA, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse Kubernetes CA certificate")
+		return fmt.Errorf("failed to parse Kubernetes CA certificate: %w", err)
 	}
 
 	block, _ = pem.Decode(config.Cluster().CA().Key)
@@ -159,7 +160,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	k8sKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse Kubernetes key")
+		return fmt.Errorf("failed to parse Kubernetes key: %w", err)
 	}
 
 	apiServiceIP, err := tnet.NthIPInNetwork(serviceCIDR, 1)
@@ -195,7 +196,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	as, err := asset.NewDefaultAssets(conf)
 	if err != nil {
-		return errors.Wrap(err, "failed to create list of assets")
+		return fmt.Errorf("failed to create list of assets: %w", err)
 	}
 
 	if err = as.WriteFiles(constants.AssetsDirectory); err != nil {

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/defaults"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
@@ -96,7 +95,7 @@ func (c *Containerd) HealthFunc(runtime.Configurator) health.Check {
 		}
 
 		if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
-			return errors.Errorf("unexpected serving status: %d", resp.Status)
+			return fmt.Errorf("unexpected serving status: %d", resp.Status)
 		}
 
 		return nil

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -22,7 +22,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	criconstants "github.com/containerd/cri/pkg/constants"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/cni"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
@@ -107,7 +106,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, config runtime.Configurator) erro
 
 	image := fmt.Sprintf("%s:v%s", constants.KubernetesImage, config.Cluster().Version())
 	if _, err = client.Pull(containerdctx, image, containerdapi.WithPullUnpack); err != nil {
-		return fmt.Errorf("failed to pull image %q: %v", image, err)
+		return fmt.Errorf("failed to pull image %q: %w", image, err)
 	}
 
 	return nil
@@ -233,7 +232,7 @@ func (k *Kubelet) HealthFunc(runtime.Configurator) health.Check {
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return errors.Errorf("expected HTTP status OK, got %s", resp.Status)
+			return fmt.Errorf("expected HTTP status OK, got %s", resp.Status)
 		}
 
 		return nil

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -15,7 +15,6 @@ import (
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
@@ -84,7 +83,7 @@ func (o *OSD) Runner(config runtime.Configurator) (runner.Runner, error) {
 		err := retry.Constant(10*time.Minute, opts...).Retry(func() error {
 			h, err := kubernetes.NewHelper()
 			if err != nil {
-				return retry.ExpectedError(errors.Wrap(err, "failed to create client"))
+				return retry.ExpectedError(fmt.Errorf("failed to create client: %w", err))
 			}
 
 			endpoints, err = h.MasterIPs()

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
@@ -95,7 +94,7 @@ func (c *SystemContainerd) HealthFunc(runtime.Configurator) health.Check {
 		}
 
 		if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
-			return errors.Errorf("unexpected serving status: %d", resp.Status)
+			return fmt.Errorf("unexpected serving status: %d", resp.Status)
 		}
 
 		return nil

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -98,7 +97,7 @@ func (s *singleton) Start(serviceIDs ...string) error {
 	for _, id := range serviceIDs {
 		svcrunner := s.state[id]
 		if svcrunner == nil {
-			multiErr = multierror.Append(multiErr, errors.Errorf("service %q not defined", id))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("service %q not defined", id))
 		}
 
 		s.runningMu.Lock()
@@ -275,7 +274,7 @@ func (s *singleton) IsRunning(id string) (Service, bool, error) {
 	s.mu.Unlock()
 
 	if !exists {
-		return nil, false, errors.Errorf("service %q not defined", id)
+		return nil, false, fmt.Errorf("service %q not defined", id)
 	}
 
 	s.runningMu.Lock()
@@ -301,7 +300,7 @@ func (s *singleton) APIStart(ctx context.Context, id string) error {
 		return s.Start(id)
 	}
 
-	return errors.Errorf("service %q doesn't support start operation via API", id)
+	return fmt.Errorf("service %q doesn't support start operation via API", id)
 }
 
 // APIStop processes services stop request from the API
@@ -320,7 +319,7 @@ func (s *singleton) APIStop(ctx context.Context, id string) error {
 		return s.Stop(ctx, id)
 	}
 
-	return errors.Errorf("service %q doesn't support stop operation via API", id)
+	return fmt.Errorf("service %q doesn't support stop operation via API", id)
 }
 
 // APIRestart processes services restart request from the API
@@ -343,5 +342,5 @@ func (s *singleton) APIRestart(ctx context.Context, id string) error {
 		return s.Start(id)
 	}
 
-	return errors.Errorf("service %q doesn't support restart operation via API", id)
+	return fmt.Errorf("service %q doesn't support restart operation via API", id)
 }

--- a/internal/app/networkd/pkg/reg/reg.go
+++ b/internal/app/networkd/pkg/reg/reg.go
@@ -6,11 +6,11 @@ package reg
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 
@@ -40,7 +40,7 @@ func (r *Registrator) Register(s *grpc.Server) {
 func (r *Registrator) Routes(ctx context.Context, in *empty.Empty) (reply *networkapi.RoutesReply, err error) {
 	list, err := r.Networkd.NlConn.Route.List()
 	if err != nil {
-		return nil, errors.Errorf("failed to get route list: %v", err)
+		return nil, fmt.Errorf("failed to get route list: %w", err)
 	}
 
 	routes := []*networkapi.Route{}

--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -39,7 +39,7 @@ func init() {
 // If no servers are specified, the default will be used
 func main() {
 	if err := startup.RandSeed(); err != nil {
-		log.Fatalf("startup: %s", err)
+		log.Fatalf("startup: %v", err)
 	}
 
 	server := DefaultServer

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -6,6 +6,7 @@ package reg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,7 +18,6 @@ import (
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
 	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -317,7 +317,7 @@ func getContainerInspector(ctx context.Context, namespace string, driver osapi.C
 
 		return containerd.NewInspector(ctx, namespace, containerd.WithContainerdAddress(addr))
 	default:
-		return nil, errors.Errorf("unsupported driver %q", driver)
+		return nil, fmt.Errorf("unsupported driver %q", driver)
 	}
 }
 

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -40,7 +40,7 @@ func init() {
 // nolint: gocyclo
 func main() {
 	if err := startup.RandSeed(); err != nil {
-		log.Fatalf("failed to seed RNG: %s", err)
+		log.Fatalf("failed to seed RNG: %v", err)
 	}
 
 	content, err := config.FromFile(*configPath)

--- a/internal/pkg/containers/containerd/containerd.go
+++ b/internal/pkg/containers/containerd/containerd.go
@@ -7,6 +7,7 @@ package containerd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -19,7 +20,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/typeurl"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 
 	ctrs "github.com/talos-systems/talos/internal/pkg/containers"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -100,17 +100,17 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 
 	info, err := cntr.Info(i.nsctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting container info for %q", cntr.ID())
+		return nil, fmt.Errorf("error getting container info for %q: %w", cntr.ID(), err)
 	}
 
 	spec, err := cntr.Spec(i.nsctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting container spec for %q", cntr.ID())
+		return nil, fmt.Errorf("error getting container spec for %q: %w", cntr.ID(), err)
 	}
 
 	img, err := cntr.Image(i.nsctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting container image for %q", cntr.ID())
+		return nil, fmt.Errorf("error getting container image for %q: %w", cntr.ID(), err)
 	}
 
 	task, err := cntr.Task(i.nsctx, nil)
@@ -120,12 +120,12 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 			return nil, nil
 		}
 
-		return nil, errors.Wrapf(err, "error getting container task for %q", cntr.ID())
+		return nil, fmt.Errorf("error getting container task for %q: %w", cntr.ID(), err)
 	}
 
 	status, err := task.Status(i.nsctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error getting task status for %q", cntr.ID())
+		return nil, fmt.Errorf("error getting task status for %q: %w", cntr.ID(), err)
 	}
 
 	cp.Inspector = i
@@ -159,12 +159,12 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 	if status.Status == containerd.Running {
 		metrics, err := task.Metrics(i.nsctx)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error pulling metrics for %q", cntr.ID())
+			return nil, fmt.Errorf("error pulling metrics for %q: %w", cntr.ID(), err)
 		}
 
 		anydata, err := typeurl.UnmarshalAny(metrics.Data)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error unmarshalling metrics for %q", cntr.ID())
+			return nil, fmt.Errorf("error unmarshalling metrics for %q: %w", cntr.ID(), err)
 		}
 
 		data, ok := anydata.(*cgroups.Metrics)

--- a/internal/pkg/cri/client.go
+++ b/internal/pkg/cri/client.go
@@ -6,9 +6,9 @@ package cri
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
@@ -36,7 +36,7 @@ func NewClient(endpoint string, connectionTimeout time.Duration) (*Client, error
 		grpc.WithBackoffMaxDelay(3*time.Second),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
-		return nil, errors.Wrapf(err, "error connecting to CRI")
+		return nil, fmt.Errorf("error connecting to CRI: %w", err)
 	}
 
 	return &Client{

--- a/internal/pkg/cri/containers.go
+++ b/internal/pkg/cri/containers.go
@@ -6,8 +6,8 @@ package cri
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -19,11 +19,11 @@ func (c *Client) CreateContainer(ctx context.Context, podSandBoxID string, confi
 		SandboxConfig: sandboxConfig,
 	})
 	if err != nil {
-		return "", errors.Wrapf(err, "CreateContainer in sandbox %q from runtime service failed", podSandBoxID)
+		return "", fmt.Errorf("CreateContainer in sandbox %q from runtime service failed: %w", podSandBoxID, err)
 	}
 
 	if resp.ContainerId == "" {
-		return "", errors.Errorf("ContainerId is not set for container %q", config.GetMetadata())
+		return "", fmt.Errorf("ContainerId is not set for container %q", config.GetMetadata())
 	}
 
 	return resp.ContainerId, nil
@@ -35,7 +35,7 @@ func (c *Client) StartContainer(ctx context.Context, containerID string) error {
 		ContainerId: containerID,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "StartContainer %q from runtime service failed", containerID)
+		return fmt.Errorf("StartContainer %q from runtime service failed: %w", containerID, err)
 	}
 
 	return nil
@@ -48,7 +48,7 @@ func (c *Client) StopContainer(ctx context.Context, containerID string, timeout 
 		Timeout:     timeout,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "StopContainer %q from runtime service failed", containerID)
+		return fmt.Errorf("StopContainer %q from runtime service failed: %w", containerID, err)
 	}
 
 	return nil
@@ -61,7 +61,7 @@ func (c *Client) RemoveContainer(ctx context.Context, containerID string) error 
 		ContainerId: containerID,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "RemoveContainer %q from runtime service failed", containerID)
+		return fmt.Errorf("RemoveContainer %q from runtime service failed: %w", containerID, err)
 	}
 
 	return nil
@@ -73,7 +73,7 @@ func (c *Client) ListContainers(ctx context.Context, filter *runtimeapi.Containe
 		Filter: filter,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "ListContainers with filter %+v from runtime service failed", filter)
+		return nil, fmt.Errorf("ListContainers with filter %+v from runtime service failed: %w", filter, err)
 	}
 
 	return resp.Containers, nil
@@ -86,7 +86,7 @@ func (c *Client) ContainerStatus(ctx context.Context, containerID string, verbos
 		Verbose:     verbose,
 	})
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "ContainerStatus %q from runtime service failed", containerID)
+		return nil, nil, fmt.Errorf("ContainerStatus %q from runtime service failed: %w", containerID, err)
 	}
 
 	return resp.Status, resp.Info, nil
@@ -98,7 +98,7 @@ func (c *Client) ContainerStats(ctx context.Context, containerID string) (*runti
 		ContainerId: containerID,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "ContainerStatus %q from runtime service failed", containerID)
+		return nil, fmt.Errorf("ContainerStatus %q from runtime service failed: %w", containerID, err)
 	}
 
 	return resp.GetStats(), nil
@@ -110,7 +110,7 @@ func (c *Client) ListContainerStats(ctx context.Context, filter *runtimeapi.Cont
 		Filter: filter,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "ListContainerStats with filter %+v from runtime service failed", filter)
+		return nil, fmt.Errorf("ListContainerStats with filter %+v from runtime service failed: %w", filter, err)
 	}
 
 	return resp.GetStats(), nil

--- a/internal/pkg/cri/images.go
+++ b/internal/pkg/cri/images.go
@@ -6,8 +6,8 @@ package cri
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -18,7 +18,7 @@ func (c *Client) PullImage(ctx context.Context, image *runtimeapi.ImageSpec, san
 		SandboxConfig: sandboxConfig,
 	})
 	if err != nil {
-		return "", errors.Wrapf(err, "error pulling image %+v", image)
+		return "", fmt.Errorf("error pulling image %s: %w", image, err)
 	}
 
 	return resp.ImageRef, nil
@@ -30,7 +30,7 @@ func (c *Client) ListImages(ctx context.Context, filter *runtimeapi.ImageFilter)
 		Filter: filter,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "error listing imags")
+		return nil, fmt.Errorf("error listing images: %w", err)
 	}
 
 	return resp.Images, nil
@@ -42,12 +42,12 @@ func (c *Client) ImageStatus(ctx context.Context, image *runtimeapi.ImageSpec) (
 		Image: image,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "ImageStatus %q from image service failed", image.Image)
+		return nil, fmt.Errorf("ImageStatus %q from image service failed: %w", image.Image, err)
 	}
 
 	if resp.Image != nil {
 		if resp.Image.Id == "" || resp.Image.Size_ == 0 {
-			return nil, errors.Errorf("Id or size of image %q is not set", image.Image)
+			return nil, fmt.Errorf("id or size of image %q is not set", image.Image)
 		}
 	}
 

--- a/internal/pkg/cri/pods.go
+++ b/internal/pkg/cri/pods.go
@@ -6,8 +6,8 @@ package cri
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -23,7 +23,7 @@ func (c *Client) RunPodSandbox(ctx context.Context, config *runtimeapi.PodSandbo
 	}
 
 	if resp.PodSandboxId == "" {
-		return "", errors.Errorf("PodSandboxId is not set for sandbox %q", config.GetMetadata())
+		return "", fmt.Errorf("PodSandboxId is not set for sandbox %q", config.GetMetadata())
 	}
 
 	return resp.PodSandboxId, nil
@@ -36,7 +36,7 @@ func (c *Client) StopPodSandbox(ctx context.Context, podSandBoxID string) error 
 		PodSandboxId: podSandBoxID,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "StopPodSandbox %q from runtime service failed", podSandBoxID)
+		return fmt.Errorf("StopPodSandbox %q from runtime service failed: %w", podSandBoxID, err)
 	}
 
 	return nil
@@ -49,7 +49,7 @@ func (c *Client) RemovePodSandbox(ctx context.Context, podSandBoxID string) erro
 		PodSandboxId: podSandBoxID,
 	})
 	if err != nil {
-		return errors.Wrapf(err, "RemovePodSandbox %q from runtime service failed", podSandBoxID)
+		return fmt.Errorf("RemovePodSandbox %q from runtime service failed: %w", podSandBoxID, err)
 	}
 
 	return nil
@@ -61,7 +61,7 @@ func (c *Client) ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandb
 		Filter: filter,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "ListPodSandbox with filter %+v from runtime service failed", filter)
+		return nil, fmt.Errorf("ListPodSandbox with filter %+v from runtime service failed: %w", filter, err)
 	}
 
 	return resp.Items, nil

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -6,6 +6,7 @@ package install
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/containerd/containerd"
@@ -13,7 +14,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -43,7 +43,7 @@ func Install(ref string, disk string, platform string) error {
 	// platform name, this should be determined in the installer container.
 	var config *string
 	if config = kernel.ProcCmdline().Get(constants.KernelParamConfig).First(); config == nil {
-		return errors.Errorf("no config option was found")
+		return fmt.Errorf("no config option was found")
 	}
 
 	specOpts := []oci.SpecOpts{
@@ -74,19 +74,19 @@ func Install(ref string, disk string, platform string) error {
 	}
 
 	if err = t.Start(ctx); err != nil {
-		return errors.Wrapf(err, "failed to start task: %q", "upgrade")
+		return fmt.Errorf("failed to start %q task: %w", "upgrade", err)
 	}
 
 	statusC, err := t.Wait(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "failed waiting for task: %q", "upgrade")
+		return fmt.Errorf("failed waiting for %q task: %w", "upgrade", err)
 	}
 
 	status := <-statusC
 
 	code := status.ExitCode()
 	if code != 0 {
-		return errors.Errorf("task %q failed: exit code %d", "upgrade", code)
+		return fmt.Errorf("task %q failed: exit code %d", "upgrade", code)
 	}
 
 	return nil

--- a/internal/pkg/installer/bootloader/syslinux/syslinux.go
+++ b/internal/pkg/installer/bootloader/syslinux/syslinux.go
@@ -6,13 +6,13 @@ package syslinux
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"text/template"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/pkg/cmd"
 
@@ -118,7 +118,7 @@ func Install(base string, config interface{}) (err error) {
 	}
 
 	if err = cmd.Run("extlinux", "--install", filepath.Dir(paths[0])); err != nil {
-		return errors.Wrap(err, "failed to install extlinux")
+		return fmt.Errorf("failed to install extlinux: %w", err)
 	}
 
 	return nil

--- a/internal/pkg/installer/installer.go
+++ b/internal/pkg/installer/installer.go
@@ -5,13 +5,13 @@
 package installer
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/installer/bootloader/syslinux"
@@ -41,7 +41,7 @@ func NewInstaller(cmdline *kernel.Cmdline, install machine.Install) (i *Installe
 
 	i.manifest, err = manifest.NewManifest(install)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create installation manifest")
+		return nil, fmt.Errorf("failed to create installation manifest: %w", err)
 	}
 
 	return i, nil
@@ -53,7 +53,7 @@ func NewInstaller(cmdline *kernel.Cmdline, install machine.Install) (i *Installe
 func (i *Installer) Install() (err error) {
 	if i.install.Zero() {
 		if err = zero(i.manifest); err != nil {
-			return errors.Wrap(err, "failed to wipe device(s)")
+			return fmt.Errorf("failed to wipe device(s): %w", err)
 		}
 	}
 
@@ -155,7 +155,7 @@ func zero(manifest *manifest.Manifest) (err error) {
 		var size uint64
 
 		if _, _, ret := unix.Syscall(unix.SYS_IOCTL, f.Fd(), unix.BLKGETSIZE64, uintptr(unsafe.Pointer(&size))); ret != 0 {
-			return errors.Errorf("failed to got block device size: %v", ret)
+			return fmt.Errorf("failed to got block device size: %v", ret)
 		}
 
 		if _, err = io.CopyN(f, zero, int64(size)); err != nil {

--- a/internal/pkg/installer/manifest/manifest.go
+++ b/internal/pkg/installer/manifest/manifest.go
@@ -5,14 +5,13 @@
 package manifest
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/pkg/blockdevice"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/vfat"
@@ -62,11 +61,11 @@ func NewManifest(install machine.Install) (manifest *Manifest, err error) {
 	// Verify that the target device(s) can satisify the requested options.
 
 	if err = VerifyDataDevice(install); err != nil {
-		return nil, errors.Wrap(err, "failed to prepare ephemeral partition")
+		return nil, fmt.Errorf("failed to prepare ephemeral partition: %w", err)
 	}
 
 	if err = VerifyBootDevice(install); err != nil {
-		return nil, errors.Wrap(err, "failed to prepare boot partition")
+		return nil, fmt.Errorf("failed to prepare boot partition: %w", err)
 	}
 
 	// Initialize any slices we need. Note that a boot paritition is not
@@ -147,13 +146,13 @@ func (m *Manifest) ExecuteManifest(manifest *Manifest) (err error) {
 
 		for _, target := range targets {
 			if err = target.Partition(bd); err != nil {
-				return errors.Wrap(err, "failed to partition device")
+				return fmt.Errorf("failed to partition device: %w", err)
 			}
 		}
 
 		for _, target := range targets {
 			if err = target.Format(); err != nil {
-				return errors.Wrap(err, "failed to format device")
+				return fmt.Errorf("failed to format device: %w", err)
 			}
 		}
 	}

--- a/internal/pkg/installer/manifest/verify.go
+++ b/internal/pkg/installer/manifest/verify.go
@@ -5,7 +5,8 @@
 package manifest
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/config/machine"
@@ -23,7 +24,7 @@ func VerifyDataDevice(install machine.Install) (err error) {
 	}
 
 	if err = VerifyDiskAvailability(install.Disk(), constants.EphemeralPartitionLabel); err != nil {
-		return errors.Wrap(err, "failed to verify disk availability")
+		return fmt.Errorf("failed to verify disk availability: %w", err)
 	}
 
 	return nil
@@ -40,7 +41,7 @@ func VerifyBootDevice(install machine.Install) (err error) {
 	}
 
 	if err = VerifyDiskAvailability(install.Disk(), constants.BootPartitionLabel); err != nil {
-		return errors.Wrap(err, "failed to verify disk availability")
+		return fmt.Errorf("failed to verify disk availability: %w", err)
 	}
 
 	return nil
@@ -60,7 +61,7 @@ func VerifyDiskAvailability(devpath, label string) (err error) {
 	}
 
 	if dev.SuperBlock != nil {
-		return errors.Errorf("target install device %s is not empty, found existing %s file system", label, dev.SuperBlock.Type())
+		return fmt.Errorf("target install device %s is not empty, found existing %s file system", label, dev.SuperBlock.Type())
 	}
 
 	return nil

--- a/internal/pkg/kernel/kspp/kspp.go
+++ b/internal/pkg/kernel/kspp/kspp.go
@@ -5,8 +5,9 @@
 package kspp
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/sysctl"
@@ -29,13 +30,13 @@ func EnforceKSPPKernelParameters() error {
 	for _, values := range RequiredKSPPKernelParameters {
 		var val *string
 		if val = kernel.ProcCmdline().Get(values.Key()).First(); val == nil {
-			result = multierror.Append(result, errors.Errorf("KSPP kernel parameter %s is required", values.Key()))
+			result = multierror.Append(result, fmt.Errorf("KSPP kernel parameter %s is required", values.Key()))
 			continue
 		}
 
 		expected := values.First()
 		if *val != *expected {
-			result = multierror.Append(result, errors.Errorf("KSPP kernel parameter %s was found with value %s, expected %s", values.Key(), *val, *expected))
+			result = multierror.Append(result, fmt.Errorf("KSPP kernel parameter %s was found with value %s, expected %s", values.Key(), *val, *expected))
 		}
 	}
 

--- a/internal/pkg/kmsg/kmsg.go
+++ b/internal/pkg/kmsg/kmsg.go
@@ -5,10 +5,10 @@
 package kmsg
 
 import (
+	"fmt"
 	"log"
 	"os"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -17,7 +17,7 @@ import (
 func Setup(prefix string) (*os.File, error) {
 	out, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open /dev/kmsg")
+		return nil, fmt.Errorf("failed to open /dev/kmsg: %w", err)
 	}
 
 	log.SetOutput(out)

--- a/internal/pkg/mount/manager/manager.go
+++ b/internal/pkg/mount/manager/manager.go
@@ -5,7 +5,7 @@
 package manager
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/talos-systems/talos/internal/pkg/mount"
 )
@@ -35,18 +35,18 @@ func (m *Manager) MountAll() (err error) {
 		// Repair the disk's partition table.
 		if mountpoint.Resize {
 			if err = mountpoint.ResizePartition(); err != nil {
-				return errors.Wrap(err, "resize")
+				return fmt.Errorf("resize: %w", err)
 			}
 		}
 
 		if err = mountpoint.Mount(); err != nil {
-			return errors.Wrap(err, "mount")
+			return fmt.Errorf("mount: %w", err)
 		}
 
 		// Grow the filesystem to the maximum allowed size.
 		if mountpoint.Resize {
 			if err = mountpoint.GrowFilesystem(); err != nil {
-				return errors.Wrap(err, "grow")
+				return fmt.Errorf("grow: %w", err)
 			}
 		}
 	}
@@ -64,7 +64,7 @@ func (m *Manager) UnmountAll() (err error) {
 	for iter.Next() {
 		mountpoint := iter.Value()
 		if err = mountpoint.Unmount(); err != nil {
-			return errors.Wrap(err, "unmount")
+			return fmt.Errorf("unmount: %w", err)
 		}
 	}
 
@@ -84,7 +84,7 @@ func (m *Manager) MoveAll(prefix string) (err error) {
 	for iter.Next() {
 		mountpoint := iter.Value()
 		if err = mountpoint.Move(prefix); err != nil {
-			return errors.Wrapf(err, "move")
+			return fmt.Errorf("move: %w", err)
 		}
 	}
 

--- a/internal/pkg/mount/manager/owned/owned.go
+++ b/internal/pkg/mount/manager/owned/owned.go
@@ -5,9 +5,9 @@
 package owned
 
 import (
+	"fmt"
 	"log"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/mount"
@@ -42,7 +42,7 @@ func MountPointsForDevice(devpath string) (mountpoints *mount.Points, err error)
 				continue
 			}
 
-			return nil, errors.Errorf("probe device for filesystem %s: %v", name, err)
+			return nil, fmt.Errorf("probe device for filesystem %s: %w", name, err)
 		}
 
 		mountpoint := mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "")
@@ -81,7 +81,7 @@ func MountPointsFromLabels() (mountpoints *mount.Points, err error) {
 				continue
 			}
 
-			return nil, errors.Errorf("find device with label %s: %v", name, err)
+			return nil, fmt.Errorf("find device with label %s: %w", name, err)
 		}
 
 		mountpoint := mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "", opts...)

--- a/internal/pkg/runtime/initializer/interactive/interactive.go
+++ b/internal/pkg/runtime/initializer/interactive/interactive.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/installer"
@@ -33,7 +32,7 @@ func (i *Interactive) Initialize(platform runtime.Platform, install machine.Inst
 
 	dev, err = probe.GetDevWithFileSystemLabel(constants.ISOFilesystemLabel)
 	if err != nil {
-		return errors.Errorf("failed to find %s iso: %v", constants.ISOFilesystemLabel, err)
+		return fmt.Errorf("failed to find %s iso: %w", constants.ISOFilesystemLabel, err)
 	}
 
 	if err = unix.Mount(dev.Path, "/tmp", dev.SuperBlock.Type(), unix.MS_RDONLY, ""); err != nil {
@@ -75,7 +74,7 @@ func (i *Interactive) Initialize(platform runtime.Platform, install machine.Inst
 	}
 
 	if err = inst.Install(); err != nil {
-		return errors.Wrap(err, "failed to install")
+		return fmt.Errorf("failed to install: %w", err)
 	}
 
 	return unix.Reboot(int(unix.LINUX_REBOOT_CMD_RESTART))

--- a/internal/pkg/runtime/platform/metal/metal.go
+++ b/internal/pkg/runtime/platform/metal/metal.go
@@ -5,11 +5,11 @@
 package metal
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/kernel"
@@ -35,7 +35,7 @@ func (b *Metal) Name() string {
 func (b *Metal) Configuration() ([]byte, error) {
 	var option *string
 	if option = kernel.ProcCmdline().Get(constants.KernelParamConfig).First(); option == nil {
-		return nil, errors.Errorf("no config option was found")
+		return nil, fmt.Errorf("no config option was found")
 	}
 
 	switch *option {
@@ -66,20 +66,20 @@ func readConfigFromISO() (b []byte, err error) {
 
 	dev, err = probe.GetDevWithFileSystemLabel(constants.MetalConfigISOLabel)
 	if err != nil {
-		return nil, errors.Errorf("failed to find %s iso: %v", constants.MetalConfigISOLabel, err)
+		return nil, fmt.Errorf("failed to find %s iso: %w", constants.MetalConfigISOLabel, err)
 	}
 
 	if err = unix.Mount(dev.Path, mnt, dev.SuperBlock.Type(), unix.MS_RDONLY, ""); err != nil {
-		return nil, errors.Errorf("failed to mount iso: %v", err)
+		return nil, fmt.Errorf("failed to mount iso: %w", err)
 	}
 
 	b, err = ioutil.ReadFile(filepath.Join(mnt, filepath.Base(constants.ConfigPath)))
 	if err != nil {
-		return nil, errors.Errorf("read config: %s", err.Error())
+		return nil, fmt.Errorf("read config: %s", err.Error())
 	}
 
 	if err = unix.Unmount(mnt, 0); err != nil {
-		return nil, errors.Errorf("failed to unmount: %v", err)
+		return nil, fmt.Errorf("failed to unmount: %w", err)
 	}
 
 	return b, nil

--- a/internal/pkg/runtime/platform/platform.go
+++ b/internal/pkg/runtime/platform/platform.go
@@ -5,9 +5,9 @@
 package platform
 
 import (
+	"errors"
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -57,7 +57,7 @@ func NewPlatform() (p runtime.Platform, err error) {
 	case "vmware":
 		p = &vmware.VMware{}
 	default:
-		return nil, errors.Errorf("platform not supported: %s", platform)
+		return nil, fmt.Errorf("platform not supported: %s", platform)
 	}
 
 	return p, nil

--- a/internal/pkg/runtime/platform/vmware/vmware.go
+++ b/internal/pkg/runtime/platform/vmware/vmware.go
@@ -6,10 +6,10 @@ package vmware
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 
-	"github.com/pkg/errors"
 	"github.com/vmware/vmw-guestinfo/rpcvmx"
 	"github.com/vmware/vmw-guestinfo/vmcheck"
 
@@ -47,16 +47,16 @@ func (v *VMware) Configuration() ([]byte, error) {
 
 		val, err := config.String(constants.VMwareGuestInfoConfigKey, "")
 		if err != nil {
-			return nil, errors.Errorf("failed to get guestinfo.%s: %v", constants.VMwareGuestInfoConfigKey, err)
+			return nil, fmt.Errorf("failed to get guestinfo.%s: %w", constants.VMwareGuestInfoConfigKey, err)
 		}
 
 		if val == "" {
-			return nil, errors.Errorf("config is required, no value found for guestinfo.%s: %v", constants.VMwareGuestInfoConfigKey, err)
+			return nil, fmt.Errorf("config is required, no value found for guestinfo.%s: %w", constants.VMwareGuestInfoConfigKey, err)
 		}
 
 		b, err := base64.StdEncoding.DecodeString(val)
 		if err != nil {
-			return nil, errors.Errorf("failed to decode guestinfo.%s: %v", constants.VMwareGuestInfoConfigKey, err)
+			return nil, fmt.Errorf("failed to decode guestinfo.%s: %w", constants.VMwareGuestInfoConfigKey, err)
 		}
 
 		return b, nil

--- a/internal/pkg/runtime/runtime.go
+++ b/internal/pkg/runtime/runtime.go
@@ -5,9 +5,8 @@
 package runtime
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Mode is a runtime mode.
@@ -41,7 +40,7 @@ func ModeFromString(s string) (m Mode, err error) {
 	case "Metal":
 		return Metal, nil
 	default:
-		return m, errors.Errorf("%q is not a valid mode", s)
+		return m, fmt.Errorf("%q is not a valid mode", s)
 	}
 }
 

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -7,12 +7,12 @@ package blockdevice
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/pkg/blockdevice/table"
 	"github.com/talos-systems/talos/pkg/blockdevice/table/gpt"
@@ -121,7 +121,7 @@ func (bd *BlockDevice) RereadPartitionTable() error {
 	}
 	// Flush the block device buffers.
 	if _, _, ret := unix.Syscall(unix.SYS_IOCTL, bd.f.Fd(), unix.BLKFLSBUF, 0); ret != 0 {
-		return errors.Errorf("flush block device buffers: %v", ret)
+		return fmt.Errorf("flush block device buffers: %v", ret)
 	}
 
 	var (
@@ -142,7 +142,7 @@ func (bd *BlockDevice) RereadPartitionTable() error {
 		}
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to re-read partition table")
+		return fmt.Errorf("failed to re-read partition table: %w", err)
 	}
 
 	return err

--- a/pkg/blockdevice/lba/lba.go
+++ b/pkg/blockdevice/lba/lba.go
@@ -6,11 +6,10 @@
 package lba
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"unsafe"
-
-	"github.com/pkg/errors"
 
 	"golang.org/x/sys/unix"
 )

--- a/pkg/blockdevice/probe/probe.go
+++ b/pkg/blockdevice/probe/probe.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/pkg/blockdevice"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/iso9660"
@@ -202,7 +200,7 @@ func probeFilesystem(devpath string) (probed []*ProbedBlockDevice, err error) {
 		bd, _ = blockdevice.Open(devpath)
 
 		if sb, err = FileSystem(path); err != nil {
-			return nil, errors.Wrap(err, "unexpected error when reading super block")
+			return nil, fmt.Errorf("unexpected error when reading super block: %w", err)
 		}
 
 		probed = append(probed, &ProbedBlockDevice{BlockDevice: bd, SuperBlock: sb, Path: path})
@@ -232,5 +230,5 @@ func filterByLabel(probed []*ProbedBlockDevice, value string) (probe *ProbedBloc
 		}
 	}
 
-	return nil, errors.Errorf("no device found with label %s", value)
+	return nil, fmt.Errorf("no device found with label %s", value)
 }

--- a/pkg/blockdevice/table/gpt/header/header.go
+++ b/pkg/blockdevice/table/gpt/header/header.go
@@ -245,7 +245,7 @@ func (hdr *Header) Fields() []*serde.Field {
 			DeserializerFunc: func(contents []byte, opts interface{}) error {
 				guid, err := uuid.FromBytes(contents)
 				if err != nil {
-					return fmt.Errorf("invalid GUUID: %v", err)
+					return fmt.Errorf("invalid GUUID: %w", err)
 				}
 
 				hdr.GUUID = guid
@@ -273,7 +273,7 @@ func (hdr *Header) Fields() []*serde.Field {
 				hdr.PartitionEntriesStartLBA = binary.LittleEndian.Uint64(contents)
 				array, err := hdr.From(o.Table, lba.Range{Start: hdr.PartitionEntriesStartLBA, End: uint64(33)})
 				if err != nil {
-					return fmt.Errorf("failed to read starting LBA from header: %v", err)
+					return fmt.Errorf("failed to read starting LBA from header: %w", err)
 				}
 
 				hdr.array = array

--- a/pkg/blockdevice/table/gpt/partition/partition.go
+++ b/pkg/blockdevice/table/gpt/partition/partition.go
@@ -74,7 +74,7 @@ func (prt *Partition) Fields() []*serde.Field {
 			DeserializerFunc: func(contents []byte, opts interface{}) error {
 				guid, err := uuid.FromBytes(contents)
 				if err != nil {
-					return fmt.Errorf("invalid GUUID: %v", err)
+					return fmt.Errorf("invalid GUUID: %w", err)
 				}
 
 				// TODO: Provide a method for getting the human readable name of the type.
@@ -94,7 +94,7 @@ func (prt *Partition) Fields() []*serde.Field {
 			DeserializerFunc: func(contents []byte, opts interface{}) error {
 				guid, err := uuid.FromBytes(contents)
 				if err != nil {
-					return fmt.Errorf("invalid GUUID: %v", err)
+					return fmt.Errorf("invalid GUUID: %w", err)
 				}
 
 				prt.ID = guid

--- a/pkg/blockdevice/util/util.go
+++ b/pkg/blockdevice/util/util.go
@@ -5,9 +5,8 @@
 package util
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // PartNo returns the partition number.
@@ -29,7 +28,7 @@ func PartNo(partname string) (partno string, err error) {
 	case strings.HasPrefix(p, "xvd"):
 		return strings.TrimLeft(partname, "/abcdefghijklmnopqrstuvwxyz"), nil
 	default:
-		return "", errors.Errorf("could not determine partition number from partition name: %s", partname)
+		return "", fmt.Errorf("could not determine partition number from partition name: %s", partname)
 	}
 }
 
@@ -57,6 +56,6 @@ func DevnameFromPartname(partname string) (devname string, err error) {
 	case strings.HasPrefix(p, "xvd"):
 		return strings.TrimRight(partname, partno), nil
 	default:
-		return "", errors.Errorf("could not determine dev name from partition name: %s", partname)
+		return "", fmt.Errorf("could not determine dev name from partition name: %s", partname)
 	}
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -5,10 +5,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os/exec"
 
 	"github.com/armon/circbuf"
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/pkg/proc/reaper"
 )
@@ -35,11 +35,11 @@ func Run(name string, args ...string) error {
 	}
 
 	if err = cmd.Start(); err != nil {
-		return errors.Errorf("%s: %s", err, stderr.String())
+		return fmt.Errorf("%s: %s", err, stderr.String())
 	}
 
 	if err = reaper.WaitWrapper(usingReaper, notifyCh, cmd); err != nil {
-		return errors.Errorf("%s: %s", err, stderr.String())
+		return fmt.Errorf("%s: %s", err, stderr.String())
 	}
 
 	return nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -28,12 +27,12 @@ func New(c Content) (config runtime.Configurator, err error) {
 	case v1alpha1.Version:
 		config = &v1alpha1.Config{}
 		if err = yaml.Unmarshal(c.data, config); err != nil {
-			return config, errors.Wrap(err, "failed to parse version")
+			return config, fmt.Errorf("failed to parse version: %w", err)
 		}
 
 		return config, nil
 	default:
-		return nil, errors.Errorf("unknown version: %q", c.Version)
+		return nil, fmt.Errorf("unknown version: %q", c.Version)
 	}
 }
 
@@ -42,7 +41,7 @@ func New(c Content) (config runtime.Configurator, err error) {
 func FromFile(p string) (c Content, err error) {
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
-		return c, fmt.Errorf("read config: %v", err)
+		return c, fmt.Errorf("read config: %w", err)
 	}
 
 	return unmarshal(b)

--- a/pkg/config/types/v1alpha1/config.go
+++ b/pkg/config/types/v1alpha1/config.go
@@ -5,7 +5,9 @@
 package v1alpha1
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	"gopkg.in/yaml.v2"
 
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -57,7 +59,7 @@ func (c *Config) Validate(mode runtime.Mode) error {
 
 	if mode == runtime.Metal {
 		if c.MachineConfig.MachineInstall == nil {
-			return errors.Errorf("install instructions are required by the %q mode", runtime.Metal.String())
+			return fmt.Errorf("install instructions are required by the %q mode", runtime.Metal.String())
 		}
 	}
 

--- a/pkg/config/types/v1alpha1/network_config.go
+++ b/pkg/config/types/v1alpha1/network_config.go
@@ -7,11 +7,11 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
 
 	"github.com/talos-systems/talos/pkg/config/machine"
 )
@@ -64,7 +64,7 @@ func CheckDeviceInterface() NetworkDeviceCheck {
 		var result *multierror.Error
 
 		if d.Interface == "" {
-			result = multierror.Append(result, xerrors.Errorf("[%s] %q: %w", "networking.os.device.interface", "", ErrRequiredSection))
+			result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device.interface", "", ErrRequiredSection))
 		}
 
 		return result.ErrorOrNil()
@@ -80,18 +80,18 @@ func CheckDeviceAddressing() NetworkDeviceCheck {
 
 		// Test for both dhcp and cidr specified
 		if d.DHCP && d.CIDR != "" {
-			result = multierror.Append(result, xerrors.Errorf("[%s] %q: %w", "networking.os.device", "", ErrBadAddressing))
+			result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device", "", ErrBadAddressing))
 		}
 
 		// test for neither dhcp nor cidr specified
 		if !d.DHCP && d.CIDR == "" {
-			result = multierror.Append(result, xerrors.Errorf("[%s] %q: %w", "networking.os.device", "", ErrBadAddressing))
+			result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device", "", ErrBadAddressing))
 		}
 
 		// ensure cidr is a valid address
 		if d.CIDR != "" {
 			if _, _, err := net.ParseCIDR(d.CIDR); err != nil {
-				result = multierror.Append(result, xerrors.Errorf("[%s] %q: %w", "networking.os.device.CIDR", "", err))
+				result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device.CIDR", "", err))
 			}
 		}
 
@@ -111,11 +111,11 @@ func CheckDeviceRoutes() NetworkDeviceCheck {
 
 		for idx, route := range d.Routes {
 			if _, _, err := net.ParseCIDR(route.Network); err != nil {
-				result = multierror.Append(result, xerrors.Errorf("[%s] %q: %w", "networking.os.device.route["+strconv.Itoa(idx)+"].Network", route.Network, ErrInvalidAddress))
+				result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device.route["+strconv.Itoa(idx)+"].Network", route.Network, ErrInvalidAddress))
 			}
 
 			if ip := net.ParseIP(route.Gateway); ip == nil {
-				result = multierror.Append(result, xerrors.Errorf("[%s] %q: %w", "networking.os.device.route["+strconv.Itoa(idx)+"].Gateway", route.Gateway, ErrInvalidAddress))
+				result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device.route["+strconv.Itoa(idx)+"].Gateway", route.Gateway, ErrInvalidAddress))
 			}
 		}
 		return result.ErrorOrNil()

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -12,8 +12,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/talos-systems/talos/pkg/retry"
 )
 
@@ -98,7 +96,7 @@ func Download(endpoint string, opts ...Option) (b []byte, err error) {
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to download config from: %s", u.String())
+		return nil, fmt.Errorf("failed to download config from %q: %w", u.String(), err)
 	}
 
 	return b, nil

--- a/pkg/grpc/factory/factory.go
+++ b/pkg/grpc/factory/factory.go
@@ -6,12 +6,13 @@ package factory
 
 import (
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -116,12 +117,12 @@ func NewListener(setters ...Option) (net.Listener, error) {
 
 		// Make any dirs on the path to the listening socket.
 		if err := os.MkdirAll(filepath.Dir(address), 0700); err != nil {
-			return nil, errors.Wrap(err, "error creating containing directory for the file socket")
+			return nil, fmt.Errorf("error creating containing directory for the file socket; %w", err)
 		}
 	case "tcp":
 		address = ":" + strconv.Itoa(opts.Port)
 	default:
-		return nil, errors.Errorf("unknown network: %s", opts.Network)
+		return nil, fmt.Errorf("unknown network: %s", opts.Network)
 	}
 
 	return net.Listen(opts.Network, address)

--- a/pkg/grpc/tls/provider.go
+++ b/pkg/grpc/tls/provider.go
@@ -8,12 +8,11 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"log"
 	"net"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/talos-systems/talos/pkg/constants"
 )

--- a/pkg/grpc/tls/tls.go
+++ b/pkg/grpc/tls/tls.go
@@ -7,8 +7,8 @@ package tls
 import (
 	"crypto/tls"
 	"crypto/x509"
-
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 )
 
 // Type represents the TLS authentication type.
@@ -35,7 +35,7 @@ func WithClientAuthType(t Type) func(*tls.Config) error {
 		case ServerOnly:
 			cfg.ClientAuth = tls.NoClientCert
 		default:
-			return errors.Errorf("unhandled client auth type %+v", t)
+			return fmt.Errorf("unhandled client auth type %+v", t)
 		}
 		return nil
 	}

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -5,9 +5,8 @@
 package net
 
 import (
+	"errors"
 	"net"
-
-	"github.com/pkg/errors"
 )
 
 // IPAddrs finds and returns a list of non-loopback IPv4 addresses of the

--- a/pkg/net/net_test.go
+++ b/pkg/net/net_test.go
@@ -87,7 +87,7 @@ func TestNthIPInNetwork(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NthIPInNetwork(tt.args.network, tt.args.n)
 			if err != nil {
-				t.Errorf("%v", err)
+				t.Errorf("%w", err)
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {

--- a/pkg/proc/reaper/wait.go
+++ b/pkg/proc/reaper/wait.go
@@ -5,10 +5,9 @@
 package reaper
 
 import (
+	"fmt"
 	"os/exec"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 // WaitWrapper emulates os/exec.Command.Wait() when reaper is running.
@@ -40,11 +39,11 @@ func WaitWrapper(usingReaper bool, notifyCh <-chan ProcessInfo, cmd *exec.Cmd) e
 
 func convertWaitStatus(status syscall.WaitStatus) error {
 	if status.Signaled() {
-		return errors.Errorf("signal: %s", status.Signal())
+		return fmt.Errorf("signal: %s", status.Signal())
 	}
 
 	if status.Exited() && status.ExitStatus() != 0 {
-		return errors.Errorf("exit status %d", status.ExitStatus())
+		return fmt.Errorf("exit status %d", status.ExitStatus())
 	}
 
 	return nil

--- a/pkg/startup/rand.go
+++ b/pkg/startup/rand.go
@@ -5,18 +5,18 @@
 package startup
 
 import (
+	"fmt"
+
 	cryptorand "crypto/rand"
 	"encoding/binary"
 	"math/rand"
-
-	"github.com/pkg/errors"
 )
 
 // RandSeed default math/rand PRNG.
 func RandSeed() error {
 	seed := make([]byte, 8)
 	if _, err := cryptorand.Read(seed); err != nil {
-		return errors.Wrap(err, "error seeding rand")
+		return fmt.Errorf("error seeding rand: %w", err)
 	}
 
 	rand.Seed(int64(binary.LittleEndian.Uint64(seed)))


### PR DESCRIPTION
This removes the github.com/pkg/errors package in favor of the official
error wrapping in go 1.13.