### PR TITLE
feat: Add support for resetting the network during bootup

### DIFF
--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -53,7 +53,7 @@ func (d *Sequencer) Boot() error {
 			rootfs.NewOSReleaseTask(),
 		),
 		phase.NewPhase(
-			"initial network",
+			"discover network",
 			network.NewInitialNetworkSetupTask(),
 		),
 		phase.NewPhase(
@@ -85,6 +85,14 @@ func (d *Sequencer) Boot() error {
 		phase.NewPhase(
 			"config validation",
 			rootfs.NewValidateConfigTask(),
+		),
+		phase.NewPhase(
+			"network reset",
+			network.NewResetNetworkTask(),
+		),
+		phase.NewPhase(
+			"initial network",
+			network.NewInitialNetworkSetupTask(),
 		),
 		phase.NewPhase(
 			"start system-containerd",

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -71,7 +71,7 @@ func configureNetworking(n *networkd.Networkd) {
 		log.Fatalf("open config: %v", err)
 	}
 
-	log.Println("overlaying config network configuration")
+	log.Println("merging user defined network configuration")
 
 	if err = netconf.BuildOptions(config); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This introduces the ability to reset the network interface during the bootup sequence.
This allows for user defined static networking to be the only configuration on the
network interface instead of potentially dhcp+static.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>