### PR TITLE
test: add integration test for full boot sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ join.yaml
 docgen
 talosconfig
 kubeconfig
+hack/test/integration/matchbox/assets/*
+!hack/test/integration/matchbox/assets/.gitkeep
 
 # vim Swap
 [._]*.s[a-v][a-z]

--- a/hack/test/integration/README.md
+++ b/hack/test/integration/README.md
@@ -1,0 +1,93 @@
+# Integration Testing
+
+## Setup
+
+### Prerequisites
+
+- A linux machine with KVM enabled
+- `docker`
+- `docker-compose`
+- `virt-install`
+- `qemu-kvm`
+- `yq`
+
+```bash
+apt install -y virtinst qemu-kvm
+curl -L https://github.com/mikefarah/yq/releases/download/2.4.1/yq_linux_amd64 -o /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
+```
+
+### Start Matchbox, Dnsmasq, and HAproxy
+
+```bash
+docker-compose up
+```
+
+> Note: This will run all services in the foreground.
+
+### Create the VMs
+
+```bash
+./libvirt.sh up
+```
+
+### Getting the Console Logs
+
+```bash
+virsh console <VM>
+```
+
+### Connecting to the Nodes
+
+#### From the Host
+
+##### Setup DNS
+
+Append the following to `/etc/hosts`:
+
+```text
+172.28.1.3 kubernetes.talos.dev
+172.28.1.10 control-plane-1.talos.dev
+172.28.1.11 control-plane-2.talos.dev
+172.28.1.12 control-plane-3.talos.dev
+172.28.1.13 worker-1.talos.dev
+```
+
+##### Setup `osctl` and `kubectl`
+
+```bash
+export TALOSCONFIG=$PWD/matchbox/assets/talosconfig
+export KUBECONFIG=$PWD/matchbox/assets/kubeconfig
+```
+
+```bash
+osctl config target 172.28.1.10
+osctl kubeconfig ./matchbox/assets/kubeconfig
+```
+
+#### From a Container
+
+```bash
+./libvirt.sh workspace
+```
+
+```bash
+osctl config target 172.28.1.10
+osctl kubeconfig .
+```
+
+#### Verify Connectivity
+
+```bash
+osctl services
+kubectl get nodes
+```
+
+## Teardown
+
+To teardown the test:
+
+```bash
+docker-compose down
+./libvirt.sh down
+```

--- a/hack/test/integration/dnsmasq/talos0.conf
+++ b/hack/test/integration/dnsmasq/talos0.conf
@@ -1,0 +1,40 @@
+# dnsmasq.conf
+
+no-daemon
+dhcp-range=172.28.1.50,172.28.1.99
+dhcp-option=3,172.28.0.1
+dhcp-host=52:54:00:a1:9c:ae,172.28.1.10,1h
+dhcp-host=52:54:00:b2:2f:86,172.28.1.11,1h
+dhcp-host=52:54:00:c3:61:77,172.28.1.12,1h
+dhcp-host=52:54:00:d7:99:c7,172.28.1.13,1h
+
+enable-tftp
+tftp-root=/var/lib/tftpboot
+
+# Legacy PXE
+dhcp-match=set:bios,option:client-arch,0
+dhcp-boot=tag:bios,undionly.kpxe
+
+# UEFI
+dhcp-match=set:efi32,option:client-arch,6
+dhcp-boot=tag:efi32,ipxe.efi
+
+dhcp-match=set:efibc,option:client-arch,7
+dhcp-boot=tag:efibc,ipxe.efi
+
+dhcp-match=set:efi64,option:client-arch,9
+dhcp-boot=tag:efi64,ipxe.efi
+
+# iPXE
+dhcp-userclass=set:ipxe,iPXE
+dhcp-boot=tag:ipxe,http://matchbox.talos.dev:8080/boot.ipxe
+
+log-queries
+log-dhcp
+
+address=/matchbox.talos.dev/172.28.1.2
+address=/kubernetes.talos.dev/172.28.1.3
+address=/control-plane-1.talos.dev/172.28.1.10
+address=/control-plane-2.talos.dev/172.28.1.11
+address=/control-plane-3.talos.dev/172.28.1.12
+address=/worker-1.talos.dev/172.28.1.13

--- a/hack/test/integration/docker-compose.yaml
+++ b/hack/test/integration/docker-compose.yaml
@@ -1,0 +1,51 @@
+version: '3.7'
+
+services:
+  dnsmasq:
+    container_name: dnsmasq
+    image: quay.io/poseidon/dnsmasq:latest
+    command: ['-d']
+    networks:
+      talos:
+        ipv4_address: 172.28.1.1
+    volumes:
+      - ./dnsmasq/talos0.conf:/etc/dnsmasq.conf:Z
+    cap_add:
+      - NET_ADMIN
+    restart: always
+
+  matchbox:
+    container_name: matchbox
+    image: quay.io/poseidon/matchbox:latest
+    command: ['-address=0.0.0.0:8080', '-log-level=debug']
+    networks:
+      talos:
+        ipv4_address: 172.28.1.2
+    ports:
+      - '8080:8080'
+    volumes:
+      - ./matchbox:/var/lib/matchbox:Z
+    restart: always
+
+  haproxy:
+    container_name: haproxy
+    image: haproxy:1.9.12-alpine
+    networks:
+      talos:
+        ipv4_address: 172.28.1.3
+    ports:
+      - '6443:6443'
+    volumes:
+      - ./haproxy:/usr/local/etc/haproxy:ro
+    restart: always
+
+networks:
+  talos:
+    name: talos
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: talos0
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16

--- a/hack/test/integration/haproxy/haproxy.cfg
+++ b/hack/test/integration/haproxy/haproxy.cfg
@@ -1,0 +1,20 @@
+frontend k8s-api
+    bind 0.0.0.0:6443
+    bind 127.0.0.1:6443
+    mode tcp
+    option tcplog
+    timeout client 300000
+    default_backend k8s-api
+
+backend k8s-api
+    mode tcp
+    option tcplog
+    option tcp-check
+    timeout connect 300000
+    timeout server 300000
+    balance roundrobin
+    default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
+
+        server apiserver1 172.28.1.10:6443 check
+        server apiserver2 172.28.1.11:6443 check
+        server apiserver3 172.28.1.12:6443 check

--- a/hack/test/integration/libvirt.sh
+++ b/hack/test/integration/libvirt.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -e
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+function main {
+  case "$1" in
+    "up") up;;
+    "down") down;;
+    "workspace") workspace;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+function usage {
+  echo "USAGE: ${0##*/} <command>"
+  echo "Commands:"
+  echo -e "\up\t\spin up QEMU/KVM nodes on the talos0 bridge"
+  echo -e "\down\t\tear down the QEMU/KVM nodes"
+  echo -e "\workspace\t\run and enter a docker container ready for osctl and kubectl use"
+}
+
+NODES=(control-plane-1 control-plane-2 control-plane-3 worker-1)
+
+VM_MEMORY=${VM_MEMORY:-2048}
+VM_DISK=${VM_DISK:-10}
+
+COMMON_VIRT_OPTS="--memory=${VM_MEMORY} --cpu=host --vcpus=1 --disk pool=default,size=${VM_DISK} --os-type=linux --os-variant=generic --noautoconsole --graphics none --events on_poweroff=preserve --rng /dev/urandom"
+
+CONTROL_PLANE_1_NAME=control-plane-1
+CONTROL_PLANE_1_MAC=52:54:00:a1:9c:ae
+
+CONTROL_PLANE_2_NAME=control-plane-2
+CONTROL_PLANE_2_MAC=52:54:00:b2:2f:86
+
+CONTROL_PLANE_3_NAME=control-plane-3
+CONTROL_PLANE_3_MAC=52:54:00:c3:61:77
+
+WORKER_1_NAME=worker-1
+WORKER_1_MAC=52:54:00:d7:99:c7
+
+function up {
+    cp $PWD/../../../build/initramfs.xz ./matchbox/assets/
+    cp $PWD/../../../build/vmlinuz ./matchbox/assets/
+    cd matchbox/assets
+    $PWD/../../../../..//build/osctl-linux-amd64 config generate --install-image docker.io/autonomy/installer:latest integration-test https://kubernetes.talos.dev:6443
+    yq w -i init.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    yq w -i controlplane.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    yq w -i join.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    cd -
+    virt-install --name $CONTROL_PLANE_1_NAME --network=bridge:talos0,model=e1000,mac=$CONTROL_PLANE_1_MAC $COMMON_VIRT_OPTS --boot=hd,network
+    virt-install --name $CONTROL_PLANE_2_NAME --network=bridge:talos0,model=e1000,mac=$CONTROL_PLANE_2_MAC $COMMON_VIRT_OPTS --boot=hd,network
+    virt-install --name $CONTROL_PLANE_3_NAME --network=bridge:talos0,model=e1000,mac=$CONTROL_PLANE_3_MAC $COMMON_VIRT_OPTS --boot=hd,network
+    virt-install --name $WORKER_1_NAME        --network=bridge:talos0,model=e1000,mac=$WORKER_1_MAC        $COMMON_VIRT_OPTS --boot=hd,network
+}
+
+function down {
+    for node in ${NODES[@]}; do
+      virsh destroy $node
+    done
+    for node in ${NODES[@]}; do
+      virsh undefine $node
+    done
+    virsh pool-refresh default
+    for node in ${NODES[@]}; do
+      virsh vol-delete --pool default $node.qcow2
+    done
+}
+
+function workspace {
+  docker run --rm -it -v $PWD:/workspace -v $PWD/../../../build/osctl-linux-amd64:/bin/osctl:ro --network talos --dns 172.28.1.1 -w /workspace/matchbox/assets -e TALOSCONFIG='/workspace/matchbox/assets/talosconfig' -e KUBECONFIG='/workspace/matchbox/assets/kubeconfig' k8s.gcr.io/hyperkube:v1.16.2 bash
+}
+
+main $@

