### PR TITLE
fix: mount as rshared

### DIFF
--- a/internal/app/machined/internal/phase/rootfs/mount_shared.go
+++ b/internal/app/machined/internal/phase/rootfs/mount_shared.go
@@ -32,7 +32,7 @@ func (task *MountShared) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 func (task *MountShared) container(r runtime.Runtime) (err error) {
 	targets := []string{"/", "/var/lib/kubelet", "/etc/cni", "/run"}
 	for _, t := range targets {
-		if err = unix.Mount("", t, "", unix.MS_SHARED, ""); err != nil {
+		if err = unix.Mount("", t, "", unix.MS_SHARED|unix.MS_REC, ""); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -222,7 +222,7 @@ func unmount(p *Point) error {
 }
 
 func share(p *Point) error {
-	return unix.Mount("", p.target, "", unix.MS_SHARED, "")
+	return unix.Mount("", p.target, "", unix.MS_SHARED|unix.MS_REC, "")
 }
 
 func overlay(p *Point) error {


### PR DESCRIPTION
This adds unix.MS_REC to the shared mounts. We haven't seen any reports
of bugs yet, but in some testing I found that `Bidirectional` mounts don't
work unless the mount point is rshared.