### PR TITLE
fix: provide a way for client TLS config to use Provider

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -58,22 +58,16 @@ func main() {
 	tlsConfig, err := tls.New(
 		tls.WithClientAuthType(tls.Mutual),
 		tls.WithCACertPEM(ca),
-		tls.WithCertificateProvider(provider),
+		tls.WithServerCertificateProvider(provider),
 	)
 	if err != nil {
 		log.Fatalf("failed to create OS-level TLS configuration: %v", err)
 	}
 
-	// TODO: refactor
-	certs, err := provider.GetCertificate(nil)
-	if err != nil {
-		log.Fatalf("failed to get TLS certs: %v", err)
-	}
-
 	clientTLSConfig, err := tls.New(
 		tls.WithClientAuthType(tls.Mutual),
 		tls.WithCACertPEM(ca),
-		tls.WithKeypair(*certs), // TODO: this doesn't support cert refresh, fix me!
+		tls.WithClientCertificateProvider(provider),
 	)
 	if err != nil {
 		log.Fatalf("failed to create client TLS config: %v", err)

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -82,7 +82,7 @@ func main() {
 	tlsConfig, err := tls.New(
 		tls.WithClientAuthType(tls.ServerOnly),
 		tls.WithCACertPEM(ca),
-		tls.WithCertificateProvider(provider),
+		tls.WithServerCertificateProvider(provider),
 	)
 	if err != nil {
 		log.Fatalf("failed to create TLS config: %v", err)

--- a/pkg/grpc/tls/provider.go
+++ b/pkg/grpc/tls/provider.go
@@ -25,6 +25,9 @@ type CertificateProvider interface {
 	// GetCertificate returns the current certificate matching the given client request.
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
 
+	// GetClientCertificate returns the current certificate to present to the server.
+	GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error)
+
 	// UpdateCertificate updates the stored certificate for the given client request.
 	UpdateCertificates([]byte, *tls.Certificate) error
 }
@@ -62,6 +65,10 @@ func (p *embeddableCertificateProvider) GetCertificate(h *tls.ClientHelloInfo) (
 	defer p.RUnlock()
 
 	return p.crt, nil
+}
+
+func (p *embeddableCertificateProvider) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return p.GetCertificate(nil)
 }
 
 func (p *embeddableCertificateProvider) UpdateCertificates(ca []byte, cert *tls.Certificate) error {

--- a/pkg/grpc/tls/tls.go
+++ b/pkg/grpc/tls/tls.go
@@ -41,18 +41,34 @@ func WithClientAuthType(t Type) func(*tls.Config) error {
 	}
 }
 
-// WithCertificateProvider declares a dynamic provider for the client
+// WithServerCertificateProvider declares a dynamic provider for the server
 // certificate.
 //
 // NOTE: specifying this option will CLEAR any configured Certificates, since
 // they would otherwise override this option.
-func WithCertificateProvider(p CertificateProvider) func(*tls.Config) error {
+func WithServerCertificateProvider(p CertificateProvider) func(*tls.Config) error {
 	return func(cfg *tls.Config) error {
 		if p == nil {
 			return errors.New("no provider")
 		}
 		cfg.Certificates = nil
 		cfg.GetCertificate = p.GetCertificate
+		return nil
+	}
+}
+
+// WithClientCertificateProvider declares a dynamic provider for the client
+// certificate.
+//
+// NOTE: specifying this option will CLEAR any configured Certificates, since
+// they would otherwise override this option.
+func WithClientCertificateProvider(p CertificateProvider) func(*tls.Config) error {
+	return func(cfg *tls.Config) error {
+		if p == nil {
+			return errors.New("no provider")
+		}
+		cfg.Certificates = nil
+		cfg.GetClientCertificate = p.GetClientCertificate
 		return nil
 	}
 }


### PR DESCRIPTION
In `tls.Config`, there are two hooks for getting certificate for client
and server config. So we need separate configuration methods to
configure them both.

Required in apid to provide refreshing TLS client cert to
grpc.ClientConn.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>