### PR TITLE
chore: Rename proto files into more appropriate names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,19 +38,19 @@ FROM build AS generate-build
 WORKDIR /osd
 COPY ./api/os ./proto
 # Generate additional grpc functionality only for OSD
-RUN protoc -I./proto --plugin=proxy --proxy_out=plugins=grpc+proxy:proto proto/api.proto
+RUN protoc -I./proto --plugin=proxy --proxy_out=plugins=grpc+proxy:proto proto/os.proto
 WORKDIR /trustd
 COPY ./api/security ./proto
-RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+RUN protoc -I./proto --go_out=plugins=grpc:proto proto/security.proto
 WORKDIR /machined
 COPY ./api/machine ./proto
-RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+RUN protoc -I./proto --go_out=plugins=grpc:proto proto/machine.proto
 WORKDIR /ntpd
 COPY ./api/time ./proto
-RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+RUN protoc -I./proto --go_out=plugins=grpc:proto proto/time.proto
 WORKDIR /networkd
 COPY ./api/network ./proto
-RUN protoc -I./proto --go_out=plugins=grpc:proto proto/api.proto
+RUN protoc -I./proto --go_out=plugins=grpc:proto proto/network.proto
 
 
 FROM scratch AS generate

--- a/api/machine/machine.proto
+++ b/api/machine/machine.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto;
+package machineapi;
 
 option go_package = "machineapi";
 option java_multiple_files = true;

--- a/api/network/network.proto
+++ b/api/network/network.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto;
+package networkapi;
 
 option go_package = "networkapi";
 option java_multiple_files = true;

--- a/api/os/os.proto
+++ b/api/os/os.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto;
+package osapi;
 
 option go_package = "osapi";
 option java_multiple_files = true;

--- a/api/security/security.proto
+++ b/api/security/security.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto;
+package securityapi;
 
 option go_package = "securityapi";
 option java_multiple_files = true;

--- a/api/time/time.proto
+++ b/api/time/time.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto;
+package timeapi;
 
 option go_package = "timeapi";
 option java_multiple_files = true;


### PR DESCRIPTION
This is partially driven by the upcoming api changes, but when we tell protoc to look for api.proto,
it'll find the first match in the includes(`-I`) directive.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>