### PR TITLE
fix: set --upgrade flag properly on installs

### DIFF
--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -54,10 +54,10 @@ func Install(r runtime.Runtime) error {
 	args := []string{
 		"/bin/osctl",
 		"install",
-		"--disk", r.Config().Machine().Install().Disk(),
-		"--platform", r.Platform().Name(),
-		"--config", *config,
-		"--upgrade", upgrade,
+		"--disk=" + r.Config().Machine().Install().Disk(),
+		"--platform=" + r.Platform().Name(),
+		"--config=" + *config,
+		"--upgrade=" + upgrade,
 	}
 
 	for _, arg := range r.Config().Machine().Install().ExtraKernelArgs() {


### PR DESCRIPTION
For some reason, if the `--upgrade` flag wasn't in the form of
`--upgrade=<true|false>` (with an `=`), the flag was always true. This
adds `=` to all flags.