### PR TITLE
fix: stop etcd and remove data-dir

### DIFF
--- a/internal/app/machined/internal/phase/services/stop_services.go
+++ b/internal/app/machined/internal/phase/services/stop_services.go
@@ -35,7 +35,7 @@ func (task *StopServices) standard(r runtime.Runtime) (err error) {
 		services := []string{"containerd", "networkd", "ntpd", "udevd"}
 
 		if r.Config().Machine().Type() == machine.Bootstrap || r.Config().Machine().Type() == machine.ControlPlane {
-			services = append(services, "etcd", "trustd")
+			services = append(services, "trustd")
 		}
 
 		for _, service := range services {


### PR DESCRIPTION
We need to stop etcd earlier in the upgrade sequence to prevent machined
from trying to restart it after leaving the etcd cluster. We also need
to remove the data-dir since all the data becomes invalid once we leave
the etcd cluster.