### PR TITLE
fix(image): Use correct args for vmware

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -166,6 +166,8 @@ const (
 	MetalConfigISOLabel = "metal-iso"
 
 	// ConfigGuestInfo is the name of the VMware guestinfo config strategy.
+	// Deprecation notice:
+	// This parameter is no longer used and will be removed in the next release.
 	ConfigGuestInfo = "guestinfo"
 
 	// VMwareGuestInfoConfigKey is the guestinfo key used to provide a config file.


### PR DESCRIPTION
This fixes the console and config options for vmware.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>