### PR TITLE
fix: Avoid running bootkube on reboots

### DIFF
--- a/cmd/osctl/cmd/cluster/pkg/node/node.go
+++ b/cmd/osctl/cmd/cluster/pkg/node/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/go-connections/nat"
 
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // Request represents the set of options available for configuring a node.
@@ -121,7 +122,7 @@ func NewNode(clusterName string, req *Request) (err error) {
 
 		fallthrough
 	case generate.TypeControlPlane:
-		containerConfig.Volumes["/var/lib/etcd"] = struct{}{}
+		containerConfig.Volumes[constants.EtcdDataPath] = struct{}{}
 
 		if req.IP == nil {
 			return errors.New("an IP address must be provided when creating a master node")

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -122,6 +122,7 @@ func (e *Etcd) Runner(config runtime.Configurator) (runner.Runner, error) {
 		ProcessArgs: []string{
 			"/usr/local/bin/etcd",
 			"--name=" + hostname,
+			"--data-dir=" + constants.EtcdDataPath,
 			"--listen-peer-urls=https://0.0.0.0:2380",
 			"--listen-client-urls=https://0.0.0.0:2379",
 			"--initial-advertise-peer-urls=https://" + ips[0].String() + ":2380",

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -1,0 +1,40 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package etcd
+
+import (
+	"time"
+
+	"go.etcd.io/etcd/clientv3"
+	"go.etcd.io/etcd/pkg/transport"
+
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+// NewLocalClient initializes and returns an etcd client configured to talk to
+// a local endpoint.
+func NewLocalClient() (client *clientv3.Client, err error) {
+	tlsInfo := transport.TLSInfo{
+		CertFile:      constants.KubernetesEtcdPeerCert,
+		KeyFile:       constants.KubernetesEtcdPeerKey,
+		TrustedCAFile: constants.KubernetesEtcdCACert,
+	}
+
+	tlsConfig, err := tlsInfo.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err = clientv3.New(clientv3.Config{
+		Endpoints:   []string{"127.0.0.1:2379"},
+		DialTimeout: 5 * time.Second,
+		TLS:         tlsConfig,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -244,6 +244,10 @@ const (
 
 	// DefaultServiceCIDR is the default service CIDR block.
 	DefaultServiceCIDR = "10.96.0.0/12"
+
+	// InitializedKey is the key used to indicate if the cluster has been
+	// initialized.
+	InitializedKey = "initialized"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Since bootkube should only be ran once, we need a way to determine if it
has already been ran. This makes use of etcd to store a key-value pair
indicating that the cluster has been initialized.