### PR TITLE
fix: stop leaking file descriptors

### DIFF
--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -186,7 +186,7 @@ func (d *Sequencer) Upgrade(req *machineapi.UpgradeRequest) error {
 		return err
 	}
 
-	devname := dev.BlockDevice.Device().Name()
+	devname := dev.Device().Name()
 
 	if err := dev.Close(); err != nil {
 		return err

--- a/internal/pkg/installer/manifest/verify.go
+++ b/internal/pkg/installer/manifest/verify.go
@@ -60,6 +60,9 @@ func VerifyDiskAvailability(devpath, label string) (err error) {
 		return nil
 	}
 
+	// nolint: errcheck
+	defer dev.Close()
+
 	if dev.SuperBlock != nil {
 		return fmt.Errorf("target install device %s is not empty, found existing %s file system", label, dev.SuperBlock.Type())
 	}

--- a/internal/pkg/mount/manager/owned/owned.go
+++ b/internal/pkg/mount/manager/owned/owned.go
@@ -45,6 +45,9 @@ func MountPointsForDevice(devpath string) (mountpoints *mount.Points, err error)
 			return nil, fmt.Errorf("probe device for filesystem %s: %w", name, err)
 		}
 
+		// nolint: errcheck
+		defer dev.Close()
+
 		mountpoint := mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "")
 		mountpoints.Set(name, mountpoint)
 	}
@@ -83,6 +86,9 @@ func MountPointsFromLabels() (mountpoints *mount.Points, err error) {
 
 			return nil, fmt.Errorf("find device with label %s: %w", name, err)
 		}
+
+		// nolint: errcheck
+		defer dev.Close()
 
 		mountpoint := mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "", opts...)
 		mountpoints.Set(name, mountpoint)

--- a/internal/pkg/runtime/initializer/interactive/interactive.go
+++ b/internal/pkg/runtime/initializer/interactive/interactive.go
@@ -33,6 +33,9 @@ func (i *Interactive) Initialize(r runtime.Runtime) (err error) {
 		return fmt.Errorf("failed to find %s iso: %w", constants.ISOFilesystemLabel, err)
 	}
 
+	// nolint: errcheck
+	defer dev.Close()
+
 	if err = unix.Mount(dev.Path, "/tmp", dev.SuperBlock.Type(), unix.MS_RDONLY, ""); err != nil {
 		return err
 	}

--- a/internal/pkg/runtime/platform/metal/metal.go
+++ b/internal/pkg/runtime/platform/metal/metal.go
@@ -69,6 +69,9 @@ func readConfigFromISO() (b []byte, err error) {
 		return nil, fmt.Errorf("failed to find %s iso: %w", constants.MetalConfigISOLabel, err)
 	}
 
+	// nolint: errcheck
+	defer dev.Close()
+
 	if err = unix.Mount(dev.Path, mnt, dev.SuperBlock.Type(), unix.MS_RDONLY, ""); err != nil {
 		return nil, fmt.Errorf("failed to mount iso: %w", err)
 	}


### PR DESCRIPTION
This ensures that probed block devices are closed.