--- a/hack/test/integration/matchbox/groups/control-plane-1.json
+++ b/hack/test/integration/matchbox/groups/control-plane-1.json
@@ -1,0 +1,8 @@
+{
+  "id": "control-plane-1",
+  "name": "control-plane-1",
+  "profile": "init",
+  "selector": {
+    "mac": "52:54:00:a1:9c:ae"
+  }
+}

--- a/hack/test/integration/matchbox/groups/control-plane-2.json
+++ b/hack/test/integration/matchbox/groups/control-plane-2.json
@@ -1,0 +1,8 @@
+{
+  "id": "control-plane-2",
+  "name": "control-plane-2",
+  "profile": "controlplane",
+  "selector": {
+    "mac": "52:54:00:b2:2f:86"
+  }
+}

--- a/hack/test/integration/matchbox/groups/control-plane-3.json
+++ b/hack/test/integration/matchbox/groups/control-plane-3.json
@@ -1,0 +1,8 @@
+{
+  "id": "control-plane-3",
+  "name": "control-plane-3",
+  "profile": "controlplane",
+  "selector": {
+    "mac": "52:54:00:c3:61:77"
+  }
+}

--- a/hack/test/integration/matchbox/groups/default.json
+++ b/hack/test/integration/matchbox/groups/default.json
@@ -1,0 +1,5 @@
+{
+  "id": "default",
+  "name": "default",
+  "profile": "default"
+}

