### PR TITLE
fix: don't use 127.0.0.1 for etcd client

### DIFF
--- a/internal/app/machined/internal/phase/upgrade/leave_etcd.go
+++ b/internal/app/machined/internal/phase/upgrade/leave_etcd.go
@@ -42,7 +42,7 @@ func (task *LeaveEtcd) standard(r runtime.Runtime) (err error) {
 		return err
 	}
 
-	client, err := etcd.NewClient([]string{"127.0.0.1:2379"})
+	client, err := etcd.NewClientFromControlPlaneIPs(r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We should use 127.0.0.1 only in special cases (like when bootstrapping
the cluster). There is the potential that the local etcd member is
unhealthy and/or not responsive. This adds function for creating an etcd
client configured with all control plane node IPs in order to better
handle this case.