### PR TITLE
chore: fix E2E script

### DIFF
--- a/hack/test/basic-integration.sh
+++ b/hack/test/basic-integration.sh
@@ -34,6 +34,4 @@ mkdir -p "${TMP}"
 
 "${OSCTL}" cluster create --name basic-integration --image "${TALOS_IMG}" --masters=3 --mtu 1440 --cpus 4.0 --wait --endpoint "${ENDPOINT}"
 
-trap "${OSCTL} cluster destroy --name basic-integration" EXIT
-
 "${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}" -talos.k8sendpoint "${ENDPOINT}:6443"

--- a/hack/test/e2e-runner.sh
+++ b/hack/test/e2e-runner.sh
@@ -4,7 +4,7 @@ export TALOS_IMG="docker.io/autonomy/talos:${TAG}"
 export TMP="/tmp/e2e"
 export TMPPLATFORM="${TMP}/${PLATFORM}"
 export OSCTL="${PWD}/${ARTIFACTS}/osctl-linux-amd64"
-export INTEGRATIONTEST="${PWD}/bin/integration-test"
+export INTEGRATION_TEST="${PWD}/${ARTIFACTS}/integration-test-linux-amd64"
 export TALOSCONFIG="${TMPPLATFORM}/talosconfig"
 export KUBECONFIG="${TMPPLATFORM}/kubeconfig"
 
@@ -36,12 +36,12 @@ e2e_run() {
   docker run \
          --rm \
          --interactive \
-         --net=integration \
+         --net=basic-integration \
          --entrypoint=/bin/bash \
          --mount type=bind,source=${TMP},target=${TMP} \
          --mount type=bind,source=${PWD}/hack/test/manifests,target=/e2emanifests \
          -v ${OSCTL}:/bin/osctl:ro \
-         -v ${INTEGRATIONTEST}:/bin/integration-test:ro \
+         -v ${INTEGRATION_TEST}:/bin/integration-test:ro \
          -e KUBECONFIG=${KUBECONFIG} \
          -e TALOSCONFIG=${TALOSCONFIG} \
          k8s.gcr.io/hyperkube:${KUBERNETES_VERSION} -c "${1}"


### PR DESCRIPTION
The basic integration cluster name was changed in a previous PR. This
aligns the E2E script with the new naming conventions, and mounts the
correct integration test binary.