### PR TITLE
chore: Fix formatting ( make fmt )

### DIFF
--- a/api/api.pb.go
+++ b/api/api.pb.go
@@ -27,9 +27,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -241,50 +243,62 @@ type Interface = network.Interface
 // AddressFamily from public import network/network.proto
 type AddressFamily = network.AddressFamily
 
-var AddressFamily_name = network.AddressFamily_name
-var AddressFamily_value = network.AddressFamily_value
+var (
+	AddressFamily_name  = network.AddressFamily_name
+	AddressFamily_value = network.AddressFamily_value
+)
 
-const AddressFamily_AF_UNSPEC = AddressFamily(network.AddressFamily_AF_UNSPEC)
-const AddressFamily_AF_INET = AddressFamily(network.AddressFamily_AF_INET)
-const AddressFamily_IPV4 = AddressFamily(network.AddressFamily_IPV4)
-const AddressFamily_AF_INET6 = AddressFamily(network.AddressFamily_AF_INET6)
-const AddressFamily_IPV6 = AddressFamily(network.AddressFamily_IPV6)
+const (
+	AddressFamily_AF_UNSPEC = AddressFamily(network.AddressFamily_AF_UNSPEC)
+	AddressFamily_AF_INET   = AddressFamily(network.AddressFamily_AF_INET)
+	AddressFamily_IPV4      = AddressFamily(network.AddressFamily_IPV4)
+	AddressFamily_AF_INET6  = AddressFamily(network.AddressFamily_AF_INET6)
+	AddressFamily_IPV6      = AddressFamily(network.AddressFamily_IPV6)
+)
 
 // RouteProtocol from public import network/network.proto
 type RouteProtocol = network.RouteProtocol
 
-var RouteProtocol_name = network.RouteProtocol_name
-var RouteProtocol_value = network.RouteProtocol_value
+var (
+	RouteProtocol_name  = network.RouteProtocol_name
+	RouteProtocol_value = network.RouteProtocol_value
+)
 
-const RouteProtocol_RTPROT_UNSPEC = RouteProtocol(network.RouteProtocol_RTPROT_UNSPEC)
-const RouteProtocol_RTPROT_REDIRECT = RouteProtocol(network.RouteProtocol_RTPROT_REDIRECT)
-const RouteProtocol_RTPROT_KERNEL = RouteProtocol(network.RouteProtocol_RTPROT_KERNEL)
-const RouteProtocol_RTPROT_BOOT = RouteProtocol(network.RouteProtocol_RTPROT_BOOT)
-const RouteProtocol_RTPROT_STATIC = RouteProtocol(network.RouteProtocol_RTPROT_STATIC)
-const RouteProtocol_RTPROT_GATED = RouteProtocol(network.RouteProtocol_RTPROT_GATED)
-const RouteProtocol_RTPROT_RA = RouteProtocol(network.RouteProtocol_RTPROT_RA)
-const RouteProtocol_RTPROT_MRT = RouteProtocol(network.RouteProtocol_RTPROT_MRT)
-const RouteProtocol_RTPROT_ZEBRA = RouteProtocol(network.RouteProtocol_RTPROT_ZEBRA)
-const RouteProtocol_RTPROT_BIRD = RouteProtocol(network.RouteProtocol_RTPROT_BIRD)
-const RouteProtocol_RTPROT_DNROUTED = RouteProtocol(network.RouteProtocol_RTPROT_DNROUTED)
-const RouteProtocol_RTPROT_XORP = RouteProtocol(network.RouteProtocol_RTPROT_XORP)
-const RouteProtocol_RTPROT_NTK = RouteProtocol(network.RouteProtocol_RTPROT_NTK)
-const RouteProtocol_RTPROT_DHCP = RouteProtocol(network.RouteProtocol_RTPROT_DHCP)
-const RouteProtocol_RTPROT_MROUTED = RouteProtocol(network.RouteProtocol_RTPROT_MROUTED)
-const RouteProtocol_RTPROT_BABEL = RouteProtocol(network.RouteProtocol_RTPROT_BABEL)
+const (
+	RouteProtocol_RTPROT_UNSPEC   = RouteProtocol(network.RouteProtocol_RTPROT_UNSPEC)
+	RouteProtocol_RTPROT_REDIRECT = RouteProtocol(network.RouteProtocol_RTPROT_REDIRECT)
+	RouteProtocol_RTPROT_KERNEL   = RouteProtocol(network.RouteProtocol_RTPROT_KERNEL)
+	RouteProtocol_RTPROT_BOOT     = RouteProtocol(network.RouteProtocol_RTPROT_BOOT)
+	RouteProtocol_RTPROT_STATIC   = RouteProtocol(network.RouteProtocol_RTPROT_STATIC)
+	RouteProtocol_RTPROT_GATED    = RouteProtocol(network.RouteProtocol_RTPROT_GATED)
+	RouteProtocol_RTPROT_RA       = RouteProtocol(network.RouteProtocol_RTPROT_RA)
+	RouteProtocol_RTPROT_MRT      = RouteProtocol(network.RouteProtocol_RTPROT_MRT)
+	RouteProtocol_RTPROT_ZEBRA    = RouteProtocol(network.RouteProtocol_RTPROT_ZEBRA)
+	RouteProtocol_RTPROT_BIRD     = RouteProtocol(network.RouteProtocol_RTPROT_BIRD)
+	RouteProtocol_RTPROT_DNROUTED = RouteProtocol(network.RouteProtocol_RTPROT_DNROUTED)
+	RouteProtocol_RTPROT_XORP     = RouteProtocol(network.RouteProtocol_RTPROT_XORP)
+	RouteProtocol_RTPROT_NTK      = RouteProtocol(network.RouteProtocol_RTPROT_NTK)
+	RouteProtocol_RTPROT_DHCP     = RouteProtocol(network.RouteProtocol_RTPROT_DHCP)
+	RouteProtocol_RTPROT_MROUTED  = RouteProtocol(network.RouteProtocol_RTPROT_MROUTED)
+	RouteProtocol_RTPROT_BABEL    = RouteProtocol(network.RouteProtocol_RTPROT_BABEL)
+)
 
 // InterfaceFlags from public import network/network.proto
 type InterfaceFlags = network.InterfaceFlags
 
