### PR TITLE
test: add integration tests for (most) CLI commands

### DIFF
--- a/cmd/osctl/cmd/gen.go
+++ b/cmd/osctl/cmd/gen.go
@@ -244,8 +244,8 @@ func init() {
 	crtCmd.Flags().IntVar(&hours, "hours", 24, "the hours from now on which the certificate validity period ends")
 	// Keypairs
 	keypairCmd.Flags().StringVar(&ip, "ip", "", "generate the certificate for this IP address")
-	keypairCmd.Flags().StringVar(&ca, "ca", "", "path to the PEM encoded CERTIFICATE")
-	helpers.Should(cobra.MarkFlagRequired(keypairCmd.Flags(), "ca"))
+	keypairCmd.Flags().StringVar(&organization, "organization", "", "X.509 distinguished name for the Organization")
+	helpers.Should(cobra.MarkFlagRequired(keypairCmd.Flags(), "organization"))
 	// Certificate Signing Requests
 	csrCmd.Flags().StringVar(&key, "key", "", "path to the PEM encoded EC or RSA PRIVATE KEY")
 	helpers.Should(cobra.MarkFlagRequired(csrCmd.Flags(), "key"))

--- a/cmd/osctl/cmd/kubeconfig.go
+++ b/cmd/osctl/cmd/kubeconfig.go
@@ -25,7 +25,7 @@ var kubeconfigCmd = &cobra.Command{
 	Short: "Download the admin kubeconfig from the node",
 	Long: `Download the admin kubeconfig from the node.
 Kubeconfig will be written to PWD/kubeconfig or [local-path]/kubeconfig if specified.`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "kubeconfig"); err != nil {

--- a/internal/integration/cli/completion.go
+++ b/internal/integration/cli/completion.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// CompletionSuite verifies dmesg command
+type CompletionSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *CompletionSuite) SuiteName() string {
+	return "cli.CompletionSuite"
+}
+
+// TestSuccess runs comand with success.
+func (suite *CompletionSuite) TestSuccess() {
+	suite.RunOsctl([]string{"completion", "bash"})
+	suite.RunOsctl([]string{"completion", "zsh"})
+}
+
+func init() {
+	allSuites = append(allSuites, new(CompletionSuite))
+}

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// ContainersSuite verifies dmesg command
+type ContainersSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *ContainersSuite) SuiteName() string {
+	return "cli.ContainersSuite"
+}
+
+// TestContainerd inspects containers via containerd driver.
+func (suite *ContainersSuite) TestContainerd() {
+	suite.RunOsctl([]string{"containers"},
+		base.StdoutShouldMatch(regexp.MustCompile(`IMAGE`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`talos/osd`)),
+	)
+	suite.RunOsctl([]string{"containers", "-k"},
+		base.StdoutShouldMatch(regexp.MustCompile(`kubelet`)),
+	)
+}
+
+// TestCRI inspects containers via CRI driver.
+func (suite *ContainersSuite) TestCRI() {
+	suite.RunOsctl([]string{"containers", "-c"},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(`CRI inspector is supported only for K8s namespace`)))
+	suite.RunOsctl([]string{"containers", "-ck"},
+		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, new(ContainersSuite))
+}

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// GenSuite verifies dmesg command
+type GenSuite struct {
+	base.CLISuite
+
+	tmpDir   string
+	savedCwd string
+}
+
+// SuiteName ...
+func (suite *GenSuite) SuiteName() string {
+	return "cli.GenSuite"
+}
+
+func (suite *GenSuite) SetupTest() {
+	var err error
+	suite.tmpDir, err = ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+	suite.savedCwd, err = os.Getwd()
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(os.Chdir(suite.tmpDir))
+}
+
+func (suite *GenSuite) TearDownTest() {
+	suite.Require().NoError(os.Chdir(suite.savedCwd))
+	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
+}
+
+// TestCA ...
+func (suite *GenSuite) TestCA() {
+	suite.RunOsctl([]string{"gen", "ca", "--organization", "Foo"},
+		base.StdoutEmpty())
+
+	suite.Assert().FileExists("Foo.crt")
+	suite.Assert().FileExists("Foo.sha256")
+	suite.Assert().FileExists("Foo.key")
+}
+
+// TestKey ...
+func (suite *GenSuite) TestKey() {
+	suite.RunOsctl([]string{"gen", "key", "--name", "Foo"},
+		base.StdoutEmpty())
+
+	suite.Assert().FileExists("Foo.key")
+}
+
+// TestCSR ...
+func (suite *GenSuite) TestCSR() {
+	suite.RunOsctl([]string{"gen", "key", "--name", "Foo"},
+		base.StdoutEmpty())
+
+	suite.RunOsctl([]string{"gen", "csr", "--key", "Foo.key", "--ip", "10.0.0.1"},
+		base.StdoutEmpty())
+
+	suite.Assert().FileExists("Foo.csr")
+}
+
+// TestCrt ...
+func (suite *GenSuite) TestCrt() {
+	suite.RunOsctl([]string{"gen", "ca", "--organization", "Foo"},
+		base.StdoutEmpty())
+
+	suite.RunOsctl([]string{"gen", "key", "--name", "Bar"},
+		base.StdoutEmpty())
+
+	suite.RunOsctl([]string{"gen", "csr", "--key", "Bar.key", "--ip", "10.0.0.1"},
+		base.StdoutEmpty())
+
+	suite.RunOsctl([]string{"gen", "crt", "--ca", "Foo", "--csr", "Bar.csr", "--name", "foobar"},
+		base.StdoutEmpty())
+
+	suite.Assert().FileExists("foobar.crt")
+}
+
+// TestKeypair ...
+func (suite *GenSuite) TestKeypair() {
+	suite.RunOsctl([]string{"gen", "keypair", "--organization", "Foo", "--ip", "10.0.0.1"},
+		base.StdoutEmpty())
+
+	suite.Assert().FileExists("Foo.crt")
+	suite.Assert().FileExists("Foo.key")
+}
+
+func init() {
+	allSuites = append(allSuites, new(GenSuite))
+}

