### PR TITLE
fix: mount /run as shared in container mode

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/mount_shared.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_shared.go
@@ -30,7 +30,7 @@ func (task *MountShared) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *MountShared) container(r runtime.Runtime) (err error) {
-	targets := []string{"/", "/var/lib/kubelet", "/etc/cni"}
+	targets := []string{"/", "/var/lib/kubelet", "/etc/cni", "/run"}
 	for _, t := range targets {
 		if err = unix.Mount("", t, "", unix.MS_SHARED, ""); err != nil {
 			return err


### PR DESCRIPTION
In container mode we need to mount /run as SHARED. This showed up when
running a pod that needed to get information from `/var/run/netns`. but
couldn't because the mounts from the host were not being propagated into
the container.