### PR TITLE
chore: disable iso artifact creation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3688,7 +3688,6 @@ steps:
     - _out/installer.tar
     - _out/osctl-darwin-amd64
     - _out/osctl-linux-amd64
-    - _out/talos.iso
     - _out/vmware.ova
     - _out/vmlinux
     - _out/vmlinuz

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -422,7 +422,6 @@ local release = {
       '_out/installer.tar',
       '_out/osctl-darwin-amd64',
       '_out/osctl-linux-amd64',
-      '_out/talos.iso',
       '_out/vmware.ova',
       '_out/vmlinux',
       '_out/vmlinuz',


### PR DESCRIPTION
This PR will disable iso creation for now. We plan to reincorporate the
ability to use ISOs once we've researched #1722.

Will close #1442

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>