### PR TITLE
feat: add create and overwrite file operations

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -242,6 +242,10 @@ install:
 #### files
 
 Allows the addition of user specified files.
+The value of `op` can be `create`, `overwrite`, or `append`.
+In the case of `create`, `path` must not exist.
+In the case of `overwrite`, and `append`, `path` must be a valid file.
+If an `op` value of `append` is used, the existing file will be appended.
 Note that the file contents are not required to be base64 encoded.
 
 Type: `array`
@@ -249,11 +253,12 @@ Type: `array`
 Examples:
 
 ```yaml
-kubelet:
-  contents: |
-    ...
-  permissions: 0666
-  path: /tmp/file.txt
+files:
+  - content: |
+      ...
+    permissions: 0666
+    path: /tmp/file.txt
+    op: append
 
 ```
 

--- a/docs/website/content/v0.3/en/customization/proxy.md
+++ b/docs/website/content/v0.3/en/customization/proxy.md
@@ -10,7 +10,7 @@ Put into each machine the PEM encoded certificate:
 machine:
   ...
   files:
-    - contents: |
+    - content: |
         -----BEGIN CERTIFICATE-----
         ...
         -----END CERTIFICATE-----

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -44,7 +44,7 @@ type Env = map[string]string
 
 // File represents a file to write to disk.
 type File struct {
-	Contents    string      `yaml:"contents"`
+	Content     string      `yaml:"content"`
 	Permissions os.FileMode `yaml:"permissions"`
 	Path        string      `yaml:"path"`
 	Op          string      `yaml:"op"`

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -125,14 +125,19 @@ type MachineConfig struct {
 	MachineInstall *InstallConfig `yaml:"install,omitempty"`
 	//   description: |
 	//     Allows the addition of user specified files.
+	//     The value of `op` can be `create`, `overwrite`, or `append`.
+	//     In the case of `create`, `path` must not exist.
+	//     In the case of `overwrite`, and `append`, `path` must be a valid file.
+	//     If an `op` value of `append` is used, the existing file will be appended.
 	//     Note that the file contents are not required to be base64 encoded.
 	//   examples:
 	//     - |
-	//       kubelet:
-	//         contents: |
-	//           ...
-	//         permissions: 0666
-	//         path: /tmp/file.txt
+	//       files:
+	//         - content: |
+	//             ...
+	//           permissions: 0666
+	//           path: /tmp/file.txt
+	//           op: append
 	MachineFiles []machine.File `yaml:"files,omitempty"` // Note: The specified `path` is relative to `/var`.
 	//   description: |
 	//     The `env` field allows for the addition of environment variables to a machine.


### PR DESCRIPTION
Explicit over implicit is the reasoning here. I think it will be more
clear to users this way.