### PR TITLE
feat: allow configurable SANs for API

### DIFF
--- a/pkg/crypto/x509/x509.go
+++ b/pkg/crypto/x509/x509.go
@@ -505,7 +505,7 @@ func NewCertificateAndKeyFromFiles(crt, key string) (p *PEMEncodedCertificateAnd
 
 // NewCSRAndIdentity generates and PEM encoded certificate and key, along with a
 // CSR for the generated key.
-func NewCSRAndIdentity(hostname string, ips []net.IP) (csr *CertificateSigningRequest, identity *PEMEncodedCertificateAndKey, err error) {
+func NewCSRAndIdentity(dnsNames []string, ips []net.IP) (csr *CertificateSigningRequest, identity *PEMEncodedCertificateAndKey, err error) {
 	var key *Ed25519Key
 
 	key, err = NewEd25519Key()
@@ -528,7 +528,7 @@ func NewCSRAndIdentity(hostname string, ips []net.IP) (csr *CertificateSigningRe
 	}
 
 	opts := []Option{}
-	opts = append(opts, DNSNames([]string{hostname}))
+	opts = append(opts, DNSNames(dnsNames))
 	opts = append(opts, IPAddresses(ips))
 
 	csr, err = NewCertificateSigningRequest(priv, opts...)

--- a/pkg/grpc/tls/local.go
+++ b/pkg/grpc/tls/local.go
@@ -25,7 +25,7 @@ type renewingLocalCertificateProvider struct {
 
 // NewLocalRenewingFileCertificateProvider returns a new CertificateProvider
 // which manages and updates its certificates using a local key.
-func NewLocalRenewingFileCertificateProvider(caKey, caCrt []byte, hostname string, ips []net.IP) (CertificateProvider, error) {
+func NewLocalRenewingFileCertificateProvider(caKey, caCrt []byte, dnsNames []string, ips []net.IP) (CertificateProvider, error) {
 	g, err := gen.NewLocalGenerator(caKey, caCrt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS generator: %w", err)
@@ -38,7 +38,7 @@ func NewLocalRenewingFileCertificateProvider(caKey, caCrt []byte, hostname strin
 	}
 
 	provider.embeddableCertificateProvider = embeddableCertificateProvider{
-		hostname:   hostname,
+		dnsNames:   dnsNames,
 		ips:        ips,
 		updateFunc: provider.update,
 	}
@@ -70,7 +70,7 @@ func (p *renewingLocalCertificateProvider) update() (ca []byte, cert tls.Certifi
 		identity *x509.PEMEncodedCertificateAndKey
 	)
 
-	csr, identity, err = x509.NewCSRAndIdentity(p.hostname, p.ips)
+	csr, identity, err = x509.NewCSRAndIdentity(p.dnsNames, p.ips)
 	if err != nil {
 		return nil, cert, err
 	}

--- a/pkg/grpc/tls/provider.go
+++ b/pkg/grpc/tls/provider.go
@@ -38,7 +38,7 @@ type embeddableCertificateProvider struct {
 	ca  []byte
 	crt *tls.Certificate
 
-	hostname string
+	dnsNames []string
 	ips      []net.IP
 
 	updateFunc  func() ([]byte, tls.Certificate, error)

--- a/pkg/grpc/tls/remote.go
+++ b/pkg/grpc/tls/remote.go
@@ -22,7 +22,7 @@ type renewingRemoteCertificateProvider struct {
 
 // NewRemoteRenewingFileCertificateProvider returns a new CertificateProvider
 // which manages and updates its certificates from the security API.
-func NewRemoteRenewingFileCertificateProvider(token string, endpoints []string, port int, hostname string, ips []net.IP) (CertificateProvider, error) {
+func NewRemoteRenewingFileCertificateProvider(token string, endpoints []string, port int, dnsNames []string, ips []net.IP) (CertificateProvider, error) {
 	g, err := gen.NewRemoteGenerator(token, endpoints, port)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS generator: %w", err)
@@ -33,7 +33,7 @@ func NewRemoteRenewingFileCertificateProvider(token string, endpoints []string, 
 	}
 
 	provider.embeddableCertificateProvider = embeddableCertificateProvider{
-		hostname:   hostname,
+		dnsNames:   dnsNames,
 		ips:        ips,
 		updateFunc: provider.update,
 	}
@@ -65,7 +65,7 @@ func (p *renewingRemoteCertificateProvider) update() (ca []byte, cert tls.Certif
 		identity *x509.PEMEncodedCertificateAndKey
 	)
 
-	csr, identity, err = x509.NewCSRAndIdentity(p.hostname, p.ips)
+	csr, identity, err = x509.NewCSRAndIdentity(p.dnsNames, p.ips)
 	if err != nil {
 		return nil, cert, err
 	}


### PR DESCRIPTION
This adds the ability to supply additional SANs for apid and trustd.

Closes #1512.