### PR TITLE
refactor: use all validation code

### DIFF
--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -5,7 +5,6 @@
 package v1alpha1
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/config/cluster"
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -44,43 +42,6 @@ func (c *Config) Machine() machine.Machine {
 // Cluster implements the Configurator interface.
 func (c *Config) Cluster() cluster.Cluster {
 	return c.ClusterConfig
-}
-
-// Validate implements the Configurator interface.
-// nolint: gocyclo
-func (c *Config) Validate(mode runtime.Mode) error {
-	if c.MachineConfig == nil {
-		return errors.New("machine instructions are required")
-	}
-
-	if c.ClusterConfig == nil {
-		return errors.New("cluster instructions are required")
-	}
-
-	if c.Cluster().Endpoint() == nil || c.Cluster().Endpoint().String() == "" {
-		return errors.New("a cluster endpoint is required")
-	}
-
-	if mode == runtime.Metal {
-		if c.MachineConfig.MachineInstall == nil {
-			return fmt.Errorf("install instructions are required by the %q mode", runtime.Metal.String())
-		}
-	}
-
-	if c.Machine().Type() == machine.Bootstrap {
-		switch c.Cluster().Network().CNI().Name() {
-		case "custom":
-			if len(c.Cluster().Network().CNI().URLs()) == 0 {
-				return errors.New("a cni url should be specified if using \"custom\" option for cni")
-			}
-		case constants.DefaultCNI:
-			// it's flannel bby
-		default:
-			return errors.New("cni name should be one of [custom,flannel]")
-		}
-	}
-
-	return nil
 }
 
 // String implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -553,29 +553,3 @@ type CNIConfig struct {
 	//     URLs containing manifests to apply for CNI.
 	CNIUrls []string `yaml:"urls,omitempty"`
 }
-
-// Bond contains the various options for configuring a bonded interface.
-type Bond struct {
-	//   description: |
-	//     The bond mode.
-	Mode string `yaml:"mode"`
-	//   description: |
-	//     The hash policy.
-	HashPolicy string `yaml:"hashpolicy"`
-	//   description: |
-	//     The LACP rate.
-	LACPRate string `yaml:"lacprate"`
-	//   description: |
-	//     The interfaces if which the bond should be comprised of.
-	Interfaces []string `yaml:"interfaces"`
-}
-
-// Route represents a network route.
-type Route struct {
-	//   description: |
-	//     TODO.
-	Network string `yaml:"network"`
-	//   description: |
-	//     TODO.
-	Gateway string `yaml:"gateway"`
-}


### PR DESCRIPTION
This adds some missing validation steps by using a single validation
entrypoint.