### PR TITLE
feat(networkd): Add support for kernel nfsroot arguments.

### DIFF
--- a/internal/app/machined/internal/phase/network/network.go
+++ b/internal/app/machined/internal/phase/network/network.go
@@ -5,13 +5,10 @@
 package network
 
 import (
-	"log"
-
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
-	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 )
 
@@ -34,13 +31,6 @@ func (task *InitialNetworkSetup) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *InitialNetworkSetup) runtime(r runtime.Runtime) (err error) {
-	// Check to see if a static IP was set via kernel args;
-	// if so, we'll skip the initial dhcp discovery
-	if option := kernel.ProcCmdline().Get("ip").First(); option != nil {
-		log.Println("skipping initial network setup, found kernel arg 'ip'")
-		return nil
-	}
-
 	nwd, err := networkd.New(r.Config())
 	if err != nil {
 		return err

--- a/internal/app/machined/internal/phase/network/reset.go
+++ b/internal/app/machined/internal/phase/network/reset.go
@@ -5,11 +5,8 @@
 package network
 
 import (
-	"log"
-
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
-	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 )
 
@@ -33,13 +30,6 @@ func (task *ResetNetworkNetwork) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 
 // nolint: gocyclo
 func (task *ResetNetworkNetwork) runtime(r runtime.Runtime) (err error) {
-	// Check to see if a static IP was set via kernel args;
-	// if so, we'll skip the initial dhcp discovery
-	if option := kernel.ProcCmdline().Get("ip").First(); option != nil {
-		log.Println("skipping initial network setup, found kernel arg 'ip'")
-		return nil
-	}
-
 	nwd, err := networkd.New(r.Config())
 	if err != nil {
 		return err

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/reg"
-	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
@@ -44,12 +43,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Check to see if a static IP was set via kernel args;
-	// if so, we'll skip the networking configuration via networkd
-	if option := kernel.ProcCmdline().Get("ip").First(); option == nil {
-		if err = nwd.Configure(); err != nil {
-			log.Fatal(err)
-		}
+	if err = nwd.Configure(); err != nil {
+		log.Fatal(err)
 	}
 
 	log.Println("completed initial network configuration")

--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -17,8 +17,9 @@ import (
 // Static implements the Addressing interface
 type Static struct {
 	Device      *machine.Device
+	FQDN        string
 	NetIf       *net.Interface
-	NameServers []string
+	NameServers []net.IP
 }
 
 // Discover doesnt do anything in the static configuration since all
@@ -94,12 +95,12 @@ func (s *Static) Routes() (routes []*Route) {
 
 // Resolvers returns the DNS resolvers
 func (s *Static) Resolvers() []net.IP {
-	return []net.IP{}
+	return s.NameServers
 }
 
 // Hostname returns the hostname
 func (s *Static) Hostname() string {
-	return ""
+	return s.FQDN
 }
 
 // Link returns the underlying net.Interface that this address

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/internal/pkg/kernel"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/config/machine"
 )
@@ -43,6 +44,7 @@ type Networkd struct {
 func New(config runtime.Configurator) (*Networkd, error) {
 	var (
 		hostname  string
+		option    *string
 		result    *multierror.Error
 		resolvers []string
 	)
@@ -70,6 +72,11 @@ func New(config runtime.Configurator) (*Networkd, error) {
 		if len(config.Machine().Network().Resolvers()) > 0 {
 			resolvers = config.Machine().Network().Resolvers()
 		}
+	}
+
+	if option = kernel.ProcCmdline().Get("ip").First(); option != nil {
+		name, opts := buildKernelOptions(*option)
+		netconf[name] = opts
 	}
 
 	log.Println("discovering local interfaces")


### PR DESCRIPTION
This adds support for parsing/honoring the `ip=` kernel argument that can
be supplied to configure an interface on the host.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>