### PR TITLE
docs: add troubleshooting guide on common PKI scenarios

### DIFF
--- a/docs/website/content/v0.3.en.json
+++ b/docs/website/content/v0.3.en.json
@@ -80,6 +80,16 @@
     ]
   },
   {
+    "title": "Troubleshooting",
+    "path": "v0.3/en/troubleshooting",
+    "items": [
+      {
+        "title": "PKI",
+        "path": "v0.3/en/troubleshooting/pki"
+      }
+    ]
+  },
+  {
     "title": "Components",
     "path": "v0.3/en/components",
     "items": [

--- a/docs/website/content/v0.3/en/troubleshooting/index.md
+++ b/docs/website/content/v0.3/en/troubleshooting/index.md
@@ -1,0 +1,5 @@
+---
+title: 'Troubleshooting'
+---
+
+In this section we will provide guidance on troubleshooting various scenarios you may find yourself in.

--- a/docs/website/content/v0.3/en/troubleshooting/pki.md
+++ b/docs/website/content/v0.3/en/troubleshooting/pki.md
@@ -1,0 +1,48 @@
+---
+title: 'PKI'
+---
+
+## Generating an Administrator Key Pair
+
+In order to create a key pair, you will need the root CA.
+
+Save the the CA public key, and CA private key as `ca.crt`, and `ca.key` respectively.
+Now, run the following commands to generate a certificate:
+
+```bash
+osctl gen key --name admin
+osctl gen csr --key admin.key --ip 127.0.0.1
+osctl gen crt --ca ca --csr admin.csr --name admin
+```
+
+Now, base64 encode `admin.crt`, and `admin.key`:
+
+```bash
+cat admin.crt | base64
+cat admin.key | base64
+```
+
+You can now set the `crt` and `key` fields in the `talosconfig` to the base64 encoded strings.
+
+## Renewing an Expired Administrator Certificate
+
+In order to renew the certificate, you will need the root CA, and the admin private key.
+The base64 encoded key can be found in any one of the control plane node's configuration file.
+Where it is exactly will depend on the specific version of the configuration file you are using.
+
+Save the the CA public key, CA private key, and admin private key as `ca.crt`, `ca.key`, and `admin.key` respectively.
+Now, run the following commands to generate a certificate:
+
+```bash
+osctl gen csr --key admin.key --ip 127.0.0.1
+osctl gen crt --ca ca --csr admin.csr --name admin
+```
+
+You should see `admin.crt` in your current directory.
+Now, base64 encode `admin.crt`:
+
+```bash
+cat admin.crt | base64
+```
+
+You can now set the certificate in the `talosconfig` to the base64 encoded string.

--- a/docs/website/docgen.config.js
+++ b/docs/website/docgen.config.js
@@ -3,6 +3,6 @@ module.exports = {
   availableRoutesFile: `${__dirname}/routes.json`,
   contentInputFolder: `${__dirname}/content/`,
   menuInputFile: `${__dirname}/content/{version}.{lang}.json`,
-  sectionsOutputFile: `${__dirname}/static/{version}.sections.{lang}.json`,
-  menuOutputFile: `${__dirname}/static/{version}.menu.{lang}.json`
+  menuOutputFile: `${__dirname}/static/{version}.menu.{lang}.json`,
+  sectionsOutputFile: `${__dirname}/static/{version}.sections.{lang}.json`
 }

--- a/docs/website/docgen.js
+++ b/docs/website/docgen.js
@@ -90,18 +90,16 @@ const Docgen = {
         return
         break
       default:
-        // [ content-delivery, en, json ]
         const contentPathParts = contentFilePath
           .replace(config.contentInputFolder, '')
           .split('.')
 
-        // content-delivery
-        const version = contentPathParts.shift()
+        const version = contentPathParts.slice(0, -2).join('.')
 
-        // en
-        const lang = contentPathParts.shift()
+        const lang = contentPathParts.slice(-2)[0]
 
         Docgen.exportMenu(version, lang)
+
         break
     }
   },


### PR DESCRIPTION
This adds a "Troubleshooting" section to the documention along with a
guide on generating a certificate. This covers the scenario when a
user's certificate has expired.

Closes #1274.