### PR TITLE
docs: add note on CRNG initialization

### DIFF
--- a/docs/website/components/CommunityDropdown.vue
+++ b/docs/website/components/CommunityDropdown.vue
@@ -14,7 +14,7 @@
       </svg>
     </button>
     <ul class="dropdown-menu absolute pt-1 w-full shadow-md">
-      <li class="text-center" v-for="link in links" :key="link.url">
+      <li v-for="link in links" :key="link.url" class="text-center">
         <a
           :href="link.url"
           class="text-center rounded-t py-2 px-4 block whitespace-no-wrap"

--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -14,11 +14,11 @@
       </svg>
     </button>
     <ul class="dropdown-menu absolute pt-1 w-full shadow-md">
-      <li class="" v-for="option in options" :key="option.version">
+      <li v-for="option in options" :key="option.version" class="">
         <a
-          @click="handleClick(option)"
           :href="option.url"
           class="rounded-t py-2 px-4 block whitespace-no-wrap"
+          @click="handleClick(option)"
           >{{ version(option) }}</a
         >
       </li>

--- a/docs/website/components/Sidebar.vue
+++ b/docs/website/components/Sidebar.vue
@@ -4,8 +4,8 @@
       <li
         v-for="entry in $store.state.sidebar.menu"
         :key="entry.title"
-        @click="selected = entry.title"
         class="py-2"
+        @click="selected = entry.title"
       >
         <a
           class="sidebar-category"

--- a/docs/website/content/v0.3/en/guides/metal/index.md
+++ b/docs/website/content/v0.3/en/guides/metal/index.md
@@ -34,6 +34,10 @@ Talos also enforces some minimum requirements from the KSPP (kernel self-protect
 - `slab_nomerge`
 - `pti=on`
 
+You may experience long boot times due to low entropy.
+In newer versions of Linux, the initialization of the Cryptographically (Secure) Random Number Generator (CRNG) will block until it is properly seeded from the entropy pool at boot time.
+To work around this, add `random.trust_cpu=on` to the list of kernel arguments.
+
 ## Cluster interaction
 
 After the machines have booted up, you'll want to manage your Talos config file.

--- a/docs/website/nuxt.config.js
+++ b/docs/website/nuxt.config.js
@@ -49,6 +49,10 @@ export default {
   /*
    ** Nuxt.js dev-modules configuration
    */
+  eslint: {
+    fix: true
+  },
+
   // PurgeCSS is automatically installed by @nuxtjs/tailwindcss
   purgeCSS: {},
 


### PR DESCRIPTION
This adds a note on the usage of random.trust_cpu to get around slow
boot times due to low entropy.

Closes #1240.