### PR TITLE
feat: support configurable docker-based clusters

### DIFF
--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -20,6 +20,7 @@ osctl cluster create [flags]
   -h, --help                        help for create
       --image string                the image to use (default "docker.io/autonomy/talos:latest")
       --init-node-as-endpoint       use init node as endpoint instead of any load balancer endpoint
+  -i, --input-dir string            location of pre-generated config files
       --kubernetes-version string   desired kubernetes version to run (default "1.17.0")
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)

--- a/internal/pkg/provision/access/adapter.go
+++ b/internal/pkg/provision/access/adapter.go
@@ -51,7 +51,7 @@ func (a *adapter) Client(endpoints ...string) (*client.Client, error) {
 		return cli, nil
 	}
 
-	configContext, creds, err := client.NewClientContextAndCredentialsFromParsedConfig(a.TalosConfig(), "")
+	configContext, creds, err := client.NewClientContextAndCredentialsFromParsedConfig(a.options.TalosConfig, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -7,6 +7,8 @@ package provision
 import (
 	"io"
 	"os"
+
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 )
 
 // Option controls Provisioner.
@@ -21,16 +23,6 @@ func WithLogWriter(w io.Writer) Option {
 	}
 }
 
-// WithForceInitNodeAsEndpoint uses direct IP of init node as endpoint instead of (default)
-// mode.
-func WithForceInitNodeAsEndpoint() Option {
-	return func(o *Options) error {
-		o.ForceInitNodeAsEndpoint = true
-
-		return nil
-	}
-}
-
 // WithEndpoint specifies endpoint to use when acessing Talos cluster.
 func WithEndpoint(endpoint string) Option {
 	return func(o *Options) error {
@@ -40,11 +32,20 @@ func WithEndpoint(endpoint string) Option {
 	}
 }
 
+// WithTalosConfig specifies talosconfig to use when acessing Talos cluster.
+func WithTalosConfig(talosConfig *config.Config) Option {
+	return func(o *Options) error {
+		o.TalosConfig = talosConfig
+
+		return nil
+	}
+}
+
 // Options describes Provisioner parameters.
 type Options struct {
-	LogWriter               io.Writer
-	ForceInitNodeAsEndpoint bool
-	ForceEndpoint           string
+	LogWriter     io.Writer
+	TalosConfig   *config.Config
+	ForceEndpoint string
 }
 
 // DefaultOptions returns default options.

--- a/internal/pkg/provision/providers/docker/create.go
+++ b/internal/pkg/provision/providers/docker/create.go
@@ -6,58 +6,40 @@ package docker
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 
-	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
 
 // Create Talos cluster as a set of docker containers on docker network.
 //
 //nolint: gocyclo
 func (p *provisioner) Create(ctx context.Context, request provision.ClusterRequest, opts ...provision.Option) (provision.Cluster, error) {
+	var err error
+
 	options := provision.DefaultOptions()
 
 	for _, opt := range opts {
-		if err := opt(&options); err != nil {
+		if err = opt(&options); err != nil {
 			return nil, err
 		}
 	}
 
-	if err := p.ensureImageExists(ctx, request.Image, &options); err != nil {
+	if err = p.ensureImageExists(ctx, request.Image, &options); err != nil {
 		return nil, err
-	}
-
-	initNode, err := request.Nodes.FindInitNode()
-	if err != nil {
-		return nil, err
-	}
-
-	fmt.Fprintln(options.LogWriter, "generating PKI and tokens")
-
-	input, err := generate.NewInput(request.Name, fmt.Sprintf("https://%s:6443", initNode.IP), request.KubernetesVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	if options.ForceEndpoint != "" {
-		input.AdditionalSubjectAltNames = append(input.AdditionalSubjectAltNames, options.ForceEndpoint)
-		input.AdditionalMachineCertSANs = append(input.AdditionalMachineCertSANs, options.ForceEndpoint)
 	}
 
 	fmt.Fprintln(options.LogWriter, "creating network", request.Network.Name)
 
 	if err = p.createNetwork(ctx, request.Network); err != nil {
-		return nil, fmt.Errorf("a cluster might already exist, run \"osctl cluster destroy\" to permanently delete the existing cluster, and try again: %w", err)
+		return nil, fmt.Errorf("unable to create or re-use a docker network: %w", err)
 	}
 
 	var nodeInfo []provision.NodeInfo
 
 	fmt.Fprintln(options.LogWriter, "creating master nodes")
 
-	if nodeInfo, err = p.createNodes(ctx, request, input, request.Nodes.MasterNodes()); err != nil {
+	if nodeInfo, err = p.createNodes(ctx, request, request.Nodes.MasterNodes()); err != nil {
 		return nil, err
 	}
 
@@ -65,33 +47,13 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	var workerNodeInfo []provision.NodeInfo
 
-	if workerNodeInfo, err = p.createNodes(ctx, request, input, request.Nodes.WorkerNodes()); err != nil {
+	if workerNodeInfo, err = p.createNodes(ctx, request, request.Nodes.WorkerNodes()); err != nil {
 		return nil, err
 	}
 
 	nodeInfo = append(nodeInfo, workerNodeInfo...)
 
-	endpoints := []string{"127.0.0.1"}
-
-	if options.ForceEndpoint != "" {
-		endpoints = []string{options.ForceEndpoint}
-	} else if options.ForceInitNodeAsEndpoint {
-		endpoints = []string{initNode.IP.String()}
-	}
-
 	res := &result{
-		talosConfig: &config.Config{
-			Context: request.Name,
-			Contexts: map[string]*config.Context{
-				request.Name: {
-					Endpoints: endpoints,
-					CA:        base64.StdEncoding.EncodeToString(input.Certs.OS.Crt),
-					Crt:       base64.StdEncoding.EncodeToString(input.Certs.Admin.Crt),
-					Key:       base64.StdEncoding.EncodeToString(input.Certs.Admin.Key),
-				},
-			},
-		},
-
 		clusterInfo: provision.ClusterInfo{
 			ClusterName: request.Name,
 			Network: provision.NetworkInfo{

--- a/internal/pkg/provision/providers/docker/reflect.go
+++ b/internal/pkg/provision/providers/docker/reflect.go
@@ -14,8 +14,6 @@ import (
 
 func (p *provisioner) Reflect(ctx context.Context, clusterName string) (provision.Cluster, error) {
 	res := &result{
-		talosConfig: nil, // TODO: recover talosConfig
-
 		clusterInfo: provision.ClusterInfo{
 			ClusterName: clusterName,
 		},

--- a/internal/pkg/provision/providers/docker/result.go
+++ b/internal/pkg/provision/providers/docker/result.go
@@ -5,18 +5,11 @@
 package docker
 
 import (
-	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/internal/pkg/provision"
 )
 
 type result struct {
-	talosConfig *config.Config
-
 	clusterInfo provision.ClusterInfo
-}
-
-func (res *result) TalosConfig() *config.Config {
-	return res.talosConfig
 }
 
 func (res *result) Info() provision.ClusterInfo {

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -79,9 +79,10 @@ func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 
 // NodeRequest describes a request for a node.
 type NodeRequest struct {
-	Type generate.Type
-	Name string
-	IP   net.IP
+	Type       generate.Type
+	Name       string
+	IP         net.IP
+	ConfigData string
 
 	// Share of CPUs, in 1e-9 fractions
 	NanoCPUs int64

--- a/internal/pkg/provision/result.go
+++ b/internal/pkg/provision/result.go
@@ -7,13 +7,11 @@ package provision
 import (
 	"net"
 
-	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
 
 // Cluster describes the provisioned Cluster.
 type Cluster interface {
-	TalosConfig() *config.Config
 	Info() ClusterInfo
 }
 

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package generate
+
+// GenOption controls generate options specific to input generation.
+type GenOption func(o *GenOptions) error
+
+// WithEndpointList specifies endpoints to use when acessing Talos cluster.
+func WithEndpointList(endpoints []string) GenOption {
+	return func(o *GenOptions) error {
+		o.EndpointList = endpoints
+
+		return nil
+	}
+}
+
+// GenOptions describes generate parameters.
+type GenOptions struct {
+	EndpointList []string
+}
+
+// DefaultGenOptions returns default options.
+func DefaultGenOptions() GenOptions {
+	return GenOptions{
+		EndpointList: []string{"127.0.0.1"},
+	}
+}


### PR DESCRIPTION
This PR will allow users to issue `osctl config generate`, tweak the
configs to their liking, then use those configs to call `osctl cluster
create`.

Example workflow:

```
osctl config generate my-cluster https://10.5.0.2:6443 -o ./my-cluster

** tweaky tweak **

osctl cluster create --name my-cluster --input-dir "$PWD/my-cluster"
```

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>