### PR TITLE
fix(networkd): Fix incorrect resolver settings

### DIFF
--- a/internal/app/machined/internal/phase/network/network.go
+++ b/internal/app/machined/internal/phase/network/network.go
@@ -38,5 +38,5 @@ func (task *InitialNetworkSetup) runtime(r runtime.Runtime) (err error) {
 		return err
 	}
 
-	return nwd.Hostname()
+	return nil
 }

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -91,6 +91,11 @@ func (n *Networkd) Runner(config runtime.Configurator) (runner.Runner, error) {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
 
+	// This is really only here to support container runtime
+	if p, ok := os.LookupEnv("PLATFORM"); ok {
+		env = append(env, fmt.Sprintf("%s=%s", "PLATFORM", p))
+	}
+
 	return restart.New(containerd.NewRunner(
 		config.Debug(),
 		&args,


### PR DESCRIPTION
This  modifies the way the hostname gets set. Previously, we would run
through the entire addressing and resolver configuration and then set the
hostname. This is problematic because the resolver depends on the functionality
of Hostname() ( resolver configuration relies on the domainname of the host ).

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>