### PR TITLE
fix: use specified kubelet and etcd images

### DIFF
--- a/cmd/osctl/cmd/install_linux.go
+++ b/cmd/osctl/cmd/install_linux.go
@@ -40,9 +40,7 @@ var installCmd = &cobra.Command{
 
 		config = &v1alpha1.Config{
 			ClusterConfig: &v1alpha1.ClusterConfig{
-				ControlPlane: &v1alpha1.ControlPlaneConfig{
-					Version: constants.DefaultKubernetesVersion,
-				},
+				ControlPlane: &v1alpha1.ControlPlaneConfig{},
 			},
 			MachineConfig: &v1alpha1.MachineConfig{
 				MachineInstall: &v1alpha1.InstallConfig{

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -295,7 +295,8 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	images := asset.DefaultImages
 
-	images.Hyperkube = fmt.Sprintf("k8s.gcr.io/hyperkube:v%s", config.Cluster().Version())
+	images.Hyperkube = config.Machine().Kubelet().Image()
+
 	// TODO(andrewrynhard): This is a hack workaround for now. Update this once
 	// there is an official image.
 	images.PodCheckpointer = "docker.io/autonomy/pod-checkpointer:51fba9528e96d3be488562574c288b2fb82a1e3b"

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -39,8 +39,6 @@ import (
 	"github.com/talos-systems/talos/pkg/retry"
 )
 
-var etcdImage = fmt.Sprintf("%s:%s", constants.EtcdImage, constants.DefaultEtcdVersion)
-
 // Etcd implements the Service interface. It serves as the concrete type with
 // the required methods.
 type Etcd struct{}
@@ -69,8 +67,8 @@ func (e *Etcd) PreFunc(ctx context.Context, config runtime.Configurator) (err er
 
 	// Pull the image and unpack it.
 	containerdctx := namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
-	if _, err = client.Pull(containerdctx, etcdImage, containerdapi.WithPullUnpack); err != nil {
-		return fmt.Errorf("failed to pull image %q: %w", etcdImage, err)
+	if _, err = client.Pull(containerdctx, config.Cluster().Etcd().Image(), containerdapi.WithPullUnpack); err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", config.Cluster().Etcd().Image(), err)
 	}
 
 	return nil
@@ -118,7 +116,7 @@ func (e *Etcd) Runner(config runtime.Configurator) (runner.Runner, error) {
 		config.Debug(),
 		&args,
 		runner.WithNamespace(constants.SystemContainerdNamespace),
-		runner.WithContainerImage(etcdImage),
+		runner.WithContainerImage(config.Cluster().Etcd().Image()),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			oci.WithHostNamespace(specs.NetworkNamespace),

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -106,9 +106,8 @@ func (k *Kubelet) PreFunc(ctx context.Context, config runtime.Configurator) erro
 	// Pull the image and unpack it.
 	containerdctx := namespaces.WithNamespace(ctx, "k8s.io")
 
-	image := fmt.Sprintf("%s:v%s", constants.KubernetesImage, config.Cluster().Version())
-	if _, err = client.Pull(containerdctx, image, containerdapi.WithPullUnpack); err != nil {
-		return fmt.Errorf("failed to pull image %q: %w", image, err)
+	if _, err = client.Pull(containerdctx, config.Machine().Kubelet().Image(), containerdapi.WithPullUnpack); err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", config.Machine().Kubelet().Image(), err)
 	}
 
 	return nil
@@ -131,8 +130,6 @@ func (k *Kubelet) DependsOn(config runtime.Configurator) []string {
 
 // Runner implements the Service interface.
 func (k *Kubelet) Runner(config runtime.Configurator) (runner.Runner, error) {
-	image := fmt.Sprintf("%s:v%s", constants.KubernetesImage, config.Cluster().Version())
-
 	a, err := k.args(config)
 	if err != nil {
 		return nil, err
@@ -181,7 +178,7 @@ func (k *Kubelet) Runner(config runtime.Configurator) (runner.Runner, error) {
 		config.Debug(),
 		&args,
 		runner.WithNamespace(criconstants.K8sContainerdNamespace),
-		runner.WithContainerImage(image),
+		runner.WithContainerImage(config.Machine().Kubelet().Image()),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			containerd.WithRootfsPropagation("shared"),

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -14,7 +14,6 @@ import (
 // Cluster defines the requirements for a config that pertains to cluster
 // related options.
 type Cluster interface {
-	Version() string
 	Endpoint() *url.URL
 	Token() Token
 	CertSANs() []string

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -150,6 +150,7 @@ type Time interface {
 // Kubelet defines the requirements for a config that pertains to kubelet
 // related options.
 type Kubelet interface {
+	Image() string
 	ExtraArgs() map[string]string
 	ExtraMounts() []specs.Mount
 }

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -35,7 +35,6 @@ func controlPlaneUd(in *Input) (string, error) {
 	cluster := &v1alpha1.ClusterConfig{
 		BootstrapToken: in.Secrets.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
-			Version:  in.KubernetesVersion,
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		EtcdConfig: &v1alpha1.EtcdConfig{

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -37,7 +37,6 @@ func initUd(in *Input) (string, error) {
 	cluster := &v1alpha1.ClusterConfig{
 		ClusterName: in.ClusterName,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
-			Version:  in.KubernetesVersion,
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		APIServer: &v1alpha1.APIServerConfig{

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -36,7 +36,6 @@ func workerUd(in *Input) (string, error) {
 		ClusterCA:      &x509.PEMEncodedCertificateAndKey{Crt: in.Certs.K8s.Crt},
 		BootstrapToken: in.Secrets.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
-			Version:  in.KubernetesVersion,
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		ClusterNetwork: &v1alpha1.ClusterNetworkConfig{

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -191,6 +191,17 @@ func (m *MachineConfig) SetCertSANs(sans []string) {
 	m.MachineCertSANs = append(m.MachineCertSANs, sans...)
 }
 
+// Image implements the Configurator interface.
+func (k *KubeletConfig) Image() string {
+	image := k.KubeletImage
+
+	if image == "" {
+		image = fmt.Sprintf("%s:v%s", constants.KubernetesImage, constants.DefaultKubernetesVersion)
+	}
+
+	return image
+}
+
 // ExtraArgs implements the Configurator interface.
 func (k *KubeletConfig) ExtraArgs() map[string]string {
 	if k == nil {
@@ -207,11 +218,6 @@ func (k *KubeletConfig) ExtraArgs() map[string]string {
 // ExtraMounts implements the Configurator interface.
 func (k *KubeletConfig) ExtraMounts() []specs.Mount {
 	return nil
-}
-
-// Version implements the Configurator interface.
-func (c *ClusterConfig) Version() string {
-	return c.ControlPlane.Version
 }
 
 // Endpoint implements the Configurator interface.
@@ -264,7 +270,13 @@ func (c *ClusterConfig) Etcd() cluster.Etcd {
 
 // Image implements the Configurator interface.
 func (e *EtcdConfig) Image() string {
-	return e.ContainerImage
+	image := e.ContainerImage
+
+	if image == "" {
+		image = fmt.Sprintf("%s:%s", constants.EtcdImage, constants.DefaultEtcdVersion)
+	}
+
+	return image
 }
 
 // CA implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -187,7 +187,6 @@ type ClusterConfig struct {
 	//   examples:
 	//     - |
 	//       controlPlane:
-	//         version: 1.17.0
 	//         endpoint: https://1.2.3.4
 	//         localAPIServerPort: 443
 	ControlPlane *ControlPlaneConfig `yaml:"controlPlane"`
@@ -273,7 +272,7 @@ type KubeletConfig struct {
 	//     The `image` field is an optional reference to an alternative hyperkube image.
 	//   examples:
 	//     - "image: docker.io/<org>/hyperkube:latest"
-	Image string `yaml:"image,omitempty"`
+	KubeletImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     The `extraArgs` field is used to provide additional flags to the kubelet.
 	//   examples:
@@ -423,11 +422,6 @@ func (e *Endpoint) MarshalYAML() (interface{}, error) {
 
 // ControlPlaneConfig represents control plane config vals.
 type ControlPlaneConfig struct {
-	//   description: |
-	//     Indicates which version of Kubernetes for all control plane components.
-	//   examples:
-	//     - 1.17.0
-	Version string `yaml:"version"` // Note: The version must be of the format `major.minor.patch`, _without_ a leading `v`.
 	//   description: |
 	//     Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
 	//     It is single-valued, and may optionally include a port number.


### PR DESCRIPTION
In our config we allow users to override the etcd and kubelet images,
but we don't actually make use of the fields. This ensures that user
specified images are honored.