### PR TITLE
chore: Add link name to dhcp addressing error

### DIFF
--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -170,7 +170,7 @@ func (d *DHCP) discover() (*dhcpv4.DHCPv4, error) {
 	_, ack, err := cli.Request(context.Background(), mods...)
 	if err != nil {
 		// TODO: Make this a well defined error so we can make it not fatal
-		log.Println("failed dhcp request")
+		log.Println("failed dhcp request for", d.NetIf.Name)
 		return nil, err
 	}
 


### PR DESCRIPTION
Minor fix to print out the interface name along with the failure message.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>