### PR TITLE
fix(networkd): Ignore loopback interface during hostname decision.

### DIFF
--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -302,6 +302,12 @@ func (n *Networkd) decideHostname() (hostname string, domainname string, address
 	// Loop through address responses and use the first hostname
 	// and address response.
 	for _, iface := range n.Interfaces {
+		// Skip loopback interface because it will always have
+		// a hardcoded hostname of `talos-ip`
+		if iface.Link != nil && iface.Link.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+
 		for _, method := range iface.AddressMethod {
 			if !method.Valid() {
 				continue


### PR DESCRIPTION
This should disregard the loopback from the hostname decision since it will always be hardcoded
to the default talos hostname.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>