### PR TITLE
feat: add config nodes command

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -41,9 +41,10 @@ var configCmd = &cobra.Command{
 
 // configEndpointCmd represents the config endpoint command.
 var configEndpointCmd = &cobra.Command{
-	Use:   "endpoint <endpoint>...",
-	Short: "Set the endpoint(s) for the current context",
-	Long:  ``,
+	Use:     "endpoint <endpoint>...",
+	Aliases: []string{"endpoints"},
+	Short:   "Set the endpoint(s) for the current context",
+	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		c, err := config.Open(talosconfig)
 		if err != nil {
@@ -54,6 +55,28 @@ var configEndpointCmd = &cobra.Command{
 		}
 
 		c.Contexts[c.Context].Endpoints = args
+		if err := c.Save(talosconfig); err != nil {
+			helpers.Fatalf("error writing config: %s", err)
+		}
+	},
+}
+
+// configNodeCmd represents the config node command.
+var configNodeCmd = &cobra.Command{
+	Use:     "node <endpoint>...",
+	Aliases: []string{"nodes"},
+	Short:   "Set the node(s) for the current context",
+	Long:    ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		c, err := config.Open(talosconfig)
+		if err != nil {
+			helpers.Fatalf("error reading config: %s", err)
+		}
+		if c.Context == "" {
+			helpers.Fatalf("no context is set")
+		}
+
+		c.Contexts[c.Context].Nodes = args
 		if err := c.Save(talosconfig); err != nil {
 			helpers.Fatalf("error writing config: %s", err)
 		}
@@ -227,7 +250,7 @@ func writeV1Alpha1Config(input *genv1alpha1.Input, t genv1alpha1.Type, name stri
 }
 
 func init() {
-	configCmd.AddCommand(configContextCmd, configEndpointCmd, configAddCmd, configGenerateCmd)
+	configCmd.AddCommand(configContextCmd, configEndpointCmd, configNodeCmd, configAddCmd, configGenerateCmd)
 	configAddCmd.Flags().StringVar(&ca, "ca", "", "the path to the CA certificate")
 	configAddCmd.Flags().StringVar(&crt, "crt", "", "the path to the certificate")
 	configAddCmd.Flags().StringVar(&key, "key", "", "the path to the key")

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -107,7 +107,7 @@ func Execute() {
 
 	rootCmd.PersistentFlags().StringVar(&talosconfig, "talosconfig", defaultTalosConfig, "The path to the Talos configuration file")
 	rootCmd.PersistentFlags().StringVar(&cmdcontext, "context", "", "Context to be used in command")
-	rootCmd.PersistentFlags().StringSliceVarP(&nodes, "nodes", "", []string{}, "target the specified nodes")
+	rootCmd.PersistentFlags().StringSliceVarP(&nodes, "nodes", "n", []string{}, "target the specified nodes")
 	rootCmd.PersistentFlags().StringSliceVarP(&endpoints, "endpoints", "e", []string{}, "override default endpoints in Talos configuration")
 
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
This adds a `osctl config nodes` command that updates the talosconfig
with the specified nodes.