### PR TITLE
fix: close io.ReadCloser

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -269,6 +269,9 @@ func ensureImageExists(ctx context.Context, cli *client.Client, image string) er
 			return err
 		}
 
+		// nolint: errcheck
+		defer reader.Close()
+
 		if _, err = io.Copy(ioutil.Discard, reader); err != nil {
 			return err
 		}


### PR DESCRIPTION
In the ImagePull func comments it mentions that it is up to the caller
to handle the io.ReadCloser and close it properly. This ensures that we
do.