### PR TITLE
feat(networkd): Add support for custom nameservers

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1/reference.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1/reference.md
@@ -37,6 +37,7 @@ machine:
     extraArgs: []string
   network: (optional)
     hostname: string
+    nameservers: []string
     interfaces:
       - interface: string
         cidr: string
@@ -120,6 +121,10 @@ The only supported environment variables are:
 #### machine.network.hostname
 
 `hostname` can be used to statically set the hostname for the host.
+
+#### machine.network.nameservers
+
+`nameservers` can be used to statically set the nameservers for the host.
 
 #### machine.network.interfaces
 

--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -16,8 +16,9 @@ import (
 
 // Static implements the Addressing interface
 type Static struct {
-	Device *machine.Device
-	NetIf  *net.Interface
+	Device      *machine.Device
+	NetIf       *net.Interface
+	NameServers []string
 }
 
 // Discover doesnt do anything in the static configuration since all
@@ -91,10 +92,17 @@ func (s *Static) Routes() (routes []*Route) {
 }
 
 // Resolvers returns the DNS resolvers
-// TODO: Currently we dont support specifying resolvers via config
 func (s *Static) Resolvers() []net.IP {
-	// TODO: Think about how we want to expose this via config
-	return []net.IP{}
+	if len(s.NameServers) == 0 {
+		return []net.IP{}
+	}
+
+	resolvers := make([]net.IP, 0, len(s.NameServers))
+	for _, resolver := range s.NameServers {
+		resolvers = append(resolvers, net.ParseIP(resolver))
+	}
+
+	return resolvers
 }
 
 // Hostname returns the hostname

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -37,13 +37,8 @@ func (n *NetConf) BuildOptions(config runtime.Configurator) error {
 			}
 
 			if device.CIDR != "" {
-				s := &address.Static{Device: &device, NetIf: link}
+				s := &address.Static{Device: &device, NetIf: link, NameServers: config.Machine().Network().Resolvers()}
 				(*n)[link] = append(opts, nic.WithAddressing(s))
-			}
-
-			// Configure MTU
-			if device.MTU != 0 {
-				(*n)[link] = append(opts, nic.WithMTU(uint32(device.MTU)))
 			}
 		}
 	}

--- a/internal/app/networkd/pkg/networkd/netconf_test.go
+++ b/internal/app/networkd/pkg/networkd/netconf_test.go
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package networkd
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/machine"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+)
+
+type NetconfSuite struct {
+	suite.Suite
+}
+
+func TestNetconfSuite(t *testing.T) {
+	// Hide all our state transition messages
+	// log.SetOutput(ioutil.Discard)
+	suite.Run(t, new(NetconfSuite))
+}
+
+func (suite *NetconfSuite) TestNetconf() {
+	conf := sampleConfig()
+	eth0 := &net.Interface{Index: 1, MTU: 1500, Name: "eth0"}
+	nc := NetConf{eth0: []nic.Option{nic.WithName(eth0.Name)}}
+	err := nc.BuildOptions(conf)
+	suite.Assert().NoError(err)
+
+	iface, err := nic.Create(eth0, nc[eth0]...)
+	suite.Assert().NoError(err)
+
+	suite.Assert().Equal(iface.AddressMethod[0].Resolvers()[0], net.ParseIP(conf.Machine().Network().Resolvers()[0]))
+	suite.Assert().Equal(iface.AddressMethod[0].Resolvers()[1], net.ParseIP(conf.Machine().Network().Resolvers()[1]))
+	suite.Assert().Equal(int(iface.AddressMethod[0].MTU()), conf.Machine().Network().Devices()[0].MTU)
+	// nolint: errcheck
+	addr, _, _ := net.ParseCIDR(conf.Machine().Network().Devices()[0].CIDR)
+	suite.Assert().Equal(iface.AddressMethod[0].Address().IP, addr)
+}
+
+func sampleConfig() runtime.Configurator {
+	return &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNetwork: &v1alpha1.NetworkConfig{
+				NameServers:     []string{"1.2.3.4", "2.3.4.5"},
+				NetworkHostname: "myhostname",
+				NetworkInterfaces: []machine.Device{
+					{
+						Interface: "eth0",
+						CIDR:      "192.168.0.10/24",
+						MTU:       9100,
+						DHCP:      false,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -61,6 +61,7 @@ type Security interface {
 type Network interface {
 	Hostname() string
 	SetHostname(string)
+	Resolvers() []string
 	Devices() []Device
 }
 

--- a/pkg/config/types/v1alpha1/network_config.go
+++ b/pkg/config/types/v1alpha1/network_config.go
@@ -20,6 +20,7 @@ import (
 type NetworkConfig struct {
 	NetworkHostname   string           `yaml:"hostname,omitempty"`
 	NetworkInterfaces []machine.Device `yaml:"interfaces,omitempty"`
+	NameServers       []string         `yaml:"nameservers,omitempty"`
 }
 
 // NetworkDeviceCheck defines the function type for checks.
@@ -39,6 +40,11 @@ func (n *NetworkConfig) SetHostname(hostname string) {
 // Devices implements the Configurator interface.
 func (n *NetworkConfig) Devices() []machine.Device {
 	return n.NetworkInterfaces
+}
+
+// Resolvers implements the Configurator interface.
+func (n *NetworkConfig) Resolvers() []string {
+	return n.NameServers
 }
 
 // Validate triggers the specified validation checks to run.


### PR DESCRIPTION
This adds support for specify nameservers in the config.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>