### PR TITLE
fix: raise default NOFILE limit

### DIFF
--- a/internal/app/machined/internal/phase/limits/limits.go
+++ b/internal/app/machined/internal/phase/limits/limits.go
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package limits
+
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+)
+
+// FileLimitTask represents the FileLimitTask task.
+type FileLimitTask struct{}
+
+// NewFileLimitTask initializes and returns a FileLimitTask task.
+func NewFileLimitTask() phase.Task {
+	return &FileLimitTask{}
+}
+
+// TaskFunc returns the runtime function.
+func (task *FileLimitTask) TaskFunc(mode runtime.Mode) phase.TaskFunc {
+	switch mode {
+	case runtime.Container:
+		return nil
+	default:
+		return task.standard
+	}
+}
+
+func (task *FileLimitTask) standard(r runtime.Runtime) (err error) {
+	// TODO(andrewrynhard): Should we read limit from /proc/sys/fs/nr_open?
+	if err = unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{Cur: 1048576, Max: 1048576}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/app/machined/internal/phase/limits/limits_test.go
+++ b/internal/app/machined/internal/phase/limits/limits_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package limits_test
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	// added for accurate coverage estimation
+	//
+	// please remove it once any unit-test is added
+	// for this package
+}

--- a/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
@@ -13,6 +13,7 @@ import (
 	configtask "github.com/talos-systems/talos/internal/app/machined/internal/phase/config"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/disk"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/kubernetes"
+	"github.com/talos-systems/talos/internal/app/machined/internal/phase/limits"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/network"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/platform"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase/rootfs"
@@ -46,6 +47,7 @@ func (d *Sequencer) Boot() error {
 			rootfs.NewMountCgroupsTask(),
 			rootfs.NewMountSubDevicesTask(),
 			sysctls.NewSysctlsTask(),
+			limits.NewFileLimitTask(),
 		),
 		phase.NewPhase(
 			"configure Integrity Measurement Architecture",


### PR DESCRIPTION
The default NOFILE is 1024 soft and 4096 hard. Without PAM, or a shell,
and no way to set limits in Kubernetes, out only option is to raise the
limit for all processes by raising the limit on PID 1. All processes
forked by PID 1 will inherit the limits for PID 1.