### PR TITLE
docs: disable PurgeCSS

### DIFF
--- a/docs/website/nuxt.config.js
+++ b/docs/website/nuxt.config.js
@@ -54,7 +54,9 @@ export default {
   },
 
   // PurgeCSS is automatically installed by @nuxtjs/tailwindcss
-  purgeCSS: {},
+  purgeCSS: {
+    enabled: false
+  },
 
   /*
    ** Nuxt.js modules


### PR DESCRIPTION
PurgeCSS seems to be removing portions of the styles in
docs/website/assets/css. This disables it until we can figure out a
better solution.