### PR TITLE
refactor: remove CNI bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,6 @@ FROM build AS rootfs-base
 COPY --from=docker.io/autonomy/fhs:febbf49 / /rootfs
 COPY --from=docker.io/autonomy/ca-certificates:febbf49 / /rootfs
 COPY --from=docker.io/autonomy/containerd:febbf49 / /rootfs
-COPY --from=docker.io/autonomy/cni:febbf49 / /rootfs
 COPY --from=docker.io/autonomy/dosfstools:febbf49 / /rootfs
 COPY --from=docker.io/autonomy/eudev:febbf49 / /rootfs
 COPY --from=docker.io/autonomy/iptables:febbf49 / /rootfs

--- a/internal/app/machined/internal/cni/cni.go
+++ b/internal/app/machined/internal/cni/cni.go
@@ -15,7 +15,6 @@ import (
 func Mounts(config runtime.Configurator) ([]specs.Mount, error) {
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: "/etc/cni", Source: "/etc/cni", Options: []string{"rbind", "rshared", "rw"}},
-		{Type: "bind", Destination: "/opt/cni", Source: "/opt/cni", Options: []string{"rbind", "rshared", "rw"}},
 	}
 
 	return mounts, nil


### PR DESCRIPTION
The common pattern is for CNIs to install everything required. I don't
think we need to do this beforehand anymore. If we end up finding that
we do we can always add it back.