### PR TITLE
fix: pass x509 options to NewCertificateFromCSR

### DIFF
--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -195,7 +195,10 @@ func NewTalosCA() (ca *x509.CertificateAuthority, err error) {
 func NewAdminCertificateAndKey(crt, key []byte, loopback string) (p *x509.PEMEncodedCertificateAndKey, err error) {
 	ips := []net.IP{net.ParseIP(loopback)}
 
-	opts := []x509.Option{x509.IPAddresses(ips)}
+	opts := []x509.Option{
+		x509.IPAddresses(ips),
+		x509.NotAfter(time.Now().Add(87600 * time.Hour)),
+	}
 
 	caPemBlock, _ := pem.Decode(crt)
 	if caPemBlock == nil {

--- a/pkg/crypto/x509/x509.go
+++ b/pkg/crypto/x509/x509.go
@@ -646,7 +646,7 @@ func NewCertficateAndKey(crt *x509.Certificate, key interface{}, setters ...Opti
 		return nil, fmt.Errorf("failed to parse CSR: %w", err)
 	}
 
-	c, err = NewCertificateFromCSR(crt, key, cr)
+	c, err = NewCertificateFromCSR(crt, key, cr, setters...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create certificate from CSR: %w", err)
 	}


### PR DESCRIPTION
This ensures that certificates are generated with the supplied options.

Fixes #1401.