### PR TITLE
docs: add ephemeral feature note

### DIFF
--- a/docs/website/pages/index.vue
+++ b/docs/website/pages/index.vue
@@ -149,6 +149,13 @@
             </div>
           </div>
           <div class="text-center w-full px-2 py-2 m-2">
+            <h2>Ephemeral</h2>
+            <div>
+              Talos runs in memory from a Squashfs, and persists nothing,
+              leaving the primary disk entirely to Kubernetes.
+            </div>
+          </div>
+          <div class="text-center w-full px-2 py-2 m-2">
             <h2>Current</h2>
             <div>
               Stay current with our commitment to an


### PR DESCRIPTION
This adds a feature about how Talos is ephemeral. I feel this is
important to get across to our users.