### PR TITLE
fix: check for installer image before proceeding with upgrade

### DIFF
--- a/internal/app/machined/internal/phase/upgrade/upgrade.go
+++ b/internal/app/machined/internal/phase/upgrade/upgrade.go
@@ -45,7 +45,8 @@ func (task *Upgrade) standard(r runtime.Runtime) (err error) {
 		r = runtime.NewRuntime(r.Platform(), runtime.Configurator(cfg), runtime.Upgrade)
 	}
 
-	if err = install.RunInstallerContainer(r); err != nil {
+	// We pull the installer image when we receive an upgrade request. No need to re-pull inside of installer container
+	if err = install.RunInstallerContainer(r, install.WithImagePull(false)); err != nil {
 		return err
 	}
 

--- a/internal/pkg/install/options.go
+++ b/internal/pkg/install/options.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package install
+
+// Option controls generate options specific to input generation.
+type Option func(o *Options) error
+
+// WithImagePull disables pulling the installer image during an install
+func WithImagePull(shouldPull bool) Option {
+	return func(o *Options) error {
+		o.ImagePull = shouldPull
+
+		return nil
+	}
+}
+
+// Options describes generate parameters.
+type Options struct {
+	ImagePull bool
+}
+
+// DefaultInstallOptions returns default options.
+func DefaultInstallOptions() Options {
+	return Options{
+		ImagePull: true,
+	}
+}


### PR DESCRIPTION
This PR will add in some code to pre-pull the installer image before we
run an upgrade of a given talos node. Additionally, this will add some
functional args to the install package to allow for specifying whether
or not to pull the installer image. This was needed since there was no
sense in pulling the installer again once we made it that far into the
upgrade process.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
(cherry picked from commit 5e8cab4dd54923907cd4dc1266063d6962f498ec)