### PR TITLE
test: add 'integration-test' to e2e runs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -156,6 +156,24 @@ steps:
   depends_on:
   - fetch-tags
 
+- name: integration-test
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make integration-test
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - fetch-tags
+
 - name: rootfs
   pull: always
   image: autonomy/build-container:latest
@@ -366,6 +384,7 @@ steps:
   depends_on:
   - container
   - osctl-linux
+  - integration-test
 
 - name: push
   pull: always
@@ -592,6 +611,24 @@ steps:
   depends_on:
   - fetch-tags
 
+- name: integration-test
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make integration-test
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - fetch-tags
+
 - name: rootfs
   pull: always
   image: autonomy/build-container:latest
@@ -802,6 +839,7 @@ steps:
   depends_on:
   - container
   - osctl-linux
+  - integration-test
 
 - name: push
   pull: always
@@ -1201,6 +1239,24 @@ steps:
   depends_on:
   - fetch-tags
 
+- name: integration-test
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make integration-test
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - fetch-tags
+
 - name: rootfs
   pull: always
   image: autonomy/build-container:latest
@@ -1411,6 +1467,7 @@ steps:
   depends_on:
   - container
   - osctl-linux
+  - integration-test
 
 - name: push
   pull: always
@@ -1853,6 +1910,24 @@ steps:
   depends_on:
   - fetch-tags
 
+- name: integration-test
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make integration-test
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - fetch-tags
+
 - name: rootfs
   pull: always
   image: autonomy/build-container:latest
@@ -2063,6 +2138,7 @@ steps:
   depends_on:
   - container
   - osctl-linux
+  - integration-test
 
 - name: push
   pull: always
@@ -2505,6 +2581,24 @@ steps:
   depends_on:
   - fetch-tags
 
+- name: integration-test
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make integration-test
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - fetch-tags
+
 - name: rootfs
   pull: always
   image: autonomy/build-container:latest
@@ -2715,6 +2809,7 @@ steps:
   depends_on:
   - container
   - osctl-linux
+  - integration-test
 
 - name: push
   pull: always

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ container: buildkitd
 	@docker load < build/$@.tar
 
 .PHONY: basic-integration
-basic-integration: integration-test
+basic-integration:
 	@TAG=$(TAG) ./hack/test/$@.sh
 
 .PHONY: capi

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -137,9 +137,10 @@ local osd = Step("osd", depends_on=[fetchtags]);
 local trustd = Step("trustd", depends_on=[fetchtags]);
 local ntpd = Step("ntpd", depends_on=[fetchtags]);
 local networkd = Step("networkd", depends_on=[fetchtags]);
+local apid = Step("apid", depends_on=[fetchtags]);
 local osctl_linux = Step("osctl-linux", depends_on=[fetchtags]);
 local osctl_darwin = Step("osctl-darwin", depends_on=[fetchtags]);
-local apid = Step("apid", depends_on=[fetchtags]);
+local integration_test = Step("integration-test", depends_on=[fetchtags]);
 local rootfs =  Step("rootfs", depends_on=[machined, osd, trustd, ntpd, networkd, apid]);
 local initramfs = Step("initramfs", depends_on=[rootfs]);
 local installer = Step("installer", depends_on=[rootfs]);
@@ -150,7 +151,7 @@ local markdownlint = Step("markdownlint");
 local image_test = Step("image-test", depends_on=[installer]);
 local unit_tests = Step("unit-tests", depends_on=[rootfs]);
 local unit_tests_race = Step("unit-tests-race", depends_on=[lint]);
