### PR TITLE
feat: osctl logs now supports multiple targets

### DIFF
--- a/cmd/osctl/cmd/logs.go
+++ b/cmd/osctl/cmd/logs.go
@@ -5,8 +5,11 @@
 package cmd
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
@@ -14,6 +17,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/api/common"
+	"github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -47,20 +51,122 @@ var logsCmd = &cobra.Command{
 				helpers.Fatalf("error fetching logs: %s", err)
 			}
 
-			for {
-				data, err := stream.Recv()
-				if err != nil {
-					if err == io.EOF || status.Code(err) == codes.Canceled {
-						return
-					}
-					helpers.Fatalf("error streaming logs: %s", err)
+			defaultNode := remotePeer(stream.Context())
+
+			respCh, errCh := newLineSlicer(stream)
+
+			for data := range respCh {
+				if data.Metadata != nil && data.Metadata.Error != "" {
+					_, err = fmt.Fprintf(os.Stderr, "ERROR: %s\n", data.Metadata.Error)
+					helpers.Should(err)
 				}
 
-				_, err = os.Stdout.Write(data.Bytes)
+				node := defaultNode
+				if data.Metadata != nil && data.Metadata.Hostname != "" {
+					node = data.Metadata.Hostname
+				}
+
+				_, err = fmt.Printf("%s: %s\n", node, data.Bytes)
 				helpers.Should(err)
 			}
+
+			helpers.Should(<-errCh)
 		})
 	},
+}
+
+// lineSlicer splits random chunks of bytes coming from nodes into a stream
+// of lines aggregated per node.
+type lineSlicer struct {
+	respCh chan *common.DataResponse
+	errCh  chan error
+	pipes  map[string]*io.PipeWriter
+	wg     sync.WaitGroup
+}
+
+func newLineSlicer(stream machine.Machine_LogsClient) (chan *common.DataResponse, chan error) {
+	slicer := &lineSlicer{
+		respCh: make(chan *common.DataResponse),
+		errCh:  make(chan error, 1),
+		pipes:  map[string]*io.PipeWriter{},
+	}
+
+	go slicer.run(stream)
+
+	return slicer.respCh, slicer.errCh
+}
+
+func (slicer *lineSlicer) chopper(r io.Reader, hostname string) {
+	defer slicer.wg.Done()
+
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		slicer.respCh <- &common.DataResponse{
+			Metadata: &common.ResponseMetadata{
+				Hostname: hostname,
+			},
+			Bytes: scanner.Bytes(),
+		}
+	}
+}
+
+func (slicer *lineSlicer) getPipe(node string) *io.PipeWriter {
+	pipe, ok := slicer.pipes[node]
+	if !ok {
+		var piper *io.PipeReader
+		piper, pipe = io.Pipe()
+
+		slicer.wg.Add(1)
+
+		go slicer.chopper(piper, node)
+
+		slicer.pipes[node] = pipe
+	}
+
+	return pipe
+}
+
+func (slicer *lineSlicer) cleanupChoppers() {
+	for _, p := range slicer.pipes {
+		_ = p.Close() //nolint: errcheck
+	}
+
+	slicer.wg.Wait()
+}
+
+func (slicer *lineSlicer) run(stream machine.Machine_LogsClient) {
+	defer close(slicer.errCh)
+	defer close(slicer.respCh)
+
+	defer slicer.cleanupChoppers()
+
+	for {
+		data, err := stream.Recv()
+		if err != nil {
+			if err == io.EOF || status.Code(err) == codes.Canceled {
+				return
+			}
+			slicer.errCh <- err
+
+			return
+		}
+
+		if data.Metadata != nil && data.Metadata.Error != "" {
+			// errors are delivered OOB
+			slicer.respCh <- data
+			continue
+		}
+
+		node := ""
+
+		if data.Metadata != nil {
+			node = data.Metadata.Hostname
+		}
+
+		_, err = slicer.getPipe(node).Write(data.Bytes)
+		helpers.Should(err)
+	}
 }
 
 func init() {

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 	"path"
@@ -17,6 +18,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc/peer"
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
@@ -191,4 +193,16 @@ func extractTarGz(localPath string, r io.Reader) {
 			}
 		}
 	}
+}
+
+func remotePeer(ctx context.Context) (peerHost string) {
+	peerHost = "unknown"
+
+	remote, ok := peer.FromContext(ctx)
+	if ok {
+		peerHost = remote.Addr.String()
+		peerHost, _, _ = net.SplitHostPort(peerHost) //nolint: errcheck
+	}
+
+	return
 }


### PR DESCRIPTION
Update cli so that with multiple targets work pretty much like
`tail -f one.log two.log`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>