### PR TITLE
chore: publish boot.tar.gz

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3667,7 +3667,28 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - installer
+  - basic-integration
+
+- name: boot
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make boot
+  environment:
+    BINDIR: /usr/local/bin
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - basic-integration
 
 - name: release
   image: plugins/github-release
@@ -3681,6 +3702,7 @@ steps:
     files:
     - _out/aws.tar.gz
     - _out/azure.tar.gz
+    - _out/boot.tar.gz
     - _out/container.tar
     - _out/digital-ocean.tar.gz
     - _out/gcp.tar.gz
@@ -3697,6 +3719,7 @@ steps:
   depends_on:
   - kernel
   - iso
+  - boot
   - image-gcp
   - image-azure
   - image-aws

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,10 @@ images: image-aws image-azure image-digital-ocean image-gcp image-vmware ## Buil
 iso: ## Builds the ISO and outputs it to the artifact directory.
 	@docker run --rm -i -v $(PWD)/$(ARTIFACTS):/out autonomy/installer:$(TAG) iso
 
+.PHONY: boot
+boot: ## Creates a compressed tarball that includes vmlinuz and initramfs.xz. Note that these files must already be present in the artifacts directory.
+	@tar  -C $(ARTIFACTS) -czf $(ARTIFACTS)/boot.tar.gz vmlinuz initramfs.xz
+
 # Code Quality
 
 .PHONY: fmt

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -403,7 +403,8 @@ local ami_trigger = {
 };
 
 local kernel = Step('kernel');
-local iso = Step('iso', depends_on=[installer]);
+local iso = Step('iso', depends_on=[basic_integration]);
+local boot = Step('boot', depends_on=[basic_integration]);
 
 // TODO(andrewrynhard): We should run E2E tests on a release.
 local release = {
@@ -415,6 +416,7 @@ local release = {
     files: [
       '_out/aws.tar.gz',
       '_out/azure.tar.gz',
+      '_out/boot.tar.gz',
       '_out/container.tar',
       '_out/digital-ocean.tar.gz',
       '_out/gcp.tar.gz',
@@ -431,12 +433,13 @@ local release = {
   when: {
     event: ['tag'],
   },
-  depends_on: [kernel.name, iso.name, image_gcp.name, image_azure.name, image_aws.name, push.name]
+  depends_on: [kernel.name, iso.name, boot.name, image_gcp.name, image_azure.name, image_aws.name, push.name]
 };
 
 local release_steps = default_steps + [
   kernel,
   iso,
+  boot,
   release,
 ];
 


### PR DESCRIPTION
This adds a convenience tarball that includes vmlinuz, and initramfs.xz
in a single tarball.