### PR TITLE
fix: Reset default http client to work around proxyEnv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 	go.etcd.io/etcd v3.3.13+incompatible
 	golang.org/x/crypto v0.0.0-20191108234033-bd318be0434a
-	golang.org/x/net v0.0.0-20191204025024-5ee1b9f4859a // indirect
+	golang.org/x/net v0.0.0-20191204025024-5ee1b9f4859a
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e
 	golang.org/x/text v0.3.2

--- a/internal/app/machined/internal/sequencer/v1alpha1/types.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/types.go
@@ -93,6 +93,7 @@ func (d *Sequencer) Boot() error {
 		phase.NewPhase(
 			"network reset",
 			network.NewResetNetworkTask(),
+			configtask.NewExtraEnvVarsTask(),
 		),
 		phase.NewPhase(
 			"initial network",
@@ -129,7 +130,6 @@ func (d *Sequencer) Boot() error {
 		),
 		phase.NewPhase(
 			"user requests",
-			configtask.NewExtraEnvVarsTask(),
 			configtask.NewExtraFilesTask(),
 			configtask.NewSysctlsTask(),
 		),


### PR DESCRIPTION
This fixes an issue where the default http client transport only reads the
environment variables once. This allows us to use a default/native network
configuration via dhcp to fetch userdata and then update the environment
after applying the configuration from userdata.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>