### PR TITLE
feat: Add support for kernel network config (ip=)

### DIFF
--- a/internal/app/networkd/pkg/address/kernel.go
+++ b/internal/app/networkd/pkg/address/kernel.go
@@ -1,0 +1,181 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package address
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/pkg/kernel"
+)
+
+// Kernel implements the Addressing interface
+type Kernel struct {
+	Addr              string
+	ServerAddress     string
+	Gateway           string
+	Netmask           string
+	FQDN              string
+	Device            string
+	Auto              string
+	PrimaryResolver   string
+	SecondaryResolver string
+	NTPServer         string
+}
+
+// Discover doesnt do anything in the static configuration since all
+// the necessary configuration data is supplied via config.
+// nolint: gocyclo
+func (k *Kernel) Discover(ctx context.Context) error {
+	var (
+		option *string
+		err    error
+	)
+
+	if option = kernel.ProcCmdline().Get("ip").First(); option == nil {
+		return fmt.Errorf("%s", "no kernel.ip argument supplied, skipping")
+	}
+
+	// TODO may need to move this earlier in networkd; if ip.dhcp is specified
+	// we shouldnt do anything because we dont know which (all?) interfaces the kernel
+	// will autoconfigure
+	if *option == "dhcp" {
+		return fmt.Errorf("unsupported kernel.ip configuration method: %s", *option)
+	}
+
+	// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
+	// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>
+	fields := strings.Split(*option, ":")
+
+	if len(fields) < 4 {
+		return fmt.Errorf("invalid kernel option syntax: found %d fields but there must be at least 4", len(fields))
+	}
+
+	for idx, field := range fields {
+		switch idx {
+		case 0:
+			k.Addr = field
+		case 1:
+			k.ServerAddress = field
+		case 2:
+			k.Gateway = field
+		case 3:
+			k.Netmask = field
+		case 4:
+			k.FQDN = field
+		case 5:
+			k.Device = field
+		case 6:
+			k.Auto = field
+		case 7:
+			k.PrimaryResolver = field
+		case 8:
+			k.SecondaryResolver = field
+		case 9:
+			k.NTPServer = field
+		}
+	}
+
+	return err
+}
+
+// Name returns back the name of the address method.
+func (k *Kernel) Name() string {
+	return "kernel"
+}
+
+// Address returns the IP address
+func (k *Kernel) Address() *net.IPNet {
+	return &net.IPNet{
+		IP:   net.ParseIP(k.Addr),
+		Mask: k.Mask(),
+	}
+}
+
+// Mask returns the netmask.
+func (k *Kernel) Mask() net.IPMask {
+	netmask := net.ParseIP(k.Netmask).To4()
+	return net.IPv4Mask(netmask[0], netmask[1], netmask[2], netmask[3])
+}
+
+// MTU returns the specified MTU.
+func (k *Kernel) MTU() uint32 {
+	return 1500
+}
+
+// TTL returns the address lifetime. Since this is static, there is
+// no TTL (0).
+func (k *Kernel) TTL() time.Duration {
+	return 0
+}
+
+// Family qualifies the address as ipv4 or ipv6
+func (k *Kernel) Family() int {
+	if k.Address().IP.To4() != nil {
+		return unix.AF_INET
+	}
+
+	return unix.AF_INET6
+}
+
+// Scope sets the address scope
+func (k *Kernel) Scope() uint8 {
+	return unix.RT_SCOPE_UNIVERSE
+}
+
+// Routes aggregates the specified routes for a given device configuration
+func (k *Kernel) Routes() (routes []*Route) {
+	return []*Route{}
+}
+
+// Resolvers returns the DNS resolvers
+func (k *Kernel) Resolvers() []net.IP {
+	resolvers := []net.IP{}
+
+	for _, resolver := range []string{k.PrimaryResolver, k.SecondaryResolver} {
+		if addr := net.ParseIP(resolver); addr != nil {
+			resolvers = append(resolvers, addr)
+		}
+	}
+
+	return resolvers
+}
+
+// Hostname returns the hostname
+func (k *Kernel) Hostname() string {
+	return strings.Split(k.FQDN, ".")[0]
+}
+
+// Link returns the underlying net.Interface that this address
+// method is configured for
+func (k Kernel) Link() *net.Interface {
+	// Try out some common names and take the first
+	// found interface
+	if k.Device != "" {
+		for _, iface := range []string{"eth0", "eth1", "eno1", "eno2", "bond0"} {
+			if _, err := net.InterfaceByName(iface); err == nil {
+				k.Device = iface
+				break
+			}
+		}
+	}
+
+	iface, err := net.InterfaceByName(k.Device)
+	if err != nil {
+		return nil
+	}
+
+	return iface
+}
+
+// Valid denotes if this address method should be used.
+func (k *Kernel) Valid() bool {
+	return true
+}

