### PR TITLE
feat: add metadata file to boot partition

### DIFF
--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	bootloader      bool
+	upgradeArg      bool
 	disk            string
 	endpoint        string
 	platformArg     string
@@ -66,7 +67,13 @@ var installCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err = i.Install(); err != nil {
+
+		sequence := runtime.None
+		if upgradeArg {
+			sequence = runtime.Upgrade
+		}
+
+		if err = i.Install(sequence); err != nil {
 			log.Fatal(err)
 		}
 
@@ -79,6 +86,7 @@ func init() {
 	installCmd.Flags().StringVar(&disk, "disk", "", "The path to the disk to install to")
 	installCmd.Flags().StringVar(&endpoint, "config", "", "The value of "+constants.KernelParamConfig)
 	installCmd.Flags().StringVar(&platformArg, "platform", "", "The value of "+constants.KernelParamPlatform)
+	installCmd.Flags().BoolVar(&upgradeArg, "upgrade", false, "Indicates that the install is being performed by an upgrade")
 	installCmd.Flags().StringArrayVar(&extraKernelArgs, "extra-kernel-arg", []string{}, "Extra argument to pass to the kernel")
 	rootCmd.AddCommand(installCmd)
 }

--- a/internal/app/machined/internal/phase/phase.go
+++ b/internal/app/machined/internal/phase/phase.go
@@ -45,7 +45,7 @@ type Runner struct {
 }
 
 // NewRunner initializes and returns a Runner.
-func NewRunner(config runtime.Configurator) (*Runner, error) {
+func NewRunner(config runtime.Configurator, sequence runtime.Sequence) (*Runner, error) {
 	platform, err := platform.NewPlatform()
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func NewRunner(config runtime.Configurator) (*Runner, error) {
 	}
 
 	runner := &Runner{
-		runtime: runtime.NewRuntime(platform, config),
+		runtime: runtime.NewRuntime(platform, config, sequence),
 	}
 
 	return runner, nil

--- a/internal/app/machined/internal/phase/phase_test.go
+++ b/internal/app/machined/internal/phase/phase_test.go
@@ -60,7 +60,7 @@ func (suite *PhaseSuite) TearDownSuite() {
 }
 
 func (suite *PhaseSuite) TestRunSuccess() {
-	r, err := phase.NewRunner(nil)
+	r, err := phase.NewRunner(nil, runtime.None)
 	suite.Require().NoError(err)
 
 	taskErr := make(chan error)
@@ -90,7 +90,7 @@ func (suite *PhaseSuite) TestRunSuccess() {
 }
 
 func (suite *PhaseSuite) TestRunFailures() {
-	r, err := phase.NewRunner(nil)
+	r, err := phase.NewRunner(nil, runtime.None)
 	suite.Require().NoError(err)
 
 	taskErr := make(chan error, 1)

--- a/internal/app/machined/internal/phase/rootfs/check_install.go
+++ b/internal/app/machined/internal/phase/rootfs/check_install.go
@@ -5,10 +5,10 @@
 package rootfs
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/pkg/metadata"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/constants"
 )
@@ -32,6 +32,10 @@ func (task *CheckInstall) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *CheckInstall) standard(r runtime.Runtime) (err error) {
-	_, err = os.Stat(filepath.Join(constants.BootMountPoint, "installed"))
+	_, err = metadata.Open(filepath.Join(constants.BootMountPoint, constants.MetadataFile))
+	if err != nil {
+		return err
+	}
+
 	return err
 }

--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -42,7 +42,7 @@ func (task *Upgrade) standard(r runtime.Runtime) (err error) {
 		cfg.MachineConfig.MachineInstall.InstallDisk = task.disk
 		cfg.MachineConfig.MachineInstall.InstallImage = task.image
 
-		r = runtime.NewRuntime(r.Platform(), runtime.Configurator(cfg))
+		r = runtime.NewRuntime(r.Platform(), runtime.Configurator(cfg), runtime.Upgrade)
 	}
 
 	if err = install.Install(r); err != nil {

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/signal"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/sysctls"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/upgrade"
+	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -31,7 +32,7 @@ type Sequencer struct{}
 
 // Boot implements the Sequencer interface.
 func (d *Sequencer) Boot() error {
-	phaserunner, err := phase.NewRunner(nil)
+	phaserunner, err := phase.NewRunner(nil, runtime.Boot)
 	if err != nil {
 		return err
 	}
@@ -75,7 +76,7 @@ func (d *Sequencer) Boot() error {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	phaserunner, err = phase.NewRunner(config)
+	phaserunner, err = phase.NewRunner(config, runtime.Boot)
 	if err != nil {
 		return err
 	}
@@ -147,7 +148,7 @@ func (d *Sequencer) Shutdown() error {
 		return err
 	}
 
-	phaserunner, err := phase.NewRunner(config)
+	phaserunner, err := phase.NewRunner(config, runtime.Shutdown)
 	if err != nil {
 		return err
 	}
@@ -174,7 +175,7 @@ func (d *Sequencer) Upgrade(req *machineapi.UpgradeRequest) error {
 		return err
 	}
 
-	phaserunner, err := phase.NewRunner(config)
+	phaserunner, err := phase.NewRunner(config, runtime.Upgrade)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/metadata/metadata.go
+++ b/internal/pkg/metadata/metadata.go
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package metadata
+
+import (
+	"errors"
+	"io/ioutil"
+	"time"
+
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Metadata represents the node metadata.
+type Metadata struct {
+	Timestamp time.Time `yaml:"timestamp"`
+	Upgraded  bool      `yaml:"upgraded"`
+}
+
+// NewMetadata initializes and returns the metadata.
+func NewMetadata(sequence runtime.Sequence) *Metadata {
+	upgraded := sequence == runtime.Upgrade
+
+	return &Metadata{
+		Timestamp: time.Now(),
+		Upgraded:  upgraded,
+	}
+}
+
+// Open attempts to read the metadata.
+func Open(file string) (m *Metadata, err error) {
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		return nil, errors.New("metadata file is empty")
+	}
+
+	m = &Metadata{}
+
+	if err = yaml.Unmarshal(b, m); err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// Bytes returns to byte slice representation of the metadata.
+func (m *Metadata) Bytes() ([]byte, error) {
+	return yaml.Marshal(m)
+}

--- a/internal/pkg/runtime/initializer/interactive/interactive.go
+++ b/internal/pkg/runtime/initializer/interactive/interactive.go
@@ -74,7 +74,7 @@ func (i *Interactive) Initialize(r runtime.Runtime) (err error) {
 		return err
 	}
 
-	if err = inst.Install(); err != nil {
+	if err = inst.Install(r.Sequence()); err != nil {
 		return fmt.Errorf("failed to install: %w", err)
 	}
 

--- a/internal/pkg/runtime/runtime.go
+++ b/internal/pkg/runtime/runtime.go
@@ -9,6 +9,20 @@ import (
 	"strings"
 )
 
+// Sequence represents the sequence type.
+type Sequence int
+
+const (
+	// None is the none sequence.
+	None Sequence = iota
+	// Boot is the boot sequence.
+	Boot
+	// Shutdown is the shutdown sequence.
+	Shutdown
+	// Upgrade is the upgrade sequence.
+	Upgrade
+)
+
 // Mode is a runtime mode.
 type Mode int
 
@@ -48,13 +62,15 @@ func ModeFromString(s string) (m Mode, err error) {
 type Runtime interface {
 	Platform() Platform
 	Config() Configurator
+	Sequence() Sequence
 }
 
 // NewRuntime initializes and returns the runtime interface.
-func NewRuntime(p Platform, c Configurator) Runtime {
+func NewRuntime(p Platform, c Configurator, s Sequence) Runtime {
 	return &DefaultRuntime{
 		p: p,
 		c: c,
+		s: s,
 	}
 }
 
@@ -62,6 +78,7 @@ func NewRuntime(p Platform, c Configurator) Runtime {
 type DefaultRuntime struct {
 	p Platform
 	c Configurator
+	s Sequence
 }
 
 // Platform implements the Runtime interface.
@@ -72,4 +89,9 @@ func (d *DefaultRuntime) Platform() Platform {
 // Config implements the Runtime interface.
 func (d *DefaultRuntime) Config() Configurator {
 	return d.c
+}
+
+// Sequence implements the Runtime interface.
+func (d *DefaultRuntime) Sequence() Sequence {
+	return d.s
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -248,6 +248,9 @@ const (
 	// InitializedKey is the key used to indicate if the cluster has been
 	// initialized.
 	InitializedKey = "initialized"
+
+	// MetadataFile is the name of the file that contains a node's metadata.
+	MetadataFile = "metadata.yaml"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
This introduces the notion of metadata for a node. In this initial pass
there are only two fields. A timestamp to indicate when the install was
performed, and a field to indicate if the install was performed as part
of an upgrade.