--- a/internal/integration/cli/interfaces.go
+++ b/internal/integration/cli/interfaces.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// InterfacesSuite verifies dmesg command
+type InterfacesSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *InterfacesSuite) SuiteName() string {
+	return "cli.InterfacesSuite"
+}
+
+// TestSuccess verifies successful execution.
+func (suite *InterfacesSuite) TestSuccess() {
+	suite.RunOsctl([]string{"interfaces"},
+		base.StdoutShouldMatch(regexp.MustCompile(`lo`)))
+}
+
+func init() {
+	allSuites = append(allSuites, new(InterfacesSuite))
+}

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -25,8 +25,8 @@ func (suite *KubeconfigSuite) SuiteName() string {
 	return "cli.KubeconfigSuite"
 }
 
-// TestSuccess runs comand with success.
-func (suite *KubeconfigSuite) TestSuccess() {
+// TestDirectory generates kubeconfig in specified directory.
+func (suite *KubeconfigSuite) TestDirectory() {
 	tempDir, err := ioutil.TempDir("", "talos")
 	suite.Require().NoError(err)
 
@@ -35,8 +35,29 @@ func (suite *KubeconfigSuite) TestSuccess() {
 	suite.RunOsctl([]string{"kubeconfig", tempDir},
 		base.StdoutEmpty())
 
-	_, err = os.Stat(filepath.Join(tempDir, "kubeconfig"))
+	suite.Require().FileExists(filepath.Join(tempDir, "kubeconfig"))
+
+	// TODO: launch kubectl with config to verify it
+}
+
+// TestCwd generates kubeconfig in cwd.
+func (suite *KubeconfigSuite) TestCwd() {
+	tempDir, err := ioutil.TempDir("", "talos")
 	suite.Require().NoError(err)
+
+	defer os.RemoveAll(tempDir) //nolint: errcheck
+
+	savedCwd, err := os.Getwd()
+	suite.Require().NoError(err)
+
+	defer os.Chdir(savedCwd) //nolint: errcheck
+
+	suite.Require().NoError(os.Chdir(tempDir))
+
+	suite.RunOsctl([]string{"kubeconfig"},
+		base.StdoutEmpty())
+
+	suite.Require().FileExists(filepath.Join(tempDir, "kubeconfig"))
 }
 
 // TestMultiNodeFail verifies that command fails with multiple nodes.

--- a/internal/integration/cli/memory.go
+++ b/internal/integration/cli/memory.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// MemorySuite verifies dmesg command
+type MemorySuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *MemorySuite) SuiteName() string {
+	return "cli.MemorySuite"
+}
+
+// TestSuccess verifies successful execution.
+func (suite *MemorySuite) TestSuccess() {
+	suite.RunOsctl([]string{"memory"},
+		base.StdoutShouldMatch(regexp.MustCompile(`FREE`)))
+}
+
+// TestVerbose verifies verbose mode.
+func (suite *MemorySuite) TestVerbose() {
+	suite.RunOsctl([]string{"memory", "-v"},
+		base.StdoutShouldMatch(regexp.MustCompile(`MemFree: \d+ kB`)))
+}
+
+func init() {
+	allSuites = append(allSuites, new(MemorySuite))
+}

--- a/internal/integration/cli/mounts.go
+++ b/internal/integration/cli/mounts.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// MountsSuite verifies dmesg command
+type MountsSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *MountsSuite) SuiteName() string {
+	return "cli.MountsSuite"
+}
+
+// TestSuccess verifies successful execution.
+func (suite *MountsSuite) TestSuccess() {
+	suite.RunOsctl([]string{"mounts"},
+		base.StdoutShouldMatch(regexp.MustCompile(`FILESYSTEM`)))
+}
+
+func init() {
+	allSuites = append(allSuites, new(MountsSuite))
+}

