### PR TITLE
chore: re-enable e2e for aws clusters

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1026,6 +1026,26 @@ steps:
   depends_on:
   - image-gcp
 
+- name: e2e-integration-aws
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make e2e-integration
+  environment:
+    BINDIR: /usr/local/bin
+    BUILDKIT_HOST: ${BUILDKIT_HOST=tcp://buildkitd.ci.svc:1234}
+    PLATFORM: aws
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - capi
+  - push-image-aws
+
 - name: e2e-integration-gcp
   pull: always
   image: autonomy/build-container:latest

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ image-vmware:
 
 .PHONY: push-image-aws
 push-image-aws:
-	@TAG=$(TAG) ./hack/test/aws-setup.sh
+	@TAG=$(TAG) SHA=$(SHA) ./hack/test/aws-setup.sh
 
 .PHONY: push-image-azure
 push-image-azure:

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -260,7 +260,7 @@ local e2e_steps = default_steps + [
   push_image_aws,
   push_image_azure,
   push_image_gcp,
-  //e2e_integration_aws,
+  e2e_integration_aws,
   // e2e_integration_azure,
   e2e_integration_gcp,
 ];

--- a/hack/test/aws-setup.sh
+++ b/hack/test/aws-setup.sh
@@ -57,5 +57,5 @@ ami=$(aws ec2 register-image --region ${REGION} \
 
 ## Setup the cluster YAML.
 sed -e "s#{{REGION}}#${REGION}#g" \
-    -e "s/{{TAG}}/${TAG}/" \
+    -e "s/{{TAG}}/${SHA}/" \
     -e "s#{{AMI}}#${ami}#g" ${PWD}/hack/test/manifests/aws-cluster.yaml > ${TMP}/cluster.yaml

--- a/hack/test/capi.sh
+++ b/hack/test/capi.sh
@@ -9,8 +9,15 @@ source ./hack/test/e2e-runner.sh
 mkdir -p ${TMP}
 cp ${PWD}/hack/test/manifests/provider-components.yaml ${TMP}/provider-components.yaml
 
-## Template out gcp components
+## Installs envsubst command
 apk add --no-cache gettext
+
+## Template out aws components
+## Using a local copy until v0.5.0 of the provider is cut.
+export AWS_B64ENCODED_CREDENTIALS=${AWS_SVC_ACCT}
+cat ${PWD}/hack/test/manifests/capa-components.yaml| envsubst > ${TMP}/capa-components.yaml
+
+## Template out gcp components
 export GCP_B64ENCODED_CREDENTIALS=${GCE_SVC_ACCT} 
 cat ${PWD}/hack/test/manifests/capg-components.yaml| envsubst > ${TMP}/capg-components.yaml
 ##Until next alpha release, keep a local copy of capg-components.yaml. 
@@ -20,6 +27,7 @@ cat ${PWD}/hack/test/manifests/capg-components.yaml| envsubst > ${TMP}/capg-comp
 ## Drop in capi stuff
 e2e_run "kubectl apply -f ${TMP}/provider-components.yaml"
 e2e_run "kubectl apply -f ${CAPI_COMPONENTS}"
+e2e_run "kubectl apply -f ${TMP}/capa-components.yaml"
 e2e_run "kubectl apply -f ${TMP}/capg-components.yaml"
 
 ## Wait for talosconfig in cm then dump it out

--- a/hack/test/manifests/aws-cluster.yaml
+++ b/hack/test/manifests/aws-cluster.yaml
@@ -1,128 +1,240 @@
-apiVersion: cluster.k8s.io/v1alpha1
+## Cluster configs
+
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Cluster
 metadata:
-  annotations: null
   name: talos-e2e-{{TAG}}-aws
+  namespace: default
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - 192.168.0.0/16
-    serviceDomain: cluster.local
-    services:
-      cidrBlocks:
-        - 10.96.0.0/12
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosClusterProviderSpec
-      platform:
-        config: |-
-          region: "{{REGION}}"
-        type: aws
-      controlplane:
-        count: 3
-        k8sversion: "1.16.2"
+      - 192.168.0.0/16
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: AWSCluster
+    name: talos-e2e-{{TAG}}-aws
+    namespace: default
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSCluster
+metadata:
+  name: talos-e2e-{{TAG}}-aws
+  namespace: default
+spec:
+  region: {{REGION}}
+  sshKeyName: debug
+  networkSpec:
+    vpc:
+      id: "vpc-ff5c5687"
+---
+
+## Controlplane 0 configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfig
+metadata:
+  name: talos-e2e-{{TAG}}-aws-controlplane-0
+  namespace: default
+spec:
+  machineType: init
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    set: master
-  name: talos-e2e-{{TAG}}-aws-master-0
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
+    cluster.x-k8s.io/control-plane: "true"
+  name: talos-e2e-{{TAG}}-aws-controlplane-0
+  namespace: default
 spec:
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosMachineProviderSpec
-      platform:
-        config: |-
-          region: "{{REGION}}"
-          instances:
-            type:  "t3.small"
-            ami: "{{AMI}}"
-            keypair: "e2e"
-            disks:
-              size: 10
-        type: aws
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: TalosConfig
+      name: talos-e2e-{{TAG}}-aws-controlplane-0
+      namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: AWSMachine
+    name: talos-e2e-{{TAG}}-aws-controlplane-0
+    namespace: default
+  version: 1.16.2
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: talos-e2e-{{TAG}}-aws-controlplane-0
+  namespace: default
+spec:
+  instanceType: t3.small
+  sshKeyName: debug
+  ami:
+    id: {{AMI}}
+  subnet:
+    id: "subnet-c4e9b3a0"
+  additionalSecurityGroups:
+    - id: "sg-ebe8e59f"
+  publicIP: true
+---
+
+## Controlplane 1 configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfig
+metadata:
+  name: talos-e2e-{{TAG}}-aws-controlplane-1
+  namespace: default
+spec:
+  machineType: controlplane
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    set: master
-  name: talos-e2e-{{TAG}}-aws-master-1
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
+    cluster.x-k8s.io/control-plane: "true"
+  name: talos-e2e-{{TAG}}-aws-controlplane-1
+  namespace: default
 spec:
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosMachineProviderSpec
-      platform:
-        config: |-
-          region: "{{REGION}}"
-          instances:
-            type:  "t3.small"
-            ami: "{{AMI}}"
-            keypair: "e2e"
-            disks:
-              size: 10
-        type: aws
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: TalosConfig
+      name: talos-e2e-{{TAG}}-aws-controlplane-1
+      namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: AWSMachine
+    name: talos-e2e-{{TAG}}-aws-controlplane-1
+    namespace: default
+  version: 1.16.2
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: talos-e2e-{{TAG}}-aws-controlplane-1
+  namespace: default
+spec:
+  instanceType: t3.small
+  sshKeyName: debug
+  ami:
+    id: {{AMI}}
+  subnet:
+    id: "subnet-c4e9b3a0"
+  additionalSecurityGroups:
+    - id: "sg-ebe8e59f"
+  publicIP: true
+---
+
+## Controlplane 2 configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfig
+metadata:
+  name: talos-e2e-{{TAG}}-aws-controlplane-2
+  namespace: default
+spec:
+  machineType: controlplane
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: Machine
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    set: master
-  name: talos-e2e-{{TAG}}-aws-master-2
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
+    cluster.x-k8s.io/control-plane: "true"
+  name: talos-e2e-{{TAG}}-aws-controlplane-2
+  namespace: default
 spec:
-  providerSpec:
-    value:
-      apiVersion: talosproviderconfig/v1alpha1
-      kind: TalosMachineProviderSpec
-      platform:
-        config: |-
-          region: "{{REGION}}"
-          instances:
-            type:  "t3.small"
-            ami: "{{AMI}}"
-            keypair: "e2e"
-            disks:
-              size: 10
-        type: aws
+  bootstrap:
+    configRef:
+      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+      kind: TalosConfig
+      name: talos-e2e-{{TAG}}-aws-controlplane-2
+      namespace: default
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+    kind: AWSMachine
+    name: talos-e2e-{{TAG}}-aws-controlplane-2
+    namespace: default
+  version: 1.16.2
 ---
-apiVersion: cluster.k8s.io/v1alpha1
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachine
+metadata:
+  name: talos-e2e-{{TAG}}-aws-controlplane-2
+  namespace: default
+spec:
+  instanceType: t3.small
+  sshKeyName: debug
+  ami:
+    id: {{AMI}}
+  subnet:
+    id: "subnet-c4e9b3a0"
+  additionalSecurityGroups:
+    - id: "sg-ebe8e59f"
+  publicIP: true
+---
+
+## Worker deployment configs
+
+apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+kind: TalosConfigTemplate
+metadata:
+  name: talos-e2e-{{TAG}}-aws-workers
+  namespace: default
+spec:
+  template:
+    spec:
+      machineType: "join"
+---
+apiVersion: cluster.x-k8s.io/v1alpha2
 kind: MachineDeployment
 metadata:
   labels:
-    cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    set: worker
+    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
+    nodepool: nodepool-0
   name: talos-e2e-{{TAG}}-aws-workers
+  namespace: default
 spec:
   replicas: 3
   selector:
     matchLabels:
-      cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-      set: worker
+      cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
+      nodepool: nodepool-0
   template:
     metadata:
       labels:
-        cluster.k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-        set: worker
+        cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
+        nodepool: nodepool-0
     spec:
-      providerSpec:
-        value:
-          apiVersion: talosproviderconfig/v1alpha1
-          kind: TalosMachineProviderSpec
-          platform:
-            config: |-
-              region: "{{REGION}}"
-              instances:
-                type:  "t3.small"
-                ami: "{{AMI}}"
-                keypair: "e2e"
-                disks:
-                  size: 10
-            type: aws
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha2
+          kind: TalosConfigTemplate
+          name: talos-e2e-{{TAG}}-aws-workers
+          namespace: default
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+        kind: AWSMachineTemplate
+        name: talos-e2e-{{TAG}}-aws-workers
+        namespace: default
+      version: 1.16.2
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
+kind: AWSMachineTemplate
+metadata:
+  name: talos-e2e-{{TAG}}-aws-workers
+  namespace: default
+spec:
+  template:
+    spec:
+      instanceType: t3.small
+      sshKeyName: debug
+      ami:
+        id: {{AMI}}
+      subnet:
+        id: "subnet-c4e9b3a0"
+      additionalSecurityGroups:
+        - id: "sg-ebe8e59f"
+      publicIP: true

--- a/hack/test/manifests/capa-components.yaml
+++ b/hack/test/manifests/capa-components.yaml
@@ -1,0 +1,1121 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: capa-controller-manager
+  name: capa-system
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: awsclusters.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSCluster
+    listKind: AWSClusterList
+    plural: awsclusters
+    singular: awscluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: AWSCluster is the Schema for the awsclusters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AWSClusterSpec defines the desired state of AWSCluster
+          properties:
+            additionalTags:
+              additionalProperties:
+                type: string
+              description: AdditionalTags is an optional set of tags to add to AWS
+                resources managed by the AWS provider, in addition to the ones added
+                by default.
+              type: object
+            controlPlaneLoadBalancer:
+              description: ControlPlaneLoadBalancer is optional configuration for
+                customizing control plane behavior
+              properties:
+                scheme:
+                  description: Scheme sets the scheme of the load balancer (defaults
+                    to Internet-facing)
+                  type: string
+              type: object
+            networkSpec:
+              description: NetworkSpec encapsulates all things related to AWS network.
+              properties:
+                subnets:
+                  description: Subnets configuration.
+                  items:
+                    description: SubnetSpec configures an AWS Subnet.
+                    properties:
+                      availabilityZone:
+                        description: AvailabilityZone defines the availability zone
+                          to use for this subnet in the cluster's region.
+                        type: string
+                      cidrBlock:
+                        description: CidrBlock is the CIDR block to be used when the
+                          provider creates a managed VPC.
+                        type: string
+                      id:
+                        description: ID defines a unique identifier to reference this
+                          resource.
+                        type: string
+                      isPublic:
+                        description: IsPublic defines the subnet as a public subnet.
+                          A subnet is public when it is associated with a route table
+                          that has a route to an internet gateway.
+                        type: boolean
+                      natGatewayId:
+                        description: NatGatewayID is the NAT gateway id associated
+                          with the subnet. Ignored unless the subnet is managed by
+                          the provider, in which case this is set on the public subnet
+                          where the NAT gateway resides. It is then used to determine
+                          routes for private subnets in the same AZ as the public
+                          subnet.
+                        type: string
+                      routeTableId:
+                        description: RouteTableID is the routing table id associated
+                          with the subnet.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a collection of tags describing the resource.
+                        type: object
+                    type: object
+                  type: array
+                vpc:
+                  description: VPC configuration.
+                  properties:
+                    cidrBlock:
+                      description: CidrBlock is the CIDR block to be used when the
+                        provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                      type: string
+                    id:
+                      description: ID is the vpc-id of the VPC this provider should
+                        use to create resources.
+                      type: string
+                    internetGatewayId:
+                      description: InternetGatewayID is the id of the internet gateway
+                        associated with the VPC.
+                      type: string
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: Tags is a collection of tags describing the resource.
+                      type: object
+                  type: object
+              type: object
+            region:
+              description: The AWS Region the cluster lives in.
+              type: string
+            sshKeyName:
+              description: SSHKeyName is the name of the ssh key to attach to the
+                bastion host.
+              type: string
+          type: object
+        status:
+          description: AWSClusterStatus defines the observed state of AWSCluster
+          properties:
+            apiEndpoints:
+              description: APIEndpoints represents the endpoints to communicate with
+                the control plane.
+              items:
+                description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              type: array
+            bastion:
+              description: Instance describes an AWS instance.
+              properties:
+                ebsOptimized:
+                  description: Indicates whether the instance is optimized for Amazon
+                    EBS I/O.
+                  type: boolean
+                enaSupport:
+                  description: Specifies whether enhanced networking with ENA is enabled.
+                  type: boolean
+                iamProfile:
+                  description: The name of the IAM instance profile associated with
+                    the instance, if applicable.
+                  type: string
+                id:
+                  type: string
+                imageId:
+                  description: The ID of the AMI used to launch the instance.
+                  type: string
+                instanceState:
+                  description: The current state of the instance.
+                  type: string
+                networkInterfaces:
+                  description: Specifies ENIs attached to instance
+                  items:
+                    type: string
+                  type: array
+                privateIp:
+                  description: The private IPv4 address assigned to the instance.
+                  type: string
+                publicIp:
+                  description: The public IPv4 address assigned to the instance, if
+                    applicable.
+                  type: string
+                rootDeviceSize:
+                  description: Specifies size (in Gi) of the root storage device
+                  format: int64
+                  type: integer
+                securityGroupIds:
+                  description: SecurityGroupIDs are one or more security group IDs
+                    this instance belongs to.
+                  items:
+                    type: string
+                  type: array
+                sshKeyName:
+                  description: The name of the SSH key pair.
+                  type: string
+                subnetId:
+                  description: The ID of the subnet of the instance.
+                  type: string
+                tags:
+                  additionalProperties:
+                    type: string
+                  description: The tags associated with the instance.
+                  type: object
+                type:
+                  description: The instance type.
+                  type: string
+                userData:
+                  description: UserData is the raw data script passed to the instance
+                    which is run upon bootstrap. This field must not be base64 encoded
+                    and should only be used when running a new instance.
+                  type: string
+              required:
+              - id
+              type: object
+            network:
+              description: Network encapsulates AWS networking resources.
+              properties:
+                apiServerElb:
+                  description: APIServerELB is the Kubernetes api server classic load
+                    balancer.
+                  properties:
+                    attributes:
+                      description: Attributes defines extra attributes associated
+                        with the load balancer.
+                      properties:
+                        idleTimeout:
+                          description: IdleTimeout is time that the connection is
+                            allowed to be idle (no data has been sent over the connection)
+                            before it is closed by the load balancer.
+                          format: int64
+                          type: integer
+                      type: object
+                    dnsName:
+                      description: DNSName is the dns name of the load balancer.
+                      type: string
+                    healthChecks:
+                      description: HealthCheck is the classic elb health check associated
+                        with the load balancer.
+                      properties:
+                        healthyThreshold:
+                          format: int64
+                          type: integer
+                        interval:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        target:
+                          type: string
+                        timeout:
+                          description: A Duration represents the elapsed time between
+                            two instants as an int64 nanosecond count. The representation
+                            limits the largest representable duration to approximately
+                            290 years.
+                          format: int64
+                          type: integer
+                        unhealthyThreshold:
+                          format: int64
+                          type: integer
+                      required:
+                      - healthyThreshold
+                      - interval
+                      - target
+                      - timeout
+                      - unhealthyThreshold
+                      type: object
+                    listeners:
+                      description: Listeners is an array of classic elb listeners
+                        associated with the load balancer. There must be at least
+                        one.
+                      items:
+                        description: ClassicELBListener defines an AWS classic load
+                          balancer listener.
+                        properties:
+                          instancePort:
+                            format: int64
+                            type: integer
+                          instanceProtocol:
+                            description: ClassicELBProtocol defines listener protocols
+                              for a classic load balancer.
+                            type: string
+                          port:
+                            format: int64
+                            type: integer
+                          protocol:
+                            description: ClassicELBProtocol defines listener protocols
+                              for a classic load balancer.
+                            type: string
+                        required:
+                        - instancePort
+                        - instanceProtocol
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                    name:
+                      description: The name of the load balancer. It must be unique
+                        within the set of load balancers defined in the region. It
+                        also serves as identifier.
+                      type: string
+                    scheme:
+                      description: Scheme is the load balancer scheme, either internet-facing
+                        or private.
+                      type: string
+                    securityGroupIds:
+                      description: SecurityGroupIDs is an array of security groups
+                        assigned to the load balancer.
+                      items:
+                        type: string
+                      type: array
+                    subnetIds:
+                      description: SubnetIDs is an array of subnets in the VPC attached
+                        to the load balancer.
+                      items:
+                        type: string
+                      type: array
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: Tags is a map of tags associated with the load
+                        balancer.
+                      type: object
+                  type: object
+                securityGroups:
+                  additionalProperties:
+                    description: SecurityGroup defines an AWS security group.
+                    properties:
+                      id:
+                        description: ID is a unique identifier.
+                        type: string
+                      ingressRule:
+                        description: IngressRules is the inbound rules associated
+                          with the security group.
+                        items:
+                          description: IngressRule defines an AWS ingress rule for
+                            security groups.
+                          properties:
+                            cidrBlocks:
+                              description: List of CIDR blocks to allow access from.
+                                Cannot be specified with SourceSecurityGroupID.
+                              items:
+                                type: string
+                              type: array
+                            description:
+                              type: string
+                            fromPort:
+                              format: int64
+                              type: integer
+                            protocol:
+                              description: SecurityGroupProtocol defines the protocol
+                                type for a security group rule.
+                              type: string
+                            sourceSecurityGroupIds:
+                              description: The security group id to allow access from.
+                                Cannot be specified with CidrBlocks.
+                              items:
+                                type: string
+                              type: array
+                            toPort:
+                              format: int64
+                              type: integer
+                          required:
+                          - description
+                          - fromPort
+                          - protocol
+                          - toPort
+                          type: object
+                        type: array
+                      name:
+                        description: Name is the security group name.
+                        type: string
+                      tags:
+                        additionalProperties:
+                          type: string
+                        description: Tags is a map of tags associated with the security
+                          group.
+                        type: object
+                    required:
+                    - id
+                    - name
+                    type: object
+                  description: SecurityGroups is a map from the role/kind of the security
+                    group to its unique name, if any.
+                  type: object
+              type: object
+            ready:
+              type: boolean
+          required:
+          - ready
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: awsmachines.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSMachine
+    listKind: AWSMachineList
+    plural: awsmachines
+    singular: awsmachine
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: AWSMachine is the Schema for the awsmachines API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AWSMachineSpec defines the desired state of AWSMachine
+          properties:
+            additionalSecurityGroups:
+              description: AdditionalSecurityGroups is an array of references to security
+                groups that should be applied to the instance. These security groups
+                would be set in addition to any security groups defined at the cluster
+                level or in the actuator.
+              items:
+                description: AWSResourceReference is a reference to a specific AWS
+                  resource by ID, ARN, or filters. Only one of ID, ARN or Filters
+                  may be specified. Specifying more than one will result in a validation
+                  error.
+                properties:
+                  arn:
+                    description: ARN of resource
+                    type: string
+                  filters:
+                    description: 'Filters is a set of key/value pairs used to identify
+                      a resource They are applied according to the rules defined by
+                      the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                    items:
+                      description: Filter is a filter used to identify an AWS resource
+                      properties:
+                        name:
+                          description: Name of the filter. Filter names are case-sensitive.
+                          type: string
+                        values:
+                          description: Values includes one or more filter values.
+                            Filter values are case-sensitive.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      - values
+                      type: object
+                    type: array
+                  id:
+                    description: ID of resource
+                    type: string
+                type: object
+              type: array
+            additionalTags:
+              additionalProperties:
+                type: string
+              description: AdditionalTags is an optional set of tags to add to an
+                instance, in addition to the ones added by default by the AWS provider.
+                If both the AWSCluster and the AWSMachine specify the same tag name
+                with different values, the AWSMachine's value takes precedence.
+              type: object
+            ami:
+              description: AMI is the reference to the AMI from which to create the
+                machine instance.
+              properties:
+                arn:
+                  description: ARN of resource
+                  type: string
+                filters:
+                  description: 'Filters is a set of key/value pairs used to identify
+                    a resource They are applied according to the rules defined by
+                    the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                  items:
+                    description: Filter is a filter used to identify an AWS resource
+                    properties:
+                      name:
+                        description: Name of the filter. Filter names are case-sensitive.
+                        type: string
+                      values:
+                        description: Values includes one or more filter values. Filter
+                          values are case-sensitive.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - name
+                    - values
+                    type: object
+                  type: array
+                id:
+                  description: ID of resource
+                  type: string
+              type: object
+            availabilityZone:
+              description: AvailabilityZone is references the AWS availability zone
+                to use for this instance. If multiple subnets are matched for the
+                availability zone, the first one return is picked.
+              type: string
+            iamInstanceProfile:
+              description: IAMInstanceProfile is a name of an IAM instance profile
+                to assign to the instance
+              type: string
+            imageLookupOrg:
+              description: ImageLookupOrg is the AWS Organization ID to use for image
+                lookup if AMI is not set.
+              type: string
+            instanceType:
+              description: 'InstanceType is the type of instance to create. Example:
+                m4.xlarge'
+              type: string
+            networkInterfaces:
+              description: NetworkInterfaces is a list of ENIs to associate with the
+                instance. A maximum of 2 may be specified.
+              items:
+                type: string
+              maxItems: 2
+              type: array
+            providerID:
+              description: ProviderID is the unique identifier as specified by the
+                cloud provider.
+              type: string
+            publicIP:
+              description: 'PublicIP specifies whether the instance should get a public
+                IP. Precedence for this setting is as follows: 1. This field if set
+                2. Cluster/flavor setting 3. Subnet default'
+              type: boolean
+            rootDeviceSize:
+              description: RootDeviceSize is the size of the root volume in gigabytes(GB).
+              format: int64
+              type: integer
+            sshKeyName:
+              description: SSHKeyName is the name of the ssh key to attach to the
+                instance.
+              type: string
+            subnet:
+              description: Subnet is a reference to the subnet to use for this instance.
+                If not specified, the cluster subnet will be used.
+              properties:
+                arn:
+                  description: ARN of resource
+                  type: string
+                filters:
+                  description: 'Filters is a set of key/value pairs used to identify
+                    a resource They are applied according to the rules defined by
+                    the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                  items:
+                    description: Filter is a filter used to identify an AWS resource
+                    properties:
+                      name:
+                        description: Name of the filter. Filter names are case-sensitive.
+                        type: string
+                      values:
+                        description: Values includes one or more filter values. Filter
+                          values are case-sensitive.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - name
+                    - values
+                    type: object
+                  type: array
+                id:
+                  description: ID of resource
+                  type: string
+              type: object
+          type: object
+        status:
+          description: AWSMachineStatus defines the observed state of AWSMachine
+          properties:
+            addresses:
+              description: Addresses contains the AWS instance associated addresses.
+              items:
+                description: NodeAddress contains information for the node's address.
+                properties:
+                  address:
+                    description: The node address.
+                    type: string
+                  type:
+                    description: Node address type, one of Hostname, ExternalIP or
+                      InternalIP.
+                    type: string
+                required:
+                - address
+                - type
+                type: object
+              type: array
+            errorMessage:
+              description: "ErrorMessage will be set in the event that there is a
+                terminal problem reconciling the Machine and will contain a more verbose
+                string suitable for logging and human consumption. \n This field should
+                not be set for transitive errors that a controller faces that are
+                expected to be fixed automatically over time (like service outages),
+                but instead indicate that something is fundamentally wrong with the
+                Machine's spec or the configuration of the controller, and that manual
+                intervention is required. Examples of terminal errors would be invalid
+                combinations of settings in the spec, values that are unsupported
+                by the controller, or the responsible controller itself being critically
+                misconfigured. \n Any transient errors that occur during the reconciliation
+                of Machines can be added as events to the Machine object and/or logged
+                in the controller's output."
+              type: string
+            errorReason:
+              description: "ErrorReason will be set in the event that there is a terminal
+                problem reconciling the Machine and will contain a succinct value
+                suitable for machine interpretation. \n This field should not be set
+                for transitive errors that a controller faces that are expected to
+                be fixed automatically over time (like service outages), but instead
+                indicate that something is fundamentally wrong with the Machine's
+                spec or the configuration of the controller, and that manual intervention
+                is required. Examples of terminal errors would be invalid combinations
+                of settings in the spec, values that are unsupported by the controller,
+                or the responsible controller itself being critically misconfigured.
+                \n Any transient errors that occur during the reconciliation of Machines
+                can be added as events to the Machine object and/or logged in the
+                controller's output."
+              type: string
+            instanceState:
+              description: InstanceState is the state of the AWS instance for this
+                machine.
+              type: string
+            ready:
+              description: Ready is true when the provider resource is ready.
+              type: boolean
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: awsmachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: AWSMachineTemplate
+    listKind: AWSMachineTemplateList
+    plural: awsmachinetemplates
+    singular: awsmachinetemplate
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: AWSMachineTemplate is the Schema for the awsmachinetemplates API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AWSMachineTemplateSpec defines the desired state of AWSMachineTemplate
+          properties:
+            template:
+              description: AWSMachineTemplateResource describes the data needed to
+                create am AWSMachine from a template
+              properties:
+                spec:
+                  description: Spec is the specification of the desired behavior of
+                    the machine.
+                  properties:
+                    additionalSecurityGroups:
+                      description: AdditionalSecurityGroups is an array of references
+                        to security groups that should be applied to the instance.
+                        These security groups would be set in addition to any security
+                        groups defined at the cluster level or in the actuator.
+                      items:
+                        description: AWSResourceReference is a reference to a specific
+                          AWS resource by ID, ARN, or filters. Only one of ID, ARN
+                          or Filters may be specified. Specifying more than one will
+                          result in a validation error.
+                        properties:
+                          arn:
+                            description: ARN of resource
+                            type: string
+                          filters:
+                            description: 'Filters is a set of key/value pairs used
+                              to identify a resource They are applied according to
+                              the rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                            items:
+                              description: Filter is a filter used to identify an
+                                AWS resource
+                              properties:
+                                name:
+                                  description: Name of the filter. Filter names are
+                                    case-sensitive.
+                                  type: string
+                                values:
+                                  description: Values includes one or more filter
+                                    values. Filter values are case-sensitive.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - name
+                              - values
+                              type: object
+                            type: array
+                          id:
+                            description: ID of resource
+                            type: string
+                        type: object
+                      type: array
+                    additionalTags:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalTags is an optional set of tags to add
+                        to an instance, in addition to the ones added by default by
+                        the AWS provider. If both the AWSCluster and the AWSMachine
+                        specify the same tag name with different values, the AWSMachine's
+                        value takes precedence.
+                      type: object
+                    ami:
+                      description: AMI is the reference to the AMI from which to create
+                        the machine instance.
+                      properties:
+                        arn:
+                          description: ARN of resource
+                          type: string
+                        filters:
+                          description: 'Filters is a set of key/value pairs used to
+                            identify a resource They are applied according to the
+                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                          items:
+                            description: Filter is a filter used to identify an AWS
+                              resource
+                            properties:
+                              name:
+                                description: Name of the filter. Filter names are
+                                  case-sensitive.
+                                type: string
+                              values:
+                                description: Values includes one or more filter values.
+                                  Filter values are case-sensitive.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - name
+                            - values
+                            type: object
+                          type: array
+                        id:
+                          description: ID of resource
+                          type: string
+                      type: object
+                    availabilityZone:
+                      description: AvailabilityZone is references the AWS availability
+                        zone to use for this instance. If multiple subnets are matched
+                        for the availability zone, the first one return is picked.
+                      type: string
+                    iamInstanceProfile:
+                      description: IAMInstanceProfile is a name of an IAM instance
+                        profile to assign to the instance
+                      type: string
+                    imageLookupOrg:
+                      description: ImageLookupOrg is the AWS Organization ID to use
+                        for image lookup if AMI is not set.
+                      type: string
+                    instanceType:
+                      description: 'InstanceType is the type of instance to create.
+                        Example: m4.xlarge'
+                      type: string
+                    networkInterfaces:
+                      description: NetworkInterfaces is a list of ENIs to associate
+                        with the instance. A maximum of 2 may be specified.
+                      items:
+                        type: string
+                      maxItems: 2
+                      type: array
+                    providerID:
+                      description: ProviderID is the unique identifier as specified
+                        by the cloud provider.
+                      type: string
+                    publicIP:
+                      description: 'PublicIP specifies whether the instance should
+                        get a public IP. Precedence for this setting is as follows:
+                        1. This field if set 2. Cluster/flavor setting 3. Subnet default'
+                      type: boolean
+                    rootDeviceSize:
+                      description: RootDeviceSize is the size of the root volume in
+                        gigabytes(GB).
+                      format: int64
+                      type: integer
+                    sshKeyName:
+                      description: SSHKeyName is the name of the ssh key to attach
+                        to the instance.
+                      type: string
+                    subnet:
+                      description: Subnet is a reference to the subnet to use for
+                        this instance. If not specified, the cluster subnet will be
+                        used.
+                      properties:
+                        arn:
+                          description: ARN of resource
+                          type: string
+                        filters:
+                          description: 'Filters is a set of key/value pairs used to
+                            identify a resource They are applied according to the
+                            rules defined by the AWS API: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html'
+                          items:
+                            description: Filter is a filter used to identify an AWS
+                              resource
+                            properties:
+                              name:
+                                description: Name of the filter. Filter names are
+                                  case-sensitive.
+                                type: string
+                              values:
+                                description: Values includes one or more filter values.
+                                  Filter values are case-sensitive.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - name
+                            - values
+                            type: object
+                          type: array
+                        id:
+                          description: ID of resource
+                          type: string
+                      type: object
+                  type: object
+              required:
+              - spec
+              type: object
+          required:
+          - template
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capa-leader-election-role
+  namespace: capa-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: capa-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachines/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: capa-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: capa-leader-election-rolebinding
+  namespace: capa-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capa-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capa-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capa-manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capa-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: capa-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capa-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capa-system
+---
+apiVersion: v1
+data:
+  credentials: ${AWS_B64ENCODED_CREDENTIALS}
+kind: Secret
+metadata:
+  name: capa-manager-bootstrap-credentials
+  namespace: capa-system
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    control-plane: capa-controller-manager
+  name: capa-controller-manager-metrics-service
+  namespace: capa-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: capa-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: capa-controller-manager
+  name: capa-controller-manager
+  namespace: capa-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: capa-controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: capa-controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        env:
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /home/.aws/credentials
+        image: rsmitty/cluster-api-aws-controller-amd64:5c33007
+        imagePullPolicy: IfNotPresent
+        name: manager
+        volumeMounts:
+        - mountPath: /home/.aws
+          name: credentials
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      volumes:
+      - name: credentials
+        secret:
+          secretName: capa-manager-bootstrap-credentials


### PR DESCRIPTION
This PR adds in the necessary manifests and fixes to deploy aws clusters
as part of e2e testing.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>