### PR TITLE
fix: conditionally create a new etcd cluster

### DIFF
--- a/internal/app/machined/internal/phase/platform/platform.go
+++ b/internal/app/machined/internal/phase/platform/platform.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/pkg/metadata"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/runtime/initializer"
 )
@@ -57,6 +58,11 @@ func (task *Platform) runtime(r runtime.Runtime) (err error) {
 	if r.Platform().Mode() == runtime.Container {
 		// TODO: add ::1 back once I figure out why bootkube barfs
 		sans = append(sans, "127.0.0.1")
+
+		m := metadata.NewMetadata(r.Sequence())
+		if err = m.Save(); err != nil {
+			return err
+		}
 	}
 
 	r.Config().Machine().Security().SetCertSANs(sans)

--- a/internal/app/machined/internal/phase/rootfs/check_install.go
+++ b/internal/app/machined/internal/phase/rootfs/check_install.go
@@ -5,12 +5,9 @@
 package rootfs
 
 import (
-	"path/filepath"
-
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/metadata"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // CheckInstall represents the CheckInstall task.
@@ -32,7 +29,7 @@ func (task *CheckInstall) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *CheckInstall) standard(r runtime.Runtime) (err error) {
-	_, err = metadata.Open(filepath.Join(constants.BootMountPoint, constants.MetadataFile))
+	_, err = metadata.Open()
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -27,6 +27,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/etcd"
+	"github.com/talos-systems/talos/internal/pkg/metadata"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -106,7 +107,12 @@ func (e *Etcd) Runner(config runtime.Configurator) (runner.Runner, error) {
 	initialClusterState := "new"
 	initialCluster := hostname + "=https://" + ips[0].String() + ":2380"
 
-	if config.Machine().Type() == machine.ControlPlane {
+	metadata, err := metadata.Open()
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Machine().Type() == machine.ControlPlane || metadata.Upgraded {
 		initialClusterState = "existing"
 
 		initialCluster, err = buildInitialCluster(config, hostname, ips[0].String())

--- a/internal/pkg/installer/installer.go
+++ b/internal/pkg/installer/installer.go
@@ -7,7 +7,6 @@ package installer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"unsafe"
@@ -135,16 +134,7 @@ func (i *Installer) Install(sequence runtime.Sequence) (err error) {
 
 	metadata := metadata.NewMetadata(sequence)
 
-	b, err := metadata.Bytes()
-	if err != nil {
-		return err
-	}
-
-	if err = ioutil.WriteFile(filepath.Join(constants.BootMountPoint, constants.MetadataFile), b, 0400); err != nil {
-		return err
-	}
-
-	return nil
+	return metadata.Save()
 }
 
 func zero(manifest *manifest.Manifest) (err error) {

--- a/internal/pkg/metadata/metadata.go
+++ b/internal/pkg/metadata/metadata.go
@@ -7,9 +7,11 @@ package metadata
 import (
 	"errors"
 	"io/ioutil"
+	"path/filepath"
 	"time"
 
 	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/constants"
 
 	"gopkg.in/yaml.v2"
 )
@@ -31,8 +33,10 @@ func NewMetadata(sequence runtime.Sequence) *Metadata {
 }
 
 // Open attempts to read the metadata.
-func Open(file string) (m *Metadata, err error) {
-	b, err := ioutil.ReadFile(file)
+func Open() (m *Metadata, err error) {
+	m = &Metadata{}
+
+	b, err := ioutil.ReadFile(m.Path())
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +45,6 @@ func Open(file string) (m *Metadata, err error) {
 		return nil, errors.New("metadata file is empty")
 	}
 
-	m = &Metadata{}
-
 	if err = yaml.Unmarshal(b, m); err != nil {
 		return nil, err
 	}
@@ -50,7 +52,23 @@ func Open(file string) (m *Metadata, err error) {
 	return m, nil
 }
 
+// Save attempts to save the metadata.
+func (m *Metadata) Save() (err error) {
+	var b []byte
+
+	if b, err = m.Bytes(); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(m.Path(), b, 0400)
+}
+
 // Bytes returns to byte slice representation of the metadata.
 func (m *Metadata) Bytes() ([]byte, error) {
 	return yaml.Marshal(m)
+}
+
+// Path returns the path to the metadata.
+func (m *Metadata) Path() string {
+	return filepath.Join(constants.BootMountPoint, constants.MetadataFile)
 }


### PR DESCRIPTION
This fixes a long standing issue with upgrading the init node. We
currently have no way of knowing whether the init node should join an
existing etcd cluster, or create a new one. This makes use of the node's
metadata to determine if the node has already created the etcd cluster.