### PR TITLE
test: fix integration version test as 'NODE:' was removed

### DIFF
--- a/internal/integration/cli/version.go
+++ b/internal/integration/cli/version.go
@@ -26,7 +26,7 @@ func (suite *VersionSuite) SuiteName() string {
 func (suite *VersionSuite) TestExpectedVersionMaster() {
 	suite.RunOsctl([]string{"version"},
 		base.StdoutShouldMatch(regexp.MustCompile(`Client:\n\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
-		base.StdoutShouldMatch(regexp.MustCompile(`Server:\n\s*NODE:[^\n]+\n\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
+		base.StdoutShouldMatch(regexp.MustCompile(`Server:\n(\s*NODE:[^\n]+\n)?\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
 	)
 }
 


### PR DESCRIPTION
When invoked without `-t`, `osctl` shouldn't print `NODE:` anymore.

Question: how tests are passing without the fix...?

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>