### PR TITLE
fix: issues discovered by lgtm tool

### DIFF
--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/safepath"
 )
 
 var (
@@ -183,7 +184,12 @@ func extractTarGz(localPath string, r io.ReadCloser) error {
 			return fmt.Errorf("error reading tar header: %s", err)
 		}
 
-		path := filepath.Clean(filepath.Join(localPath, hdr.Name))
+		hdrPath := safepath.CleanPath(hdr.Name)
+		if hdrPath == "" {
+			return fmt.Errorf("empty tar header path")
+		}
+
+		path := filepath.Join(localPath, hdrPath)
 		// TODO: do we need to clean up any '..' references?
 
 		switch hdr.Typeflag {

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -156,7 +156,7 @@ func (n *NetworkInterface) Configure() (err error) {
 		link, err = n.rtnlConn.LinkByIndex(n.Link.Index)
 		if err != nil {
 			// nolint: errcheck
-			retry.UnexpectedError(err)
+			return retry.UnexpectedError(err)
 		}
 
 		if link.Flags&net.FlagUp != net.FlagUp {

--- a/pkg/safepath/safepath.go
+++ b/pkg/safepath/safepath.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package safepath
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CleanPath makes a path safe for use with filepath.Join. This is done by not
+// only cleaning the path, but also (if the path is relative) adding a leading
+// '/' and cleaning it (then removing the leading '/'). This ensures that a
+// path resulting from prepending another path will always resolve to lexically
+// be a subdirectory of the prefixed path. This is all done lexically, so paths
+// that include symlinks won't be safe as a result of using CleanPath.
+func CleanPath(path string) string {
+	// Deal with empty strings nicely.
+	if path == "" {
+		return ""
+	}
+
+	// Ensure that all paths are cleaned (especially problematic ones like
+	// "/../../../../../" which can cause lots of issues).
+	path = filepath.Clean(path)
+
+	// If the path isn't absolute, we need to do more processing to fix paths
+	// such as "../../../../<etc>/some/path". We also shouldn't convert absolute
+	// paths to relative ones.
+	if !filepath.IsAbs(path) {
+		path = filepath.Clean(string(os.PathSeparator) + path)
+		// This can't fail, as (by definition) all paths are relative to root.
+		path, _ = filepath.Rel(string(os.PathSeparator), path) //nolint: errcheck
+	}
+
+	// Clean the path again for good measure.
+	return filepath.Clean(path)
+}

--- a/pkg/safepath/safepath_test.go
+++ b/pkg/safepath/safepath_test.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package safepath_test
+
+import (
+	"testing"
+
+	"github.com/talos-systems/talos/pkg/safepath"
+)
+
+func TestCleanPath(t *testing.T) {
+	path := safepath.CleanPath("")
+	if path != "" {
+		t.Errorf("expected to receive empty string and received %s", path)
+	}
+
+	path = safepath.CleanPath("rootfs")
+	if path != "rootfs" {
+		t.Errorf("expected to receive 'rootfs' and received %s", path)
+	}
+
+	path = safepath.CleanPath("../../../var")
+	if path != "var" {
+		t.Errorf("expected to receive 'var' and received %s", path)
+	}
+
+	path = safepath.CleanPath("/../../../var")
+	if path != "/var" {
+		t.Errorf("expected to receive '/var' and received %s", path)
+	}
+
+	path = safepath.CleanPath("/foo/bar/")
+	if path != "/foo/bar" {
+		t.Errorf("expected to receive '/foo/bar' and received %s", path)
+	}
+
+	path = safepath.CleanPath("/foo/bar/../")
+	if path != "/foo" {
+		t.Errorf("expected to receive '/foo' and received %s", path)
+	}
+}


### PR DESCRIPTION
Using `SafePath` function from `runc` (but had to create local copy as
`runc` doesn't build on OS X).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>