### PR TITLE
feat: prepend cluster name to config generate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,15 @@ bin
 build
 images
 .vscode
+*-init.yaml
+*-controlplane.yaml
+*-join.yaml
+*-talosconfig
 init.yaml
 controlplane.yaml
 join.yaml
-docgen
 talosconfig
+docgen
 kubeconfig
 hack/test/integration/matchbox/assets/*
 !hack/test/integration/matchbox/assets/.gitkeep

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -231,7 +231,7 @@ func genV1Alpha1Config(args []string) error {
 		return fmt.Errorf("failed to marshal config: %+v", err)
 	}
 
-	fullFilePath := filepath.Join(outputDir, "talosconfig")
+	fullFilePath := filepath.Join(outputDir, input.ClusterName+"-talosconfig")
 
 	if err = ioutil.WriteFile(fullFilePath, data, 0644); err != nil {
 		return fmt.Errorf("%w", err)
@@ -250,7 +250,7 @@ func writeV1Alpha1Config(input *genv1alpha1.Input, t genv1alpha1.Type, name stri
 		return err
 	}
 
-	name = strings.ToLower(name) + ".yaml"
+	name = strings.ToLower(input.ClusterName+"-"+name) + ".yaml"
 	fullFilePath := filepath.Join(outputDir, name)
 
 	if err = ioutil.WriteFile(fullFilePath, []byte(data), 0644); err != nil {

--- a/docs/website/content/v0.3/en/guides/cloud/aws.md
+++ b/docs/website/content/v0.3/en/guides/cloud/aws.md
@@ -140,11 +140,13 @@ We will need these soon.
 Using the DNS name of the loadbalancer created earlier, generate the base configuration files for the Talos machines:
 
 ```bash
-$ osctl config generate talos-k8s-aws-tutorial https://<load balancer IP or DNS>
-created init.yaml
-created controlplane.yaml
-created join.yaml
-created talosconfig
+export CLUSTER_NAME=talos-k8s-aws-tutorial
+
+$ osctl config generate $CLUSTER_NAME https://<load balancer IP or DNS>
+created talos-k8s-aws-tutorial-init.yaml
+created talos-k8s-aws-tutorial-controlplane.yaml
+created talos-k8s-aws-tutorial-join.yaml
+created talos-k8s-aws-tutorial-talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
@@ -152,12 +154,12 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
-$ osctl validate --config controlplane.yaml --mode cloud
-controlplane.yaml is valid for cloud mode
-$ osctl validate --config join.yaml --mode cloud
-join.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-init.yaml --mode cloud
+talos-k8s-aws-tutorial-init.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-controlplane.yaml --mode cloud
+talos-k8s-aws-tutorial-controlplane.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-join.yaml --mode cloud
+talos-k8s-aws-tutorial-join.yaml is valid for cloud mode
 ```
 
 ### Create the EC2 Instances
@@ -173,7 +175,7 @@ aws ec2 run-instances \
     --image-id $AMI \
     --count 1 \
     --instance-type t3.small \
-    --user-data file://init.yaml \
+    --user-data file://$CLUSTER_NAME-init.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
 ```
@@ -186,7 +188,7 @@ aws ec2 run-instances \
     --image-id $AMI \
     --count 2 \
     --instance-type t3.small \
-    --user-data file://controlplane.yaml \
+    --user-data file://$CLUSTER_NAME-controlplane.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
 ```
@@ -199,7 +201,7 @@ aws ec2 run-instances \
     --image-id $AMI \
     --count 3 \
     --instance-type t3.small \
-    --user-data file://join.yaml \
+    --user-data file://$CLUSTER_NAME-join.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
 ```
@@ -240,6 +242,6 @@ aws elbv2 create-listener \
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig .
+osctl --talosconfig $CLUSTER_NAME-talosconfig config endpoint <control plane 1 IP>
+osctl --talosconfig $CLUSTER_NAME-talosconfig kubeconfig .
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/azure.md
+++ b/docs/website/content/v0.3/en/guides/cloud/azure.md
@@ -188,13 +188,15 @@ done
 With our networking bits setup, we'll fetch the IP for our load balancer and create our configuration files.
 
 ```bash
+export CLUSTER_NAME=talos-k8s-azure-tutorial
+
 LB_PUBLIC_IP=$(az network public-ip show \
               --resource-group $GROUP \
               --name talos-public-ip \
               --query [ipAddress] \
               --output tsv)
 
-osctl config generate talos-k8s-azure-tutorial https://${LB_PUBLIC_IP}:6443
+osctl config generate $CLUSTER_NAME https://${LB_PUBLIC_IP}:6443
 ```
 
 ### Compute Creation
@@ -211,7 +213,7 @@ az vm availability-set create \
 az vm create \
   --name talos-controlplane-0 \
   --image talos \
-  --custom-data ./init.yaml \
+  --custom-data ./$CLUSTER_NAME-init.yaml \
   -g $GROUP \
   --admin-username talos \
   --generate-ssh-keys \
@@ -227,7 +229,7 @@ for i in $( seq 1 2 ); do
   az vm create \
     --name talos-controlplane-$i \
     --image talos \
-    --custom-data ./controlplane.yaml \
+    --custom-data ./$CLUSTER_NAME-controlplane.yaml \
     -g $GROUP \
     --admin-username talos \
     --generate-ssh-keys \
@@ -243,7 +245,7 @@ done
   az vm create \
     --name talos-worker-0 \
     --image talos \
-    --custom-data ./join.yaml \
+    --custom-data ./$CLUSTER_NAME-join.yaml \
     -g $GROUP \
     --admin-username talos \
     --generate-ssh-keys \
@@ -272,7 +274,7 @@ CONTROL_PLANE_0_IP=$(az network public-ip show \
                     --name talos-controlplane-public-ip-0 \
                     --query [ipAddress] \
                     --output tsv)
-osctl --talosconfig ./talosconfig config endpoint $CONTROL_PLANE_0_IP
-osctl --talosconfig ./talosconfig kubeconfig .
+osctl --talosconfig ./$CLUSTER_NAME-talosconfig config endpoint $CONTROL_PLANE_0_IP
+osctl --talosconfig ./$CLUSTER_NAME-talosconfig kubeconfig .
 kubectl --kubeconfig ./kubeconfig get nodes
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/digitalocean.md
+++ b/docs/website/content/v0.3/en/guides/cloud/digitalocean.md
@@ -53,11 +53,13 @@ Save it, as we will need it in the next step.
 Using the DNS name of the loadbalancer created earlier, generate the base configuration files for the Talos machines:
 
 ```bash
-$ osctl config generate talos-k8s-digital-ocean-tutorial https://<load balancer IP or DNS>
-created init.yaml
-created controlplane.yaml
-created join.yaml
-created talosconfig
+export CLUSTER_NAME=talos-k8s-digital-ocean-tutorial
+
+$ osctl config generate $CLUSTER_NAME https://<load balancer IP or DNS>
+created talos-k8s-digital-ocean-tutorial-init.yaml
+created talos-k8s-digital-ocean-tutorial-controlplane.yaml
+created talos-k8s-digital-ocean-tutorial-join.yaml
+created talos-k8s-digital-ocean-tutorial-talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
@@ -65,12 +67,12 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
-$ osctl validate --config controlplane.yaml --mode cloud
-controlplane.yaml is valid for cloud mode
-$ osctl validate --config join.yaml --mode cloud
-join.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-init.yaml --mode cloud
+talos-k8s-digital-ocean-tutorial-init.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-controlplane.yaml --mode cloud
+talos-k8s-digital-ocean-tutorial-controlplane.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-join.yaml --mode cloud
+talos-k8s-digital-ocean-tutorial-join.yaml is valid for cloud mode
 ```
 
 ### Create the Droplets
@@ -84,7 +86,7 @@ doctl compute droplet create \
     --size s-2vcpu-4gb \
     --enable-private-networking \
     --tag-names talos-digital-ocean-tutorial-control-plane \
-    --user-data-file init.yaml \
+    --user-data-file $CLUSTER_NAME-init.yaml \
     --ssh-keys <ssh key fingerprint> \
     talos-control-plane-1
 ```
@@ -103,7 +105,7 @@ doctl compute droplet create \
     --size s-2vcpu-4gb \
     --enable-private-networking \
     --tag-names talos-digital-ocean-tutorial-control-plane \
-    --user-data-file controlplane.yaml \
+    --user-data-file $CLUSTER_NAME-controlplane.yaml \
     --ssh-keys <ssh key fingerprint> \
     talos-control-plane-2
 doctl compute droplet create \
@@ -112,7 +114,7 @@ doctl compute droplet create \
     --size s-2vcpu-4gb \
     --enable-private-networking \
     --tag-names talos-digital-ocean-tutorial-control-plane \
-    --user-data-file controlplane.yaml \
+    --user-data-file $CLUSTER_NAME-controlplane.yaml \
     --ssh-keys <ssh key fingerprint> \
     talos-control-plane-3
 ```
@@ -127,7 +129,7 @@ doctl compute droplet create \
     --image <image ID> \
     --size s-2vcpu-4gb \
     --enable-private-networking \
-    --user-data-file join.yaml \
+    --user-data-file $CLUSTER_NAME-join.yaml \
     --ssh-keys <ssh key fingerprint> \
     talos-worker-1
 ```
@@ -143,6 +145,6 @@ doctl compute droplet get --format PublicIPv4 <droplet ID>
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig .
+osctl --talosconfig $CLUSTER_NAME-talosconfig config endpoint <control plane 1 IP>
+osctl --talosconfig $CLUSTER_NAME-talosconfig kubeconfig .
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/vmware.md
+++ b/docs/website/content/v0.3/en/guides/cloud/vmware.md
@@ -23,21 +23,23 @@ Prior to starting, it is important to have the following infrastructure in place
 Using the DNS name or name of the loadbalancer used in the prereq steps, generate the base configuration files for the Talos machines:
 
 ```bash
-$ osctl config generate talos-k8s-vmware-tutorial https://<load balancer IP or DNS>
-created init.yaml
-created controlplane.yaml
-created join.yaml
-created talosconfig
+export CLUSTER_NAME=talos-k8s-vmware-tutorial
+
+$ osctl config generate $CLUSTER_NAME https://<load balancer IP or DNS>
+created talos-k8s-vmware-tutorial-init.yaml
+created talos-k8s-vmware-tutorial-controlplane.yaml
+created talos-k8s-vmware-tutorial-join.yaml
+created talos-k8s-vmware-tutorial-talosconfig
 ```
 
 > Note: If you are using a DNS record, you will want to specify the port for the API Server (`tcp/6443`)
 
 ```bash
-$ osctl config generate talos-k8s-vmware-tutorial https://<DNS name>:6443
-created init.yaml
-created controlplane.yaml
-created join.yaml
-created talosconfig
+$ osctl config generate $CLUSTER_NAME https://<DNS name>:6443
+created talos-k8s-vmware-tutorial-init.yaml
+created talos-k8s-vmware-tutorial-controlplane.yaml
+created talos-k8s-vmware-tutorial-join.yaml
+created talos-k8s-vmware-tutorial-talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
@@ -45,12 +47,12 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
-$ osctl validate --config controlplane.yaml --mode cloud
-controlplane.yaml is valid for cloud mode
-$ osctl validate --config join.yaml --mode cloud
-join.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-init.yaml --mode cloud
+talos-k8s-vmware-tutorial-init.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-controlplane.yaml --mode cloud
+talos-k8s-vmware-tutorial-controlplane.yaml is valid for cloud mode
+$ osctl validate --config $CLUSTER_NAME-join.yaml --mode cloud
+talos-k8s-vmware-tutorial-join.yaml is valid for cloud mode
 ```
 
 ### Set Environment Variables
@@ -108,7 +110,7 @@ To facilitate persistent storage using the vSphere cloud provider integration wi
 
 ```bash
 govc vm.change \
-  -e "guestinfo.talos.config=$(cat init.yaml | base64)" \
+  -e "guestinfo.talos.config=$(cat $CLUSTER_NAME-init.yaml | base64)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/control-plane-1
 ```
@@ -140,12 +142,12 @@ govc vm.power -on control-plane-1
 ```bash
 govc vm.clone -on=false -vm talos-$TALOS_VERSION control-plane-2
 govc vm.change \
-  -e "guestinfo.talos.config=$(base64 controlplane.yaml)" \
+  -e "guestinfo.talos.config=$(base64 $CLUSTER_NAME-controlplane.yaml)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/control-plane-2
 govc vm.clone -on=false -vm talos-$TALOS_VERSION control-plane-3
 govc vm.change \
-  -e "guestinfo.talos.config=$(base64 controlplane.yaml)" \
+  -e "guestinfo.talos.config=$(base64 $CLUSTER_NAME-controlplane.yaml)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/control-plane-3
 ```
@@ -176,12 +178,12 @@ govc vm.power -on control-plane-3
 ```bash
 govc vm.clone -on=false -vm talos-$TALOS_VERSION worker-1
 govc vm.change \
-  -e "guestinfo.talos.config=$(base64 join.yaml)" \
+  -e "guestinfo.talos.config=$(base64 $CLUSTER_NAME-join.yaml)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/worker-1
 govc vm.clone -on=false -vm talos-$TALOS_VERSION worker-2
 govc vm.change \
-  -e "guestinfo.talos.config=$(base64 join.yaml)" \
+  -e "guestinfo.talos.config=$(base64 $CLUSTER_NAME-join.yaml)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/worker-2
 ```
@@ -212,6 +214,6 @@ govc vm.power -on worker-2
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig .
+osctl --talosconfig $CLUSTER_NAME-talosconfig config endpoint <control plane 1 IP>
+osctl --talosconfig $CLUSTER_NAME-talosconfig kubeconfig .
 ```

--- a/docs/website/content/v0.3/en/guides/metal/matchbox.md
+++ b/docs/website/content/v0.3/en/guides/metal/matchbox.md
@@ -17,11 +17,13 @@ The setup and configuration of DHCP will not be covered.
 Using the DNS name of the load balancer, generate the base configuration files for the Talos machines:
 
 ```bash
-$ osctl config generate talos-k8s-metal-tutorial https://<load balancer IP or DNS>
-created init.yaml
-created controlplane.yaml
-created join.yaml
-created talosconfig
+export CLUSTER_NAME=talos-k8s-metal-tutorial
+
+$ osctl config generate $CLUSTER_NAME https://<load balancer IP or DNS>
+created talos-k8s-metal-tutorial-init.yaml
+created talos-k8s-metal-tutorial-controlplane.yaml
+created talos-k8s-metal-tutorial-join.yaml
+created talos-k8s-metal-tutorial-talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
@@ -29,19 +31,19 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode metal
-init.yaml is valid for metal mode
-$ osctl validate --config controlplane.yaml --mode metal
-controlplane.yaml is valid for metal mode
-$ osctl validate --config join.yaml --mode metal
-join.yaml is valid for metal mode
+$ osctl validate --config $CLUSTER_NAME-init.yaml --mode metal
+talos-k8s-metal-tutorial-init.yaml is valid for metal mode
+$ osctl validate --config $CLUSTER_NAME-controlplane.yaml --mode metal
+talos-k8s-metal-tutorial-controlplane.yaml is valid for metal mode
+$ osctl validate --config $CLUSTER_NAME-join.yaml --mode metal
+talos-k8s-metal-tutorial-join.yaml is valid for metal mode
 ```
 
 #### Publishing the Machine Configuration Files
 
 In bare-metal setups it is up to the user to provide the configuration files over HTTP(S).
 A special kernel parameter (`talos.config`) must be used to inform Talos about _where_ it should retreive its' configuration file.
-To keep things simple we will place `init.yaml`, `controlplane.yaml`, and `join.yaml` into Matchbox's `assets` directory.
+To keep things simple we will place `$CLUSTER_NAME-init.yaml`, `$CLUSTER_NAME-controlplane.yaml`, and `$CLUSTER_NAME-join.yaml` into Matchbox's `assets` directory.
 This directory is automatically served by Matchbox.
 
 ### Create the Matchbox Configuration Files
@@ -71,7 +73,7 @@ Download these files from the [release](https://github.com/talos-systems/talos/r
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev/assets/init.yaml"
+      "talos.config=http://matchbox.talos.dev/assets/$CLUSTER_NAME-init.yaml"
     ]
   }
 }
@@ -99,7 +101,7 @@ Download these files from the [release](https://github.com/talos-systems/talos/r
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev/assets/controlplane.yaml"
+      "talos.config=http://matchbox.talos.dev/assets/$CLUSTER_NAME-controlplane.yaml"
     ]
   }
 }
@@ -125,7 +127,7 @@ Download these files from the [release](https://github.com/talos-systems/talos/r
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev/assets/join.yaml"
+      "talos.config=http://matchbox.talos.dev/assets/$CLUSTER_NAME-join.yaml"
     ]
   }
 }
@@ -186,6 +188,6 @@ Talos will come up on each machine, grab its' configuration file, and bootstrap 
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-osctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-osctl --talosconfig talosconfig kubeconfig .
+osctl --talosconfig $CLUSTER_NAME-talosconfig config endpoint <control plane 1 IP>
+osctl --talosconfig $CLUSTER_NAME-talosconfig kubeconfig .
 ```

--- a/hack/test/integration/libvirt.sh
+++ b/hack/test/integration/libvirt.sh
@@ -55,10 +55,10 @@ function up {
     cp $PWD/../../../build/vmlinuz ./matchbox/assets/
     cd ./matchbox/assets
     $PWD/../../../../../build/osctl-linux-amd64 config generate --install-image ${INSTALLER} integration-test https://kubernetes.talos.dev:6443
-    yq w -i init.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
-    yq w -i init.yaml cluster.network.cni.name 'custom'
-    yq w -i init.yaml cluster.network.cni.urls[+] "${CNI_URL}"
-    yq w -i controlplane.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    yq w -i integration-test-init.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    yq w -i integration-test-init.yaml cluster.network.cni.name 'custom'
+    yq w -i integration-test-init.yaml cluster.network.cni.urls[+] "${CNI_URL}"
+    yq w -i integration-test-controlplane.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
     yq w -i join.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
     cd -
     virt-install --name $CONTROL_PLANE_1_NAME --network=bridge:talos0,model=e1000,mac=$CONTROL_PLANE_1_MAC $COMMON_VIRT_OPTS --boot=hd,network
@@ -81,7 +81,7 @@ function down {
 }
 
 function workspace {
-  docker run --rm -it -v $PWD:/workspace -v $PWD/../../../build/osctl-linux-amd64:/bin/osctl:ro --network talos --dns 172.28.1.1 -w /workspace/matchbox/assets -e TALOSCONFIG='/workspace/matchbox/assets/talosconfig' -e KUBECONFIG='/workspace/matchbox/assets/kubeconfig' --entrypoint /bin/bash k8s.gcr.io/hyperkube:v1.17.0
+  docker run --rm -it -v $PWD:/workspace -v $PWD/../../../build/osctl-linux-amd64:/bin/osctl:ro --network talos --dns 172.28.1.1 -w /workspace/matchbox/assets -e TALOSCONFIG='/workspace/matchbox/assets/integration-test-talosconfig' -e KUBECONFIG='/workspace/matchbox/assets/kubeconfig' --entrypoint /bin/bash k8s.gcr.io/hyperkube:v1.17.0
 }
 
 main $@

--- a/hack/test/integration/matchbox/profiles/controlplane.json
+++ b/hack/test/integration/matchbox/profiles/controlplane.json
@@ -18,7 +18,7 @@
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev:8080/assets/controlplane.yaml"
+      "talos.config=http://matchbox.talos.dev:8080/assets/integration-test-controlplane.yaml"
     ]
   }
 }

--- a/hack/test/integration/matchbox/profiles/default.json
+++ b/hack/test/integration/matchbox/profiles/default.json
@@ -18,7 +18,7 @@
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev:8080/assets/join.yaml"
+      "talos.config=http://matchbox.talos.dev:8080/assets/integration-test-join.yaml"
     ]
   }
 }

--- a/hack/test/integration/matchbox/profiles/init.json
+++ b/hack/test/integration/matchbox/profiles/init.json
@@ -18,7 +18,7 @@
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev:8080/assets/init.yaml"
+      "talos.config=http://matchbox.talos.dev:8080/assets/integration-test-init.yaml"
     ]
   }
 }


### PR DESCRIPTION
This PR will take the cluster name and add it to the node type that is
generated by osctl config generate (ex: "mycluster-init.yaml"). Driver
for this is to help make it clearer which cluster a given yaml applies
to. Will also help with the ux of being able to config docker-based
talos clusters.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>