### PR TITLE
fix: recover from panics in grpc servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect

--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -91,12 +91,12 @@ func main() {
 			NetworkClient: networkClient,
 		},
 		factory.Port(constants.OsdPort),
+		factory.WithStreamInterceptor(protoProxy.StreamInterceptor()),
+		factory.WithUnaryInterceptor(protoProxy.UnaryInterceptor()),
 		factory.ServerOptions(
 			grpc.Creds(
 				credentials.NewTLS(tlsConfig),
 			),
-			grpc.UnaryInterceptor(protoProxy.UnaryInterceptor()),
-			grpc.StreamInterceptor(protoProxy.StreamInterceptor()),
 		),
 	)
 	if err != nil {

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -93,11 +93,11 @@ func main() {
 	err = factory.ListenAndServe(
 		&reg.Registrator{Config: config},
 		factory.Port(constants.TrustdPort),
+		factory.WithUnaryInterceptor(creds.UnaryInterceptor()),
 		factory.ServerOptions(
 			grpc.Creds(
 				credentials.NewTLS(tlsConfig),
 			),
-			grpc.UnaryInterceptor(creds.UnaryInterceptor()),
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
This installs default middleware to recover from panics (convert them to
errors) in all the grpc servers by default.

Slight refactoring to allow that as grpc can only accept Unary/Stream
interceptors only once.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>