### PR TITLE
test: fix flakey test on linear retries

### DIFF
--- a/pkg/retry/linear_test.go
+++ b/pkg/retry/linear_test.go
@@ -34,7 +34,7 @@ func Test_linearRetryer_Retry(t *testing.T) {
 			name: "test expected number of retries",
 			fields: fields{
 				retryer: retryer{
-					duration: 1 * time.Second,
+					duration: 1*time.Second + 200*time.Millisecond,
 					options:  NewDefaultOptions(WithUnits(100 * time.Millisecond)),
 				},
 			},
@@ -44,7 +44,7 @@ func Test_linearRetryer_Retry(t *testing.T) {
 					return ExpectedError(fmt.Errorf("expected"))
 				},
 			},
-			expectedCount: 4,
+			expectedCount: 5,
 			wantErr:       true,
 		},
 		{


### PR DESCRIPTION
Retry intervals `0 + 100 + 200 + 300 + 400` ms (1000ms) align perfectly
with retry timeout (1s), so test might fire 4 or 5 retries depending on
timing.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>