### PR TITLE
fix: osctl panic when metadata is nil

### DIFF
--- a/cmd/osctl/cmd/containers.go
+++ b/cmd/osctl/cmd/containers.go
@@ -78,7 +78,13 @@ func containerRender(reply *osapi.ContainersReply) {
 				display = "└─ " + display
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", resp.Metadata.Hostname, p.Namespace, display, p.Image, p.Pid, p.Status)
+			node := ""
+
+			if resp.Metadata != nil {
+				node = resp.Metadata.Hostname
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n", node, p.Namespace, display, p.Image, p.Pid, p.Status)
 		}
 	}
 

--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -35,7 +35,7 @@ var dmesgCmd = &cobra.Command{
 			}
 
 			for _, resp := range reply.Response {
-				if len(reply.Response) > 1 {
+				if len(reply.Response) > 1 && resp.Metadata != nil {
 					fmt.Println(resp.Metadata.Hostname)
 				}
 				_, err = os.Stdout.Write(resp.Bytes)

--- a/cmd/osctl/cmd/memory.go
+++ b/cmd/osctl/cmd/memory.go
@@ -51,9 +51,15 @@ func briefRender(reply *osapi.MemInfoReply) {
 	fmt.Fprintln(w, "NODE\tTOTAL\tUSED\tFREE\tSHARED\tBUFFERS\tCACHE\tAVAILABLE")
 
 	for _, resp := range reply.Response {
+		node := ""
+
+		if resp.Metadata != nil {
+			node = resp.Metadata.Hostname
+		}
+
 		// Default to displaying output as MB
 		fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
-			resp.Metadata.Hostname,
+			node,
 			resp.Meminfo.Memtotal/1024,
 			(resp.Meminfo.Memtotal-resp.Meminfo.Memfree-resp.Meminfo.Cached-resp.Meminfo.Buffers)/1024,
 			resp.Meminfo.Memfree/1024,
@@ -70,7 +76,10 @@ func briefRender(reply *osapi.MemInfoReply) {
 func verboseRender(reply *osapi.MemInfoReply) {
 	// Dump as /proc/meminfo
 	for _, resp := range reply.Response {
-		fmt.Printf("%s: %s\n", "NODE", resp.Metadata.Hostname)
+		if resp.Metadata != nil {
+			fmt.Printf("%s: %s\n", "NODE", resp.Metadata.Hostname)
+		}
+
 		fmt.Printf("%s: %d %s\n", "MemTotal", resp.Meminfo.Memtotal, "kB")
 		fmt.Printf("%s: %d %s\n", "MemFree", resp.Meminfo.Memfree, "kB")
 		fmt.Printf("%s: %d %s\n", "MemAvailable", resp.Meminfo.Memavailable, "kB")

--- a/cmd/osctl/cmd/processes.go
+++ b/cmd/osctl/cmd/processes.go
@@ -180,6 +180,7 @@ var cpu = func(p1, p2 *osapi.Process) bool {
 	return p1.CpuTime > p2.CpuTime
 }
 
+//nolint: gocyclo
 func processesOutput(ctx context.Context, c *client.Client) (output string, err error) {
 	reply, err := c.Processes(ctx)
 	if err != nil {
@@ -216,9 +217,15 @@ func processesOutput(ctx context.Context, c *client.Client) (output string, err 
 				args = p.Args
 			}
 
+			node := ""
+
+			if resp.Metadata != nil {
+				node = resp.Metadata.Hostname
+			}
+
 			s = append(s,
 				fmt.Sprintf("%12s | %6d | %1s | %4d | %8.2f | %7s | %7s | %s",
-					resp.Metadata.Hostname, p.Pid, p.State, p.Threads, p.CpuTime, bytefmt.ByteSize(p.VirtualMemory), bytefmt.ByteSize(p.ResidentMemory), args))
+					node, p.Pid, p.State, p.Threads, p.CpuTime, bytefmt.ByteSize(p.VirtualMemory), bytefmt.ByteSize(p.ResidentMemory), args))
 		}
 	}
 

--- a/cmd/osctl/cmd/stats.go
+++ b/cmd/osctl/cmd/stats.go
@@ -76,7 +76,13 @@ func statsRender(reply *osapi.StatsReply) {
 				display = "└─ " + display
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", resp.Metadata.Hostname, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
+			node := ""
+
+			if resp.Metadata != nil {
+				node = resp.Metadata.Hostname
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%.2f\t%d\n", node, s.Namespace, display, float64(s.MemoryUsage)*1e-6, s.CpuUsage)
 		}
 	}
 

--- a/cmd/osctl/cmd/version.go
+++ b/cmd/osctl/cmd/version.go
@@ -42,13 +42,10 @@ var versionCmd = &cobra.Command{
 				helpers.Fatalf("error getting version: %s", err)
 			}
 			for _, resp := range reply.Response {
-				node := ""
-
 				if resp.Metadata != nil {
-					node = resp.Metadata.Hostname
+					fmt.Printf("\t%s:        %s\n", "NODE", resp.Metadata.Hostname)
 				}
 
-				fmt.Printf("\t%s:        %s\n", "NODE", node)
 				version.PrintLongVersionFromExisting(resp.Version)
 			}
 		})


### PR DESCRIPTION
If `osctl` invocation doesn't have `-t`, response doesn't contain
`.Metadata` field, so we need to check for it explicitly.

Some commands in osctl had this check, some didn't, now all the commands
have this check.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>