### PR TITLE
chore: re-enable e2e testing for gcp

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -988,46 +988,6 @@ steps:
   depends_on:
   - image-gcp
 
-- name: e2e-integration-aws
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make e2e-integration
-  environment:
-    BINDIR: /usr/local/bin
-    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
-    PLATFORM: aws
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - capi
-  - push-image-aws
-
-- name: e2e-integration-azure
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make e2e-integration
-  environment:
-    BINDIR: /usr/local/bin
-    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
-    PLATFORM: azure
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - capi
-  - push-image-azure
-
 - name: e2e-integration-gcp
   pull: always
   image: autonomy/build-container:latest

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ push-image-azure:
 
 .PHONY: push-image-gcp
 push-image-gcp:
-	@TAG=$(TAG) ./hack/test/gcp-setup.sh
+	@TAG=$(TAG) SHA=$(SHA) ./hack/test/gcp-setup.sh
 
 .PHONY: image-test
 image-test:
@@ -281,7 +281,7 @@ capi:
 
 .PHONY: e2e-integration
 e2e-integration:
-	@TAG=$(TAG) ./hack/test/$@.sh
+	@TAG=$(TAG) SHA=$(SHA) ./hack/test/$@.sh
 
 .PHONY: unit-tests
 unit-tests: buildkitd

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -258,8 +258,8 @@ local e2e_steps = default_steps + [
   push_image_aws,
   push_image_azure,
   push_image_gcp,
-  e2e_integration_aws,
-  e2e_integration_azure,
+  //e2e_integration_aws,
+  // e2e_integration_azure,
   e2e_integration_gcp,
 ];
 

--- a/hack/test/capi.sh
+++ b/hack/test/capi.sh
@@ -7,21 +7,25 @@ source ./hack/test/e2e-runner.sh
 
 ## Create tmp dir
 mkdir -p ${TMP}
+cp ${PWD}/hack/test/manifests/provider-components.yaml ${TMP}/provider-components.yaml
+
+## Template out gcp components
+apk add --no-cache gettext
+export GCP_B64ENCODED_CREDENTIALS=${GCE_SVC_ACCT} 
+cat ${PWD}/hack/test/manifests/capg-components.yaml| envsubst > ${TMP}/capg-components.yaml
+##Until next alpha release, keep a local copy of capg-components.yaml. 
+##They've got an incorrect image pull policy.
+##curl -L ${CAPG_COMPONENTS} | envsubst > ${TMP}/capg-components.yaml
 
 ## Drop in capi stuff
-sed "s/{{PACKET_AUTH_TOKEN}}/${PACKET_AUTH_TOKEN}/" ${PWD}/hack/test/manifests/provider-components.yaml > ${TMP}/provider-components.yaml
-
-sed -e "s#{{GCE_SVC_ACCT}}#${GCE_SVC_ACCT}#" \
-    -e "s#{{AZURE_SVC_ACCT}}#${AZURE_SVC_ACCT}#" \
-    -e "s#{{AWS_SVC_ACCT}}#${AWS_SVC_ACCT}#" ${PWD}/hack/test/manifests/capi-secrets.yaml > ${TMP}/capi-secrets.yaml
-
-e2e_run "kubectl apply -f ${TMP}/provider-components.yaml -f ${TMP}/capi-secrets.yaml"
+e2e_run "kubectl apply -f ${TMP}/provider-components.yaml"
+e2e_run "kubectl apply -f ${CAPI_COMPONENTS}"
+e2e_run "kubectl apply -f ${TMP}/capg-components.yaml"
 
 ## Wait for talosconfig in cm then dump it out
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-         pod='pod/cluster-api-provider-talos-controller-manager-0'
-         until KUBECONFIG=${TMP}/kubeconfig kubectl wait --timeout=1s --for=condition=Ready -n ${CAPI_NS} \${pod}; do
+         until KUBECONFIG=${TMP}/kubeconfig kubectl wait --timeout=1s --for=condition=Ready -n ${CABPT_NS} pods --all; do
            [[ \$(date +%s) -gt \$timeout ]] && exit 1
-           echo 'Waiting to CAPT pod to be available...'
+           echo 'Waiting to CABPT pod to be available...'
            sleep 10
          done"

--- a/hack/test/e2e-integration.sh
+++ b/hack/test/e2e-integration.sh
@@ -6,14 +6,11 @@ source ./hack/test/e2e-runner.sh
 ## Create tmp dir
 mkdir -p ${TMPPLATFORM}
 
-NAME_PREFIX="talos-e2e-${TAG}-${PLATFORM}"
+NAME_PREFIX="talos-e2e-${SHA}-${PLATFORM}"
 
 ## Cleanup the platform resources upon any exit
 cleanup() {
-  e2e_run "KUBECONFIG=${TMP}/kubeconfig kubectl delete machine ${NAME_PREFIX}-master-0 ${NAME_PREFIX}-master-1 ${NAME_PREFIX}-master-2
-           KUBECONFIG=${TMP}/kubeconfig kubectl scale machinedeployment ${NAME_PREFIX}-workers --replicas=0
-           KUBECONFIG=${TMP}/kubeconfig kubectl delete machinedeployment ${NAME_PREFIX}-workers
-           KUBECONFIG=${TMP}/kubeconfig kubectl delete cluster ${NAME_PREFIX}"
+  e2e_run "KUBECONFIG=${TMP}/kubeconfig kubectl delete cluster ${NAME_PREFIX}"
 }
 
 trap cleanup EXIT
