### PR TITLE
chore: remove CertificateKey

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 30%
+        target: 29%
         threshold: 0.5%
         base: auto
     patch: off

--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -373,18 +373,6 @@ Examples:
 wlzjyw.bei2zfylhs2by0wd
 ```
 
-#### certificateKey
-
-TODO: Remove this.
-
-Type: `string`
-
-Examples:
-
-```yaml
-20d9aafb46d6db4c0958db5b3fc481c8c14fc9b1abd8ac43194f4246b77131be
-```
-
 #### aescbcEncryptionSecret
 
 The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -33,7 +33,7 @@ func controlPlaneUd(in *Input) (string, error) {
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
-		BootstrapToken: in.KubeadmTokens.BootstrapToken,
+		BootstrapToken: in.Secrets.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Version:  in.KubernetesVersion,
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
@@ -47,8 +47,7 @@ func controlPlaneUd(in *Input) (string, error) {
 			ServiceSubnet: in.ServiceNet,
 		},
 		ClusterCA:                     in.Certs.K8s,
-		CertificateKey:                in.KubeadmTokens.CertificateKey,
-		ClusterAESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,
+		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
 	}
 
 	ud := v1alpha1.Config{

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -54,9 +54,8 @@ func initUd(in *Input) (string, error) {
 			ServiceSubnet: in.ServiceNet,
 		},
 		ClusterCA:                     in.Certs.K8s,
-		BootstrapToken:                in.KubeadmTokens.BootstrapToken,
-		CertificateKey:                in.KubeadmTokens.CertificateKey,
-		ClusterAESCBCEncryptionSecret: in.KubeadmTokens.AESCBCEncryptionSecret,
+		BootstrapToken:                in.Secrets.BootstrapToken,
+		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
 	}
 
 	ud := v1alpha1.Config{

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -34,7 +34,7 @@ func workerUd(in *Input) (string, error) {
 
 	cluster := &v1alpha1.ClusterConfig{
 		ClusterCA:      &x509.PEMEncodedCertificateAndKey{Crt: in.Certs.K8s.Crt},
-		BootstrapToken: in.KubeadmTokens.BootstrapToken,
+		BootstrapToken: in.Secrets.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Version:  in.KubernetesVersion,
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -203,11 +203,6 @@ type ClusterConfig struct {
 	//     - wlzjyw.bei2zfylhs2by0wd
 	BootstrapToken string `yaml:"token,omitempty"`
 	//   description: |
-	//     TODO: Remove this.
-	//   examples:
-	//     - 20d9aafb46d6db4c0958db5b3fc481c8c14fc9b1abd8ac43194f4246b77131be
-	CertificateKey string `yaml:"certificateKey"`
-	//   description: |
 	//     The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 	//   examples:
 	//     - z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=


### PR DESCRIPTION
This was used by kubeadm. We no longer need it.