### PR TITLE
chore: add simple health check for etcd service

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -23,6 +23,7 @@ import (
 	"go.etcd.io/etcd/clientv3"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
@@ -167,6 +168,23 @@ func (e *Etcd) Runner(config runtime.Configurator) (runner.Runner, error) {
 	),
 		restart.WithType(restart.Forever),
 	), nil
+}
+
+// HealthFunc implements the HealthcheckedService interface
+func (e *Etcd) HealthFunc(runtime.Configurator) health.Check {
+	return func(ctx context.Context) error {
+		client, err := etcd.NewClient([]string{"127.0.0.1:2379"})
+		if err != nil {
+			return err
+		}
+
+		return client.Close()
+	}
+}
+
+// HealthSettings implements the HealthcheckedService interface
+func (e *Etcd) HealthSettings(runtime.Configurator) *health.Settings {
+	return &health.DefaultSettings
 }
 
 // nolint: gocyclo

--- a/internal/app/machined/pkg/system/services/etcd_test.go
+++ b/internal/app/machined/pkg/system/services/etcd_test.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestEtcdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Etcd))
+}


### PR DESCRIPTION
Fixes #1419

This is required to avoid later startup failures while trying to connect
to etcd if it hasn't actually bootstrapped.

This health check does just connectivity check, no quorum/leader checks,
as they should depend on cluster state in general.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>