### PR TITLE
fix: fix error format

### DIFF
--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -172,7 +172,7 @@ func (n *NetworkInterface) Configure() (err error) {
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to bring up interface%s: %w", n.Link.Name, err)
+		return fmt.Errorf("failed to bring up interface %q: %w", n.Link.Name, err)
 	}
 
 	return err


### PR DESCRIPTION
Minor fix to error string format that also uses %q instead of %s. The
quoted format helps when there are hidden characters.