### PR TITLE
fix: make logging middleware first in the list, fix duration

### DIFF
--- a/pkg/grpc/middleware/log/log.go
+++ b/pkg/grpc/middleware/log/log.go
@@ -63,7 +63,7 @@ func (m *Middleware) UnaryInterceptor() grpc.UnaryServerInterceptor {
 			msg = err.Error()
 		}
 
-		m.logger.Printf("%s [%s] %.3fms unary %s (%s)", code, info.FullMethod, duration.Seconds()/1000.0, msg, extractMetadata(ctx))
+		m.logger.Printf("%s [%s] %s unary %s (%s)", code, info.FullMethod, duration, msg, extractMetadata(ctx))
 
 		return resp, err
 	}
@@ -84,7 +84,7 @@ func (m *Middleware) StreamInterceptor() grpc.StreamServerInterceptor {
 			msg = err.Error()
 		}
 
-		m.logger.Printf("%s [%s] %.3fms stream %s (%s)", code, info.FullMethod, duration.Seconds()/1000.0, msg, extractMetadata(stream.Context()))
+		m.logger.Printf("%s [%s] %s stream %s (%s)", code, info.FullMethod, duration, msg, extractMetadata(stream.Context()))
 
 		return err
 	}


### PR DESCRIPTION
Logging middleware should be the first one to log the request properly
including logging before proxy goes into action.

I had sec -> msec convertion wrong, but in the end I thought I should
replace it simply with `duration.String()` which is nicer.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>