### PR TITLE
fix: check if endpoint is nil

### DIFF
--- a/pkg/config/types/v1alpha1/config.go
+++ b/pkg/config/types/v1alpha1/config.go
@@ -57,7 +57,7 @@ func (c *Config) Validate(mode runtime.Mode) error {
 		return errors.New("cluster instructions are required")
 	}
 
-	if c.Cluster().Endpoint().String() == "" {
+	if c.Cluster().Endpoint() == nil || c.Cluster().Endpoint().String() == "" {
 		return errors.New("a cluster endpoint is required")
 	}
 


### PR DESCRIPTION
This fixes a panic by checking if the cluster endpoint is nil before
using it.