### PR TITLE
docs: Add examples to networkd

### DIFF
--- a/docs/website/content/v0.3/en/components/networkd.md
+++ b/docs/website/content/v0.3/en/components/networkd.md
@@ -11,3 +11,49 @@ This can be overridden by supplying one of the following kernel arguments:
 - `talos.network.interface.ignore` - specify a list of interfaces to skip discovery on
 - `ip` - `ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>` as documented in the [kernel here](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt)
   - ex, `ip=10.0.0.99:::255.0.0.0:control-1:eth0:off:10.0.0.1`
+
+## Examples
+
+Documentation for the network section components can be found under the configuration reference.
+
+### Static Addressing
+
+Static addressing is comprised of specifying `cidr`, `routes` ( remember to add your default gateway ), and `interface`.
+Most likely you'll also want to define the `nameservers` so you have properly functioning DNS.
+
+```yaml
+machine:
+  network:
+    hostname: talos
+    nameservers:
+    - 10.0.0.1
+    time:
+      servers:
+        - time.cloudflare.com
+    interfaces:
+    - interface: eth0
+      cidr: 10.0.0.201/8
+      mtu: 8765
+      routes:
+        - network: 0.0.0.0/0
+          gateway: 10.0.0.1
+    - interface: eth1
+      ignore: true
+```
+
+### Additional Addresses for an Interface
+
+In some environments you may need to set additional addresses on an interface.
+In the following example, we set two additional addresses on the loopback interface.
+
+```yaml
+machine:
+  network:
+    interfaces:
+    - interface: lo0
+      cidr: 192.168.0.21/24
+    - interface: lo0
+      cidr: 10.2.2.2/24
+
+
+```


### PR DESCRIPTION
Add simple examples around static addressing and assigning multiple addresses
to a single interface.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>