### PR TITLE
chore: use osctl cluster --wait in basic-integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -564,7 +564,7 @@ steps:
 
 - name: basic-integration
   pull: always
-  image: golang:1.13
+  image: autonomy/build-container:latest
   commands:
   - make basic-integration
   environment:
@@ -629,6 +629,9 @@ services:
   - --mtu=1440
   - --log-level=error
   privileged: true
+  ports:
+  - 6443
+  - 50000
   volumes:
   - name: dockersock
     path: /var/run
@@ -1224,7 +1227,7 @@ steps:
 
 - name: basic-integration
   pull: always
-  image: golang:1.13
+  image: autonomy/build-container:latest
   commands:
   - make basic-integration
   environment:
@@ -1422,6 +1425,9 @@ services:
   - --mtu=1440
   - --log-level=error
   privileged: true
+  ports:
+  - 6443
+  - 50000
   volumes:
   - name: dockersock
     path: /var/run
@@ -2012,7 +2018,7 @@ steps:
 
 - name: basic-integration
   pull: always
-  image: golang:1.13
+  image: autonomy/build-container:latest
   commands:
   - make basic-integration
   environment:
@@ -2244,6 +2250,9 @@ services:
   - --mtu=1440
   - --log-level=error
   privileged: true
+  ports:
+  - 6443
+  - 50000
   volumes:
   - name: dockersock
     path: /var/run
@@ -2834,7 +2843,7 @@ steps:
 
 - name: basic-integration
   pull: always
-  image: golang:1.13
+  image: autonomy/build-container:latest
   commands:
   - make basic-integration
   environment:
@@ -3066,6 +3075,9 @@ services:
   - --mtu=1440
   - --log-level=error
   privileged: true
+  ports:
+  - 6443
+  - 50000
   volumes:
   - name: dockersock
     path: /var/run
@@ -3656,7 +3668,7 @@ steps:
 
 - name: basic-integration
   pull: always
-  image: golang:1.13
+  image: autonomy/build-container:latest
   commands:
   - make basic-integration
   environment:
@@ -3783,6 +3795,9 @@ services:
   - --mtu=1440
   - --log-level=error
   privileged: true
+  ports:
+  - 6443
+  - 50000
   volumes:
   - name: dockersock
     path: /var/run

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ integration-test: ## Runs the CLI and API integration tests against a running cl
 
 .PHONY: basic-integration
 basic-integration: ## Runs the basic integration test.
-	@TAG=$(TAG) SHA=$(SHA) ARTIFACTS=$(ARTIFACTS) go run ./internal/test-framework/main.go $@ --artifacts=$(ARTIFACTS)
+	@$(MAKE) hack-test-$@
 
 .PHONY: e2e-integration
 e2e-integration: ## Runs the E2E integration for the specified cloud provider.

--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -16,13 +16,16 @@ osctl cluster create [flags]
 ```
       --cidr string                 CIDR of the docker bridge network (default "10.5.0.0/24")
       --cpus string                 the share of CPUs as fraction (each container) (default "1.5")
+      --endpoint string             use endpoint instead of provider defaults
   -h, --help                        help for create
       --image string                the image to use (default "docker.io/autonomy/talos:latest")
+      --init-node-as-endpoint       use init node as endpoint instead of any load balancer endpoint
       --kubernetes-version string   desired kubernetes version to run (default "1.17.0")
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
       --mtu int                     MTU of the docker bridge network (default 1500)
       --wait                        wait for the cluster to be ready before returning
+      --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
       --workers int                 the number of workers to create (default 1)
 ```
 

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -102,6 +102,10 @@ local docker = {
     '--mtu=1440',
     '--log-level=error',
   ],
+  ports: [
+    6443,
+    50000,
+  ],
   volumes: volumes.ForStep(),
 };
 
@@ -190,7 +194,7 @@ local image_gcp = Step("image-gcp", depends_on=[installer]);
 local image_vmware = Step("image-vmware", depends_on=[installer]);
 local unit_tests = Step("unit-tests", depends_on=[rootfs, talos]);
 local unit_tests_race = Step("unit-tests-race", depends_on=[golint]);
