### PR TITLE
feat: Add support for defining ntp servers via config

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -191,6 +191,8 @@ Examples:
 ```yaml
 network:
   hostname: worker-1
+  timeservers:
+    - time.cloudflare.com
   interfaces:
   nameservers:
     - 9.8.7.6
@@ -296,6 +298,21 @@ env:
 ```yaml
 env:
   https_proxy: http://DOMAIN\\USERNAME:PASSWORD@SERVER:PORT/
+
+```
+
+#### time
+
+Used to configure the machine's time settings.
+
+Type: `TimeConfig`
+
+Examples:
+
+```yaml
+time:
+  servers:
+    - time.cloudflare.com
 
 ```
 
@@ -574,23 +591,6 @@ Examples:
 /dev/nvme0
 ```
 
-#### extraDisks
-
-Allows for extra mounts of extra disks.
-
-Type: `array`
-
-Examples:
-
-```yaml
-extraDisks:
-  device: /dev/sdb
-  partitions:
-    size:
-    mountpoint: /var/lib/etcd
-
-```
-
 #### extraKernelArgs
 
 Allows for supplying extra kernel args to the bootloader config.
@@ -657,6 +657,19 @@ Valid Values:
 - `yes`
 - `false`
 - `no`
+
+---
+
+### TimeConfig
+
+#### servers
+
+Specifies time (ntp) servers to use for setting system time.
+Defaults to `pool.ntp.org`
+
+> Note: This parameter only supports a single time server
+
+Type: `array`
 
 ---
 

--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -55,8 +55,9 @@ func main() {
 	}
 
 	// Check if ntp servers are defined
-	if config.Machine().Time().Server() != "" {
-		server = config.Machine().Time().Server()
+	// Support for only a single time server currently
+	if len(config.Machine().Time().Servers()) >= 1 {
+		server = config.Machine().Time().Servers()[0]
 	}
 
 	n, err := ntp.NewNTPClient(

--- a/internal/app/ntpd/pkg/ntp/ntpd_test.go
+++ b/internal/app/ntpd/pkg/ntp/ntpd_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
 type NtpSuite struct {
@@ -26,4 +29,43 @@ func (suite *NtpSuite) TestQuery() {
 
 	_, err = n.Query()
 	suite.Assert().NoError(err)
+}
+
+func (suite *NtpSuite) TestNtpConfig() {
+	server := "time.cloudflare.com"
+
+	// Test unset config, single server config, multiple server config
+	for _, conf := range []runtime.Configurator{&v1alpha1.Config{MachineConfig: &v1alpha1.MachineConfig{}}, sampleConfigSingleServer(), sampleConfigMultipleServers()} {
+		// Check if ntp servers are defined
+		// Support for only a single time server currently
+		if len(conf.Machine().Time().Servers()) >= 1 {
+			server = conf.Machine().Time().Servers()[0]
+		}
+
+		n, err := NewNTPClient(
+			WithServer(server),
+		)
+		suite.Assert().NoError(err)
+		suite.Assert().Equal(server, n.Server)
+	}
+}
+
+func sampleConfigSingleServer() runtime.Configurator {
+	return &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineTime: &v1alpha1.TimeConfig{
+				TimeServers: []string{"my.timeserver.org.biz.highfive"},
+			},
+		},
+	}
+}
+
+func sampleConfigMultipleServers() runtime.Configurator {
+	return &v1alpha1.Config{
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineTime: &v1alpha1.TimeConfig{
+				TimeServers: []string{"my.timeserver.org.biz.highfive", "another.my.timeserver.gov.org.https.time"},
+			},
+		},
+	}
 }

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -119,7 +119,7 @@ type Partition struct {
 // Time defines the requirements for a config that pertains to time related
 // options.
 type Time interface {
-	Server() string
+	Servers() []string
 }
 
 // Kubelet defines the requirements for a config that pertains to kubelet

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -109,7 +109,11 @@ func (m *MachineConfig) Network() machine.Network {
 
 // Time implements the Configurator interface.
 func (m *MachineConfig) Time() machine.Time {
-	return m
+	if m.MachineTime == nil {
+		return &TimeConfig{}
+	}
+
+	return m.MachineTime
 }
 
 // Kubelet implements the Configurator interface.
@@ -316,6 +320,11 @@ func (n *NetworkConfig) Devices() []machine.Device {
 // Resolvers implements the Configurator interface.
 func (n *NetworkConfig) Resolvers() []string {
 	return n.NameServers
+}
+
+// Servers implements the Configurator interface.
+func (t *TimeConfig) Servers() []string {
+	return t.TimeServers
 }
 
 // Image implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -93,6 +93,8 @@ type MachineConfig struct {
 	//     - |
 	//       network:
 	//         hostname: worker-1
+	//         timeservers:
+	//           - time.cloudflare.com
 	//         interfaces:
 	//         nameservers:
 	//           - 9.8.7.6
@@ -159,6 +161,14 @@ type MachineConfig struct {
 	//       env:
 	//         https_proxy: http://DOMAIN\\USERNAME:PASSWORD@SERVER:PORT/
 	MachineEnv machine.Env `yaml:"env,omitempty"`
+	//   description: |
+	//     Used to configure the machine's time settings.
+	//   examples:
+	//     - |
+	//       time:
+	//         servers:
+	//           - time.cloudflare.com
+	MachineTime *TimeConfig `yaml:"time,omitempty"`
 }
 
 // ClusterConfig reperesents the cluster-wide config values
@@ -366,6 +376,16 @@ type InstallConfig struct {
 	//     - false
 	//     - no
 	InstallForce bool `yaml:"force"`
+}
+
+// TimeConfig represents the options for configuring time on a node.
+type TimeConfig struct {
+	//   description: |
+	//     Specifies time (ntp) servers to use for setting system time.
+	//     Defaults to `pool.ntp.org`
+	//
+	//     > Note: This parameter only supports a single time server
+	TimeServers []string `yaml:"servers,omitempty"`
 }
 
 // Endpoint struct holds the endpoint url parsed out of machine config.


### PR DESCRIPTION
This introduces support for defining ntp servers via `config.machine.time.servers` parameter.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>