@@ -23,11 +20,25 @@ e2e_run "KUBECONFIG=${TMP}/kubeconfig kubectl apply -f ${TMPPLATFORM}/cluster.ya
 
 ## Wait for talosconfig in cm then dump it out
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-         until KUBECONFIG=${TMP}/kubeconfig kubectl get cm -n ${CAPI_NS} ${NAME_PREFIX}-master-0; do
+         until [ -n \"\${STATUS_TALOSCONFIG}\" ]; do
            [[ \$(date +%s) -gt \$timeout ]] && exit 1
            sleep 10
+           STATUS_TALOSCONFIG=\$( KUBECONFIG=${TMP}/kubeconfig kubectl get talosconfig ${NAME_PREFIX}-controlplane-0 -o jsonpath='{.status.talosConfig}' ) 
          done
-         KUBECONFIG=${TMP}/kubeconfig kubectl get cm -n ${CAPI_NS} ${NAME_PREFIX}-master-0 -o jsonpath='{.data.talosconfig}' > ${TALOSCONFIG}"
+         echo \"\${STATUS_TALOSCONFIG}\" > ${TALOSCONFIG}"
+
+## Wait until we have an IP for master 0
+e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
+         until [ -n \"\${MASTER_0_IP}\" ]; do
+           [[ \$(date +%s) -gt \$timeout ]] && exit 1
+           sleep 10
+           MASTER_0_IP=\$( KUBECONFIG=${TMP}/kubeconfig kubectl get machine -o go-template --template='{{range .status.addresses}}{{if eq .type \"ExternalIP\"}}{{.address}}{{end}}{{end}}' ${NAME_PREFIX}-controlplane-0 )
+         done
+         echo \${MASTER_0_IP} > ${TMP}/master0ip"
+
+## Target master 0 for osctl
+e2e_run "MASTER_0_IP=\$( cat ${TMP}/master0ip )
+         /bin/osctl config target \${MASTER_0_IP}"
 
 ## Wait for kubeconfig from capi master-0
 e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
@@ -41,14 +52,6 @@ e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
          until kubectl get nodes -o go-template='{{ len .items }}' | grep ${NUM_NODES} >/dev/null; do
            [[ \$(date +%s) -gt \$timeout ]] && exit 1
            kubectl get nodes -o wide
-           sleep 10
-         done"
-
-## Wait for kube-proxy up
-e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
-         until kubectl get po -n kube-system -l k8s-app=kube-proxy -o go-template='{{ len .items }}' | grep ${NUM_NODES} > /dev/null; do
-           [[ \$(date +%s) -gt \$timeout ]] && exit 1
-           kubectl get po -n kube-system -l k8s-app=kube-proxy
            sleep 10
          done"
 

--- a/hack/test/e2e-runner.sh
+++ b/hack/test/e2e-runner.sh
@@ -1,5 +1,5 @@
 # NB: There is a known bug that causes CRD scaling issues in 1.15 kubectl or later.
-export KUBERNETES_VERSION=v1.14.6
+export KUBERNETES_VERSION=v1.16.2
 export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
 export TMP="/tmp/e2e"
 export TMPPLATFORM="${TMP}/${PLATFORM}"
@@ -10,17 +10,26 @@ export KUBECONFIG="${TMPPLATFORM}/kubeconfig"
 ## Long timeout due to provisioning times
 export TIMEOUT=9000
 
-## Total number of nodes we'll be waiting to come up (3 Masters + 3 Workers)
+## Total number of nodes we'll be waiting to come up (3 Masters, 3 Workers)
 export NUM_NODES=6
 
-## ClusterAPI Provider Talos (CAPT)
-export CAPT_VERSION="0.1.0-alpha.2"
-export PROVIDER_COMPONENTS="https://github.com/talos-systems/cluster-api-provider-talos/releases/download/v${CAPT_VERSION}/provider-components.yaml"
-export KUSTOMIZE_VERSION="1.0.11"
+## ClusterAPI Bootstrap Provider Talos (CABPT)
+export CABPT_VERSION="0.1.0-alpha.0"
+export CABPT_COMPONENTS="https://github.com/talos-systems/cluster-api-bootstrap-provider-talos/releases/download/v${CABPT_VERSION}/provider-components.yaml"
+
+## ClusterAPI (CAPI)
+export CAPI_VERSION="0.2.6"
+export CAPI_COMPONENTS="https://github.com/kubernetes-sigs/cluster-api/releases/download/v${CAPI_VERSION}/cluster-api-components.yaml"
+
+## ClusterAPI Provider GCP (CAPG)
+export CAPG_VERSION="0.2.0-alpha.2"
+export CAPG_COMPONENTS="https://github.com/kubernetes-sigs/cluster-api-provider-gcp/releases/download/v${CAPG_VERSION}/infrastructure-components.yaml"
+
+export KUSTOMIZE_VERSION="3.1.0"
 export KUSTOMIZE_URL="https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64"
 export SONOBUOY_VERSION="0.16.1"
 export SONOBUOY_URL="https://github.com/heptio/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_amd64.tar.gz"
-export CAPI_NS="cluster-api-provider-talos-system"
+export CABPT_NS="cabpt-system"
 
 e2e_run() {
   docker run \

--- a/hack/test/gcp-setup.sh
+++ b/hack/test/gcp-setup.sh
@@ -12,11 +12,11 @@ echo $GCE_SVC_ACCT | base64 -d > ${TMP}/svc-acct.json
 gcloud auth activate-service-account --key-file ${TMP}/svc-acct.json
 
 ## Push talos-gcp to storage bucket
-gsutil cp ./build/gcp.tar.gz gs://talos-e2e/gcp-${TAG}.tar.gz
+gsutil cp ./build/gcp.tar.gz gs://talos-e2e/gcp-${SHA}.tar.gz
 
 ## Create image from talos-gcp
-gcloud --quiet --project talos-testbed compute images delete talos-e2e-${TAG} || true ##Ignore error if image doesn't exist
-gcloud --quiet --project talos-testbed compute images create talos-e2e-${TAG} --source-uri gs://talos-e2e/gcp-${TAG}.tar.gz
+gcloud --quiet --project talos-testbed compute images delete talos-e2e-${SHA} || true ##Ignore error if image doesn't exist
+gcloud --quiet --project talos-testbed compute images create talos-e2e-${SHA} --source-uri gs://talos-e2e/gcp-${SHA}.tar.gz
 
 ## Setup the cluster YAML.
-sed "s/{{TAG}}/${TAG}/" ${PWD}/hack/test/manifests/gcp-cluster.yaml > ${TMP}/cluster.yaml
+sed -e "s/{{TAG}}/${SHA}/" ${PWD}/hack/test/manifests/gcp-cluster.yaml > ${TMP}/cluster.yaml

--- a/hack/test/manifests/capg-components.yaml
+++ b/hack/test/manifests/capg-components.yaml
@@ -1,0 +1,728 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: capa-controller-manager
+  name: capg-system
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: gcpclusters.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: GCPCluster
+    plural: gcpclusters
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: GCPCluster is the Schema for the gcpclusters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GCPClusterSpec defines the desired state of GCPCluster
+          properties:
+            additionalLabels:
+              additionalProperties:
+                type: string
+              description: AdditionalLabels is an optional set of tags to add to GCP
+                resources managed by the GCP provider, in addition to the ones added
+                by default.
+              type: object
+            network:
+              description: NetworkSpec encapsulates all things related to GCP network.
+              properties:
+                autoCreateSubnetworks:
+                  description: "AutoCreateSubnetworks: When set to true, the VPC network
+                    is created in \"auto\" mode. When set to false, the VPC network
+                    is created in \"custom\" mode. \n An auto mode VPC network starts
+                    with one subnet per region. Each subnet has a predetermined range
+                    as described in Auto mode VPC network IP ranges. \n Defaults to
+                    true."
+                  type: boolean
+                loadBalancerBackendPort:
+                  description: Allow for configuration of load balancer backend (useful
+                    for changing apiserver port)
+                  format: int32
+                  type: integer
+                name:
+                  description: Name is the name of the network to be used.
+                  type: string
+                subnets:
+                  description: Subnets configuration.
+                  items:
+                    description: SubnetSpec configures an GCP Subnet.
+                    properties:
+                      cidrBlock:
+                        description: CidrBlock is the range of internal addresses
+                          that are owned by this subnetwork. Provide this property
+                          when you create the subnetwork. For example, 10.0.0.0/8
+                          or 192.168.0.0/16. Ranges must be unique and non-overlapping
+                          within a network. Only IPv4 is supported. This field can
+                          be set only at resource creation time.
+                        type: string
+                      description:
+                        description: Description is an optional description associated
+                          with the resource.
+                        type: string
+                      name:
+                        description: Name defines a unique identifier to reference
+                          this resource.
+                        type: string
+                      privateGoogleAccess:
+                        description: PrivateGoogleAccess defines whether VMs in this
+                          subnet can access Google services without assigning external
+                          IP addresses
+                        type: boolean
+                      region:
+                        description: Region is the name of the region where the Subnetwork
+                          resides.
+                        type: string
+                      routeTableId:
+                        description: 'EnableFlowLogs: Whether to enable flow logging
+                          for this subnetwork. If this field is not explicitly set,
+                          it will not appear in get listings. If not set the default
+                          behavior is to disable flow logging.'
+                        type: boolean
+                      secondaryCidrBlocks:
+                        additionalProperties:
+                          type: string
+                        description: SecondaryCidrBlocks defines secondary CIDR ranges,
+                          from which secondary IP ranges of a VM may be allocated
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            project:
+              description: Project is the name of the project to deploy the cluster
+                to.
+              type: string
+            region:
+              description: The GCP Region the cluster lives in.
+              type: string
+          required:
+          - project
+          - region
+          type: object
+        status:
+          description: GCPClusterStatus defines the observed state of GCPCluster
+          properties:
+            apiEndpoints:
+              description: APIEndpoints represents the endpoints to communicate with
+                the control plane.
+              items:
+                description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              type: array
+            network:
+              description: Network encapsulates GCP networking resources.
+              properties:
+                apiServerBackendService:
+                  description: APIServerBackendService is the full reference to the
+                    backend service created for the API Server.
+                  type: string
+                apiServerForwardingRule:
+                  description: APIServerForwardingRule is the full reference to the
+                    forwarding rule created for the API Server.
+                  type: string
+                apiServerHealthCheck:
+                  description: APIServerHealthCheck is the full reference to the health
+                    check created for the API Server.
+                  type: string
+                apiServerInstanceGroups:
+                  additionalProperties:
+                    type: string
+                  description: APIServerInstanceGroups is a map from zone to the full
+                    reference to the instance groups created for the control plane
+                    nodes created in the same zone.
+                  type: object
+                apiServerIpAddress:
+                  description: APIServerAddress is the IPV4 global address assigned
+                    to the load balancer created for the API Server.
+                  type: string
+                apiServerTargetProxy:
+                  description: APIServerTargetProxy is the full reference to the target
+                    proxy created for the API Server.
+                  type: string
+                firewallRules:
+                  additionalProperties:
+                    type: string
+                  description: FirewallRules is a map from the name of the rule to
+                    its full reference.
+                  type: object
+                selfLink:
+                  description: SelfLink is the link to the Network used for this cluster.
+                  type: string
+              type: object
+            ready:
+              description: Bastion Instance `json:"bastion,omitempty"`
+              type: boolean
+          required:
+          - ready
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: gcpmachines.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: GCPMachine
+    plural: gcpmachines
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: GCPMachine is the Schema for the gcpmachines API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GCPMachineSpec defines the desired state of GCPMachine
+          properties:
+            additionalLabels:
+              additionalProperties:
+                type: string
+              description: AdditionalLabels is an optional set of tags to add to an
+                instance, in addition to the ones added by default by the GCP provider.
+                If both the GCPCluster and the GCPMachine specify the same tag name
+                with different values, the GCPMachine's value takes precedence.
+              type: object
+            additionalNetworkTags:
+              description: AdditionalNetworkTags is a list of network tags that should
+                be applied to the instance. These tags are set in addition to any
+                network tags defined at the cluster level or in the actuator.
+              items:
+                type: string
+              type: array
+            image:
+              description: Image is the full reference to a valid image to be used
+                for this machine. Takes precedence over ImageFamily.
+              type: string
+            imageFamily:
+              description: ImageFamily is the full reference to a valid image family
+                to be used for this machine.
+              type: string
+            instanceType:
+              description: 'InstanceType is the type of instance to create. Example:
+                n1.standard-2'
+              type: string
+            providerID:
+              description: ProviderID is the unique identifier as specified by the
+                cloud provider.
+              type: string
+            publicIP:
+              description: PublicIP specifies whether the instance should get a public
+                IP. Set this to true if you don't have a NAT instances or Cloud Nat
+                setup.
+              type: boolean
+            rootDeviceSize:
+              description: RootDeviceSize is the size of the root volume in GB. Defaults
+                to 30.
+              format: int64
+              type: integer
+            serviceAccounts:
+              description: 'ServiceAccount specifies the service account email and
+                which scopes to assign to the machine. Defaults to: email: "default",
+                scope: []{compute.CloudPlatformScope}'
+              properties:
+                email:
+                  description: 'Email: Email address of the service account.'
+                  type: string
+                scopes:
+                  description: 'Scopes: The list of scopes to be made available for
+                    this service account.'
+                  items:
+                    type: string
+                  type: array
+              type: object
+            subnet:
+              description: Subnet is a reference to the subnetwork to use for this
+                instance. If not specified, the first subnetwork retrieved from the
+                Cluster Region and Network is picked.
+              type: string
+            zone:
+              description: Zone is references the GCP zone to use for this instance.
+              type: string
+          required:
+          - instanceType
+          - zone
+          type: object
+        status:
+          description: GCPMachineStatus defines the observed state of GCPMachine
+          properties:
+            addresses:
+              description: Addresses contains the GCP instance associated addresses.
+              items:
+                description: NodeAddress contains information for the node's address.
+                properties:
+                  address:
+                    description: The node address.
+                    type: string
+                  type:
+                    description: Node address type, one of Hostname, ExternalIP or
+                      InternalIP.
+                    type: string
+                required:
+                - address
+                - type
+                type: object
+              type: array
+            errorMessage:
+              description: "ErrorMessage will be set in the event that there is a
+                terminal problem reconciling the Machine and will contain a more verbose
+                string suitable for logging and human consumption. \n This field should
+                not be set for transitive errors that a controller faces that are
+                expected to be fixed automatically over time (like service outages),
+                but instead indicate that something is fundamentally wrong with the
+                Machine's spec or the configuration of the controller, and that manual
+                intervention is required. Examples of terminal errors would be invalid
+                combinations of settings in the spec, values that are unsupported
+                by the controller, or the responsible controller itself being critically
+                misconfigured. \n Any transient errors that occur during the reconciliation
+                of Machines can be added as events to the Machine object and/or logged
+                in the controller's output."
+              type: string
+            errorReason:
+              description: "ErrorReason will be set in the event that there is a terminal
+                problem reconciling the Machine and will contain a succinct value
+                suitable for machine interpretation. \n This field should not be set
+                for transitive errors that a controller faces that are expected to
+                be fixed automatically over time (like service outages), but instead
+                indicate that something is fundamentally wrong with the Machine's
+                spec or the configuration of the controller, and that manual intervention
+                is required. Examples of terminal errors would be invalid combinations
+                of settings in the spec, values that are unsupported by the controller,
+                or the responsible controller itself being critically misconfigured.
+                \n Any transient errors that occur during the reconciliation of Machines
+                can be added as events to the Machine object and/or logged in the
+                controller's output."
+              type: string
+            instanceState:
+              description: InstanceStatus is the status of the GCP instance for this
+                machine.
+              type: string
+            ready:
+              description: Ready is true when the provider resource is ready.
+              type: boolean
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: gcpmachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: GCPMachineTemplate
+    plural: gcpmachinetemplates
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: GCPMachineTemplate is the Schema for the gcpmachinetemplates API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: GCPMachineTemplateSpec defines the desired state of GCPMachineTemplate
+          properties:
+            template:
+              description: GCPMachineTemplateResource describes the data needed to
+                create am GCPMachine from a template
+              properties:
+                spec:
+                  description: Spec is the specification of the desired behavior of
+                    the machine.
+                  properties:
+                    additionalLabels:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalLabels is an optional set of tags to
+                        add to an instance, in addition to the ones added by default
+                        by the GCP provider. If both the GCPCluster and the GCPMachine
+                        specify the same tag name with different values, the GCPMachine's
+                        value takes precedence.
+                      type: object
+                    additionalNetworkTags:
+                      description: AdditionalNetworkTags is a list of network tags
+                        that should be applied to the instance. These tags are set
+                        in addition to any network tags defined at the cluster level
+                        or in the actuator.
+                      items:
+                        type: string
+                      type: array
+                    image:
+                      description: Image is the full reference to a valid image to
+                        be used for this machine. Takes precedence over ImageFamily.
+                      type: string
+                    imageFamily:
+                      description: ImageFamily is the full reference to a valid image
+                        family to be used for this machine.
+                      type: string
+                    instanceType:
+                      description: 'InstanceType is the type of instance to create.
+                        Example: n1.standard-2'
+                      type: string
+                    providerID:
+                      description: ProviderID is the unique identifier as specified
+                        by the cloud provider.
+                      type: string
+                    publicIP:
+                      description: PublicIP specifies whether the instance should
+                        get a public IP. Set this to true if you don't have a NAT
+                        instances or Cloud Nat setup.
+                      type: boolean
+                    rootDeviceSize:
+                      description: RootDeviceSize is the size of the root volume in
+                        GB. Defaults to 30.
+                      format: int64
+                      type: integer
+                    serviceAccounts:
+                      description: 'ServiceAccount specifies the service account email
+                        and which scopes to assign to the machine. Defaults to: email:
+                        "default", scope: []{compute.CloudPlatformScope}'
+                      properties:
+                        email:
+                          description: 'Email: Email address of the service account.'
+                          type: string
+                        scopes:
+                          description: 'Scopes: The list of scopes to be made available
+                            for this service account.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    subnet:
+                      description: Subnet is a reference to the subnetwork to use
+                        for this instance. If not specified, the first subnetwork
+                        retrieved from the Cluster Region and Network is picked.
+                      type: string
+                    zone:
+                      description: Zone is references the GCP zone to use for this
+                        instance.
+                      type: string
+                  required:
+                  - instanceType
+                  - zone
+                  type: object
+              required:
+              - spec
+              type: object
+          required:
+          - template
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capg-leader-election-role
+  namespace: capg-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: capg-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - gcpclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - gcpclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - gcpmachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - gcpmachines/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capg-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capg-leader-election-rolebinding
+  namespace: capg-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capg-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capg-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capg-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capg-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capg-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capg-system
+---
+apiVersion: v1
+data:
+  credentials.json: ${GCP_B64ENCODED_CREDENTIALS}
+kind: Secret
+metadata:
+  name: capg-manager-bootstrap-credentials
+  namespace: capg-system
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    control-plane: capa-controller-manager
+  name: capg-controller-manager-metrics-service
+  namespace: capg-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: capa-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: capa-controller-manager
+  name: capg-controller-manager
+  namespace: capg-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: capa-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: capa-controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /home/.gcp/credentials.json
+        image: rsmitty/cluster-api-gcp-controller-amd64:latest
+        imagePullPolicy: Always
+        name: manager
+        volumeMounts:
+        - mountPath: /home/.gcp
+          name: credentials
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: credentials
+        secret:
+          secretName: capg-manager-bootstrap-credentials

--- a/hack/test/manifests/gcp-cluster.yaml
+++ b/hack/test/manifests/gcp-cluster.yaml
@@ -1,129 +1,222 @@
-apiVersion: cluster.k8s.io/v1alpha1
+## Cluster configs
+
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Cluster
 metadata:
-  annotations: null
   name: talos-e2e-{{TAG}}-gcp
+  namespace: default
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/16
-    serviceDomain: cluster.local
-    services:
-      cidrBlocks:
-        - 10.96.0.0/12
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosClusterProviderSpec
-      platform:
-        config: |-
-          region: "us-central1"
-          project: "talos-testbed"
-        type: gce
-      controlplane:
-        count: 3
-        k8sversion: "1.16.1"
+      - 192.168.0.0/16
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: GCPCluster
+    name: talos-e2e-{{TAG}}-gcp
+    namespace: default
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: GCPCluster
+metadata:
+  name: talos-e2e-{{TAG}}-gcp
+  namespace: default
+spec:
+  project: talos-testbed
+  region: us-central1
+---
+
+## Controlplane 0 configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfig
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-controlplane-0
+  labels:
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+spec:
+  machineType: init
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    set: master
-  name: talos-e2e-{{TAG}}-gcp-master-0
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+    cluster.x-k8s.io/control-plane: "true"
+  name: talos-e2e-{{TAG}}-gcp-controlplane-0
+  namespace: default
 spec:
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosMachineProviderSpec
-      platform:
-        config: |-
-          zone: "us-central1-c"
-          project: "talos-testbed"
-          instances:
-            type:  "n1-standard-2"
-            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
-            disks:
-              size: 50
-        type: gce
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: TalosConfig
+      name: talos-e2e-{{TAG}}-gcp-controlplane-0
+      namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: GCPMachine
+    name: talos-e2e-{{TAG}}-gcp-controlplane-0
+    namespace: default
+  version: 1.16.1
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: GCPMachine
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-controlplane-0
+  namespace: default
+spec:
+  instanceType: n1-standard-2
+  zone: us-central1-a
+  image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
+  serviceAccounts: {}
+  publicIP: true
+---
+
+## Controlplane 1 configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfig
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-controlplane-1
+  labels:
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+spec:
+  machineType: controlplane
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    set: master
-  name: talos-e2e-{{TAG}}-gcp-master-1
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+    cluster.x-k8s.io/control-plane: "true"
+  name: talos-e2e-{{TAG}}-gcp-controlplane-1
+  namespace: default
 spec:
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosMachineProviderSpec
-      platform:
-        config: |-
-          zone: "us-central1-c"
-          project: "talos-testbed"
-          instances:
-            type:  "n1-standard-2"
-            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
-            disks:
-              size: 50
-        type: gce
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: TalosConfig
+      name: talos-e2e-{{TAG}}-gcp-controlplane-1
+      namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: GCPMachine
+    name: talos-e2e-{{TAG}}-gcp-controlplane-1
+    namespace: default
+  version: 1.16.1
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: GCPMachine
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-controlplane-1
+  namespace: default
+spec:
+  instanceType: n1-standard-2
+  zone: us-central1-a
+  image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
+  serviceAccounts: {}
+  publicIP: true
+---
+
+## Controlplane 2 configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfig
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-controlplane-2
+  labels:
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+spec:
+  machineType: controlplane
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    set: master
-  name: talos-e2e-{{TAG}}-gcp-master-2
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+    cluster.x-k8s.io/control-plane: "true"
+  name: talos-e2e-{{TAG}}-gcp-controlplane-2
+  namespace: default
 spec:
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosMachineProviderSpec
-      platform:
-        config: |-
-          zone: "us-central1-c"
-          project: "talos-testbed"
-          instances:
-            type:  "n1-standard-2"
-            image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
-            disks:
-              size: 50
-        type: gce
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: TalosConfig
+      name: talos-e2e-{{TAG}}-gcp-controlplane-2
+      namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: GCPMachine
+    name: talos-e2e-{{TAG}}-gcp-controlplane-2
+    namespace: default
+  version: 1.16.1
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: GCPMachine
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-controlplane-2
+  namespace: default
+spec:
+  instanceType: n1-standard-2
+  zone: us-central1-a
+  image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
+  serviceAccounts: {}
+  publicIP: true
+---
+
+## Worker deployment configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfigTemplate
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-workers
+  namespace: default
+spec:
+  template:
+    spec:
+      machineType: "join"
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    set: worker
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+    nodepool: nodepool-0
   name: talos-e2e-{{TAG}}-gcp-workers
+  namespace: default
 spec:
   replicas: 3
   selector:
     matchLabels:
-      cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-      set: worker
+      cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+      nodepool: nodepool-0
   template:
     metadata:
       labels:
-        cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-        set: worker
+        cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+        nodepool: nodepool-0
     spec:
-      providerSpec:
-        value:
-          apiVersion: talosproviderconfig/v1alpha1
-          kind: TalosMachineProviderSpec
-          platform:
-            config: |-
-              zone: "us-central1-c"
-              project: "talos-testbed"
-              instances:
-                type:  "n1-standard-2"
-                image: "https://www.googleapis.com/compute/v1/projects/talos-testbed/global/images/talos-e2e-{{TAG}}"
-                disks:
-                  size: 50
-            type: gce
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          kind: TalosConfigTemplate
+          name: talos-e2e-{{TAG}}-gcp-workers
+          namespace: default
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: GCPMachineTemplate
+        name: talos-e2e-{{TAG}}-gcp-workers
+        namespace: default
+      version: 1.16.1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: GCPMachineTemplate
+metadata:
+  name: talos-e2e-{{TAG}}-gcp-workers
+  namespace: default
+spec:
+  template:
+    spec:
+      instanceType: n1-standard-2
+      zone: us-central1-a
+      image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}

--- a/hack/test/manifests/provider-components.yaml
+++ b/hack/test/manifests/provider-components.yaml
@@ -3,14 +3,144 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: cluster-api-provider-talos-system
+  name: cabpt-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: cluster-api-provider-talos-manager-role
+  name: talosconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: TalosConfig
+    plural: talosconfigs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: TalosConfig is the Schema for the talosconfigs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TalosConfigSpec defines the desired state of TalosConfig
+          properties:
+            machineType:
+              type: string
+          type: object
+        status:
+          description: TalosConfigStatus defines the observed state of TalosConfig
+          properties:
+            bootstrapData:
+              description: BootstrapData will be a slice of bootstrap data
+              format: byte
+              type: string
+            errorMessage:
+              description: ErrorMessage will be set on non-retryable errors
+              type: string
+            errorReason:
+              description: ErrorReason will be set on non-retryable errors
+              type: string
+            ready:
+              description: Ready indicates the BootstrapData field is ready to be
+                consumed
+              type: boolean
+            talosConfig:
+              description: Talos config will be a string containing the config for
+                download
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: talosconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: TalosConfigTemplate
+    plural: talosconfigtemplates
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: TalosConfigTemplate is the Schema for the talosconfigtemplates
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TalosConfigTemplateSpec defines the desired state of TalosConfigTemplate
+          properties:
+            template:
+              description: TalosConfigTemplateResource defines the Template structure
+              properties:
+                spec:
+                  description: TalosConfigSpec defines the desired state of TalosConfig
+                  properties:
+                    machineType:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - template
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cabpt-leader-election-role
+  namespace: cabpt-system
 rules:
 - apiGroups:
   - ""
@@ -25,1331 +155,189 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - cluster.k8s.io
+  - ""
   resources:
-  - clusters
-  - clusters/status
+  - configmaps/status
   verbs:
   - get
-  - list
-  - watch
-- apiGroups:
-  - cluster.k8s.io
-  resources:
-  - machines
-  - machines/status
-  - machinedeployments
-  - machinedeployments/status
-  - machinesets
-  - machinesets/status
-  - machineclasses
-  verbs:
-  - get
-  - list
-  - watch
-  - create
   - update
   - patch
-  - delete
-- apiGroups:
-  - cluster.k8s.io
-  resources:
-  - clusters
-  - clusters/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
 - apiGroups:
   - ""
   resources:
-  - nodes
   - events
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  creationTimestamp: null
-  name: cluster-api-provider-talos-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-api-provider-talos-manager-role
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: cluster-api-provider-talos-system
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-api-provider-talos-webhook-server-secret
-  namespace: cluster-api-provider-talos-system
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: cluster-api-provider-talos-controller-manager-service
-  namespace: cluster-api-provider-talos-system
-spec:
-  ports:
-  - port: 443
-  selector:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: cluster-api-provider-talos-controller-manager
-  namespace: cluster-api-provider-talos-system
-spec:
-  selector:
-    matchLabels:
-      control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
-  serviceName: cluster-api-provider-talos-controller-manager-service
-  template:
-    metadata:
-      labels:
-        control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
-    spec:
-      containers:
-      - command:
-        - /manager
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: AZURE_AUTH_LOCATION
-          value: /.azure/service-account.json
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /.gce/service-account.json
-        - name: PACKET_AUTH_TOKEN
-          value: '{{PACKET_AUTH_TOKEN}}'
-        image: autonomy/cluster-api-provider-talos:latest
-        imagePullPolicy: Always
-        name: manager
-        ports:
-        - containerPort: 9876
-          name: webhook-server
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
-        - mountPath: /.azure
-          name: azure-credentials
-        - mountPath: /.gce
-          name: gce-credentials
-        - mountPath: /.aws
-          name: aws-credentials
-        - mountPath: /etc/ssl/certs
-          name: certs
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: cluster-api-provider-talos-webhook-server-secret
-      - name: azure-credentials
-        secret:
-          secretName: azure-credentials
-      - name: gce-credentials
-        secret:
-          secretName: gce-credentials
-      - name: aws-credentials
-        secret:
-          secretName: aws-credentials
-      - hostPath:
-          path: /etc/ssl/certs
-        name: certs
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: cluster-api-system
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: clusters.cluster.k8s.io
-spec:
-  group: cluster.k8s.io
-  names:
-    kind: Cluster
-    plural: clusters
-    shortNames:
-    - cl
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            clusterNetwork:
-              description: Cluster network configuration
-              properties:
-                pods:
-                  description: The network ranges from which Pod networks are allocated.
-                  properties:
-                    cidrBlocks:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - cidrBlocks
-                  type: object
-                serviceDomain:
-                  description: Domain name for services.
-                  type: string
-                services:
-                  description: The network ranges from which service VIPs are allocated.
-                  properties:
-                    cidrBlocks:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - cidrBlocks
-                  type: object
-              required:
-              - services
-              - pods
-              - serviceDomain
-              type: object
-            providerSpec:
-              description: Provider-specific serialized configuration to use during
-                cluster creation. It is recommended that providers maintain their
-                own versioned API types that should be serialized/deserialized from
-                this field.
-              properties:
-                value:
-                  description: Value is an inlined, serialized representation of the
-                    resource configuration. It is recommended that providers maintain
-                    their own versioned API types that should be serialized/deserialized
-                    from this field, akin to component config.
-                  type: object
-                valueFrom:
-                  description: Source for the provider configuration. Cannot be used
-                    if value is not empty.
-                  properties:
-                    machineClass:
-                      description: The machine class from which the provider config
-                        should be sourced.
-                      properties:
-                        provider:
-                          description: Provider is the name of the cloud-provider
-                            which MachineClass is intended for.
-                          type: string
-                      type: object
-                  type: object
-              type: object
-          required:
-          - clusterNetwork
-          type: object
-        status:
-          properties:
-            apiEndpoints:
-              description: APIEndpoint represents the endpoint to communicate with
-                the IP.
-              items:
-                properties:
-                  host:
-                    description: The hostname on which the API server is serving.
-                    type: string
-                  port:
-                    description: The port on which the API server is serving.
-                    format: int64
-                    type: integer
-                required:
-                - host
-                - port
-                type: object
-              type: array
-            errorMessage:
-              description: If set, indicates that there is a problem reconciling the
-                state, and will be set to a descriptive error message.
-              type: string
-            errorReason:
-              description: If set, indicates that there is a problem reconciling the
-                state, and will be set to a token value suitable for programmatic
-                interpretation.
-              type: string
-            providerStatus:
-              description: Provider-specific status. It is recommended that providers
-                maintain their own versioned API types that should be serialized/deserialized
-                from this field.
-              type: object
-          type: object
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: machineclasses.cluster.k8s.io
-spec:
-  group: cluster.k8s.io
-  names:
-    kind: MachineClass
-    plural: machineclasses
-    shortNames:
-    - mc
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        providerSpec:
-          description: Provider-specific configuration to use during node creation.
-          type: object
-      required:
-      - providerSpec
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: machinedeployments.cluster.k8s.io
-spec:
-  group: cluster.k8s.io
-  names:
-    kind: MachineDeployment
-    plural: machinedeployments
-    shortNames:
-    - md
-  scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.labelSelector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            minReadySeconds:
-              description: Minimum number of seconds for which a newly created machine
-                should be ready. Defaults to 0 (machine will be considered available
-                as soon as it is ready)
-              format: int32
-              type: integer
-            paused:
-              description: Indicates that the deployment is paused.
-              type: boolean
-            progressDeadlineSeconds:
-              description: The maximum time in seconds for a deployment to make progress
-                before it is considered to be failed. The deployment controller will
-                continue to process failed deployments and a condition with a ProgressDeadlineExceeded
-                reason will be surfaced in the deployment status. Note that progress
-                will not be estimated during the time a deployment is paused. Defaults
-                to 600s.
-              format: int32
-              type: integer
-            replicas:
-              description: Number of desired machines. Defaults to 1. This is a pointer
-                to distinguish between explicit zero and not specified.
-              format: int32
-              type: integer
-            revisionHistoryLimit:
-              description: The number of old MachineSets to retain to allow rollback.
-                This is a pointer to distinguish between explicit zero and not specified.
-                Defaults to 1.
-              format: int32
-              type: integer
-            selector:
-              description: Label selector for machines. Existing MachineSets whose
-                machines are selected by this will be the ones affected by this deployment.
-                It must match the machine template's labels.
-              type: object
-            strategy:
-              description: The deployment strategy to use to replace existing machines
-                with new ones.
-              properties:
-                rollingUpdate:
-                  description: Rolling update config params. Present only if MachineDeploymentStrategyType
-                    = RollingUpdate.
-                  properties:
-                    maxSurge:
-                      anyOf:
-                      - type: string
-                      - type: integer
-                      description: 'The maximum number of machines that can be scheduled
-                        above the desired number of machines. Value can be an absolute
-                        number (ex: 5) or a percentage of desired machines (ex: 10%).
-                        This can not be 0 if MaxUnavailable is 0. Absolute number
-                        is calculated from percentage by rounding up. Defaults to
-                        1. Example: when this is set to 30%, the new MachineSet can
-                        be scaled up immediately when the rolling update starts, such
-                        that the total number of old and new machines do not exceed
-                        130% of desired machines. Once old machines have been killed,
-                        new MachineSet can be scaled up further, ensuring that total
-                        number of machines running at any time during the update is
-                        at most 130% of desired machines.'
-                    maxUnavailable:
-                      anyOf:
-                      - type: string
-                      - type: integer
-                      description: 'The maximum number of machines that can be unavailable
-                        during the update. Value can be an absolute number (ex: 5)
-                        or a percentage of desired machines (ex: 10%). Absolute number
-                        is calculated from percentage by rounding down. This can not
-                        be 0 if MaxSurge is 0. Defaults to 0. Example: when this is
-                        set to 30%, the old MachineSet can be scaled down to 70% of
-                        desired machines immediately when the rolling update starts.
-                        Once new machines are ready, old MachineSet can be scaled
-                        down further, followed by scaling up the new MachineSet, ensuring
-                        that the total number of machines available at all times during
-                        the update is at least 70% of desired machines.'
-                  type: object
-                type:
-                  description: Type of deployment. Currently the only supported strategy
-                    is "RollingUpdate". Default is RollingUpdate.
-                  type: string
-              type: object
-            template:
-              description: Template describes the machines that will be created.
-              properties:
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-                  properties:
-                    configSource:
-                      description: ConfigSource is used to populate in the associated
-                        Node for dynamic kubelet config. This field already exists
-                        in Node, so any updates to it in the Machine spec will be
-                        automatically copied to the linked NodeRef from the status.
-                        The rest of dynamic kubelet config support should then work
-                        as-is.
-                      type: object
-                    metadata:
-                      description: ObjectMeta will autopopulate the Node created.
-                        Use this to indicate what labels, annotations, name prefix,
-                        etc., should be used when creating the Node.
-                      type: object
-                    providerID:
-                      description: ProviderID is the identification ID of the machine
-                        provided by the provider. This field must match the provider
-                        ID as seen on the node object corresponding to this machine.
-                        This field is required by higher level consumers of cluster-api.
-                        Example use case is cluster autoscaler with cluster-api as
-                        provider. Clean-up logic in the autoscaler compares machines
-                        to nodes to find out machines at provider which could not
-                        get registered as Kubernetes nodes. With cluster-api as a
-                        generic out-of-tree provider for autoscaler, this field is
-                        required by autoscaler to be able to have a provider view
-                        of the list of machines. Another list of nodes is queried
-                        from the k8s apiserver and then a comparison is done to find
-                        out unregistered machines and are marked for delete. This
-                        field will be set by the actuators and consumed by higher
-                        level entities like autoscaler that will be interfacing with
-                        cluster-api as generic provider.
-                      type: string
-                    providerSpec:
-                      description: ProviderSpec details Provider-specific configuration
-                        to use during node creation.
-                      properties:
-                        value:
-                          description: Value is an inlined, serialized representation
-                            of the resource configuration. It is recommended that
-                            providers maintain their own versioned API types that
-                            should be serialized/deserialized from this field, akin
-                            to component config.
-                          type: object
-                        valueFrom:
-                          description: Source for the provider configuration. Cannot
-                            be used if value is not empty.
-                          properties:
-                            machineClass:
-                              description: The machine class from which the provider
-                                config should be sourced.
-                              properties:
-                                provider:
-                                  description: Provider is the name of the cloud-provider
-                                    which MachineClass is intended for.
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    taints:
-                      description: The list of the taints to be applied to the corresponding
-                        Node in additive manner. This list will not overwrite any
-                        other taints added to the Node on an ongoing basis by other
-                        entities. These taints should be actively reconciled e.g.
-                        if you ask the machine controller to apply a taint and then
-                        manually remove the taint the machine controller will put
-                        it back) but not have the machine controller remove any taints
-                      items:
-                        type: object
-                      type: array
-                    versions:
-                      description: Versions of key software to use. This field is
-                        optional at cluster creation time, and omitting the field
-                        indicates that the cluster installation tool should select
-                        defaults for the user. These defaults may differ based on
-                        the cluster installer, but the tool should populate the values
-                        it uses when persisting Machine objects. A Machine spec missing
-                        this field at runtime is invalid.
-                      properties:
-                        controlPlane:
-                          description: ControlPlane is the semantic version of the
-                            Kubernetes control plane to run. This should only be populated
-                            when the machine is a control plane.
-                          type: string
-                        kubelet:
-                          description: Kubelet is the semantic version of kubelet
-                            to run
-                          type: string
-                      required:
-                      - kubelet
-                      type: object
-                  required:
-                  - providerSpec
-                  type: object
-              type: object
-          required:
-          - selector
-          - template
-          type: object
-        status:
-          properties:
-            availableReplicas:
-              description: Total number of available machines (ready for at least
-                minReadySeconds) targeted by this deployment.
-              format: int32
-              type: integer
-            observedGeneration:
-              description: The generation observed by the deployment controller.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: Total number of ready machines targeted by this deployment.
-              format: int32
-              type: integer
-            replicas:
-              description: Total number of non-terminated machines targeted by this
-                deployment (their labels match the selector).
-              format: int32
-              type: integer
-            unavailableReplicas:
-              description: Total number of unavailable machines targeted by this deployment.
-                This is the total number of machines that are still required for the
-                deployment to have 100% available capacity. They may either be machines
-                that are running but not yet available or machines that still have
-                not been created.
-              format: int32
-              type: integer
-            updatedReplicas:
-              description: Total number of non-terminated machines targeted by this
-                deployment that have the desired template spec.
-              format: int32
-              type: integer
-          type: object
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: machines.cluster.k8s.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.providerID
-    description: Provider ID
-    name: ProviderID
-    type: string
-  - JSONPath: .status.phase
-    description: Machine status such as Terminating/Pending/Running/Failed etc
-    name: Phase
-    type: string
-  - JSONPath: .status.nodeRef.name
-    description: Node name associated with this machine
-    name: NodeName
-    priority: 1
-    type: string
-  group: cluster.k8s.io
-  names:
-    kind: Machine
-    plural: machines
-    shortNames:
-    - ma
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            configSource:
-              description: ConfigSource is used to populate in the associated Node
-                for dynamic kubelet config. This field already exists in Node, so
-                any updates to it in the Machine spec will be automatically copied
-                to the linked NodeRef from the status. The rest of dynamic kubelet
-                config support should then work as-is.
-              type: object
-            metadata:
-              description: ObjectMeta will autopopulate the Node created. Use this
-                to indicate what labels, annotations, name prefix, etc., should be
-                used when creating the Node.
-              type: object
-            providerID:
-              description: ProviderID is the identification ID of the machine provided
-                by the provider. This field must match the provider ID as seen on
-                the node object corresponding to this machine. This field is required
-                by higher level consumers of cluster-api. Example use case is cluster
-                autoscaler with cluster-api as provider. Clean-up logic in the autoscaler
-                compares machines to nodes to find out machines at provider which
-                could not get registered as Kubernetes nodes. With cluster-api as
-                a generic out-of-tree provider for autoscaler, this field is required
-                by autoscaler to be able to have a provider view of the list of machines.
-                Another list of nodes is queried from the k8s apiserver and then a
-                comparison is done to find out unregistered machines and are marked
-                for delete. This field will be set by the actuators and consumed by
-                higher level entities like autoscaler that will be interfacing with
-                cluster-api as generic provider.
-              type: string
-            providerSpec:
-              description: ProviderSpec details Provider-specific configuration to
-                use during node creation.
-              properties:
-                value:
-                  description: Value is an inlined, serialized representation of the
-                    resource configuration. It is recommended that providers maintain
-                    their own versioned API types that should be serialized/deserialized
-                    from this field, akin to component config.
-                  type: object
-                valueFrom:
-                  description: Source for the provider configuration. Cannot be used
-                    if value is not empty.
-                  properties:
-                    machineClass:
-                      description: The machine class from which the provider config
-                        should be sourced.
-                      properties:
-                        provider:
-                          description: Provider is the name of the cloud-provider
-                            which MachineClass is intended for.
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            taints:
-              description: The list of the taints to be applied to the corresponding
-                Node in additive manner. This list will not overwrite any other taints
-                added to the Node on an ongoing basis by other entities. These taints
-                should be actively reconciled e.g. if you ask the machine controller
-                to apply a taint and then manually remove the taint the machine controller
-                will put it back) but not have the machine controller remove any taints
-              items:
-                type: object
-              type: array
-            versions:
-              description: Versions of key software to use. This field is optional
-                at cluster creation time, and omitting the field indicates that the
-                cluster installation tool should select defaults for the user. These
-                defaults may differ based on the cluster installer, but the tool should
-                populate the values it uses when persisting Machine objects. A Machine
-                spec missing this field at runtime is invalid.
-              properties:
-                controlPlane:
-                  description: ControlPlane is the semantic version of the Kubernetes
-                    control plane to run. This should only be populated when the machine
-                    is a control plane.
-                  type: string
-                kubelet:
-                  description: Kubelet is the semantic version of kubelet to run
-                  type: string
-              required:
-              - kubelet
-              type: object
-          required:
-          - providerSpec
-          type: object
-        status:
-          properties:
-            addresses:
-              description: Addresses is a list of addresses assigned to the machine.
-                Queried from cloud provider, if available.
-              items:
-                type: object
-              type: array
-            conditions:
-              description: 'Conditions lists the conditions synced from the node conditions
-                of the corresponding node-object. Machine-controller is responsible
-                for keeping conditions up-to-date. MachineSet controller will be taking
-                these conditions as a signal to decide if machine is healthy or needs
-                to be replaced. Refer: https://kubernetes.io/docs/concepts/architecture/nodes/#condition'
-              items:
-                type: object
-              type: array
-            errorMessage:
-              description: ErrorMessage will be set in the event that there is a terminal
-                problem reconciling the Machine and will contain a more verbose string
-                suitable for logging and human consumption.  This field should not
-                be set for transitive errors that a controller faces that are expected
-                to be fixed automatically over time (like service outages), but instead
-                indicate that something is fundamentally wrong with the Machine's
-                spec or the configuration of the controller, and that manual intervention
-                is required. Examples of terminal errors would be invalid combinations
-                of settings in the spec, values that are unsupported by the controller,
-                or the responsible controller itself being critically misconfigured.  Any
-                transient errors that occur during the reconciliation of Machines
-                can be added as events to the Machine object and/or logged in the
-                controller's output.
-              type: string
-            errorReason:
-              description: ErrorReason will be set in the event that there is a terminal
-                problem reconciling the Machine and will contain a succinct value
-                suitable for machine interpretation.  This field should not be set
-                for transitive errors that a controller faces that are expected to
-                be fixed automatically over time (like service outages), but instead
-                indicate that something is fundamentally wrong with the Machine's
-                spec or the configuration of the controller, and that manual intervention
-                is required. Examples of terminal errors would be invalid combinations
-                of settings in the spec, values that are unsupported by the controller,
-                or the responsible controller itself being critically misconfigured.  Any
-                transient errors that occur during the reconciliation of Machines
-                can be added as events to the Machine object and/or logged in the
-                controller's output.
-              type: string
-            lastOperation:
-              description: LastOperation describes the last-operation performed by
-                the machine-controller. This API should be useful as a history in
-                terms of the latest operation performed on the specific machine. It
-                should also convey the state of the latest-operation for example if
-                it is still on-going, failed or completed successfully.
-              properties:
-                description:
-                  description: Description is the human-readable description of the
-                    last operation.
-                  type: string
-                lastUpdated:
-                  description: LastUpdated is the timestamp at which LastOperation
-                    API was last-updated.
-                  format: date-time
-                  type: string
-                state:
-                  description: State is the current status of the last performed operation.
-                    E.g. Processing, Failed, Successful etc
-                  type: string
-                type:
-                  description: Type is the type of operation which was last performed.
-                    E.g. Create, Delete, Update etc
-                  type: string
-              type: object
-            lastUpdated:
-              description: LastUpdated identifies when this status was last observed.
-              format: date-time
-              type: string
-            nodeRef:
-              description: NodeRef will point to the corresponding Node if it exists.
-              type: object
-            phase:
-              description: Phase represents the current phase of machine actuation.
-                E.g. Pending, Running, Terminating, Failed etc.
-              type: string
-            providerStatus:
-              description: ProviderStatus details a Provider-specific status. It is
-                recommended that providers maintain their own versioned API types
-                that should be serialized/deserialized from this field.
-              type: object
-            versions:
-              description: 'Versions specifies the current versions of software on
-                the corresponding Node (if it exists). This is provided for a few
-                reasons:  1) It is more convenient than checking the NodeRef, traversing
-                it to    the Node, and finding the appropriate field in Node.Status.NodeInfo    (which
-                uses different field names and formatting). 2) It removes some of
-                the dependency on the structure of the Node,    so that if the structure
-                of Node.Status.NodeInfo changes, only    machine controllers need
-                to be updated, rather than every client    of the Machines API. 3)
-                There is no other simple way to check the control plane    version.
-                A client would have to connect directly to the apiserver    running
-                on the target node in order to find out its version.'
-              properties:
-                controlPlane:
-                  description: ControlPlane is the semantic version of the Kubernetes
-                    control plane to run. This should only be populated when the machine
-                    is a control plane.
-                  type: string
-                kubelet:
-                  description: Kubelet is the semantic version of kubelet to run
-                  type: string
-              required:
-              - kubelet
-              type: object
-          type: object
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: machinesets.cluster.k8s.io
-spec:
-  group: cluster.k8s.io
-  names:
-    kind: MachineSet
-    plural: machinesets
-    shortNames:
-    - ms
-  scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.labelSelector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            deletePolicy:
-              description: DeletePolicy defines the policy used to identify nodes
-                to delete when downscaling. Defaults to "Random".  Valid values are
-                "Random, "Newest", "Oldest"
-              enum:
-              - Random
-              - Newest
-              - Oldest
-              type: string
-            minReadySeconds:
-              description: MinReadySeconds is the minimum number of seconds for which
-                a newly created machine should be ready. Defaults to 0 (machine will
-                be considered available as soon as it is ready)
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas is the number of desired replicas. This is a pointer
-                to distinguish between explicit zero and unspecified. Defaults to
-                1.
-              format: int32
-              type: integer
-            selector:
-              description: 'Selector is a label query over machines that should match
-                the replica count. Label keys and values that must match in order
-                to be controlled by this MachineSet. It must match the machine template''s
-                labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
-              type: object
-            template:
-              description: Template is the object that describes the machine that
-                will be created if insufficient replicas are detected.
-              properties:
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-                  properties:
-                    configSource:
-                      description: ConfigSource is used to populate in the associated
-                        Node for dynamic kubelet config. This field already exists
-                        in Node, so any updates to it in the Machine spec will be
-                        automatically copied to the linked NodeRef from the status.
-                        The rest of dynamic kubelet config support should then work
-                        as-is.
-                      type: object
-                    metadata:
-                      description: ObjectMeta will autopopulate the Node created.
-                        Use this to indicate what labels, annotations, name prefix,
-                        etc., should be used when creating the Node.
-                      type: object
-                    providerID:
-                      description: ProviderID is the identification ID of the machine
-                        provided by the provider. This field must match the provider
-                        ID as seen on the node object corresponding to this machine.
-                        This field is required by higher level consumers of cluster-api.
-                        Example use case is cluster autoscaler with cluster-api as
-                        provider. Clean-up logic in the autoscaler compares machines
-                        to nodes to find out machines at provider which could not
-                        get registered as Kubernetes nodes. With cluster-api as a
-                        generic out-of-tree provider for autoscaler, this field is
-                        required by autoscaler to be able to have a provider view
-                        of the list of machines. Another list of nodes is queried
-                        from the k8s apiserver and then a comparison is done to find
-                        out unregistered machines and are marked for delete. This
-                        field will be set by the actuators and consumed by higher
-                        level entities like autoscaler that will be interfacing with
-                        cluster-api as generic provider.
-                      type: string
-                    providerSpec:
-                      description: ProviderSpec details Provider-specific configuration
-                        to use during node creation.
-                      properties:
-                        value:
-                          description: Value is an inlined, serialized representation
-                            of the resource configuration. It is recommended that
-                            providers maintain their own versioned API types that
-                            should be serialized/deserialized from this field, akin
-                            to component config.
-                          type: object
-                        valueFrom:
-                          description: Source for the provider configuration. Cannot
-                            be used if value is not empty.
-                          properties:
-                            machineClass:
-                              description: The machine class from which the provider
-                                config should be sourced.
-                              properties:
-                                provider:
-                                  description: Provider is the name of the cloud-provider
-                                    which MachineClass is intended for.
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    taints:
-                      description: The list of the taints to be applied to the corresponding
-                        Node in additive manner. This list will not overwrite any
-                        other taints added to the Node on an ongoing basis by other
-                        entities. These taints should be actively reconciled e.g.
-                        if you ask the machine controller to apply a taint and then
-                        manually remove the taint the machine controller will put
-                        it back) but not have the machine controller remove any taints
-                      items:
-                        type: object
-                      type: array
-                    versions:
-                      description: Versions of key software to use. This field is
-                        optional at cluster creation time, and omitting the field
-                        indicates that the cluster installation tool should select
-                        defaults for the user. These defaults may differ based on
-                        the cluster installer, but the tool should populate the values
-                        it uses when persisting Machine objects. A Machine spec missing
-                        this field at runtime is invalid.
-                      properties:
-                        controlPlane:
-                          description: ControlPlane is the semantic version of the
-                            Kubernetes control plane to run. This should only be populated
-                            when the machine is a control plane.
-                          type: string
-                        kubelet:
-                          description: Kubelet is the semantic version of kubelet
-                            to run
-                          type: string
-                      required:
-                      - kubelet
-                      type: object
-                  required:
-                  - providerSpec
-                  type: object
-              type: object
-          required:
-          - selector
-          type: object
-        status:
-          properties:
-            availableReplicas:
-              description: The number of available replicas (ready for at least minReadySeconds)
-                for this MachineSet.
-              format: int32
-              type: integer
-            errorMessage:
-              type: string
-            errorReason:
-              description: In the event that there is a terminal problem reconciling
-                the replicas, both ErrorReason and ErrorMessage will be set. ErrorReason
-                will be populated with a succinct value suitable for machine interpretation,
-                while ErrorMessage will contain a more verbose string suitable for
-                logging and human consumption.  These fields should not be set for
-                transitive errors that a controller faces that are expected to be
-                fixed automatically over time (like service outages), but instead
-                indicate that something is fundamentally wrong with the MachineTemplate's
-                spec or the configuration of the machine controller, and that manual
-                intervention is required. Examples of terminal errors would be invalid
-                combinations of settings in the spec, values that are unsupported
-                by the machine controller, or the responsible machine controller itself
-                being critically misconfigured.  Any transient errors that occur during
-                the reconciliation of Machines can be added as events to the MachineSet
-                object and/or logged in the controller's output.
-              type: string
-            fullyLabeledReplicas:
-              description: The number of replicas that have labels matching the labels
-                of the machine template of the MachineSet.
-              format: int32
-              type: integer
-            observedGeneration:
-              description: ObservedGeneration reflects the generation of the most
-                recently observed MachineSet.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: The number of ready replicas for this MachineSet. A machine
-                is considered ready when the node has been created and is "Ready".
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas is the most recently observed number of replicas.
-              format: int32
-              type: integer
-          required:
-          - replicas
-          type: object
-  version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: cluster-api-manager-role
+  name: cabpt-manager-role
 rules:
