### PR TITLE
feat: allow deep-linking to specific docs pages

### DIFF
--- a/docs/website/components/Content.vue
+++ b/docs/website/components/Content.vue
@@ -29,8 +29,15 @@ export default {
 
   computed: {
     doc() {
-      const activeDocPath = this.$store.getters['sidebar/getActiveDocPath']
       const sections = this.$store.getters['sidebar/getSections']
+      let activeDocPath = ''
+
+      // if there's an #anchor specified, go there instead of the top-level
+      if (this.$route.hash) {
+        activeDocPath = this.$route.hash.substring(1)
+      } else {
+        activeDocPath = this.$store.getters['sidebar/getActiveDocPath']
+      }
 
       return sections[activeDocPath]
     }

--- a/docs/website/components/Sidebar.vue
+++ b/docs/website/components/Sidebar.vue
@@ -9,7 +9,7 @@
       >
         <a
           class="sidebar-category"
-          :href="'#' + entry.title"
+          :href="'#' + entry.path"
           @click="handleClick(entry)"
         >
           <span class="relative">{{ entry.title }}</span>
@@ -18,7 +18,7 @@
           <li v-for="item in entry.items" :key="item.path" class="ml-0">
             <a
               class="sidebar-item"
-              :href="'#' + item.title"
+              :href="'#' + item.path"
               @click="handleClick(item)"
             >
               <span class="relative">{{ item.title }}</span>
@@ -27,7 +27,7 @@
               <li v-for="child in item.children" :key="child.path" class="ml-0">
                 <a
                   class="sidebar-child"
-                  :href="'#' + child.title"
+                  :href="'#' + child.path"
                   @click="handleClick(child)"
                 >
                   <span class="relative">{{ child.title }}</span>


### PR DESCRIPTION
This changes the way the sidebar anchors are constructed, and if
there is an anchor in the URL, the Content component will render
the requested page, instead of just the top-level docs page.

Signed-off-by: Tim Gerla <tim@gerla.net>