### PR TITLE
fix: prevent nil pointer panic

### DIFF
--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -179,6 +179,10 @@ func (m *MachineConfig) SetCertSANs(sans []string) {
 
 // ExtraArgs implements the Configurator interface.
 func (k *KubeletConfig) ExtraArgs() map[string]string {
+	if k == nil {
+		k = &KubeletConfig{}
+	}
+
 	if k.KubeletExtraArgs == nil {
 		k.KubeletExtraArgs = make(map[string]string)
 	}


### PR DESCRIPTION
This KubeletConfig should be checked for `nil`, and initialized if
needed, before attempting to access its' fields.