### PR TITLE
refactor: align platform names with kernel args

### DIFF
--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -6,7 +6,6 @@ package upgrade
 
 import (
 	"fmt"
-	"strings"
 
 	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
@@ -44,7 +43,7 @@ func (task *Upgrade) standard(r runtime.Runtime) (err error) {
 		return fmt.Errorf("no config option was found")
 	}
 
-	if err = install.Install(task.ref, task.devname, strings.ToLower(r.Platform().Name())); err != nil {
+	if err = install.Install(task.ref, task.devname, r.Platform().Name()); err != nil {
 		return err
 	}
 

--- a/internal/pkg/runtime/initializer/interactive/interactive.go
+++ b/internal/pkg/runtime/initializer/interactive/interactive.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"golang.org/x/sys/unix"
 
@@ -63,7 +62,7 @@ func (i *Interactive) Initialize(platform runtime.Platform, install machine.Inst
 
 	cmdline := kernel.NewDefaultCmdline()
 	cmdline.Append("initrd", filepath.Join("/", "default", constants.InitramfsAsset))
-	cmdline.Append(constants.KernelParamPlatform, strings.ToLower(platform.Name()))
+	cmdline.Append(constants.KernelParamPlatform, platform.Name())
 	cmdline.Append(constants.KernelParamConfig, endpoint)
 
 	var inst *installer.Installer

--- a/internal/pkg/runtime/initializer/metal/metal.go
+++ b/internal/pkg/runtime/initializer/metal/metal.go
@@ -6,7 +6,6 @@ package metal
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/talos-systems/talos/internal/pkg/event"
 	installer "github.com/talos-systems/talos/internal/pkg/install"
@@ -34,7 +33,7 @@ func (b *Metal) Initialize(platform runtime.Platform, install machine.Install) (
 			return errors.New("an install image is required")
 		}
 
-		if err = installer.Install(install.Image(), install.Disk(), strings.ToLower(platform.Name())); err != nil {
+		if err = installer.Install(install.Image(), install.Disk(), platform.Name()); err != nil {
 			return err
 		}
 

--- a/internal/pkg/runtime/platform/aws/aws.go
+++ b/internal/pkg/runtime/platform/aws/aws.go
@@ -117,7 +117,7 @@ func IsEC2() (b bool) {
 
 // Name implements the platform.Platform interface.
 func (a *AWS) Name() string {
-	return "AWS"
+	return "aws"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/azure/azure.go
+++ b/internal/pkg/runtime/platform/azure/azure.go
@@ -34,7 +34,7 @@ type Azure struct{}
 
 // Name implements the platform.Platform interface.
 func (a *Azure) Name() string {
-	return "Azure"
+	return "azure"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/container/container.go
+++ b/internal/pkg/runtime/platform/container/container.go
@@ -18,7 +18,7 @@ type Container struct{}
 
 // Name implements the platform.Platform interface.
 func (c *Container) Name() string {
-	return "Container"
+	return "container"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/digitalocean/digitalocean.go
+++ b/internal/pkg/runtime/platform/digitalocean/digitalocean.go
@@ -28,7 +28,7 @@ type DigitalOcean struct{}
 
 // Name implements the platform.Platform interface.
 func (a *DigitalOcean) Name() string {
-	return "Digital Ocean"
+	return "digital-ocean"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/gcp/gcp.go
+++ b/internal/pkg/runtime/platform/gcp/gcp.go
@@ -29,7 +29,7 @@ type GCP struct{}
 
 // Name implements the platform.Platform interface.
 func (g *GCP) Name() string {
-	return "GCP"
+	return "gcp"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/iso/iso.go
+++ b/internal/pkg/runtime/platform/iso/iso.go
@@ -18,7 +18,7 @@ type ISO struct{}
 
 // Name implements the platform.Platform interface.
 func (i *ISO) Name() string {
-	return "ISO"
+	return "iso"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/metal/metal.go
+++ b/internal/pkg/runtime/platform/metal/metal.go
@@ -28,7 +28,7 @@ type Metal struct{}
 
 // Name implements the platform.Platform interface.
 func (b *Metal) Name() string {
-	return "Metal"
+	return "metal"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/packet/packet.go
+++ b/internal/pkg/runtime/platform/packet/packet.go
@@ -21,7 +21,7 @@ type Packet struct{}
 
 // Name implements the platform.Platform interface.
 func (p *Packet) Name() string {
-	return "Packet"
+	return "packet"
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/pkg/runtime/platform/vmware/vmware.go
+++ b/internal/pkg/runtime/platform/vmware/vmware.go
@@ -23,7 +23,7 @@ type VMware struct{}
 
 // Name implements the platform.Platform interface.
 func (v *VMware) Name() string {
-	return "VMware"
+	return "vmware"
 }
 
 // Configuration implements the platform.Platform interface.


### PR DESCRIPTION
This aligns platform names with tals.platofrm kernel arg.