-local basic_integration = Step("basic-integration", depends_on=[container, osctl_linux]);
+local basic_integration = Step("basic-integration", depends_on=[container, osctl_linux, integration_test]);
 
 local coverage = {
   name: 'coverage',
@@ -196,6 +197,7 @@ local default_steps = [
   networkd,
   osctl_linux,
   osctl_darwin,
+  integration_test,
   rootfs,
   initramfs,
   installer,

--- a/hack/test/e2e-integration.sh
+++ b/hack/test/e2e-integration.sh
@@ -23,7 +23,7 @@ e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
          until [ -n \"\${STATUS_TALOSCONFIG}\" ]; do
            [[ \$(date +%s) -gt \$timeout ]] && exit 1
            sleep 10
-           STATUS_TALOSCONFIG=\$( KUBECONFIG=${TMP}/kubeconfig kubectl get talosconfig ${NAME_PREFIX}-controlplane-0 -o jsonpath='{.status.talosConfig}' ) 
+           STATUS_TALOSCONFIG=\$( KUBECONFIG=${TMP}/kubeconfig kubectl get talosconfig ${NAME_PREFIX}-controlplane-0 -o jsonpath='{.status.talosConfig}' )
          done
          echo \"\${STATUS_TALOSCONFIG}\" > ${TALOSCONFIG}"
 
@@ -74,6 +74,9 @@ e2e_run "timeout=\$((\$(date +%s) + ${TIMEOUT}))
 ## Print nodes so we know everything is healthy
 echo "E2E setup complete. List of nodes: "
 e2e_run "kubectl get nodes -o wide"
+
+## Run integration tests
+e2e_run "integration-test -test.v"
 
 ## Run conformance tests if var is not null
 if [ ${CONFORMANCE:-"dontrun"} == "run" ]; then

--- a/hack/test/e2e-runner.sh
+++ b/hack/test/e2e-runner.sh
@@ -4,6 +4,7 @@ export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
 export TMP="/tmp/e2e"
 export TMPPLATFORM="${TMP}/${PLATFORM}"
 export OSCTL="${PWD}/build/osctl-linux-amd64"
+export INTEGRATIONTEST="${PWD}/bin/integration-test"
 export TALOSCONFIG="${TMPPLATFORM}/talosconfig"
 export KUBECONFIG="${TMPPLATFORM}/kubeconfig"
 
@@ -40,6 +41,7 @@ e2e_run() {
          --mount type=bind,source=${TMP},target=${TMP} \
          --mount type=bind,source=${PWD}/hack/test/manifests,target=/e2emanifests \
          -v ${OSCTL}:/bin/osctl:ro \
+         -v ${INTEGRATIONTEST}:/bin/integration-test:ro \
          -e KUBECONFIG=${KUBECONFIG} \
          -e TALOSCONFIG=${TALOSCONFIG} \
          k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"

--- a/hack/test/manifests/aws-cluster.yaml
+++ b/hack/test/manifests/aws-cluster.yaml
@@ -22,7 +22,7 @@ spec:
         type: aws
       controlplane:
         count: 3
-        k8sversion: "1.16.1"
+        k8sversion: "1.16.2"
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine
@@ -126,4 +126,3 @@ spec:
                 disks:
                   size: 10
             type: aws
-

--- a/hack/test/manifests/azure-cluster.yaml
+++ b/hack/test/manifests/azure-cluster.yaml
@@ -23,7 +23,7 @@ spec:
         type: azure
       controlplane:
         count: 3
-        k8sversion: "1.16.1"
+        k8sversion: "1.16.2"
 ---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: Machine

--- a/hack/test/manifests/gcp-cluster.yaml
+++ b/hack/test/manifests/gcp-cluster.yaml
@@ -57,7 +57,7 @@ spec:
     kind: GCPMachine
     name: talos-e2e-{{TAG}}-gcp-controlplane-0
     namespace: default
-  version: 1.16.1
+  version: 1.16.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: GCPMachine
@@ -103,7 +103,7 @@ spec:
     kind: GCPMachine
     name: talos-e2e-{{TAG}}-gcp-controlplane-1
     namespace: default
-  version: 1.16.1
+  version: 1.16.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: GCPMachine
@@ -149,7 +149,7 @@ spec:
     kind: GCPMachine
     name: talos-e2e-{{TAG}}-gcp-controlplane-2
     namespace: default
-  version: 1.16.1
+  version: 1.16.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: GCPMachine
@@ -207,7 +207,7 @@ spec:
         kind: GCPMachineTemplate
         name: talos-e2e-{{TAG}}-gcp-workers
         namespace: default
-      version: 1.16.1
+      version: 1.16.2
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
 kind: GCPMachineTemplate


### PR DESCRIPTION
Also refactored `integration-test` build as a generic step to be shared
by basic-integration and e2e-integration steps.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>