-var InterfaceFlags_name = network.InterfaceFlags_name
-var InterfaceFlags_value = network.InterfaceFlags_value
+var (
+	InterfaceFlags_name  = network.InterfaceFlags_name
+	InterfaceFlags_value = network.InterfaceFlags_value
+)
 
-const InterfaceFlags_FLAG_UNKNOWN = InterfaceFlags(network.InterfaceFlags_FLAG_UNKNOWN)
-const InterfaceFlags_FLAG_UP = InterfaceFlags(network.InterfaceFlags_FLAG_UP)
-const InterfaceFlags_FLAG_BROADCAST = InterfaceFlags(network.InterfaceFlags_FLAG_BROADCAST)
-const InterfaceFlags_FLAG_LOOPBACK = InterfaceFlags(network.InterfaceFlags_FLAG_LOOPBACK)
-const InterfaceFlags_FLAG_POINT_TO_POINT = InterfaceFlags(network.InterfaceFlags_FLAG_POINT_TO_POINT)
-const InterfaceFlags_FLAG_MULTICAST = InterfaceFlags(network.InterfaceFlags_FLAG_MULTICAST)
+const (
+	InterfaceFlags_FLAG_UNKNOWN        = InterfaceFlags(network.InterfaceFlags_FLAG_UNKNOWN)
+	InterfaceFlags_FLAG_UP             = InterfaceFlags(network.InterfaceFlags_FLAG_UP)
+	InterfaceFlags_FLAG_BROADCAST      = InterfaceFlags(network.InterfaceFlags_FLAG_BROADCAST)
+	InterfaceFlags_FLAG_LOOPBACK       = InterfaceFlags(network.InterfaceFlags_FLAG_LOOPBACK)
+	InterfaceFlags_FLAG_POINT_TO_POINT = InterfaceFlags(network.InterfaceFlags_FLAG_POINT_TO_POINT)
+	InterfaceFlags_FLAG_MULTICAST      = InterfaceFlags(network.InterfaceFlags_FLAG_MULTICAST)
+)
 
 // NodeMetadata from public import common/common.proto
 type NodeMetadata = common.NodeMetadata