-- apiGroups:
-  - cluster.k8s.io
-  resources:
-  - clusters
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - events
+  - secrets
   verbs:
+  - create
+  - delete
   - get
   - list
-  - watch
-  - create
   - patch
+  - update
+  - watch
 - apiGroups:
-  - cluster.k8s.io
+  - bootstrap.cluster.x-k8s.io
   resources:
+  - talosconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - talosconfigs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
   - machines
   - machines/status
   verbs:
   - get
   - list
   - watch
-  - create
-  - update
-  - patch
-  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cabpt-proxy-role
+rules:
 - apiGroups:
-  - cluster.k8s.io
+  - authentication.k8s.io
   resources:
-  - machinedeployments
-  - machinedeployments/status
+  - tokenreviews
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
-  - delete
 - apiGroups:
-  - cluster.k8s.io
+  - authorization.k8s.io
   resources:
-  - machinesets
-  - machinesets/status
+  - subjectaccessreviews
   verbs:
-  - get
-  - list
-  - watch
   - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - cluster.k8s.io
-  resources:
-  - machines
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - cluster.k8s.io
-  resources:
-  - machines
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cabpt-leader-election-rolebinding
+  namespace: cabpt-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cabpt-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: cabpt-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
-  name: cluster-api-manager-rolebinding
+  name: cabpt-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-api-manager-role
+  name: cabpt-manager-role
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: cluster-api-system
+  namespace: cabpt-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cabpt-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cabpt-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: cabpt-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
   labels:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: cluster-api-controller-manager-service
