### PR TITLE
refactor: set CRI config to /etc/cri/containerd.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,7 @@ COPY images/networkd.tar /rootfs/usr/images/
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
-COPY hack/containerd.toml /rootfs/etc/containerd/cri.toml
+COPY hack/containerd.toml /rootfs/etc/cri/containerd.toml
 RUN touch /rootfs/etc/resolv.conf
 RUN touch /rootfs/etc/hosts
 RUN touch /rootfs/etc/os-release

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -76,7 +76,7 @@ func (suite *ContainerdSuite) SetupSuite() {
 			"--address", suite.containerdAddress,
 			"--state", stateDir,
 			"--root", rootDir,
-			"--config", "/etc/containerd/cri.toml",
+			"--config", constants.CRIContainerdConfig,
 		},
 	}
 

--- a/internal/app/machined/pkg/system/runner/cri/cri_test.go
+++ b/internal/app/machined/pkg/system/runner/cri/cri_test.go
@@ -67,7 +67,7 @@ func (suite *CRISuite) SetupSuite() {
 			"--address", suite.containerdAddress,
 			"--state", stateDir,
 			"--root", rootDir,
-			"--config", "/etc/containerd/cri.toml",
+			"--config", constants.CRIContainerdConfig,
 		},
 	}
 

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -61,7 +61,7 @@ func (c *Containerd) Runner(config runtime.Configurator) (runner.Runner, error) 
 			"--address",
 			constants.ContainerdAddress,
 			"--config",
-			"/etc/containerd/cri.toml",
+			constants.CRIContainerdConfig,
 		},
 	}
 

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -92,7 +92,7 @@ func (suite *ContainerdSuite) SetupSuite() {
 			"--address", suite.containerdAddress,
 			"--state", stateDir,
 			"--root", rootDir,
-			"--config", "/etc/containerd/cri.toml",
+			"--config", constants.CRIContainerdConfig,
 		},
 	}
 

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -75,7 +75,7 @@ func (suite *CRISuite) SetupSuite() {
 			"--address", suite.containerdAddress,
 			"--state", stateDir,
 			"--root", rootDir,
-			"--config", "/etc/containerd/cri.toml",
+			"--config", constants.CRIContainerdConfig,
 		},
 	}
 

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -65,7 +65,7 @@ func (suite *CRISuite) SetupSuite() {
 			"--address", suite.containerdAddress,
 			"--state", stateDir,
 			"--root", rootDir,
-			"--config", "/etc/containerd/cri.toml",
+			"--config", constants.CRIContainerdConfig,
 		},
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -194,6 +194,9 @@ const (
 	// SystemContainerdAddress is the path to the system containerd socket.
 	SystemContainerdAddress = SystemRunPath + "/containerd/containerd.sock"
 
+	// CRIContainerdConfig is the path to the config for the containerd instance that provides the CRI.
+	CRIContainerdConfig = "/etc/cri/containerd.toml"
+
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 


### PR DESCRIPTION
This changes the CRI specific containerd instance's config to a
different path.