### PR TITLE
refactor: use constants.SystemContainerdNamespace

### DIFF
--- a/internal/app/machined/pkg/system/runner/cri/runner.go
+++ b/internal/app/machined/pkg/system/runner/cri/runner.go
@@ -15,6 +15,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/pkg/cri"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 type criRunner struct {
@@ -117,7 +118,7 @@ func (c *criRunner) findImage(ctx context.Context) error {
 //nolint: gocyclo
 func (c *criRunner) Open(upstreamCtx context.Context) error {
 	// validate the basic options
-	if c.opts.Namespace != "system" {
+	if c.opts.Namespace != constants.SystemContainerdNamespace {
 		return errors.New("namespaces not supported by CRI runner")
 	}
 

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -60,7 +60,7 @@ type Option func(*Options)
 func DefaultOptions() *Options {
 	return &Options{
 		Env:                     []string{},
-		Namespace:               "system",
+		Namespace:               constants.SystemContainerdNamespace,
 		LogPath:                 constants.DefaultLogPath,
 		GracefulShutdownTimeout: 10 * time.Second,
 		ContainerdAddress:       constants.ContainerdAddress,

--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -235,7 +235,7 @@ func (r *Registrator) Logs(req *osapi.LogsRequest, l osapi.OS_LogsServer) (err e
 	var chunk chunker.Chunker
 
 	switch {
-	case req.Namespace == "system" || req.Id == "kubelet" || req.Id == "kubeadm":
+	case req.Namespace == constants.SystemContainerdNamespace || req.Id == "kubelet":
 		filename := filepath.Join(constants.DefaultLogPath, filepath.Base(req.Id)+".log")
 
 		var file *os.File


### PR DESCRIPTION
This replaces hardcoded instances of "system" with
constants.SystemContainerdNamespace.