-  namespace: cluster-api-system
+  name: cabpt-controller-manager-metrics-service
+  namespace: cabpt-system
 spec:
   ports:
-  - port: 443
+  - name: https
+    port: 8443
+    targetPort: https
   selector:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
 ---
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: cluster-api-controller-manager
-  namespace: cluster-api-system
+  name: cabpt-controller-manager
+  namespace: cabpt-system
 spec:
+  replicas: 1
   selector:
     matchLabels:
       control-plane: controller-manager
-      controller-tools.k8s.io: "1.0"
-  serviceName: cluster-api-controller-manager-service
   template:
     metadata:
       labels:
         control-plane: controller-manager
-        controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        - --enable-leader-election
+        command:
         - /manager
-        image: us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller:v0.1.9
+        image: autonomy/cluster-api-talos-controller:latest
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 500m
+            memory: 500Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 500m
+            memory: 500Mi
       terminationGracePeriodSeconds: 10
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - key: CriticalAddonsOnly
-        operator: Exists
-      - effect: NoExecute
-        key: node.alpha.kubernetes.io/notReady
-        operator: Exists
-      - effect: NoExecute
-        key: node.alpha.kubernetes.io/unreachable
-        operator: Exists


### PR DESCRIPTION
This PR will re-enable e2e testing by using the new cluster api
bootstrap provider and various infra providers.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>