### PR TITLE
refactor: use config struct instead of string

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -25,6 +25,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/provision/access"
 	"github.com/talos-systems/talos/internal/pkg/provision/check"
 	"github.com/talos-systems/talos/internal/pkg/provision/providers/docker"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/constants"
 	talosnet "github.com/talos-systems/talos/pkg/net"
@@ -149,7 +150,14 @@ func create(ctx context.Context) (err error) {
 
 			var data string
 
-			data, err = generate.Config(configType, input)
+			var configStruct *v1alpha1.Config
+
+			configStruct, err = generate.Config(configType, input)
+			if err != nil {
+				return err
+			}
+
+			data, err = configStruct.String()
 			if err != nil {
 				return err
 			}

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -242,9 +242,12 @@ func genV1Alpha1Config(args []string) error {
 }
 
 func writeV1Alpha1Config(input *genv1alpha1.Input, t genv1alpha1.Type, name string) (err error) {
-	var data string
+	generatedConfig, err := genv1alpha1.Config(t, input)
+	if err != nil {
+		return err
+	}
 
-	data, err = genv1alpha1.Config(t, input)
+	configString, err := generatedConfig.String()
 	if err != nil {
 		return err
 	}
@@ -252,7 +255,7 @@ func writeV1Alpha1Config(input *genv1alpha1.Input, t genv1alpha1.Type, name stri
 	name = strings.ToLower(name) + ".yaml"
 	fullFilePath := filepath.Join(outputDir, name)
 
-	if err = ioutil.WriteFile(fullFilePath, []byte(data), 0644); err != nil {
+	if err = ioutil.WriteFile(fullFilePath, []byte(configString), 0644); err != nil {
 		return err
 	}
 

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -7,12 +7,12 @@ package generate
 import (
 	"net/url"
 
-	yaml "gopkg.in/yaml.v2"
-
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
-func controlPlaneUd(in *Input) (string, error) {
+func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
+	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
+
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "controlplane",
 		MachineToken:    in.TrustdInfo.Token,
@@ -29,7 +29,7 @@ func controlPlaneUd(in *Input) (string, error) {
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
 	if err != nil {
-		return "", err
+		return config, err
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
@@ -49,16 +49,8 @@ func controlPlaneUd(in *Input) (string, error) {
 		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
 	}
 
-	ud := v1alpha1.Config{
-		ConfigVersion: "v1alpha1",
-		MachineConfig: machine,
-		ClusterConfig: cluster,
-	}
+	config.MachineConfig = machine
+	config.ClusterConfig = cluster
 
-	udMarshal, err := yaml.Marshal(ud)
-	if err != nil {
-		return "", err
-	}
-
-	return string(udMarshal), nil
+	return config, nil
 }

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/talos-systems/talos/internal/pkg/cis"
+	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	tnet "github.com/talos-systems/talos/pkg/net"
 )
@@ -69,25 +70,25 @@ func ParseType(t string) (Type, error) {
 
 // Config returns the talos config for a given node type.
 // nolint: gocyclo
-func Config(t Type, in *Input) (s string, err error) {
+func Config(t Type, in *Input) (c *v1alpha1.Config, err error) {
 	switch t {
 	case TypeInit:
-		if s, err = initUd(in); err != nil {
-			return "", err
+		if c, err = initUd(in); err != nil {
+			return c, err
 		}
 	case TypeControlPlane:
-		if s, err = controlPlaneUd(in); err != nil {
-			return "", err
+		if c, err = controlPlaneUd(in); err != nil {
+			return c, err
 		}
 	case TypeJoin:
-		if s, err = workerUd(in); err != nil {
-			return "", err
+		if c, err = workerUd(in); err != nil {
+			return c, err
 		}
 	default:
-		return "", errors.New("failed to determine config type to generate")
+		return c, errors.New("failed to determine config type to generate")
 	}
 
-	return s, nil
+	return c, nil
 }
 
 // Input holds info about certs, ips, and node type.

--- a/pkg/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/config/types/v1alpha1/generate/generate_test.go
@@ -8,9 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v2"
 
-	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	genv1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/constants"
 )
@@ -32,29 +30,17 @@ func (suite *GenerateSuite) SetupSuite() {
 }
 
 func (suite *GenerateSuite) TestGenerateInitSuccess() {
-	dataString, err := genv1alpha1.Config(genv1alpha1.TypeInit, suite.input)
-	suite.Require().NoError(err)
-
-	data := &v1alpha1.Config{}
-	err = yaml.Unmarshal([]byte(dataString), data)
+	_, err := genv1alpha1.Config(genv1alpha1.TypeInit, suite.input)
 	suite.Require().NoError(err)
 }
 
 func (suite *GenerateSuite) TestGenerateControlPlaneSuccess() {
-	dataString, err := genv1alpha1.Config(genv1alpha1.TypeControlPlane, suite.input)
-	suite.Require().NoError(err)
-
-	data := &v1alpha1.Config{}
-	err = yaml.Unmarshal([]byte(dataString), data)
+	_, err := genv1alpha1.Config(genv1alpha1.TypeControlPlane, suite.input)
 	suite.Require().NoError(err)
 }
 
 func (suite *GenerateSuite) TestGenerateWorkerSuccess() {
-	dataString, err := genv1alpha1.Config(genv1alpha1.TypeJoin, suite.input)
-	suite.Require().NoError(err)
-
-	data := &v1alpha1.Config{}
-	err = yaml.Unmarshal([]byte(dataString), data)
+	_, err := genv1alpha1.Config(genv1alpha1.TypeJoin, suite.input)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -7,12 +7,12 @@ package generate
 import (
 	"net/url"
 
-	yaml "gopkg.in/yaml.v2"
-
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
-func initUd(in *Input) (string, error) {
+func initUd(in *Input) (*v1alpha1.Config, error) {
+	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
+
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "init",
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
@@ -31,7 +31,7 @@ func initUd(in *Input) (string, error) {
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
 	if err != nil {
-		return "", err
+		return config, err
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
@@ -57,16 +57,8 @@ func initUd(in *Input) (string, error) {
 		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
 	}
 
-	ud := v1alpha1.Config{
-		ConfigVersion: "v1alpha1",
-		MachineConfig: machine,
-		ClusterConfig: cluster,
-	}
+	config.MachineConfig = machine
+	config.ClusterConfig = cluster
 
-	udMarshal, err := yaml.Marshal(ud)
-	if err != nil {
-		return "", err
-	}
-
-	return string(udMarshal), nil
+	return config, nil
 }

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -7,13 +7,13 @@ package generate
 import (
 	"net/url"
 
-	yaml "gopkg.in/yaml.v2"
-
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
-func workerUd(in *Input) (string, error) {
+func workerUd(in *Input) (*v1alpha1.Config, error) {
+	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
+
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "worker",
 		MachineToken:    in.TrustdInfo.Token,
@@ -29,7 +29,7 @@ func workerUd(in *Input) (string, error) {
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
 	if err != nil {
-		return "", err
+		return config, err
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
@@ -45,16 +45,8 @@ func workerUd(in *Input) (string, error) {
 		},
 	}
 
-	ud := v1alpha1.Config{
-		ConfigVersion: "v1alpha1",
-		MachineConfig: machine,
-		ClusterConfig: cluster,
-	}
+	config.MachineConfig = machine
+	config.ClusterConfig = cluster
 
-	udMarshal, err := yaml.Marshal(ud)
-	if err != nil {
-		return "", err
-	}
-
-	return string(udMarshal), nil
+	return config, nil
 }


### PR DESCRIPTION
This PR will pass the configs around as structs instead of strings.
We'll be using this to do a further refactor of the cluster create
command and the configurator interface.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>