### PR TITLE
chore: use the correct condition for latest and edge pushes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -609,12 +609,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
+    branch:
+    - master
     event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
-      - cron
+    - push
   depends_on:
   - basic-integration
 
@@ -1272,12 +1270,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
+    branch:
+    - master
     event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
-      - cron
+    - push
   depends_on:
   - basic-integration
 
@@ -2063,12 +2059,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
+    branch:
+    - master
     event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
-      - cron
+    - push
   depends_on:
   - basic-integration
 
@@ -2230,11 +2224,8 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
+    cron:
+    - nightly
   depends_on:
   - conformance-aws
   - conformance-gcp
@@ -2888,12 +2879,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
+    branch:
+    - master
     event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
-      - cron
+    - push
   depends_on:
   - basic-integration
 
@@ -3055,11 +3044,8 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
+    cron:
+    - nightly
   depends_on:
   - conformance-aws
   - conformance-gcp
@@ -3713,12 +3699,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
+    branch:
+    - master
     event:
-      exclude:
-      - pull_request
-      - promote
-      - tag
-      - cron
+    - push
   depends_on:
   - basic-integration
 

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -220,14 +220,12 @@ local push_latest = {
   commands: ['make login', 'make push-latest'],
   volumes: volumes.ForStep(),
   when: {
-    event: {
-      exclude: [
-        'pull_request',
-        'promote',
-        'tag',
-        'cron',
-      ],
-    },
+    branch: [
+      'master',
+    ],
+    event: [
+      'push',
+    ],
   },
   depends_on: [basic_integration.name],
 };
@@ -333,13 +331,9 @@ local push_edge = {
   commands: ['make login', 'make push-edge'],
   volumes: volumes.ForStep(),
   when: {
-    event: {
-      exclude: [
-        'pull_request',
-        'promote',
-        'tag',
-      ],
-    },
+    cron: [
+      'nightly',
+    ],
   },
   depends_on: [conformance_aws.name, conformance_gcp.name],
 };


### PR DESCRIPTION
This updates the drone conditions to push the latest and edge tags only
for pushes to the master branch.