### PR TITLE
fix: ensure control plane endpoint is set

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -144,8 +144,6 @@ func genV1Alpha1Config(args []string) {
 	}
 
 	input.AdditionalSubjectAltNames = additionalSANs
-	input.ControlPlaneEndpoint = canonicalControlplaneEndpoint
-
 	input.InstallDisk = installDisk
 	input.InstallImage = installImage
 
@@ -205,7 +203,6 @@ func init() {
 	configGenerateCmd.Flags().StringVar(&installDisk, "install-disk", "/dev/sda", "the disk to install to")
 	configGenerateCmd.Flags().StringVar(&installImage, "install-image", fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, version.Tag), "the image used to perform an installation")
 	configGenerateCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
-	configGenerateCmd.Flags().StringVar(&canonicalControlplaneEndpoint, "controlplane-endpoint", "", "the canonical controlplane endpoint (IP or DNS name) and optional port (defaults to 6443)")
 	configGenerateCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")
 	configGenerateCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 	helpers.Should(configAddCmd.MarkFlagRequired("ca"))

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -20,21 +20,20 @@ import (
 )
 
 var (
-	ca                            string
-	crt                           string
-	additionalSANs                []string
-	canonicalControlplaneEndpoint string
-	csr                           string
-	hours                         int
-	ip                            string
-	key                           string
-	kubernetes                    bool
-	useCRI                        bool
-	name                          string
-	organization                  string
-	rsa                           bool
-	talosconfig                   string
-	target                        []string
+	ca             string
+	crt            string
+	additionalSANs []string
+	csr            string
+	hours          int
+	ip             string
+	key            string
+	kubernetes     bool
+	useCRI         bool
+	name           string
+	organization   string
+	rsa            bool
+	talosconfig    string
+	target         []string
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -71,12 +71,6 @@ run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
 ## Wait for all nodes ready
 run "kubectl wait --timeout=${TIMEOUT}s --for=condition=ready=true --all nodes"
 
-# ## Update the Corefile to make CoreDNS work in docker.
-# run "kubectl apply -f /manifests/coredns.yaml"
-
-# # Restart CoreDNS.
-# run "kubectl delete pods -l k8s-app=kube-dns -n kube-system"
-
 ## Verify that we have an HA controlplane
 run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
      until kubectl get nodes -l node-role.kubernetes.io/master='' -o go-template='{{ len .items }}' | grep 3 >/dev/null; do

--- a/pkg/config/types/v1alpha1/config.go
+++ b/pkg/config/types/v1alpha1/config.go
@@ -57,6 +57,10 @@ func (c *Config) Validate(mode runtime.Mode) error {
 		return errors.New("cluster instructions are required")
 	}
 
+	if c.Cluster().Endpoint().String() == "" {
+		return errors.New("a cluster endpoint is required")
+	}
+
 	if mode == runtime.Metal {
 		if c.MachineConfig.MachineInstall == nil {
 			return fmt.Errorf("install instructions are required by the %q mode", runtime.Metal.String())


### PR DESCRIPTION
We were mistakenly overwriting the control plane endpoint in the
`generate` command. This fixes that and adds a simple validation of the
endpoint field in the config. We should expand the validation to ensure
that a valid IP or DNS name have been provided.