### PR TITLE
refactor: pass runtime to initializer

### DIFF
--- a/internal/app/machined/internal/phase/platform/platform.go
+++ b/internal/app/machined/internal/phase/platform/platform.go
@@ -31,7 +31,7 @@ func (task *Platform) runtime(r runtime.Runtime) (err error) {
 		return err
 	}
 
-	if err = i.Initialize(r.Platform(), r.Config().Machine().Install()); err != nil {
+	if err = i.Initialize(r); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -43,7 +43,7 @@ func (task *Upgrade) standard(r runtime.Runtime) (err error) {
 		return fmt.Errorf("no config option was found")
 	}
 
-	if err = install.Install(task.ref, task.devname, r.Platform().Name()); err != nil {
+	if err = install.Install(r); err != nil {
 		return err
 	}
 

--- a/internal/pkg/runtime/initializer/cloud/cloud.go
+++ b/internal/pkg/runtime/initializer/cloud/cloud.go
@@ -9,14 +9,13 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // Cloud is an initializer that mounts an existing installation.
 type Cloud struct{}
 
 // Initialize implements the Initializer interface.
-func (c *Cloud) Initialize(platform runtime.Platform, install machine.Install) (err error) {
+func (c *Cloud) Initialize(r runtime.Runtime) (err error) {
 	var mountpoints *mount.Points
 
 	mountpoints, err = owned.MountPointsFromLabels()

--- a/internal/pkg/runtime/initializer/container/container.go
+++ b/internal/pkg/runtime/initializer/container/container.go
@@ -6,13 +6,12 @@ package container
 
 import (
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // Container is an initializer that is a noop.
 type Container struct{}
 
 // Initialize implements the Initializer interface.
-func (c *Container) Initialize(platform runtime.Platform, install machine.Install) (err error) {
+func (c *Container) Initialize(r runtime.Runtime) (err error) {
 	return nil
 }

--- a/internal/pkg/runtime/initializer/initializer.go
+++ b/internal/pkg/runtime/initializer/initializer.go
@@ -10,13 +10,12 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/runtime/initializer/container"
 	"github.com/talos-systems/talos/internal/pkg/runtime/initializer/interactive"
 	"github.com/talos-systems/talos/internal/pkg/runtime/initializer/metal"
-	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // Initializer defines a process for initializing the system based on the
 // environment it is in.
 type Initializer interface {
-	Initialize(runtime.Platform, machine.Install) error
+	Initialize(runtime.Runtime) error
 }
 
 // New initializes and returns and Initializer based on the runtime mode.

--- a/internal/pkg/runtime/initializer/interactive/interactive.go
+++ b/internal/pkg/runtime/initializer/interactive/interactive.go
@@ -17,7 +17,6 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
-	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -26,7 +25,7 @@ import (
 type Interactive struct{}
 
 // Initialize implements the Initializer interface.
-func (i *Interactive) Initialize(platform runtime.Platform, install machine.Install) (err error) {
+func (i *Interactive) Initialize(r runtime.Runtime) (err error) {
 	var dev *probe.ProbedBlockDevice
 
 	dev, err = probe.GetDevWithFileSystemLabel(constants.ISOFilesystemLabel)
@@ -62,12 +61,12 @@ func (i *Interactive) Initialize(platform runtime.Platform, install machine.Inst
 
 	cmdline := kernel.NewDefaultCmdline()
 	cmdline.Append("initrd", filepath.Join("/", "default", constants.InitramfsAsset))
-	cmdline.Append(constants.KernelParamPlatform, platform.Name())
+	cmdline.Append(constants.KernelParamPlatform, r.Platform().Name())
 	cmdline.Append(constants.KernelParamConfig, endpoint)
 
 	var inst *installer.Installer
 
-	inst, err = installer.NewInstaller(cmdline, install)
+	inst, err = installer.NewInstaller(cmdline, r.Config().Machine().Install())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/initializer/metal/metal.go
+++ b/internal/pkg/runtime/initializer/metal/metal.go
@@ -13,7 +13,6 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // Metal represents an initializer that performs a full installation to a
@@ -21,7 +20,7 @@ import (
 type Metal struct{}
 
 // Initialize implements the Initializer interface.
-func (b *Metal) Initialize(platform runtime.Platform, install machine.Install) (err error) {
+func (b *Metal) Initialize(r runtime.Runtime) (err error) {
 	// Attempt to discover a previous installation
 	// An err case should only happen if no partitions
 	// with matching labels were found
@@ -29,11 +28,11 @@ func (b *Metal) Initialize(platform runtime.Platform, install machine.Install) (
 
 	mountpoints, err = owned.MountPointsFromLabels()
 	if err != nil {
-		if install.Image() == "" {
+		if r.Config().Machine().Install().Image() == "" {
 			return errors.New("an install image is required")
 		}
 
-		if err = installer.Install(install.Image(), install.Disk(), platform.Name()); err != nil {
+		if err = installer.Install(r); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
By passing the runtime to the initializer we can flex on install options
better.