--- a/internal/integration/cli/processes.go
+++ b/internal/integration/cli/processes.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// ProcessesSuite verifies dmesg command
+type ProcessesSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *ProcessesSuite) SuiteName() string {
+	return "cli.ProcessesSuite"
+}
+
+// TestSuccess verifies successful execution.
+func (suite *ProcessesSuite) TestSuccess() {
+	suite.RunOsctl([]string{"processes"},
+		base.StdoutShouldMatch(regexp.MustCompile(`PID`)))
+}
+
+func init() {
+	allSuites = append(allSuites, new(ProcessesSuite))
+}

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// RestartSuite verifies dmesg command
+type RestartSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *RestartSuite) SuiteName() string {
+	return "cli.RestartSuite"
+}
+
+// TestSystem restarts system containerd process.
+func (suite *RestartSuite) TestSystem() {
+	suite.RunOsctl([]string{"restart", "trustd"},
+		base.StdoutEmpty())
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.RunAndWaitForMatch([]string{"containers"}, regexp.MustCompile(`trustd`), 30*time.Second)
+}
+
+// TestKubernetes restarts K8s container.
+func (suite *RestartSuite) TestK8s() {
+	suite.RunOsctl([]string{"restart", "-k", "kubelet"},
+		base.StdoutEmpty())
+
+	time.Sleep(50 * time.Millisecond)
+
+	suite.RunAndWaitForMatch([]string{"containers", "-k"}, regexp.MustCompile(`\s+kubelet\s+`), 30*time.Second)
+}
+
+func init() {
+	allSuites = append(allSuites, new(RestartSuite))
+}

--- a/internal/integration/cli/routes.go
+++ b/internal/integration/cli/routes.go
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// RoutesSuite verifies dmesg command
+type RoutesSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *RoutesSuite) SuiteName() string {
+	return "cli.RoutesSuite"
+}
+
+// TestSuccess verifies successful execution.
+func (suite *RoutesSuite) TestSuccess() {
+	suite.RunOsctl([]string{"routes"},
+		base.StdoutShouldMatch(regexp.MustCompile(`GATEWAY`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`127\.0\.0\.0/8`)),
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, new(RoutesSuite))
+}

