### PR TITLE
fix: append localhost to cert sans if docker platform

### DIFF
--- a/internal/app/machined/internal/phase/platform/platform.go
+++ b/internal/app/machined/internal/phase/platform/platform.go
@@ -54,6 +54,11 @@ func (task *Platform) runtime(r runtime.Runtime) (err error) {
 		sans = append(sans, addr.String())
 	}
 
+	if r.Platform().Mode() == runtime.Container {
+		// TODO: add ::1 back once I figure out why bootkube barfs
+		sans = append(sans, "127.0.0.1")
+	}
+
 	r.Config().Machine().Security().SetCertSANs(sans)
 	r.Config().Cluster().SetCertSANs(sans)
 

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -17,7 +17,7 @@ func controlPlaneUd(in *Input) (string, error) {
 		MachineType:     "controlplane",
 		MachineToken:    in.TrustdInfo.Token,
 		MachineCA:       in.Certs.OS,
-		MachineCertSANs: []string{"127.0.0.1", "::1"},
+		MachineCertSANs: []string{},
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
 		MachineInstall: &v1alpha1.InstallConfig{

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -123,7 +123,7 @@ func (i *Input) GetControlPlaneEndpoint() string {
 
 // GetAPIServerSANs returns the formatted list of Subject Alt Name addresses for the API Server
 func (i *Input) GetAPIServerSANs() []string {
-	list := []string{"127.0.0.1", "::1"}
+	list := []string{}
 
 	endpointURL, err := url.Parse(i.ControlPlaneEndpoint)
 	if err == nil {

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -18,7 +18,7 @@ func initUd(in *Input) (string, error) {
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
 		MachineCA:       in.Certs.OS,
-		MachineCertSANs: []string{"127.0.0.1", "::1"},
+		MachineCertSANs: []string{},
 		MachineToken:    in.TrustdInfo.Token,
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:       in.InstallDisk,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -17,7 +17,7 @@ func workerUd(in *Input) (string, error) {
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "worker",
 		MachineToken:    in.TrustdInfo.Token,
-		MachineCertSANs: []string{"127.0.0.1", "::1"},
+		MachineCertSANs: []string{},
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
 		MachineInstall: &v1alpha1.InstallConfig{


### PR DESCRIPTION
This PR fixes a bug on mac with the localhost not making it into cert
sans when doing `osctl cluster create`. Now that they're present, we're
able to use kubectl again.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>