### PR TITLE
fix: allow initial-cluster-state to be set

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -343,7 +343,6 @@ func (e *Etcd) args(config runtime.Configurator) ([]string, error) {
 	blackListArgs := argsbuilder.Args{
 		"name":                  hostname,
 		"data-dir":              constants.EtcdDataPath,
-		"initial-cluster-state": "new",
 		"listen-peer-urls":      "https://0.0.0.0:2380",
 		"listen-client-urls":    "https://0.0.0.0:2379",
 		"cert-file":             constants.KubernetesEtcdPeerCert,
@@ -361,6 +360,10 @@ func (e *Etcd) args(config runtime.Configurator) ([]string, error) {
 		if extraArgs.Contains(k) {
 			return nil, argsbuilder.NewBlacklistError(k)
 		}
+	}
+
+	if !extraArgs.Contains("initial-cluster-state") {
+		blackListArgs.Set("initial-cluster-state", "new")
 	}
 
 	// If the initial cluster isn't explicitly defined, we need to discover any


### PR DESCRIPTION
This allows power users to configure etcd's initial-cluster-state. It
was originally black listed, but I found I needed this to recover the
cluster. Over time we can have better automation, and maybe blacklist
this again, but in the mean time this should be configurable.