-local basic_integration = Step("basic-integration", image="golang:1.13", depends_on=[unit_tests, talos, osctl_linux, integration_test]);
+local basic_integration = Step("basic-integration", depends_on=[unit_tests, talos, osctl_linux, integration_test]);
 
 local coverage = {
   name: 'coverage',

--- a/hack/test/capi.sh
+++ b/hack/test/capi.sh
@@ -18,11 +18,15 @@ export AWS_B64ENCODED_CREDENTIALS=${AWS_SVC_ACCT}
 cat ${PWD}/hack/test/manifests/capa-components.yaml| envsubst > ${TMP}/capa-components.yaml
 
 ## Template out gcp components
-export GCP_B64ENCODED_CREDENTIALS=${GCE_SVC_ACCT} 
+export GCP_B64ENCODED_CREDENTIALS=${GCE_SVC_ACCT}
 cat ${PWD}/hack/test/manifests/capg-components.yaml| envsubst > ${TMP}/capg-components.yaml
-##Until next alpha release, keep a local copy of capg-components.yaml. 
+##Until next alpha release, keep a local copy of capg-components.yaml.
 ##They've got an incorrect image pull policy.
 ##curl -L ${CAPG_COMPONENTS} | envsubst > ${TMP}/capg-components.yaml
+
+## Clean up osctl endpoint, fetch kubeconfig
+e2e_run "osctl config endpoint 10.5.0.2"
+e2e_run "osctl kubeconfig ${TMP}"
 
 ## Drop in capi stuff
 e2e_run "kubectl apply -f ${TMP}/provider-components.yaml"

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -48,7 +48,7 @@ func (apiSuite *APISuite) DiscoverNodes() []string {
 
 	var err error
 
-	apiSuite.discoveredNodes, err = discoverNodesK8s(apiSuite.Client)
+	apiSuite.discoveredNodes, err = discoverNodesK8s(apiSuite.Client, &apiSuite.TalosSuite)
 	apiSuite.Require().NoError(err, "k8s discovery failed")
 
 	if apiSuite.discoveredNodes == nil {

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -11,6 +11,8 @@ package base
 type TalosSuite struct {
 	// Endpoint to use to connect, if not set config is used
 	Endpoint string
+	// K8sEndpoint is API server endpoint, if set overrides kubeconfig
+	K8sEndpoint string
 	// Nodes is a list of Talos cluster addresses (overrides discovery if set)
 	Nodes []string
 	// TalosConfig is a path to talosconfig

--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -19,7 +19,7 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 )
 
-func discoverNodesK8s(client *client.Client) ([]string, error) {
+func discoverNodesK8s(client *client.Client, suite *TalosSuite) ([]string, error) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
 	defer ctxCancel()
 
@@ -37,6 +37,9 @@ func discoverNodesK8s(client *client.Client) ([]string, error) {
 
 	// patch timeout
 	config.Timeout = time.Minute
+	if suite.K8sEndpoint != "" {
+		config.Host = suite.K8sEndpoint
+	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/internal/integration/base/discovery_nok8s.go
+++ b/internal/integration/base/discovery_nok8s.go
@@ -8,6 +8,6 @@ package base
 
 import "github.com/talos-systems/talos/cmd/osctl/pkg/client"
 
-func discoverNodesK8s(client *client.Client) ([]string, error) {
+func discoverNodesK8s(client *client.Client, suite *TalosSuite) ([]string, error) {
 	return nil, nil
 }

--- a/internal/integration/base/k8s.go
+++ b/internal/integration/base/k8s.go
@@ -8,6 +8,7 @@ package base
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -34,6 +35,12 @@ func (k8sSuite *K8sSuite) SetupSuite() {
 		return clientcmd.Load(kubeconfig)
 	})
 	k8sSuite.Require().NoError(err)
+
+	// patch timeout
+	config.Timeout = time.Minute
+	if k8sSuite.K8sEndpoint != "" {
+		config.Host = k8sSuite.K8sEndpoint
+	}
 
 	k8sSuite.Clientset, err = kubernetes.NewForConfig(config)
 	k8sSuite.Require().NoError(err)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -30,6 +30,7 @@ var allSuites []suite.TestingSuite
 var (
 	talosConfig     string
 	endpoint        string
+	k8sEndpoint     string
 	nodes           stringList
 	expectedVersion string
 	osctlPath       string
@@ -44,6 +45,7 @@ func TestIntegration(t *testing.T) {
 		if configuredSuite, ok := s.(base.ConfiguredSuite); ok {
 			configuredSuite.SetConfig(base.TalosSuite{
 				Endpoint:    endpoint,
+				K8sEndpoint: k8sEndpoint,
 				Nodes:       []string(nodes),
 				TalosConfig: talosConfig,
 				Version:     expectedVersion,
@@ -77,6 +79,7 @@ func init() {
 
 	flag.StringVar(&talosConfig, "talos.config", defaultTalosConfig, "The path to the Talos configuration file")
 	flag.StringVar(&endpoint, "talos.endpoint", "", "endpoint to use (overrides config)")
+	flag.StringVar(&k8sEndpoint, "talos.k8sendpoint", "", "Kubernetes endpoint to use (overrides kubeconfig)")
 	flag.Var(&nodes, "talos.nodes", "list of node addresses (overrides discovery)")
 	flag.StringVar(&expectedVersion, "talos.version", version.Tag, "expected Talos version")
 	flag.StringVar(&osctlPath, "talos.osctlpath", "osctl", "The path to 'osctl' binary")

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -21,9 +21,30 @@ func WithLogWriter(w io.Writer) Option {
 	}
 }
 
+// WithForceInitNodeAsEndpoint uses direct IP of init node as endpoint instead of (default)
+// mode.
+func WithForceInitNodeAsEndpoint() Option {
+	return func(o *Options) error {
+		o.ForceInitNodeAsEndpoint = true
+
+		return nil
+	}
+}
+
+// WithEndpoint specifies endpoint to use when acessing Talos cluster.
+func WithEndpoint(endpoint string) Option {
+	return func(o *Options) error {
+		o.ForceEndpoint = endpoint
+
+		return nil
+	}
+}
+
 // Options describes Provisioner parameters.
 type Options struct {
-	LogWriter io.Writer
+	LogWriter               io.Writer
+	ForceInitNodeAsEndpoint bool
+	ForceEndpoint           string
 }
 
 // DefaultOptions returns default options.

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -17,7 +17,7 @@ func controlPlaneUd(in *Input) (string, error) {
 		MachineType:     "controlplane",
 		MachineToken:    in.TrustdInfo.Token,
 		MachineCA:       in.Certs.OS,
-		MachineCertSANs: []string{},
+		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
 		MachineInstall: &v1alpha1.InstallConfig{

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -101,6 +101,7 @@ type Input struct {
 	ControlPlaneEndpoint string
 
 	AdditionalSubjectAltNames []string
+	AdditionalMachineCertSANs []string
 
 	ClusterName       string
 	ServiceDomain     string

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -18,7 +18,7 @@ func initUd(in *Input) (string, error) {
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
 		MachineCA:       in.Certs.OS,
-		MachineCertSANs: []string{},
+		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineToken:    in.TrustdInfo.Token,
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:       in.InstallDisk,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -17,7 +17,7 @@ func workerUd(in *Input) (string, error) {
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "worker",
 		MachineToken:    in.TrustdInfo.Token,
-		MachineCertSANs: []string{},
+		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
 		MachineInstall: &v1alpha1.InstallConfig{


### PR DESCRIPTION
Added flag to workaround CI/CD issue to use direct connection to docker
container (init node) instead of 127.0.0.1 passthrough (default is still
using 127.0.0.1).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>