### PR TITLE
fix: update kernel version constant

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version
-	DefaultKernelVersion = "5.3.13-talos"
+	DefaultKernelVersion = "5.3.14-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL
 	// to the config.


### PR DESCRIPTION
This is needed in order for integration tests to pass.