### PR TITLE
feat: allow extra arguments to be passed to etcd

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -778,6 +778,35 @@ ca:
 
 ```
 
+#### extraArgs
+
+Extra arguments to supply to etcd.
+Note that the following args are blacklisted:
+
+- `name`
+- `data-dir`
+- `initial-cluster-state`
+- `listen-peer-urls`
+- `listen-client-urls`
+- `cert-file`
+- `key-file`
+- `trusted-ca-file`
+- `peer-client-cert-auth`
+- `peer-cert-file`
+- `peer-trusted-ca-file`
+- `peer-key-file`
+
+Type: `map`
+
+Examples:
+
+```yaml
+extraArgs:
+  initial-cluster: https://1.2.3.4:2380
+  advertise-client-urls: https://1.2.3.4:2379
+
+```
+
 ---
 
 ### ClusterNetworkConfig

--- a/pkg/argsbuilder/argsbuilder_args.go
+++ b/pkg/argsbuilder/argsbuilder_args.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package argsbuilder
+
+import "fmt"
+
+// Key represents an arg key.
+type Key = string
+
+// Value represents an arg value.
+type Value = string
+
+// Args represents a set of args.
+type Args map[Key]Value
+
+// Merge implements the ArgsBuilder interface.
+func (a Args) Merge(args Args) ArgsBuilder {
+	for key, val := range args {
+		a[key] = val
+	}
+
+	return a
+}
+
+// Set implements the ArgsBuilder interface.
+func (a Args) Set(k, v Key) ArgsBuilder {
+	a[k] = v
+
+	return a
+}
+
+// Args implements the ArgsBuilder interface.
+func (a Args) Args() []string {
+	args := []string{}
+
+	for key, val := range a {
+		args = append(args, fmt.Sprintf("--%s=%s", key, val))
+	}
+
+	return args
+}
+
+// Get returns an args value.
+func (a Args) Get(k Key) Value {
+	return a[k]
+}
+
+// Contains checks if an arg key exists.
+func (a Args) Contains(k Key) bool {
+	_, ok := a[k]
+
+	return ok
+}

--- a/pkg/argsbuilder/argsbuilder_interface.go
+++ b/pkg/argsbuilder/argsbuilder_interface.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package argsbuilder
+
+// ArgsBuilder defines the requirements to build and manage a set of args.
+type ArgsBuilder interface {
+	Merge(Args) ArgsBuilder
+	Set(string, string) ArgsBuilder
+	Args() []string
+}

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -40,6 +40,7 @@ type Network interface {
 type Etcd interface {
 	Image() string
 	CA() *x509.PEMEncodedCertificateAndKey
+	ExtraArgs() map[string]string
 }
 
 // Token defines the requirements for a config that pertains to Kubernetes

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -236,6 +236,15 @@ func (e *EtcdConfig) CA() *x509.PEMEncodedCertificateAndKey {
 	return e.RootCA
 }
 
+// ExtraArgs implements the Configurator interface.
+func (e *EtcdConfig) ExtraArgs() map[string]string {
+	if e.EtcdExtraArgs == nil {
+		return make(map[string]string)
+	}
+
+	return e.EtcdExtraArgs
+}
+
 // Token implements the Configurator interface.
 func (c *ClusterConfig) Token() cluster.Token {
 	return c

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -474,6 +474,28 @@ type EtcdConfig struct {
 	//         crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJIekNCMHF...
 	//         key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM...
 	RootCA *x509.PEMEncodedCertificateAndKey `yaml:"ca"`
+	//   description: |
+	//     Extra arguments to supply to etcd.
+	//     Note that the following args are blacklisted:
+	//
+	//     - `name`
+	//     - `data-dir`
+	//     - `initial-cluster-state`
+	//     - `listen-peer-urls`
+	//     - `listen-client-urls`
+	//     - `cert-file`
+	//     - `key-file`
+	//     - `trusted-ca-file`
+	//     - `peer-client-cert-auth`
+	//     - `peer-cert-file`
+	//     - `peer-trusted-ca-file`
+	//     - `peer-key-file`
+	//   examples:
+	//     - |
+	//       extraArgs:
+	//         initial-cluster: https://1.2.3.4:2380
+	//         advertise-client-urls: https://1.2.3.4:2379
+	EtcdExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
 }
 
 // ClusterNetworkConfig represents kube networking config vals.


### PR DESCRIPTION
This allows for an arbitrary set of args to be passed to etcd. Due to
the fact the we do the discovery of the current cluster state, we
blacklist initial-cluster. Additionally, we black list args that would
makes sense to modify, like the path to the certs.