### PR TITLE
fix: don't log `token` metadata field in grpc request log

### DIFF
--- a/pkg/grpc/middleware/log/log_test.go
+++ b/pkg/grpc/middleware/log/log_test.go
@@ -4,11 +4,41 @@
 
 package log_test
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/assert"
+	metadata "google.golang.org/grpc/metadata"
+
+	"github.com/talos-systems/talos/pkg/grpc/middleware/log"
+)
+
+func TestExtractMetadata(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		md       metadata.MD
+		expected string
+	}{
+		{
+			name:     "empty",
+			md:       metadata.MD{},
+			expected: "",
+		},
+		{
+			name:     "regular",
+			md:       metadata.Pairs("foo", "bar", "one", "two", "a", "b"),
+			expected: "a=b;foo=bar;one=two",
+		},
+		{
+			name:     "sensitive",
+			md:       metadata.Pairs("foo", "bar", "token", "secret"),
+			expected: "foo=bar;token=<hidden>",
+		},
+	} {
+		ctx := context.Background()
+		ctx = metadata.NewIncomingContext(ctx, test.md)
+
+		assert.Equal(t, test.expected, log.ExtractMetadata(ctx), test.name)
+	}
 }


### PR DESCRIPTION
This field might contain sensitive information, so better to hide it in
the logs.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>