### PR TITLE
fix: Add host network namespace to networkd and ntpd

### DIFF
--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -103,6 +103,7 @@ func (n *Networkd) Runner(config runtime.Configurator) (runner.Runner, error) {
 				strings.ToUpper("CAP_" + capability.CAP_NET_ADMIN.String()),
 				strings.ToUpper("CAP_" + capability.CAP_NET_RAW.String()),
 			}),
+			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
 		),
 	),

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -95,6 +95,7 @@ func (n *NTPd) Runner(config runtime.Configurator) (runner.Runner, error) {
 			oci.WithCapabilities([]string{
 				strings.ToUpper("CAP_" + capability.CAP_SYS_TIME.String()),
 			}),
+			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
 		),
 	),


### PR DESCRIPTION
Without host network namespace, networkd and ntpd didnt work properly. NTP failed to
start up because it couldnt reach the ntp servers and networkd failed to configure
the interfaces and display interface information.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>