### PR TITLE
refactor: rename Helper to Client

### DIFF
--- a/internal/app/machined/internal/phase/kubernetes/cordon_and_drain.go
+++ b/internal/app/machined/internal/phase/kubernetes/cordon_and_drain.go
@@ -35,9 +35,9 @@ func (task *CordonAndDrain) standard() (err error) {
 		return err
 	}
 
-	var kubeHelper *kubernetes.Helper
+	var kubeHelper *kubernetes.Client
 
-	if kubeHelper, err = kubernetes.NewHelper(); err != nil {
+	if kubeHelper, err = kubernetes.NewClientFromKubeletKubeconfig(); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -77,7 +77,7 @@ func (o *APID) Runner(config runtime.Configurator) (runner.Runner, error) {
 		opts := []retry.Option{retry.WithUnits(3 * time.Second), retry.WithJitter(time.Second)}
 
 		err := retry.Constant(10*time.Minute, opts...).Retry(func() error {
-			h, err := kubernetes.NewHelper()
+			h, err := kubernetes.NewClientFromKubeletKubeconfig()
 			if err != nil {
 				return retry.ExpectedError(fmt.Errorf("failed to create client: %w", err))
 			}


### PR DESCRIPTION
The name helper isn't very good. This renames it to Client. A new func
was also added, NewForConfig, that will allow for the creation of the helper
client from an arbitrary Kubernetes REST config.