### PR TITLE
feat: Disable networkd configuration if `ip` kernel parameter is specified

### DIFF
--- a/docs/website/content/v0.3/en/components/networkd.md
+++ b/docs/website/content/v0.3/en/components/networkd.md
@@ -4,3 +4,10 @@ title: networkd
 
 Networkd handles all of the host level network configuration.
 Configuration is defined under the `networking` key.
+
+By default, we attempt to issue a DHCP request for every interface on the server.
+This can be overridden by supplying one of the following kernel arguments:
+
+- `talos.network.interface.ignore` - specify a list of interfaces to skip discovery on
+- `ip` - `ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>` as documented in the [kernel here](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt)
+  - ex, `ip=10.0.0.99:::255.0.0.0:control-1:eth0:off:10.0.0.1`

--- a/hack/installer/entrypoint.sh
+++ b/hack/installer/entrypoint.sh
@@ -95,6 +95,7 @@ case "$1" in
           ;;
         e )
           EXTRA_ARGS="${EXTRA_ARGS} --extra-kernel-arg=${OPTARG}"
+          echo "Using kernel parameter ${OPTARG}"
           ;;
         n )
           TALOS_RAW="/out/${OPTARG}.raw"


### PR DESCRIPTION
This allows the kernel argument `ip` to take precedence over networking configuration. Documentation for
this parameter can be found here https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>