### PR TITLE
refactor: use ConfiguratorBundle interface for config generate

### DIFF
--- a/internal/app/machined/internal/phase/platform/platform.go
+++ b/internal/app/machined/internal/phase/platform/platform.go
@@ -56,9 +56,6 @@ func (task *Platform) runtime(r runtime.Runtime) (err error) {
 	}
 
 	if r.Platform().Mode() == runtime.Container {
-		// TODO: add ::1 back once I figure out why bootkube barfs
-		sans = append(sans, "127.0.0.1")
-
 		m := metadata.NewMetadata(r.Sequence())
 		if err = m.Save(); err != nil {
 			return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,13 +88,17 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 
 	input, err := generate.NewInput(
 		options.InputOptions.ClusterName,
-		fmt.Sprintf("https://%s:6443", options.InputOptions.MasterIPs[0]),
+		options.InputOptions.Endpoint,
 		options.InputOptions.KubeVersion,
 		options.InputOptions.GenOptions...,
 	)
 	if err != nil {
 		return bundle, err
 	}
+
+	input.AdditionalSubjectAltNames = append(input.AdditionalSubjectAltNames, options.InputOptions.AdditionalSubjectAltNames...)
+	input.InstallDisk = options.InputOptions.InstallDisk
+	input.InstallImage = options.InputOptions.InstallImage
 
 	for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
 		var generatedConfig *v1alpha1.Config

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -11,10 +11,13 @@ type BundleOption func(o *BundleOptions) error
 
 // InputOptions holds necessary params for generating an input
 type InputOptions struct {
-	ClusterName string
-	MasterIPs   []string
-	KubeVersion string
-	GenOptions  []generate.GenOption
+	ClusterName               string
+	Endpoint                  string
+	KubeVersion               string
+	AdditionalSubjectAltNames []string
+	InstallDisk               string
+	InstallImage              string
+	GenOptions                []generate.GenOption
 }
 
 // BundleOptions describes generate parameters.

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -43,7 +43,5 @@ type GenOptions struct {
 
 // DefaultGenOptions returns default options.
 func DefaultGenOptions() GenOptions {
-	return GenOptions{
-		EndpointList: []string{"127.0.0.1"},
-	}
+	return GenOptions{}
 }


### PR DESCRIPTION
This PR overhauls osctl's config generate command to make use of the new
ConfigBundle implementation of the ConfiguratorBundle interface

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>