### PR TITLE
refactor: simplify NewTemporaryClientFromPKI

### DIFF
--- a/internal/app/machined/internal/phase/services/post_boot.go
+++ b/internal/app/machined/internal/phase/services/post_boot.go
@@ -34,12 +34,7 @@ func (task *LabelNodeAsMaster) standard(r runtime.Runtime) (err error) {
 		return nil
 	}
 
-	h, err := kubernetes.NewTemporaryClientFromPKI(
-		r.Config().Cluster().CA().Crt,
-		r.Config().Cluster().CA().Key,
-		r.Config().Cluster().Endpoint().Hostname(),
-		r.Config().Cluster().Endpoint().Port(),
-	)
+	h, err := kubernetes.NewTemporaryClientFromPKI(r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -49,12 +49,7 @@ func NewClient(endpoints []string) (client *clientv3.Client, err error) {
 // NewClientFromControlPlaneIPs initializes and returns an etcd client
 // configured to talk to all members.
 func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpoint *url.URL) (client *clientv3.Client, err error) {
-	h, err := kubernetes.NewTemporaryClientFromPKI(
-		creds.Crt,
-		creds.Key,
-		endpoint.Hostname(),
-		endpoint.Port(),
-	)
+	h, err := kubernetes.NewTemporaryClientFromPKI(creds, endpoint)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a simple refactor that reduces the number of arguments required
by `NewTemporaryClientFromPKI`.

Closes #1420.