### PR TITLE
chore: fix markdown lint error

### DIFF
--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -4,19 +4,19 @@
 
 ## Build Setup
 
-``` bash
+```bash
 # install dependencies
-$ npm install
+npm install
 
 # serve with hot reload at localhost:3000
-$ npm run dev
+npm run dev
 
 # build for production and launch server
-$ npm run build
-$ npm run start
+npm run build
+npm run start
 
 # generate static project
-$ npm run generate
+npm run generate
 ```
 
 For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).


### PR DESCRIPTION
Dollar signs should only be used when the command has output.