--- a/internal/integration/cli/services.go
+++ b/internal/integration/cli/services.go
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// ServicesSuite verifies dmesg command
+type ServicesSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *ServicesSuite) SuiteName() string {
+	return "cli.ServicesSuite"
+}
+
+// TestList verifies service list.
+func (suite *ServicesSuite) TestList() {
+	suite.RunOsctl([]string{"services"},
+		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`osd`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
+	)
+}
+
+// TestStatus verifies service status.
+func (suite *ServicesSuite) TestStatus() {
+	suite.RunOsctl([]string{"service", "apid"},
+		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`\[Running\]`)),
+	)
+
+	suite.RunOsctl([]string{"service", "osd", "status"},
+		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`osd`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`\[Running\]`)),
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, new(ServicesSuite))
+}

--- a/internal/integration/cli/stats.go
+++ b/internal/integration/cli/stats.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// StatsSuite verifies dmesg command
+type StatsSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *StatsSuite) SuiteName() string {
+	return "cli.StatsSuite"
+}
+
+// TestContainerd inspects stats via containerd driver.
+func (suite *StatsSuite) TestContainerd() {
+	suite.RunOsctl([]string{"stats"},
+		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`osd`)),
+	)
+	suite.RunOsctl([]string{"stats", "-k"},
+		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`kubelet`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),
+	)
+}
+
+// TestCRI inspects stats via CRI driver.
+func (suite *StatsSuite) TestCRI() {
+	suite.RunOsctl([]string{"stats", "-c"},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(`CRI inspector is supported only for K8s namespace`)))
+	suite.RunOsctl([]string{"stats", "-ck"},
+		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, new(StatsSuite))
+}

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// ValidateSuite verifies dmesg command
+type ValidateSuite struct {
+	base.CLISuite
+
+	tmpDir   string
+	savedCwd string
+}
+
+// SuiteName ...
+func (suite *ValidateSuite) SuiteName() string {
+	return "cli.ValidateSuite"
+}
+
+func (suite *ValidateSuite) SetupTest() {
+	var err error
+	suite.tmpDir, err = ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+	suite.savedCwd, err = os.Getwd()
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(os.Chdir(suite.tmpDir))
+}
+
+func (suite *ValidateSuite) TearDownTest() {
+	suite.Require().NoError(os.Chdir(suite.savedCwd))
+	suite.Require().NoError(os.RemoveAll(suite.tmpDir))
+}
+
+// TestValidate generates config and validates it for all the modes.
+func (suite *ValidateSuite) TestValidate() {
+	suite.RunOsctl([]string{"config", "generate", "foobar", "https://10.0.0.1"})
+
+	for _, configFile := range []string{"init.yaml", "controlplane.yaml", "join.yaml"} {
+		for _, mode := range []string{"Cloud", "Container", "Interactive", "Metal"} {
+			suite.RunOsctl([]string{"validate", "-m", mode, "-c", configFile})
+		}
+	}
+}
+
+func init() {
+	allSuites = append(allSuites, new(ValidateSuite))
+}

--- a/internal/integration/cli/version.go
+++ b/internal/integration/cli/version.go
@@ -30,6 +30,21 @@ func (suite *VersionSuite) TestExpectedVersionMaster() {
 	)
 }
 
+// TestShortVersion verifies short version output.
+func (suite *VersionSuite) TestShortVersion() {
+	suite.RunOsctl([]string{"version", "--short"},
+		base.StdoutShouldMatch(regexp.MustCompile(`Client\s*`+regexp.QuoteMeta(suite.Version))),
+	)
+}
+
+// TestClientVersion verifies only client version output.
+func (suite *VersionSuite) TestClient() {
+	suite.RunOsctl([]string{"version", "--client"},
+		base.StdoutShouldMatch(regexp.MustCompile(`Client:\n\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
+		base.StdoutShouldNotMatch(regexp.MustCompile(`Server`)),
+	)
+}
+
 func init() {
 	allSuites = append(allSuites, new(VersionSuite))
 }


### PR DESCRIPTION
I added tests for all the commands which work reliably in container mode.

Some tests are naive, some are more sophisticated. While going
through the tests, I think I found a small bug in `osctl gen keypair`.

When we get reliable KVM tests, I can revisit and add missing
tests for time, reboot, shutdown and friends.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>