### PR TITLE
test: add retries to the test which verifies cluster version

### DIFF
--- a/cmd/osctl/pkg/client/reply.go
+++ b/cmd/osctl/pkg/client/reply.go
@@ -34,6 +34,10 @@ func FilterReply(reply interface{}, err error) (interface{}, error) {
 		panic("reply should be pointer to struct")
 	}
 
+	if replyStructPtr.IsNil() {
+		return nil, err
+	}
+
 	replyStruct := replyStructPtr.Elem()
 	if replyStruct.Kind() != reflect.Struct {
 		panic("reply should be struct")

--- a/cmd/osctl/pkg/client/reply_test.go
+++ b/cmd/osctl/pkg/client/reply_test.go
@@ -65,6 +65,10 @@ func TestFilterResponseNil(t *testing.T) {
 	filtered, err := client.FilterReply(nil, e)
 	assert.Nil(t, filtered)
 	assert.Equal(t, e, err)
+
+	filtered, err = client.FilterReply((*common.DataReply)(nil), e)
+	assert.Nil(t, filtered)
+	assert.Equal(t, e, err)
 }
 
 func TestFilterResponseOnlyErrors(t *testing.T) {

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -48,9 +48,7 @@ func (apiSuite *APISuite) DiscoverNodes() []string {
 	var err error
 
 	apiSuite.discoveredNodes, err = discoverNodesK8s(apiSuite.Client)
-	if err != nil {
-		apiSuite.Require().Error(err)
-	}
+	apiSuite.Require().NoError(err, "k8s discovery failed")
 
 	if apiSuite.discoveredNodes == nil {
 		// still no nodes, skip the test

--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -8,6 +8,7 @@ package base
 
 import (
 	"context"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,7 +20,10 @@ import (
 )
 
 func discoverNodesK8s(client *client.Client) ([]string, error) {
-	kubeconfig, err := client.Kubeconfig(context.Background())
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
+	defer ctxCancel()
+
+	kubeconfig, err := client.Kubeconfig(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +34,9 @@ func discoverNodesK8s(client *client.Client) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// patch timeout
+	config.Timeout = time.Minute
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -40,7 +40,7 @@ func (e *ErrorSet) Error() string {
 
 	errString := fmt.Sprintf("%d error(s) occurred:", len(e.errs))
 	for _, err := range e.errs {
-		errString = fmt.Sprintf("%s\n%s", errString, err)
+		errString = fmt.Sprintf("%s\n\t%s", errString, err)
 	}
 
 	return errString
@@ -124,12 +124,20 @@ func (t ticker) Stop() {
 // ExpectedError error represents an error that is expected by the retrying
 // function. This error is ignored.
 func ExpectedError(err error) error {
+	if err == nil {
+		return nil
+	}
+
 	return expectedError{err}
 }
 
 // UnexpectedError error represents an error that is unexpected by the retrying
 // function. This error is fatal.
 func UnexpectedError(err error) error {
+	if err == nil {
+		return nil
+	}
+
 	return unexpectedError{err}
 }
 

--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -30,7 +30,7 @@ func Test_retry(t *testing.T) {
 				d: 2 * time.Second,
 				t: NewConstantTicker(NewDefaultOptions()),
 			},
-			wantString: "2 error(s) occurred:\ntest\ntimeout",
+			wantString: "2 error(s) occurred:\n\ttest\n\ttimeout",
 		},
 		{
 			name: "unexpected error string",
@@ -39,7 +39,7 @@ func Test_retry(t *testing.T) {
 				d: 2 * time.Second,
 				t: NewConstantTicker(NewDefaultOptions()),
 			},
-			wantString: "1 error(s) occurred:\ntest",
+			wantString: "1 error(s) occurred:\n\ttest",
 		},
 		{
 			name: "no error string",


### PR DESCRIPTION
It fails on AWS, need to figure out if it's transient failure or not.

While I was there, found lots of small bugs when endpoint is
unresponsive, or target nodes are unresponsive and fixed them.

In retry formatting added `\t` so that embedded errors are better
aligned in the output (same as multierror).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>