### PR TITLE
fix(machined): Add additional defaults for http transport

### DIFF
--- a/internal/app/machined/internal/phase/phase.go
+++ b/internal/app/machined/internal/phase/phase.go
@@ -7,13 +7,10 @@ package phase
 import (
 	"fmt"
 	"log"
-	"net/http"
-	"net/url"
 	goruntime "runtime"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"golang.org/x/net/http/httpproxy"
 
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
@@ -62,16 +59,6 @@ func NewRunner(config runtime.Configurator, sequence runtime.Sequence) (*Runner,
 		if err = kmsg.Setup("[talos]", true); err != nil {
 			return nil, fmt.Errorf("failed to setup logging: %w", err)
 		}
-	}
-
-	// Re-define the default http client
-	// Work around our fun proxy.Do once bug
-	http.DefaultClient = &http.Client{
-		Transport: &http.Transport{
-			Proxy: func(req *http.Request) (*url.URL, error) {
-				return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
-			},
-		},
 	}
 
 	runner := &Runner{


### PR DESCRIPTION
Followup from #1680.

This also moves the setting from phases to machine.init to set it earlier in
the boot sequence to ensure that we get the defaults set properly from the
start and set it only once.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>