### PR TITLE
chore: fix push events

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -611,6 +611,8 @@ steps:
     event:
       exclude:
       - pull_request
+      - promote
+      - cron
   depends_on:
   - basic-integration
 
@@ -636,9 +638,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    ref:
-    - refs/heads/master
-    - refs/tags/v0.4.0*
+    branch:
+    - master
+    event:
+    - push
   depends_on:
   - basic-integration
 
@@ -1298,6 +1301,8 @@ steps:
     event:
       exclude:
       - pull_request
+      - promote
+      - cron
   depends_on:
   - basic-integration
 
@@ -1323,9 +1328,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    ref:
-    - refs/heads/master
-    - refs/tags/v0.4.0*
+    branch:
+    - master
+    event:
+    - push
   depends_on:
   - basic-integration
 
@@ -2113,6 +2119,8 @@ steps:
     event:
       exclude:
       - pull_request
+      - promote
+      - cron
   depends_on:
   - basic-integration
 
@@ -2138,9 +2146,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    ref:
-    - refs/heads/master
-    - refs/tags/v0.4.0*
+    branch:
+    - master
+    event:
+    - push
   depends_on:
   - basic-integration
 
@@ -2958,6 +2967,8 @@ steps:
     event:
       exclude:
       - pull_request
+      - promote
+      - cron
   depends_on:
   - basic-integration
 
@@ -2983,9 +2994,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    ref:
-    - refs/heads/master
-    - refs/tags/v0.4.0*
+    branch:
+    - master
+    event:
+    - push
   depends_on:
   - basic-integration
 
@@ -3803,6 +3815,8 @@ steps:
     event:
       exclude:
       - pull_request
+      - promote
+      - cron
   depends_on:
   - basic-integration
 
@@ -3828,9 +3842,10 @@ steps:
   - name: tmp
     path: /tmp
   when:
-    ref:
-    - refs/heads/master
-    - refs/tags/v0.4.0*
+    branch:
+    - master
+    event:
+    - push
   depends_on:
   - basic-integration
 

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -223,6 +223,8 @@ local push = {
     event: {
       exclude: [
         'pull_request',
+        'promote',
+        'cron',
       ],
     },
   },
@@ -240,9 +242,11 @@ local push_latest = {
   commands: ['make push-latest'],
   volumes: volumes.ForStep(),
   when: {
-    ref: [
-      'refs/heads/master',
-      'refs/tags/v0.4.0*',
+    branch: [
+      'master',
+    ],
+    event: [
+      'push',
     ],
   },
   depends_on: [basic_integration.name],


### PR DESCRIPTION
Now that we have a push target and push-% target, we can simplify the drone
conditions. This updates the conditions so that the latest channel updates
on pushes to master, the edge channel updates on successful nightly cron, and
an image with the standard tag is pushed in all events except pull requests.