### PR TITLE
chore: exclude cron events in push-latest step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -614,6 +614,7 @@ steps:
       - pull_request
       - promote
       - tag
+      - cron
   depends_on:
   - basic-integration
 
@@ -1273,6 +1274,7 @@ steps:
       - pull_request
       - promote
       - tag
+      - cron
   depends_on:
   - basic-integration
 
@@ -2060,6 +2062,7 @@ steps:
       - pull_request
       - promote
       - tag
+      - cron
   depends_on:
   - basic-integration
 
@@ -2881,6 +2884,7 @@ steps:
       - pull_request
       - promote
       - tag
+      - cron
   depends_on:
   - basic-integration
 
@@ -3702,6 +3706,7 @@ steps:
       - pull_request
       - promote
       - tag
+      - cron
   depends_on:
   - basic-integration
 

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -221,6 +221,7 @@ local push_latest = {
         'pull_request',
         'promote',
         'tag',
+        'cron',
       ],
     },
   },


### PR DESCRIPTION
We shouldn't push latest on cron events.