### PR TITLE
docs: various layout and responsiveness fixes

### DIFF
--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="dropdown inline-block">
-    <button class="font-semibold py-2 px-4 rounded inline-flex items-center">
+    <button class="font-semibold py-2 pl-4 rounded inline-flex items-center">
       <span class="mr-1">{{ $store.state.sidebar.version }}</span>
       <svg
         id="dropdown-caret"

--- a/docs/website/components/Header.vue
+++ b/docs/website/components/Header.vue
@@ -1,24 +1,26 @@
 <template>
-  <header id="header" class="flex flex-wrap">
-    <div class="flex items-center justify-start max-w-6xl mx-auto py-2">
-      <Logo></Logo>
-    </div>
-    <div class="flex items-center justify-end max-w-6xl mx-auto py-6">
-      <ul class="flex flex-wrap items-center justify-end">
-        <li class="link min-w-full md:min-w-0">
-          <a href="/docs/v0.3">
-            <span class="font-semibold mr-1">Documentation</span>
-          </a>
-        </li>
-        <li class="link min-w-full md:min-w-0">
-          <CommunityDropdown></CommunityDropdown>
-        </li>
-        <li class="link min-w-full md:min-w-0">
-          <a href="/faqs">
-            <span class="font-semibold mr-1">FAQs</span>
-          </a>
-        </li>
-      </ul>
+  <header id="header">
+    <div class="flex flex-wrap w-4/5 mx-auto">
+      <div class="flex py-2">
+        <Logo></Logo>
+      </div>
+      <div class="flex py-6 ml-auto">
+        <ul class="flex flex-wrap items-center justify-end">
+          <li class="link min-w-full md:min-w-0">
+            <a href="/docs/v0.3">
+              <span class="font-semibold mr-1">Documentation</span>
+            </a>
+          </li>
+          <li class="link min-w-full md:min-w-0">
+            <CommunityDropdown></CommunityDropdown>
+          </li>
+          <li class="link min-w-full md:min-w-0">
+            <a href="/faqs">
+              <span class="font-semibold mr-1">FAQs</span>
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
   </header>
 </template>

--- a/docs/website/components/Logo.vue
+++ b/docs/website/components/Logo.vue
@@ -4,7 +4,6 @@
       id="header-logo"
       src="/images/TalosSystems_Horizontal_Logo_FullColor_RGB-for-site.svg"
       alt="Talos"
-      width="350"
     />
   </a>
 </template>

--- a/docs/website/pages/docs/_.vue
+++ b/docs/website/pages/docs/_.vue
@@ -7,11 +7,11 @@
         </div>
         <DocumentationDropdown></DocumentationDropdown>
       </div>
-      <div class="flex md:flex-wrap">
-        <div class="w-1/4 mt-1">
+      <div class="flex flex-wrap">
+        <div class="md:w-1/4 mt-1">
           <Sidebar></Sidebar>
         </div>
-        <div class="w-3/4 mt-1">
+        <div class="md:w-3/4 mt-1">
           <Content></Content>
         </div>
       </div>


### PR DESCRIPTION
- adjust ul margin to keep the bullets inside the content area
- fix a few docs page responsiveness problems on small screens
- adjust the layout of the logo relative to the docs sidebar
- clean up some vestigial CSS classes

Signed-off-by: Tim Gerla <tim@gerla.net>