### PR TITLE
fix: response filtering for client API, RunE for osctl

### DIFF
--- a/cmd/osctl/cmd/dmesg.go
+++ b/cmd/osctl/cmd/dmesg.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
@@ -27,9 +26,7 @@ var dmesgCmd = &cobra.Command{
 		}
 
 		setupClient(func(c *client.Client) {
-			md := metadata.New(make(map[string]string))
-			md.Set("targets", target...)
-			reply, err := c.Dmesg(metadata.NewOutgoingContext(globalCtx, md))
+			reply, err := c.Dmesg(globalCtx)
 			if err != nil {
 				helpers.Fatalf("error getting dmesg: %s", err)
 			}

--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -27,8 +27,8 @@ var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Upgrade Talos on the target node",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		upgrade()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return upgrade()
 	},
 }
 
@@ -37,7 +37,7 @@ func init() {
 	rootCmd.AddCommand(upgradeCmd)
 }
 
-func upgrade() {
+func upgrade() error {
 	var (
 		err        error
 		reply      *machineapi.UpgradeReply
@@ -51,7 +51,11 @@ func upgrade() {
 	})
 
 	if err != nil {
-		helpers.Fatalf("error performing upgrade: %s", err)
+		if reply == nil {
+			return fmt.Errorf("error performing upgrade: %s", err)
+		}
+
+		helpers.Warning("%s", err)
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
@@ -69,5 +73,5 @@ func upgrade() {
 		fmt.Fprintf(w, "%s\t%s\t%s\t", node, resp.Ack, time.Now())
 	}
 
-	helpers.Should(w.Flush())
+	return w.Flush()
 }

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -226,6 +226,10 @@ func (c *Client) Stats(ctx context.Context, namespace string, driver common.Cont
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*osapi.StatsReply) //nolint: errcheck
+
 	return
 }
 
@@ -239,6 +243,10 @@ func (c *Client) Containers(ctx context.Context, namespace string, driver common
 		},
 		callOptions...,
 	)
+
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*osapi.ContainersReply) //nolint: errcheck
 
 	return
 }
@@ -312,6 +320,10 @@ func (c *Client) Routes(ctx context.Context, callOptions ...grpc.CallOption) (re
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*networkapi.RoutesReply) //nolint: errcheck
+
 	return
 }
 
@@ -322,6 +334,10 @@ func (c *Client) Interfaces(ctx context.Context, callOptions ...grpc.CallOption)
 		&empty.Empty{},
 		callOptions...,
 	)
+
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*networkapi.InterfacesReply) //nolint: errcheck
 
 	return
 }
@@ -334,6 +350,10 @@ func (c *Client) Processes(ctx context.Context, callOptions ...grpc.CallOption) 
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*osapi.ProcessesReply) //nolint: errcheck
+
 	return
 }
 
@@ -345,6 +365,10 @@ func (c *Client) Memory(ctx context.Context, callOptions ...grpc.CallOption) (re
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*osapi.MemInfoReply) //nolint: errcheck
+
 	return
 }
 
@@ -355,6 +379,10 @@ func (c *Client) Mounts(ctx context.Context, callOptions ...grpc.CallOption) (re
 		&empty.Empty{},
 		callOptions...,
 	)
+
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.MountsReply) //nolint: errcheck
 
 	return
 }
@@ -385,6 +413,10 @@ func (c *Client) Upgrade(ctx context.Context, image string, callOptions ...grpc.
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.UpgradeReply) //nolint: errcheck
+
 	return
 }
 
@@ -395,6 +427,10 @@ func (c *Client) ServiceList(ctx context.Context, callOptions ...grpc.CallOption
 		&empty.Empty{},
 		callOptions...,
 	)
+
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.ServiceListReply) //nolint: errcheck
 
 	return
 }
@@ -422,6 +458,10 @@ func (c *Client) ServiceInfo(ctx context.Context, id string, callOptions ...grpc
 		return
 	}
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.ServiceListReply) //nolint: errcheck
+
 	for _, resp := range reply.Response {
 		for _, svc := range resp.Services {
 			if svc.Id == id {
@@ -444,6 +484,10 @@ func (c *Client) ServiceStart(ctx context.Context, id string, callOptions ...grp
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.ServiceStartReply) //nolint: errcheck
+
 	return
 }
 
@@ -454,6 +498,10 @@ func (c *Client) ServiceStop(ctx context.Context, id string, callOptions ...grpc
 		&machineapi.ServiceStopRequest{Id: id},
 		callOptions...,
 	)
+
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.ServiceStopReply) //nolint: errcheck
 
 	return
 }
@@ -466,6 +514,10 @@ func (c *Client) ServiceRestart(ctx context.Context, id string, callOptions ...g
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*machineapi.ServiceRestartReply) //nolint: errcheck
+
 	return
 }
 
@@ -477,6 +529,10 @@ func (c *Client) Time(ctx context.Context, callOptions ...grpc.CallOption) (repl
 		callOptions...,
 	)
 
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*timeapi.TimeReply) //nolint: errcheck
+
 	return
 }
 
@@ -487,6 +543,10 @@ func (c *Client) TimeCheck(ctx context.Context, server string, callOptions ...gr
 		&timeapi.TimeRequest{Server: server},
 		callOptions...,
 	)
+
+	var filtered interface{}
+	filtered, err = FilterReply(reply, err)
+	reply, _ = filtered.(*timeapi.TimeReply) //nolint: errcheck
 
 	return
 }


### PR DESCRIPTION
There are several changes which cleanup and address features of osctl,
mostly for multi-node requests:

* responses are filtered, so that client commands can print partial
failures/success responses;
* `RunE` is used in place of `Run` to propagate correct return sequence
on failures;
* cleaned up setting `targets` metadata on outgoing requests, it is set
by default in `globalCtx` already

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>