### PR TITLE
refactor: rename initial network task func

### DIFF
--- a/internal/app/machined/internal/phase/network/network.go
+++ b/internal/app/machined/internal/phase/network/network.go
@@ -16,16 +16,16 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 )
 
-// UserDefinedNetwork represents the UserDefinedNetwork task.
-type UserDefinedNetwork struct{}
+// InitialNetworkSetup represents the task for setting up the initial network.
+type InitialNetworkSetup struct{}
 
-// NewUserDefinedNetworkTask initializes and returns an UserDefinedNetwork task.
-func NewUserDefinedNetworkTask() phase.Task {
-	return &UserDefinedNetwork{}
+// NewInitialNetworkSetupTask initializes and returns an InitialNetworkSetup task.
+func NewInitialNetworkSetupTask() phase.Task {
+	return &InitialNetworkSetup{}
 }
 
 // TaskFunc returns the runtime function.
-func (task *UserDefinedNetwork) TaskFunc(mode runtime.Mode) phase.TaskFunc {
+func (task *InitialNetworkSetup) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 	switch mode {
 	case runtime.Container:
 		return nil
@@ -35,7 +35,7 @@ func (task *UserDefinedNetwork) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 // nolint: gocyclo
-func (task *UserDefinedNetwork) runtime(r runtime.Runtime) (err error) {
+func (task *InitialNetworkSetup) runtime(r runtime.Runtime) (err error) {
 	// Check to see if a static IP was set via kernel args;
 	// if so, we'll skip the initial dhcp discovery
 	if option := kernel.ProcCmdline().Get("ip").First(); option != nil {

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -54,7 +54,7 @@ func (d *Sequencer) Boot() error {
 		),
 		phase.NewPhase(
 			"initial network",
-			network.NewUserDefinedNetworkTask(),
+			network.NewInitialNetworkSetupTask(),
 		),
 		phase.NewPhase(
 			"config",


### PR DESCRIPTION
The name of the function was not accurate to what it does. This fixes
that.