### PR TITLE
docs: fix list-style-position

### DIFF
--- a/docs/website/pages/index.vue
+++ b/docs/website/pages/index.vue
@@ -226,4 +226,8 @@ export default {
   height: auto;
   width: 400px;
 }
+
+.c-rich-text ul {
+  list-style-position: outside;
+}
 </style>

--- a/docs/website/tailwind.config.js
+++ b/docs/website/tailwind.config.js
@@ -172,7 +172,7 @@ module.exports = {
         },
         ul: {
           listStyleType: 'disc',
-          listStylePosition: 'outside',
+          listStylePosition: 'inside',
           marginBottom: '16px'
         },
         ol: {


### PR DESCRIPTION
This sets the list-style-position to inside by default, and overrides
the landing page to use outside. This way we only need to maintain the
CSS for the landing page and not all the other potential places we would
want inside in the future.