--- a/internal/app/networkd/pkg/address/kernel_test.go
+++ b/internal/app/networkd/pkg/address/kernel_test.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package address
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/pkg/kernel"
+)
+
+type AddressSuite struct {
+	suite.Suite
+}
+
+func TestAddressSuite(t *testing.T) {
+	// Hide all our state transition messages
+	// log.SetOutput(ioutil.Discard)
+	suite.Run(t, new(AddressSuite))
+}
+
+func (suite *AddressSuite) TestFullKernelAddress() {
+	tmpfile, err := ioutil.TempFile("", "example")
+	suite.Assert().NoError(err)
+
+	// nolint: errcheck
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte("ip=1.1.1.1:2.2.2.2:3.3.3.3:255.255.255.0:hostname:eth0:none:4.4.4.4:5.5.5.5:6.6.6.6"))
+	suite.Assert().NoError(err)
+	err = tmpfile.Close()
+	suite.Assert().NoError(err)
+
+	kernel.CmdLine = tmpfile.Name()
+
+	kern := &Kernel{}
+	err = kern.Discover(context.Background())
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(kern.Name(), "kernel")
+	suite.Assert().Equal(kern.Family(), unix.AF_INET)
+	suite.Assert().Equal(kern.Address().IP, net.ParseIP("1.1.1.1"))
+	suite.Assert().Equal(kern.Mask().String(), "ffffff00")
+	suite.Assert().Equal(len(kern.Routes()), 0)
+	suite.Assert().Equal(kern.Hostname(), "hostname")
+	suite.Assert().Equal(kern.Resolvers()[0], net.ParseIP("4.4.4.4"))
+	suite.Assert().Equal(kern.Resolvers()[1], net.ParseIP("5.5.5.5"))
+}
+
+/*
+func (suite *AddressSuite) TestPartialKernelAddress() {
+	tmpfile, err := ioutil.TempFile("", "example")
+	suite.Assert().NoError(err)
+
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte("ip=1.1.1.1:2.2.2.2:3.3.3.3:255.255.255.0"))
+	suite.Assert().NoError(err)
+	err = tmpfile.Close()
+	suite.Assert().NoError(err)
+
+	kernel.CmdLine = tmpfile.Name()
+
+	kern := &Kernel{}
+	err = kern.Discover(context.Background())
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(kern.Name(), "kernel")
+	suite.Assert().Equal(kern.Family(), unix.AF_INET)
+	suite.Assert().Equal(kern.Address().IP, net.ParseIP("1.1.1.1"))
+	suite.Assert().Equal(kern.Mask().String(), "ffffff00")
+}
+
+func (suite *AddressSuite) TestIncompleteKernelAddress() {
+	tmpfile, err := ioutil.TempFile("", "example")
+	suite.Assert().NoError(err)
+
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte("ip=1.1.1.1"))
+	suite.Assert().NoError(err)
+	err = tmpfile.Close()
+	suite.Assert().NoError(err)
+
+	kernel.CmdLine = tmpfile.Name()
+
+	kern := &Kernel{}
+	err = kern.Discover(context.Background())
+	suite.Require().Error(err)
+}
+*/

--- a/internal/app/networkd/pkg/networkd/netconf_test.go
+++ b/internal/app/networkd/pkg/networkd/netconf_test.go
@@ -30,7 +30,7 @@ func (suite *NetconfSuite) TestNetconf() {
 	conf := sampleConfig()
 	eth0 := &net.Interface{Index: 1, MTU: 1500, Name: "eth0"}
 	nc := NetConf{eth0: []nic.Option{nic.WithName(eth0.Name)}}
-	err := nc.BuildOptions(conf)
+	err := nc.BuildOptionsFromConfig(conf)
 	suite.Assert().NoError(err)
 
 	iface, err := nic.Create(eth0, nc[eth0]...)

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -243,10 +243,13 @@ func parse(parameters string) (parsed Parameters) {
 	return parsed
 }
 
+// CmdLine exposed for testing purposes
+var CmdLine = "/proc/cmdline"
+
 func read() (c *Cmdline, err error) {
 	var parameters []byte
 
-	parameters, err = ioutil.ReadFile("/proc/cmdline")
+	parameters, err = ioutil.ReadFile(CmdLine)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This introduces a kernel addressing method. Given that the kernel handles this configuration
this mode is largely noop ( address should already exist/be defined ), however, this adds
the ability to handle the addressing method as a first class citizen. TLDR; we can support
configuring resolv.conf via kernel ip= argument.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>