### PR TITLE
fix: recover control plane on reboot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 replace (
 	github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 	github.com/jsimonetti/rtnetlink => github.com/bradbeam/rtnetlink v0.0.0-20191116224831-33eac9dd89f6
-	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20191127161749-57a53bb3d3da
+	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20191127182503-08e42a4c200c
 	github.com/opencontainers/runtime-spec v1.0.1 => github.com/opencontainers/runtime-spec v0.1.2-0.20180301181910-fa4b36aa9c99
 )
 

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e h1:QjF5rxNgRSLHJDwKUvfYP3qOx1vTDzUi/+oSC8FXnCI=
 github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/bootkube v0.14.1-0.20191127161749-57a53bb3d3da h1:eByLWutxH8EnTYe3fWhyzH+ZJ1HtrPvdjhLJhUrAXuU=
-github.com/talos-systems/bootkube v0.14.1-0.20191127161749-57a53bb3d3da/go.mod h1:CIpoNLW4Lm9zNVFRgqQIylnbZi/x9TnulTEA8edC0O4=
+github.com/talos-systems/bootkube v0.14.1-0.20191127182503-08e42a4c200c h1:By7EcuWOTMwvsmymyiWsi+RfK2pVbYEA6Kuk3Ma/K6g=
+github.com/talos-systems/bootkube v0.14.1-0.20191127182503-08e42a4c200c/go.mod h1:CIpoNLW4Lm9zNVFRgqQIylnbZi/x9TnulTEA8edC0O4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/u-root/u-root v6.0.0+incompatible h1:YqPGmRoRyYmeg17KIWFRSyVq6LX5T6GSzawyA6wG6EE=

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -292,6 +292,9 @@ func generateAssets(config runtime.Configurator) (err error) {
 	images := asset.DefaultImages
 
 	images.Hyperkube = fmt.Sprintf("k8s.gcr.io/hyperkube:v%s", config.Cluster().Version())
+	// TODO(andrewrynhard): This is a hack workaround for now. Update this once
+	// there is an official image.
+	images.PodCheckpointer = "docker.io/autonomy/pod-checkpointer:51fba9528e96d3be488562574c288b2fb82a1e3b"
 
 	conf := asset.Config{
 		CACert:                 k8sCA,


### PR DESCRIPTION
This brings in a patched version of the pod-checkpointer. It fixes a bug
that prevented the static pod-checkpointer from being scheduled,
preventing recovery of the control plane on a reboot of all control
plane nodes.