### PR TITLE
chore: upgrade packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,29 +206,29 @@ COPY --from=osctl-darwin-build /osctl-darwin-amd64 /osctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:b9052e5 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:b9052e5 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:d313fca /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:d313fca /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/containerd:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/eudev:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/iptables:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/libressl:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/musl:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/runc:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/socat:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:b9052e5 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:b9052e5 /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:b9052e5 /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:b9052e5 /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:b9052e5 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:d313fca / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:d313fca / /rootfs
+COPY --from=docker.io/autonomy/containerd:d313fca / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:d313fca / /rootfs
+COPY --from=docker.io/autonomy/eudev:d313fca / /rootfs
+COPY --from=docker.io/autonomy/iptables:d313fca / /rootfs
+COPY --from=docker.io/autonomy/libressl:d313fca / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:d313fca / /rootfs
+COPY --from=docker.io/autonomy/musl:d313fca / /rootfs
+COPY --from=docker.io/autonomy/runc:d313fca / /rootfs
+COPY --from=docker.io/autonomy/socat:d313fca / /rootfs
+COPY --from=docker.io/autonomy/syslinux:d313fca / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:d313fca / /rootfs
+COPY --from=docker.io/autonomy/util-linux:d313fca /lib/libblkid.* /rootfs/lib
+COPY --from=docker.io/autonomy/util-linux:d313fca /lib/libuuid.* /rootfs/lib
+COPY --from=docker.io/autonomy/kmod:d313fca /usr/lib/libkmod.* /rootfs/lib
+COPY --from=docker.io/autonomy/kernel:d313fca /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY images/apid.tar /rootfs/usr/images/
 COPY images/ntpd.tar /rootfs/usr/images/


### PR DESCRIPTION
This brings in the latest set of packages with the following changes:

- Linux v5.3.14
- Pinned ca-certificates (2019-11-27)