### PR TITLE
fix: be explicit about installs

### DIFF
--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -8,15 +8,12 @@ package cmd
 import (
 	"log"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/talos-systems/talos/internal/pkg/installer"
 	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/internal/pkg/runtime/platform"
-	machineconfig "github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/version"
@@ -40,46 +37,20 @@ var installCmd = &cobra.Command{
 			err    error
 		)
 
-		platform, err := platform.NewPlatform()
-		if err == nil {
-			if !strings.EqualFold(platform.Name(), platformArg) {
-				log.Printf("platform mismatch (%s != %s)", platform.Name(), platformArg)
-			} else {
-				var b []byte
-				b, err = platform.Configuration()
-				if err != nil {
-					log.Fatal(err)
-				}
-				var content machineconfig.Content
-				content, err = machineconfig.FromBytes(b)
-				if err != nil {
-					log.Fatal(err)
-				}
-				config, err = machineconfig.New(content)
-				if err != nil {
-					log.Fatal(err)
-				}
-				extraKernelArgs = append(extraKernelArgs, config.Machine().Install().ExtraKernelArgs()...)
-			}
-		}
-
-		if config == nil {
-			log.Printf("failed to source config from platform; falling back to defaults")
-			config = &v1alpha1.Config{
-				ClusterConfig: &v1alpha1.ClusterConfig{
-					ControlPlane: &v1alpha1.ControlPlaneConfig{
-						Version: constants.DefaultKubernetesVersion,
-					},
+		config = &v1alpha1.Config{
+			ClusterConfig: &v1alpha1.ClusterConfig{
+				ControlPlane: &v1alpha1.ControlPlaneConfig{
+					Version: constants.DefaultKubernetesVersion,
 				},
-				MachineConfig: &v1alpha1.MachineConfig{
-					MachineInstall: &v1alpha1.InstallConfig{
-						InstallForce:           true,
-						InstallBootloader:      bootloader,
-						InstallDisk:            disk,
-						InstallExtraKernelArgs: extraKernelArgs,
-					},
+			},
+			MachineConfig: &v1alpha1.MachineConfig{
+				MachineInstall: &v1alpha1.InstallConfig{
+					InstallForce:           true,
+					InstallBootloader:      bootloader,
+					InstallDisk:            disk,
+					InstallExtraKernelArgs: extraKernelArgs,
 				},
-			}
+			},
 		}
 
 		cmdline := kernel.NewCmdline("")

--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -5,28 +5,27 @@
 package upgrade
 
 import (
-	"fmt"
+	"log"
 
 	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/install"
-	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
 // Upgrade represents the task for stop all containerd tasks in the
 // k8s.io namespace.
 type Upgrade struct {
-	devname string
-	ref     string
+	disk  string
+	image string
 }
 
 // NewUpgradeTask initializes and returns an Services task.
 func NewUpgradeTask(devname string, req *machineapi.UpgradeRequest) phase.Task {
 	return &Upgrade{
-		devname: devname,
-		ref:     req.Image,
+		disk:  devname,
+		image: req.Image,
 	}
 }
 
@@ -36,11 +35,14 @@ func (task *Upgrade) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *Upgrade) standard(r runtime.Runtime) (err error) {
-	// TODO(andrewrynhard): To handle cases when the newer version changes the
-	// platform name, this should be determined in the installer container.
-	var config *string
-	if config = kernel.ProcCmdline().Get(constants.KernelParamConfig).First(); config == nil {
-		return fmt.Errorf("no config option was found")
+	log.Printf("performing upgrade via %q", task.image)
+
+	c := r.Config()
+	if cfg, ok := c.(*v1alpha1.Config); ok {
+		cfg.MachineConfig.MachineInstall.InstallDisk = task.disk
+		cfg.MachineConfig.MachineInstall.InstallImage = task.image
+
+		r = runtime.NewRuntime(r.Platform(), runtime.Configurator(cfg))
 	}
 
 	if err = install.Install(r); err != nil {


### PR DESCRIPTION
Trying to be smart about whether our not an install is being performed
as part of an upgrade has proven to be error prone. This moves to
perform installs with explicit args.