### PR TITLE
fix: set the correct kernel args for VMware

### DIFF
--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -18,6 +18,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/runtime/platform"
 	"github.com/talos-systems/talos/pkg/cmd"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 var outputArg string
@@ -39,6 +40,7 @@ func init() {
 	rootCmd.AddCommand(imageCmd)
 }
 
+//nolint: gocyclo
 func runImageCmd() (err error) {
 	p, err := platform.NewPlatform(options.Platform)
 	if err != nil {
@@ -81,6 +83,16 @@ func runImageCmd() (err error) {
 				InstallExtraKernelArgs: options.ExtraKernelArgs,
 			},
 		},
+	}
+
+	if options.ConfigSource == "" {
+		switch p.Name() {
+		case "aws", "azure", "digital-ocean", "gcp":
+			options.ConfigSource = "none"
+		case "vmware":
+			options.ConfigSource = constants.ConfigGuestInfo
+		default:
+		}
 	}
 
 	if err = pkg.Install(p, config, runtime.None, options); err != nil {

--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -33,7 +33,8 @@ func Execute() {
 var options = &pkg.InstallOptions{}
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "none", "The value of "+constants.KernelParamConfig)
+	rootCmd.PersistentFlags().StringVar(&options.ConfigSource, "config", "", "The value of "+constants.KernelParamConfig)
+	rootCmd.PersistentFlags().MarkHidden("config") //nolint: errcheck
 	rootCmd.PersistentFlags().StringVar(&options.Disk, "disk", "", "The path to the disk to install to")
 	rootCmd.PersistentFlags().StringVar(&options.Platform, "platform", "", "The value of "+constants.KernelParamPlatform)
 	rootCmd.PersistentFlags().StringArrayVar(&options.ExtraKernelArgs, "extra-kernel-arg", []string{}, "Extra argument to pass to the kernel")

--- a/internal/pkg/runtime/platform/vmware/vmware.go
+++ b/internal/pkg/runtime/platform/vmware/vmware.go
@@ -83,7 +83,7 @@ func (v *VMware) ExternalIPs() (addrs []net.IP, err error) {
 // KernelArgs implements the runtime.Platform interface.
 func (v *VMware) KernelArgs() kernel.Parameters {
 	return []*kernel.Parameter{
-		kernel.NewParameter("console").Append("ttyS0"),
+		kernel.NewParameter("console").Append("tty0"),
 		kernel.NewParameter("earlyprintk").Append("ttyS0,115200"),
 	}
 }


### PR DESCRIPTION
This enusres that we default to using `guestinfo` for VMware's config
source, and that we use tty0 instead of ttyS0 for the console.