### PR TITLE
docs: update osctl kubeconfig references

### DIFF
--- a/docs/website/content/v0.3/en/guides/cloud/aws.md
+++ b/docs/website/content/v0.3/en/guides/cloud/aws.md
@@ -241,5 +241,5 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig > kubeconfig
+osctl --talosconfig talosconfig kubeconfig .
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/digitalocean.md
+++ b/docs/website/content/v0.3/en/guides/cloud/digitalocean.md
@@ -144,5 +144,5 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig > kubeconfig
+osctl --talosconfig talosconfig kubeconfig .
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/vmware.md
+++ b/docs/website/content/v0.3/en/guides/cloud/vmware.md
@@ -77,7 +77,7 @@ export GOVC_NETWORK=<vCenter network>
 ### Download the OVA
 
 A `talos.ova` asset is published with each [release](https://github.com/talos-systems/talos/releases).
-We will refer to the version of the release as $TALOS_VERSION below.
+We will refer to the version of the release as `$TALOS_VERSION` below.
 It can be easily exported with `export TALOS_VERSION="v0.3.0-alpha.10"` or similar.
 
 ```bash
@@ -213,5 +213,5 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig > kubeconfig
+osctl --talosconfig talosconfig kubeconfig .
 ```

--- a/docs/website/content/v0.3/en/guides/getting-started/index.md
+++ b/docs/website/content/v0.3/en/guides/getting-started/index.md
@@ -29,7 +29,7 @@ Once the above finishes successfully, your talosconfig(`~/.talos/config`) will b
 ## Retrieve and Configure the `kubeconfig`
 
 ```bash
-osctl kubeconfig > kubeconfig
+osctl kubeconfig .
 kubectl --kubeconfig kubeconfig config set-cluster talos_default --server https://127.0.0.1:6443
 ```
 

--- a/docs/website/content/v0.3/en/guides/metal/matchbox.md
+++ b/docs/website/content/v0.3/en/guides/metal/matchbox.md
@@ -187,5 +187,5 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig > kubeconfig
+osctl --talosconfig talosconfig kubeconfig .
 ```


### PR DESCRIPTION
The usage of `osctl kubeconfig` has changed. This updates the docs to
reflect the change.