### PR TITLE
fix: error reporting in `osctl kubeconfig`

### DIFF
--- a/cmd/osctl/cmd/cp.go
+++ b/cmd/osctl/cmd/cp.go
@@ -79,7 +79,9 @@ captures ownership and permission bits.`,
 				}
 			}
 
-			extractTarGz(localPath, r)
+			if err = extractTarGz(localPath, r); err != nil {
+				helpers.Fatalf("%s", err)
+			}
 		})
 	},
 }


### PR DESCRIPTION
Problem seems to be on multiple levels, and there are a bit of changes
which got mixed in from another PR (just same file changed).

Core of the issue is that `helpers.Fatalf()` calls `os.Exit()` which
terminates execution and doesn't let the `defer` and other handlers to
run. This uses Cobra feature of error propagation to pop errors through
the stack back to root command.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>