### PR TITLE
chore: log ignored ACPI events

### DIFF
--- a/internal/app/machined/internal/phase/acpi/acpi.go
+++ b/internal/app/machined/internal/phase/acpi/acpi.go
@@ -134,6 +134,8 @@ func parse(msgs []genetlink.Message, event string) (bool, error) {
 			if strings.HasPrefix(ad.String(), event) {
 				return true, nil
 			}
+
+			log.Printf("ignoring ACPI event: %q", ad.String())
 		}
 	}
 


### PR DESCRIPTION
It will be useful to see what kind of ACPI events we ignore.