### PR TITLE
feat: out machined logs to /dev/kmsg and file

### DIFF
--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -34,7 +34,7 @@ func run() (err error) {
 	}
 
 	// Setup logging to /dev/kmsg.
-	_, err = kmsg.Setup("[talos] [initramfs]")
+	err = kmsg.Setup("[talos] [initramfs]", false)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/internal/phase/phase.go
+++ b/internal/app/machined/internal/phase/phase.go
@@ -56,8 +56,8 @@ func NewRunner(config runtime.Configurator) (*Runner, error) {
 		fallthrough
 	case runtime.Cloud:
 		// Setup logging to /dev/kmsg.
-		if _, err = kmsg.Setup("[talos]"); err != nil {
-			return nil, fmt.Errorf("failed to setup logging to /dev/kmsg: %w", err)
+		if err = kmsg.Setup("[talos]", true); err != nil {
+			return nil, fmt.Errorf("failed to setup logging: %w", err)
 		}
 	}
 

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -108,7 +108,6 @@ func (o *APID) Runner(config runtime.Configurator) (runner.Runner, error) {
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: constants.ConfigPath, Source: constants.ConfigPath, Options: []string{"rbind", "ro"}},
-		// Other grpc server sockets
 		{Type: "bind", Destination: constants.SystemRunPath, Source: constants.SystemRunPath, Options: []string{"bind", "ro"}},
 	}
 

--- a/internal/pkg/kmsg/kmsg.go
+++ b/internal/pkg/kmsg/kmsg.go
@@ -6,23 +6,44 @@ package kmsg
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // Setup configures the log package to write to the kernel ring buffer via
 // /dev/kmsg.
-func Setup(prefix string) (*os.File, error) {
-	out, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
+func Setup(prefix string, withLogFile bool) error {
+	kmsg, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open /dev/kmsg: %w", err)
+		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
 	}
 
-	log.SetOutput(out)
+	var writer io.Writer = kmsg
+
+	if withLogFile {
+		if err := os.MkdirAll(constants.DefaultLogPath, 0700); err != nil {
+			return err
+		}
+
+		logPath := filepath.Join(constants.DefaultLogPath, "machined.log")
+
+		f, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			return fmt.Errorf("failed to open %s: %w", logPath, err)
+		}
+
+		writer = io.MultiWriter(kmsg, f)
+	}
+
+	log.SetOutput(writer)
 	log.SetPrefix(prefix + " ")
 	log.SetFlags(0)
 
-	return out, nil
+	return nil
 }


### PR DESCRIPTION
Since dmesg is not streamed, it becomes difficult to debug issues with
machined. This fixes that by setting up the logging of machine to go to
/dev/kmsg and to a log file.