### PR TITLE
refactor: update --image shorthand flag to -i

### DIFF
--- a/cmd/osctl/cmd/upgrade.go
+++ b/cmd/osctl/cmd/upgrade.go
@@ -33,7 +33,7 @@ var upgradeCmd = &cobra.Command{
 }
 
 func init() {
-	upgradeCmd.Flags().StringVarP(&upgradeImage, "image", "u", "", "the container image to use for performing the install")
+	upgradeCmd.Flags().StringVarP(&upgradeImage, "image", "i", "", "the container image to use for performing the install")
 	rootCmd.AddCommand(upgradeCmd)
 }
 


### PR DESCRIPTION
The old flag was `--url`, so the shorthand was naturally `-u`. Now that it
is `--image`, `-u` should be `-i`.