### PR TITLE
fix: verify system disk not in use

### DIFF
--- a/internal/app/machined/internal/phase/disk/verify_availability.go
+++ b/internal/app/machined/internal/phase/disk/verify_availability.go
@@ -1,0 +1,52 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package disk
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+)
+
+// VerifyDiskAvailability represents the task for verifying that the system
+// disk is not in use.
+type VerifyDiskAvailability struct {
+	devname string
+}
+
+// NewVerifyDiskAvailabilityTask initializes and returns a
+// VerifyDiskAvailability task.
+func NewVerifyDiskAvailabilityTask(devname string) phase.Task {
+	return &VerifyDiskAvailability{
+		devname: devname,
+	}
+}
+
+// TaskFunc returns the runtime function.
+func (task *VerifyDiskAvailability) TaskFunc(mode runtime.Mode) phase.TaskFunc {
+	return func(r runtime.Runtime) error {
+		return task.standard()
+	}
+}
+
+func (task *VerifyDiskAvailability) standard() (err error) {
+	if isBusy(task.devname) {
+		return errors.New("system disk in use")
+	}
+
+	return nil
+}
+
+func isBusy(devname string) bool {
+	fd, errno := unix.Open(devname, unix.O_RDONLY|unix.O_EXCL|unix.O_CLOEXEC, 0)
+
+	// nolint: errcheck
+	defer unix.Close(fd)
+
+	return errno == unix.EBUSY
+}

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -216,6 +216,10 @@ func (d *Sequencer) Upgrade(req *machineapi.UpgradeRequest) error {
 			rootfs.NewUnmountSystemDisksTask(devname),
 		),
 		phase.NewPhase(
+			"verify system disk not in use",
+			disk.NewVerifyDiskAvailabilityTask(devname),
+		),
+		phase.NewPhase(
 			"reset partition",
 			disk.NewResetDiskTask(devname),
 		),


### PR DESCRIPTION
This adds an extra phase to the upgrade sequence that ensures we don't
hit EBUSY when attempting to delete the ephemeral partition. This is
curucial because if we fail to do so, the disk does not have a
bootloader and we effectively destroy the machine. From the Linux man
pages: If the block device is in use by the system (e.g., mounted), open()
fails with the error EBUSY.