@@ -301,11 +315,15 @@ type DataReply = common.DataReply
 // ContainerDriver from public import common/common.proto
 type ContainerDriver = common.ContainerDriver
 
-var ContainerDriver_name = common.ContainerDriver_name
-var ContainerDriver_value = common.ContainerDriver_value
+var (
+	ContainerDriver_name  = common.ContainerDriver_name
+	ContainerDriver_value = common.ContainerDriver_value
+)
 
-const ContainerDriver_CONTAINERD = ContainerDriver(common.ContainerDriver_CONTAINERD)
-const ContainerDriver_CRI = ContainerDriver(common.ContainerDriver_CRI)
+const (
+	ContainerDriver_CONTAINERD = ContainerDriver(common.ContainerDriver_CONTAINERD)
+	ContainerDriver_CRI        = ContainerDriver(common.ContainerDriver_CRI)
+)
 
 // Empty from public import google/protobuf/empty.proto
 type Empty = empty.Empty

--- a/api/common/common.pb.go
+++ b/api/common/common.pb.go
@@ -11,9 +11,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.

--- a/api/machine/machine.pb.go
+++ b/api/machine/machine.pb.go
@@ -17,9 +17,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -2226,8 +2228,10 @@ var fileDescriptor_84b4f59d98cc997c = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.

--- a/api/network/network.pb.go
+++ b/api/network/network.pb.go
@@ -16,9 +16,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -625,8 +627,10 @@ var fileDescriptor_96ad937ae012c472 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.

--- a/api/os/os.pb.go
+++ b/api/os/os.pb.go
@@ -16,9 +16,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -1520,8 +1522,10 @@ var fileDescriptor_b20a722d09fd3254 = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.

--- a/api/security/security.pb.go
+++ b/api/security/security.pb.go
@@ -13,9 +13,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -339,8 +341,10 @@ var fileDescriptor_45fd4b7e16002c2e = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.

--- a/api/time/time.pb.go
+++ b/api/time/time.pb.go
@@ -17,9 +17,11 @@ import (
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ = proto.Marshal
-var _ = fmt.Errorf
-var _ = math.Inf
+var (
+	_ = proto.Marshal
+	_ = fmt.Errorf
+	_ = math.Inf
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
@@ -216,8 +218,10 @@ var fileDescriptor_e7ed1ef5b20ef4ce = []byte{
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+var (
+	_ context.Context
+	_ grpc.ClientConn
+)
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.

--- a/cmd/osctl/cmd/processes.go
+++ b/cmd/osctl/cmd/processes.go
@@ -27,8 +27,10 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 )
 
-var sortMethod string
-var watchProcesses bool
+var (
+	sortMethod     string
+	watchProcesses bool
+)
 
 // processesCmd represents the processes command
 var processesCmd = &cobra.Command{

--- a/internal/app/machined/pkg/system/log/log.go
+++ b/internal/app/machined/pkg/system/log/log.go
@@ -14,8 +14,10 @@ import (
 	filechunker "github.com/talos-systems/talos/pkg/chunker/file"
 )
 
-var instance = map[string]*Log{}
-var mu sync.Mutex
+var (
+	instance = map[string]*Log{}
+	mu       sync.Mutex
+)
 
 // Log represents the log of a service. It supports streaming of the contents of
 // the log file by way of implementing the chunker.Chunker interface.

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -35,8 +35,10 @@ type singleton struct {
 	terminating bool
 }
 
-var instance *singleton
-var once sync.Once
+var (
+	instance *singleton
+	once     sync.Once
+)
 
 // Services returns the instance of the system services API.
 // nolint: golint

--- a/internal/pkg/kernel/kernel.go
+++ b/internal/pkg/kernel/kernel.go
@@ -118,8 +118,10 @@ type Cmdline struct {
 	Parameters
 }
 
-var instance *Cmdline
-var once sync.Once
+var (
+	instance *Cmdline
+	once     sync.Once
+)
 
 // Cmdline returns a representation of /proc/cmdline.
 // nolint: golint


### PR DESCRIPTION
Not sure if there was an update in the fmt code path, but these are the
results after running `make fmt`.

These should all be whitespace related fixes.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>