### PR TITLE
refactor: use an interface for config data

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -183,6 +183,7 @@ var configGenerateCmd = &cobra.Command{
 	},
 }
 
+// TODO(rsmitty): move this to use the configbundle interface
 func genV1Alpha1Config(args []string) error {
 	// If output dir isn't specified, set to the current working dir
 	var err error

--- a/internal/pkg/runtime/configurator.go
+++ b/internal/pkg/runtime/configurator.go
@@ -5,6 +5,7 @@
 package runtime
 
 import (
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/pkg/config/cluster"
 	"github.com/talos-systems/talos/pkg/config/machine"
 )
@@ -17,4 +18,12 @@ type Configurator interface {
 	Cluster() cluster.Cluster
 	Validate(Mode) error
 	String() (string, error)
+}
+
+// ConfiguratorBundle defines the configuration bundle interface.
+type ConfiguratorBundle interface {
+	Init() Configurator
+	ControlPlane() Configurator
+	Join() Configurator
+	TalosConfig() *config.Config
 }

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config
+
+import "github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+
+// BundleOption controls config options specific to config bundle generation.
+type BundleOption func(o *BundleOptions) error
+
+// InputOptions holds necessary params for generating an input
+type InputOptions struct {
+	ClusterName string
+	MasterIPs   []string
+	KubeVersion string
+	GenOptions  []generate.GenOption
+}
+
+// BundleOptions describes generate parameters.
+type BundleOptions struct {
+	ExistingConfigs string // path to existing config files
+	InputOptions    *InputOptions
+}
+
+// DefaultBundleOptions returns default options.
+func DefaultBundleOptions() BundleOptions {
+	return BundleOptions{}
+}
+
+// WithExistingConfigs sets the path to existing config files
+func WithExistingConfigs(configPath string) BundleOption {
+	return func(o *BundleOptions) error {
+		o.ExistingConfigs = configPath
+		return nil
+	}
+}
+
+// WithInputOptions allows passing in of various params for net-new input generation
+func WithInputOptions(inputOpts *InputOptions) BundleOption {
+	return func(o *BundleOptions) error {
+		o.InputOptions = inputOpts
+		return nil
+	}
+}

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator_bundle.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator_bundle.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1
+
+import (
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+)
+
+// ConfigBundle defines the group of v1alpha1 config files.
+//docgen: nodoc
+type ConfigBundle struct {
+	InitCfg         *Config
+	ControlPlaneCfg *Config
+	JoinCfg         *Config
+	TalosCfg        *config.Config
+}
+
+// Init implements the ConfiguratorBundle interface.
+func (c *ConfigBundle) Init() runtime.Configurator {
+	return c.InitCfg
+}
+
+// ControlPlane implements the ConfiguratorBundle interface.
+func (c *ConfigBundle) ControlPlane() runtime.Configurator {
+	return c.ControlPlaneCfg
+}
+
+// Join implements the ConfiguratorBundle interface.
+func (c *ConfigBundle) Join() runtime.Configurator {
+	return c.JoinCfg
+}
+
+// TalosConfig implements the ConfiguratorBundle interface.
+func (c *ConfigBundle) TalosConfig() *config.Config {
+	return c.TalosCfg
+}


### PR DESCRIPTION
This PR will move to using a `ConfiguratorBundle` interface for our
various config data files. This will allow us to easily abstract away
various versions and easily get the data with functions.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>