### PR TITLE
docs: add customization guide for running behing a proxy

### DIFF
--- a/docs/website/content/v0.3.en.json
+++ b/docs/website/content/v0.3.en.json
@@ -90,6 +90,10 @@
       {
         "title": "Kernel",
         "path": "v0.3/en/customization/kernel"
+      },
+      {
+        "title": "Corporate Proxy",
+        "path": "v0.3/en/customization/proxy"
       }
     ]
   },

--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -191,8 +191,6 @@ Examples:
 ```yaml
 network:
   hostname: worker-1
-  timeservers:
-    - time.cloudflare.com
   interfaces:
   nameservers:
     - 9.8.7.6

--- a/docs/website/content/v0.3/en/customization/kernel.md
+++ b/docs/website/content/v0.3/en/customization/kernel.md
@@ -13,7 +13,9 @@ COPY --from=<custom kernel image> /boot/vmlinuz /usr/install/vmlinuz
 ```
 
 ```bash
-docker build --squash --build-arg RM="/lib/modules" -t talos-installer .
+docker build --build-arg RM="/lib/modules" -t talos-installer .
 ```
+
+> Note: You can use the `--squash` flag to create smaller images.
 
 Now that we have a custom installer we can build Talos for the specific platform we wish to deploy to.

--- a/docs/website/content/v0.3/en/customization/proxy.md
+++ b/docs/website/content/v0.3/en/customization/proxy.md
@@ -1,0 +1,78 @@
+---
+title: 'Running Behind a Corporate Proxy'
+---
+
+## Creating an Image for MITM Proxies
+
+Create a `Dockerfile` that will be used to customize the installer image:
+
+```dockerfile
+FROM alpine AS ca
+COPY --from=docker.io/autonomy/ca-certificates:febbf49 / /rootfs
+COPY ca.crt /tmp/ca.crt
+RUN cat /tmp/ca.crt >> /rootfs/etc/ssl/certs/ca-certificates.crt
+
+FROM scratch AS customization
+COPY --from=ca /rootfs /
+
+FROM docker.io/autonomy/installer:latest
+COPY --from=customization / /
+```
+
+Build the image:
+
+```bash
+docker build -t <organization>/installer:latest .
+```
+
+> Note: You can use the `--squash` flag to create smaller images.
+
+At this point, you will need to generate an image for your desired platform.
+We will use VMware as an example:
+
+```bash
+docker run --rm -v /dev:/dev -v $PWD/build:/out \
+    --privileged \
+    <organization>/installer:latest \
+    install \
+    -r \
+    -p vmware \
+    -u guestinfo \
+    -e console=tty0 \
+    -e earlyprintk=ttyS0,115200
+docker run --rm -v /dev:/dev -v $PWD/build:/out \
+    --privileged \
+    <organization>/installer:latest \
+    ova
+```
+
+## Configuring a Machine to Use the Proxy
+
+To make use of a proxy:
+
+```yaml
+machine:
+  env:
+    http_proxy: <http proxy>
+    https_proxy: <https proxy>
+    no_proxy: <no proxy>
+```
+
+Additionally, configure the DNS `nameservers`, and NTP `servers`:
+
+```yaml
+machine:
+  env:
+  ...
+  time:
+    servers:
+      - <server 1>
+      - <server ...>
+      - <server n>
+  ...
+  network:
+    nameservers:
+      - <ip 1>
+      - <ip ...>
+      - <ip n>
+```

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -93,8 +93,6 @@ type MachineConfig struct {
 	//     - |
 	//       network:
 	//         hostname: worker-1
-	//         timeservers:
-	//           - time.cloudflare.com
 	//         interfaces:
 	//         nameservers:
 	//           - 9.8.7.6


### PR DESCRIPTION
This adds docs on how to run Talos behind a proxy.