### PR TITLE
fix: use proxy env vars when attempting an install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 	go.etcd.io/etcd v3.3.13+incompatible
 	golang.org/x/crypto v0.0.0-20191108234033-bd318be0434a
-	golang.org/x/net v0.0.0-20191204025024-5ee1b9f4859a // indirect
+	golang.org/x/net v0.0.0-20191204025024-5ee1b9f4859a
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e
 	golang.org/x/text v0.3.2

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -99,6 +99,10 @@ func (d *Sequencer) Boot() error {
 			network.NewInitialNetworkSetupTask(),
 		),
 		phase.NewPhase(
+			"set environment variables",
+			configtask.NewExtraEnvVarsTask(),
+		),
+		phase.NewPhase(
 			"start system-containerd",
 			services.NewStartSystemContainerdTask(),
 		),
@@ -129,7 +133,6 @@ func (d *Sequencer) Boot() error {
 		),
 		phase.NewPhase(
 			"user requests",
-			configtask.NewExtraEnvVarsTask(),
 			configtask.NewExtraFilesTask(),
 			configtask.NewSysctlsTask(),
 		),


### PR DESCRIPTION
Long story short, golang does not update its' internal proxy config
after it has been initialized. This means that if there are no proxy env
vars set, and the http client is used in any way, it will forever be
configured that way. So even if we export proxy env vars later, they
will never be respected. This addresses that by skipping the caching
mechanism that golang uses (once.Do), and forces the http client to
check for proxy env vars, for every request.