### PR TITLE
fix(osd): Add additional capabilities for osd

### DIFF
--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -111,6 +111,9 @@ func (o *OSD) Runner(config runtime.Configurator) (runner.Runner, error) {
 		runner.WithOCISpecOpts(
 			oci.WithCapabilities([]string{
 				strings.ToUpper("CAP_" + capability.CAP_SYS_PTRACE.String()),
+				strings.ToUpper("CAP_" + capability.CAP_DAC_READ_SEARCH.String()),
+				strings.ToUpper("CAP_" + capability.CAP_DAC_OVERRIDE.String()),
+				strings.ToUpper("CAP_" + capability.CAP_SYSLOG.String()),
 			}),
 			oci.WithHostNamespace(specs.PIDNamespace),
 			oci.WithMounts(mounts),


### PR DESCRIPTION
This adds `CAP_DAC_READ_SEARCH`, `CAP_DAC_OVERRIDE`, and `CAP_SYSLOG`
capabilities to osd.  This fixes the ability to read dmesg and kubeconfig.

Fixes #1370 

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>