### PR TITLE
chore: Remove increased timeouts for dhcp addressing.

### DIFF
--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -163,13 +163,11 @@ func (d *DHCP) discover() (*dhcpv4.DHCPv4, error) {
 
 	// TODO expose this ( nclient4.WithDebugLogger() ) with some
 	// debug logging option
-	cli, err := nclient4.New(d.NetIf.Name,
-		nclient4.WithTimeout(2*time.Second),
-		nclient4.WithRetry(5),
-	)
+	cli, err := nclient4.New(d.NetIf.Name)
 	if err != nil {
 		return nil, err
 	}
+
 	// nolint: errcheck
 	defer cli.Close()
 


### PR DESCRIPTION
These timeouts were initially increased to handle long times for links to be ready. I think
with the updated link ready check in networkd these timers are unnecessary.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>