### PR TITLE
chore: fix release dependency

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3921,7 +3921,7 @@ steps:
   - image-gcp
   - image-azure
   - image-aws
-  - push-latest
+  - push
 
 services:
 - name: docker

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -436,7 +436,7 @@ local release = {
   when: {
     event: ['tag'],
   },
-  depends_on: [kernel.name, iso.name, image_gcp.name, image_azure.name, image_aws.name, push_latest.name]
+  depends_on: [kernel.name, iso.name, image_gcp.name, image_azure.name, image_aws.name, push.name]
 };
 
 local release_steps = default_steps + [


### PR DESCRIPTION
The GitHub release should depend on the push step instead of
push-latest.