### PR TITLE
chore: fix releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3772,7 +3772,19 @@ steps:
     - sha512
     draft: true
     files:
-    - _out/*
+    - _out/aws.tar.gz
+    - _out/azure.tar.gz
+    - _out/container.tar
+    - _out/digital-ocean.tar.gz
+    - _out/gcp.tar.gz
+    - _out/initramfs.xz
+    - _out/installer.tar
+    - _out/osctl-darwin-amd64
+    - _out/osctl-linux-amd64
+    - _out/talos.iso
+    - _out/vmware.ova
+    - _out/vmlinux
+    - _out/vmlinuz
   when:
     event:
     - tag

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -400,7 +400,21 @@ local release = {
   settings: {
     api_key: { from_secret: 'github_token' },
     draft: true,
-    files: ['_out/*'],
+    files: [
+      '_out/aws.tar.gz',
+      '_out/azure.tar.gz',
+      '_out/container.tar',
+      '_out/digital-ocean.tar.gz',
+      '_out/gcp.tar.gz',
+      '_out/initramfs.xz',
+      '_out/installer.tar',
+      '_out/osctl-darwin-amd64',
+      '_out/osctl-linux-amd64',
+      '_out/talos.iso',
+      '_out/vmware.ova',
+      '_out/vmlinux',
+      '_out/vmlinuz',
+    ],
     checksum: ['sha256', 'sha512'],
   },
   when: {


### PR DESCRIPTION
The GitHub release plugin doesn't allow directories, and has no way to
tell it to ignore a path. The workaround is to be explicit about what
files we want in a release.