--- a/hack/test/integration/matchbox/profiles/controlplane.json
+++ b/hack/test/integration/matchbox/profiles/controlplane.json
@@ -1,0 +1,21 @@
+{
+  "id": "default",
+  "name": "default",
+  "boot": {
+    "kernel": "/assets/vmlinuz",
+    "initrd": ["/assets/initramfs.xz"],
+    "args": [
+      "initrd=initramfs.xz",
+      "page_poison=1",
+      "slab_nomerge",
+      "slub_debug=P",
+      "pti=on",
+      "random.trust_cpu=on",
+      "console=tty0",
+      "console=ttyS0",
+      "printk.devkmsg=on",
+      "talos.platform=metal",
+      "talos.config=http://matchbox.talos.dev:8080/assets/controlplane.yaml"
+    ]
+  }
+}

--- a/hack/test/integration/matchbox/profiles/default.json
+++ b/hack/test/integration/matchbox/profiles/default.json
@@ -1,0 +1,21 @@
+{
+  "id": "default",
+  "name": "default",
+  "boot": {
+    "kernel": "/assets/vmlinuz",
+    "initrd": ["/assets/initramfs.xz"],
+    "args": [
+      "initrd=initramfs.xz",
+      "page_poison=1",
+      "slab_nomerge",
+      "slub_debug=P",
+      "pti=on",
+      "random.trust_cpu=on",
+      "console=tty0",
+      "console=ttyS0",
+      "printk.devkmsg=on",
+      "talos.platform=metal",
+      "talos.config=http://matchbox.talos.dev:8080/assets/join.yaml"
+    ]
+  }
+}

--- a/hack/test/integration/matchbox/profiles/init.json
+++ b/hack/test/integration/matchbox/profiles/init.json
@@ -1,0 +1,21 @@
+{
+  "id": "default",
+  "name": "default",
+  "boot": {
+    "kernel": "/assets/vmlinuz",
+    "initrd": ["/assets/initramfs.xz"],
+    "args": [
+      "initrd=initramfs.xz",
+      "page_poison=1",
+      "slab_nomerge",
+      "slub_debug=P",
+      "pti=on",
+      "random.trust_cpu=on",
+      "console=tty0",
+      "console=ttyS0",
+      "printk.devkmsg=on",
+      "talos.platform=metal",
+      "talos.config=http://matchbox.talos.dev:8080/assets/init.yaml"
+    ]
+  }
+}


### PR DESCRIPTION
This adds an integration test that can be ran on a KVM enabled Linux
machine. It makes use of docker, matchbox, dnsmasq, libvirt, and HAproxy
to create an HA cluster.