### PR TITLE
fix: kill POD network mode pods first on upgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb // indirect
 	github.com/containerd/cri v1.11.1
 	github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c // indirect
+	github.com/containerd/go-cni v0.0.0-20191121212822-60d125212faf
 	github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c // indirect
 	github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/containerd/cri v1.11.1/go.mod h1:DavH5Qa8+6jOmeOMO3dhWoqksucZDe06Lfuh
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c h1:KFbqHhDeaHM7IfFtXHfUHMDaUStpM2YwBR+iJCIOsKk=
 github.com/containerd/fifo v0.0.0-20190816180239-bda0ff6ed73c/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
+github.com/containerd/go-cni v0.0.0-20191121212822-60d125212faf h1:eUNDEEbhwN0Tolk2blxdXaVItt8sd0aLTDSgcyqyTnE=
+github.com/containerd/go-cni v0.0.0-20191121212822-60d125212faf/go.mod h1:0mg8r6FCdbxvLDqCXwAx2rO+KA37QICjKL8+wHOG5OE=
 github.com/containerd/go-runc v0.0.0-20180907222934-5a6d9f37cfa3/go.mod h1:IV7qH3hrUgRmyYrtgEeGWJfWbgcHL9CSRruz2Vqcph0=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c h1:+RqLdWzn0xFunb+sxXaEzHOg8NuEG/eaI+9C1xXX8Mw=
@@ -90,6 +92,8 @@ github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0x
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd h1:bRLyitWw3PT/2YuVaCKTPg0cA5dOFKFwKtkfcP2dLsA=
 github.com/containerd/typeurl v0.0.0-20190911142611-5eb25027c9fd/go.mod h1:GeKYzf2pQcqv7tJ0AoCuuhtnqhva5LNU3U+OyKxxJpk=
+github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK31EJ9FzE=
+github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/coreos/bbolt v1.3.3 h1:n6AiVyVRKQFNb6mJlwESEvvLoDyiTzXX7ORAUlkeBdY=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -408,10 +412,13 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -21,9 +21,10 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	criconstants "github.com/containerd/cri/pkg/constants"
+	cni "github.com/containerd/go-cni"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/app/machined/internal/cni"
+	internalcni "github.com/talos-systems/talos/internal/app/machined/internal/cni"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/conditions"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -158,7 +159,7 @@ func (k *Kubelet) Runner(config runtime.Configurator) (runner.Runner, error) {
 	}
 
 	// Add in the additional CNI mounts.
-	cniMounts, err := cni.Mounts(config)
+	cniMounts, err := internalcni.Mounts(config)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (k *Kubelet) args(config runtime.Configurator) ([]string, error) {
 		"anonymous-auth":               "false",
 		"cert-dir":                     "/var/lib/kubelet/pki",
 		"client-ca-file":               constants.KubernetesCACert,
-		"cni-conf-dir":                 "/etc/cni/net.d",
+		"cni-conf-dir":                 cni.DefaultNetDir,
 		"pod-manifest-path":            "/etc/kubernetes/manifests",
 		"rotate-certificates":          "true",
 		"cluster-dns":                  dnsServiceIP.String(),

--- a/internal/pkg/cri/pods.go
+++ b/internal/pkg/cri/pods.go
@@ -7,7 +7,9 @@ package cri
 import (
 	"context"
 	"fmt"
+	"log"
 
+	"golang.org/x/sync/errgroup"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -78,4 +80,102 @@ func (c *Client) PodSandboxStatus(ctx context.Context, podSandBoxID string) (*ru
 	}
 
 	return resp.Status, resp.Info, nil
+}
+
+// RemovePodSandboxes removes all pods with the specified network mode. If no
+// network mode is specified, all pods will be removed.
+func (c *Client) RemovePodSandboxes(modes ...runtimeapi.NamespaceMode) (err error) {
+	ctx := context.Background()
+
+	pods, err := c.ListPodSandbox(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	var g errgroup.Group
+
+	for _, pod := range pods {
+		pod := pod // https://golang.org/doc/faq#closures_and_goroutines
+
+		status, _, err := c.PodSandboxStatus(ctx, pod.GetId())
+		if err != nil {
+			return err
+		}
+
+		networkMode := status.GetLinux().GetNamespaces().GetOptions().GetNetwork()
+
+		// If any modes are specified, we verify that the current pod is
+		// running any one of the modes. If it doesn't, we skip it.
+		if len(modes) > 0 && !contains(networkMode, modes) {
+			continue
+		}
+
+		g.Go(func() error {
+			return remove(ctx, c, pod, networkMode.String())
+		})
+	}
+
+	return g.Wait()
+}
+
+func contains(mode runtimeapi.NamespaceMode, modes []runtimeapi.NamespaceMode) bool {
+	for _, m := range modes {
+		if mode == m {
+			return true
+		}
+	}
+
+	return false
+}
+
+func remove(ctx context.Context, client *Client, pod *runtimeapi.PodSandbox, mode string) (err error) {
+	log.Printf("removing pod %s/%s with network mode %q", pod.Metadata.Namespace, pod.Metadata.Name, mode)
+
+	filter := &runtimeapi.ContainerFilter{
+		PodSandboxId: pod.Id,
+	}
+
+	containers, err := client.ListContainers(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	var g errgroup.Group
+
+	for _, container := range containers {
+		container := container // https://golang.org/doc/faq#closures_and_goroutines
+
+		g.Go(func() error {
+			log.Printf("removing container %s/%s:%s", pod.Metadata.Namespace, pod.Metadata.Name, container.Metadata.Name)
+
+			// TODO(andrewrynhard): Can we set the timeout dynamically?
+			if err = client.StopContainer(ctx, container.Id, 30); err != nil {
+				return err
+			}
+
+			if err = client.RemoveContainer(ctx, container.Id); err != nil {
+				return err
+			}
+
+			log.Printf("removed container %s/%s:%s", pod.Metadata.Namespace, pod.Metadata.Name, container.Metadata.Name)
+
+			return nil
+		})
+	}
+
+	if err = g.Wait(); err != nil {
+		return err
+	}
+
+	if err = client.StopPodSandbox(ctx, pod.Id); err != nil {
+		return err
+	}
+
+	if err = client.RemovePodSandbox(ctx, pod.Id); err != nil {
+		return err
+	}
+
+	log.Printf("removed pod %s/%s", pod.Metadata.Namespace, pod.Metadata.Name)
+
+	return nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/defaults"
+	cni "github.com/containerd/go-cni"
 )
 
 const (
@@ -65,7 +66,7 @@ const (
 	ISOFilesystemLabel = "TALOS"
 
 	// PATH defines all locations where executables are stored.
-	PATH = "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:/opt/cni/bin"
+	PATH = "/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin:" + cni.DefaultCNIDir
 
 	// CNICalico is used to specify Calico CNI.
 	CNICalico = "calico"


### PR DESCRIPTION
When we upgrade a node, we kill off all pods before performing a fresh
install. The issue with this is that we run the risk of killing the CNI
pod before we finish killing all other pods, leaving the CRI unable to
teardown the pod's networking. This works around that by first killing
any pods running without host networking so that the CNI can do its'
job, and then removing the remaining pods.