### PR TITLE
feat: implement grpc request loggging

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -93,6 +93,7 @@ func main() {
 		factory.Port(constants.OsdPort),
 		factory.WithStreamInterceptor(protoProxy.StreamInterceptor()),
 		factory.WithUnaryInterceptor(protoProxy.UnaryInterceptor()),
+		factory.WithDefaultLog(),
 		factory.ServerOptions(
 			grpc.Creds(
 				credentials.NewTLS(tlsConfig),

--- a/internal/app/machined/internal/api/api.go
+++ b/internal/app/machined/internal/api/api.go
@@ -25,7 +25,7 @@ func NewService() *Service {
 // Main is an entrypoint the the API service
 func (s *Service) Main(ctx context.Context, config runtime.Configurator, logWriter io.Writer) error {
 	api := reg.NewRegistrator(config)
-	server := factory.NewServer(api)
+	server := factory.NewServer(api, factory.WithLog("machined ", logWriter))
 
 	listener, err := factory.NewListener(factory.Network("unix"), factory.SocketPath(constants.MachineSocketPath))
 	if err != nil {

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -43,6 +43,7 @@ func main() {
 		reg.NewRegistrator(nwd),
 		factory.Network("unix"),
 		factory.SocketPath(constants.NetworkSocketPath),
+		factory.WithDefaultLog(),
 	),
 	)
 }

--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -80,6 +80,7 @@ func main() {
 			reg.NewRegistrator(n),
 			factory.Network("unix"),
 			factory.SocketPath(constants.TimeSocketPath),
+			factory.WithDefaultLog(),
 		)
 	}()
 

--- a/internal/app/osd/main.go
+++ b/internal/app/osd/main.go
@@ -26,6 +26,7 @@ func main() {
 		&reg.Registrator{},
 		factory.Network("unix"),
 		factory.SocketPath(constants.OSSocketPath),
+		factory.WithDefaultLog(),
 	),
 	)
 }

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -93,6 +93,7 @@ func main() {
 	err = factory.ListenAndServe(
 		&reg.Registrator{Config: config},
 		factory.Port(constants.TrustdPort),
+		factory.WithDefaultLog(),
 		factory.WithUnaryInterceptor(creds.UnaryInterceptor()),
 		factory.ServerOptions(
 			grpc.Creds(

--- a/pkg/grpc/middleware/log/log.go
+++ b/pkg/grpc/middleware/log/log.go
@@ -2,4 +2,90 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// Package log provides simple grpc logging middleware
 package log
+
+import (
+	"context"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	metadata "google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// Middleware provides grpc logging middleware.
+type Middleware struct {
+	logger *log.Logger
+}
+
+// NewMiddleware creates new logging middleware
+func NewMiddleware(logger *log.Logger) *Middleware {
+	return &Middleware{
+		logger: logger,
+	}
+}
+
+func extractMetadata(ctx context.Context) string {
+	md, _ := metadata.FromIncomingContext(ctx)
+	keys := make([]string, 0, len(md))
+
+	for key := range md {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	pairs := make([]string, 0, len(keys))
+
+	for _, key := range keys {
+		pairs = append(pairs, key+"="+strings.Join(md[key], ","))
+	}
+
+	return strings.Join(pairs, ";")
+}
+
+// UnaryInterceptor returns grpc UnaryServerInterceptor
+func (m *Middleware) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		startTime := time.Now()
+
+		resp, err := handler(ctx, req)
+
+		duration := time.Since(startTime)
+		code := status.Code(err)
+
+		msg := "Success"
+		if err != nil {
+			msg = err.Error()
+		}
+
+		m.logger.Printf("%s [%s] %.3fms unary %s (%s)", code, info.FullMethod, duration.Seconds()/1000.0, msg, extractMetadata(ctx))
+
+		return resp, err
+	}
+}
+
+// StreamInterceptor returns grpc StreamServerInterceptor
+func (m *Middleware) StreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		startTime := time.Now()
+
+		err := handler(srv, stream)
+
+		duration := time.Since(startTime)
+		code := status.Code(err)
+
+		msg := "Success"
+		if err != nil {
+			msg = err.Error()
+		}
+
+		m.logger.Printf("%s [%s] %.3fms stream %s (%s)", code, info.FullMethod, duration.Seconds()/1000.0, msg, extractMetadata(stream.Context()))
+
+		return err
+	}
+}

--- a/pkg/grpc/middleware/log/log_test.go
+++ b/pkg/grpc/middleware/log/log_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package log_test
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	// added for accurate coverage estimation
+	//
+	// please remove it once any unit-test is added
+	// for this package
+}


### PR DESCRIPTION
Logging is pretty simple and bare minimum is being logged. I believe
better logging can be provided for apid when it does fan-out, but that
is beyond the scope for the first PR.

Sample logs:

```
$ osctl-linux-amd64 logs machined-api
machined 2019/11/11 21:16:43 OK [/machine.Machine/ServiceList] 0.000ms unary Success (:authority=unix:/run/system/machined/machine.sock;content-type=application/grpc;user-agent=grpc-go/1.23.0)
machined 2019/11/11 21:17:09 Unknown [/machine.Machine/Logs] 0.000ms stream open /run/system/log/machined.log: no such file or directory (:authority=unix:/run/system/machined/machine.sock;content-type=application/grpc;user-agent=grpc-go/1.23.0)
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>