### PR TITLE
chore: fix flaky constant retry test

### DIFF
--- a/pkg/retry/constant_test.go
+++ b/pkg/retry/constant_test.go
@@ -34,7 +34,7 @@ func Test_constantRetryer_Retry(t *testing.T) {
 			name: "test expected number of retries",
 			fields: fields{
 				retryer: retryer{
-					duration: 2 * time.Second,
+					duration: 2500 * time.Millisecond,
 					options:  NewDefaultOptions(),
 				},
 			},
@@ -44,14 +44,14 @@ func Test_constantRetryer_Retry(t *testing.T) {
 					return ExpectedError(fmt.Errorf("expected"))
 				},
 			},
-			expectedCount: 2,
+			expectedCount: 3,
 			wantErr:       true,
 		},
 		{
 			name: "test expected number of retries with units",
 			fields: fields{
 				retryer: retryer{
-					duration: 2 * time.Second,
+					duration: 2250 * time.Millisecond,
 					options:  NewDefaultOptions(WithUnits(500 * time.Millisecond)),
 				},
 			},
@@ -61,7 +61,7 @@ func Test_constantRetryer_Retry(t *testing.T) {
 					return ExpectedError(fmt.Errorf("expected"))
 				},
 			},
-			expectedCount: 4,
+			expectedCount: 5,
 			wantErr:       true,
 		},
 		{


### PR DESCRIPTION
Failure:

```
--- FAIL: Test_constantRetryer_Retry (7.00s)
    --- FAIL: Test_constantRetryer_Retry/test_expected_number_of_retries (2.00s)
        constant_test.go:168: expected count of 2, got 3
```

The problem is that retry interval (1s) perfectly aligns with timeout
(2s), so depending on which timer fires first, function might be called
two or three times. Fix that by extending timeout a bit so it fits one
more run and not more.

P.S. This test might be still flaky under load if function doesn't have
a chance to run (starvation). Proper fix is to use fake time in the
tests.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>