### PR TITLE
feat: lock down container permissions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/ryanuber/columnize v2.1.0+incompatible
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect
+	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e
 	github.com/u-root/u-root v6.0.0+incompatible // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 	go.etcd.io/etcd v3.3.13+incompatible

--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -15,7 +15,6 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
-	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -198,11 +197,8 @@ func (c *containerdRunner) newOCISpecOpts(image oci.Image) []oci.SpecOpts {
 		oci.WithImageConfig(image),
 		oci.WithProcessArgs(c.args.ProcessArgs...),
 		oci.WithEnv(c.opts.Env),
-		oci.WithHostNamespace(specs.NetworkNamespace),
-		oci.WithHostNamespace(specs.PIDNamespace),
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,
-		oci.WithPrivileged,
 	}
 	specOpts = append(specOpts, c.opts.OCISpecOpts...)
 

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -124,6 +124,7 @@ func (o *APID) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
+			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
 		),
 	),

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -155,10 +155,8 @@ func (e *Etcd) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithContainerImage(etcdImage),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
+			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
-			oci.WithHostNamespace(specs.PIDNamespace),
-			oci.WithParentCgroupDevices,
-			oci.WithPrivileged,
 		),
 	),
 		restart.WithType(restart.Forever),

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -206,6 +206,7 @@ func (k *Kubelet) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithOCISpecOpts(
 			containerd.WithRootfsPropagation("shared"),
 			oci.WithMounts(mounts),
+			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithHostNamespace(specs.PIDNamespace),
 			oci.WithParentCgroupDevices,
 			oci.WithPrivileged,

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/syndtr/gocapability/capability"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -68,7 +70,7 @@ func (n *NTPd) Runner(config runtime.Configurator) (runner.Runner, error) {
 	}
 
 	// Ensure socket dir exists
-	if err := os.MkdirAll(filepath.Dir(constants.TimeSocketPath), os.ModeDir); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.TimeSocketPath), 0750); err != nil {
 		return nil, err
 	}
 
@@ -90,6 +92,9 @@ func (n *NTPd) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			containerd.WithMemoryLimit(int64(1000000*32)),
+			oci.WithCapabilities([]string{
+				strings.ToUpper("CAP_" + capability.CAP_SYS_TIME.String()),
+			}),
 			oci.WithMounts(mounts),
 		),
 	),

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/syndtr/gocapability/capability"
 	"google.golang.org/grpc"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
@@ -78,7 +80,7 @@ func (o *OSD) Runner(config runtime.Configurator) (runner.Runner, error) {
 	}
 
 	// Ensure socket dir exists
-	if err := os.MkdirAll(filepath.Dir(constants.OSSocketPath), os.ModeDir); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.OSSocketPath), 0750); err != nil {
 		return nil, err
 	}
 
@@ -107,6 +109,10 @@ func (o *OSD) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
+			oci.WithCapabilities([]string{
+				strings.ToUpper("CAP_" + capability.CAP_SYS_PTRACE.String()),
+			}),
+			oci.WithHostNamespace(specs.PIDNamespace),
 			oci.WithMounts(mounts),
 		),
 	),

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -91,6 +91,7 @@ func (t *Trustd) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			containerd.WithMemoryLimit(int64(1000000*512)),
+			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
 		),
 	),


### PR DESCRIPTION
This removes the default privileged mode that all containers were
started with and adds the required capabilities on a per-service basis.