### PR TITLE
chore: fix conformance

### DIFF
--- a/hack/test/conformance.sh
+++ b/hack/test/conformance.sh
@@ -25,8 +25,8 @@ e2e_run "set -eou pipefail
             --wait \
             --skip-preflight \
             --plugin e2e \
-            --plugin-env e2e.E2E_USE_GO_RUNNER=true \
-            --e2e-parallel=y \
             --mode certified-conformance
          results=\$(sonobuoy retrieve --kubeconfig ${KUBECONFIG})
-         sonobuoy e2e --kubeconfig ${KUBECONFIG} \$results"
+         sonobuoy e2e --kubeconfig ${KUBECONFIG} \$results
+         sonobuoy status --kubeconfig ${KUBECONFIG} --json | tee /tmp/status.json
+         if [ \$(cat /tmp/status.json | jq -r '.plugins[] | select(.plugin == \"e2e\") | .\"result-status\"') != 'passed' ]; then exit 1; fi"


### PR DESCRIPTION
The `--e2e-parallel` flag seems to skip all tests when running in
certified-conformance mode. This reverts that change, and also adds a
check that fails if the conformance tests do not pass. This ensures that
we are not publishing broken versions of our edge release.