### PR TITLE
fix: don't use netrc

### DIFF
--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -381,6 +381,15 @@ func fetchCNIManifests(urls []string) error {
 			continue
 		}
 
+		// Disable netrc since we don't have getent installed, and most likely
+		// never will.
+		httpGetter := &getter.HttpGetter{
+			Netrc: false,
+		}
+
+		getter.Getters["http"] = httpGetter
+		getter.Getters["https"] = httpGetter
+
 		client := &getter.Client{
 			Ctx:     ctx,
 			Src:     url,


### PR DESCRIPTION
The getter package tries to use the netrc file to gather credentials if
none are provided when using http and https getters. This disables that
because under the hood, it uses another package (go-homedir) to try and
find the netrc file. The issue is then that go-homedir tries to invoke
getent, but that is not installed on the rootfs so the command fails.