### PR TITLE
refactor: unify generate type and machine type

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
+	"github.com/talos-systems/talos/pkg/config/machine"
 	genv1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/constants"
 )
@@ -208,7 +209,7 @@ func genV1Alpha1Config(args []string) error {
 	input.InstallDisk = installDisk
 	input.InstallImage = installImage
 
-	for _, t := range []genv1alpha1.Type{genv1alpha1.TypeInit, genv1alpha1.TypeControlPlane, genv1alpha1.TypeJoin} {
+	for _, t := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
 		if err = writeV1Alpha1Config(input, t, t.String()); err != nil {
 			return fmt.Errorf("failed to generate config for %s: %w", t.String(), err)
 		}
@@ -242,7 +243,7 @@ func genV1Alpha1Config(args []string) error {
 	return nil
 }
 
-func writeV1Alpha1Config(input *genv1alpha1.Input, t genv1alpha1.Type, name string) (err error) {
+func writeV1Alpha1Config(input *genv1alpha1.Input, t machine.Type, name string) (err error) {
 	generatedConfig, err := genv1alpha1.Config(t, input)
 	if err != nil {
 		return err

--- a/internal/app/machined/internal/phase/services/post_boot.go
+++ b/internal/app/machined/internal/phase/services/post_boot.go
@@ -30,7 +30,7 @@ func (task *LabelNodeAsMaster) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *LabelNodeAsMaster) standard(r runtime.Runtime) (err error) {
-	if r.Config().Machine().Type() == machine.Worker {
+	if r.Config().Machine().Type() == machine.TypeWorker {
 		return nil
 	}
 

--- a/internal/app/machined/internal/phase/services/start_services.go
+++ b/internal/app/machined/internal/phase/services/start_services.go
@@ -58,9 +58,9 @@ func (task *StartServices) loadSystemServices(r runtime.Runtime) {
 	// Start the services common to all control plane nodes.
 
 	switch r.Config().Machine().Type() {
-	case machine.Bootstrap:
+	case machine.TypeInit:
 		fallthrough
-	case machine.ControlPlane:
+	case machine.TypeControlPlane:
 		svcs.Load(
 			&services.Etcd{},
 			&services.Trustd{},
@@ -74,7 +74,7 @@ func (task *StartServices) loadKubernetesServices(r runtime.Runtime) {
 		&services.Kubelet{},
 	)
 
-	if r.Config().Machine().Type() == machine.Bootstrap {
+	if r.Config().Machine().Type() == machine.TypeInit {
 		svcs.Load(
 			&services.Bootkube{},
 		)

--- a/internal/app/machined/internal/phase/services/stop_services.go
+++ b/internal/app/machined/internal/phase/services/stop_services.go
@@ -34,7 +34,7 @@ func (task *StopServices) standard(r runtime.Runtime) (err error) {
 	if task.upgrade {
 		services := []string{"containerd", "networkd", "ntpd", "udevd"}
 
-		if r.Config().Machine().Type() == machine.Bootstrap || r.Config().Machine().Type() == machine.ControlPlane {
+		if r.Config().Machine().Type() == machine.TypeInit || r.Config().Machine().Type() == machine.TypeControlPlane {
 			services = append(services, "trustd")
 		}
 

--- a/internal/app/machined/internal/phase/upgrade/leave_etcd.go
+++ b/internal/app/machined/internal/phase/upgrade/leave_etcd.go
@@ -33,7 +33,7 @@ func (task *LeaveEtcd) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 
 // nolint: gocyclo
 func (task *LeaveEtcd) standard(r runtime.Runtime) (err error) {
-	if r.Config().Machine().Type() == machine.Worker {
+	if r.Config().Machine().Type() == machine.TypeWorker {
 		return nil
 	}
 

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -56,7 +56,7 @@ func (o *APID) PostFunc(config runtime.Configurator) (err error) {
 
 // Condition implements the Service interface.
 func (o *APID) Condition(config runtime.Configurator) conditions.Condition {
-	if config.Machine().Type() == machine.Worker {
+	if config.Machine().Type() == machine.TypeWorker {
 		return conditions.WaitForFileToExist(constants.KubeletKubeconfig)
 	}
 
@@ -73,7 +73,7 @@ func (o *APID) Runner(config runtime.Configurator) (runner.Runner, error) {
 
 	endpoints := []string{"127.0.0.1"}
 
-	if config.Machine().Type() == machine.Worker {
+	if config.Machine().Type() == machine.TypeWorker {
 		opts := []retry.Option{retry.WithUnits(3 * time.Second), retry.WithJitter(time.Second)}
 
 		err := retry.Constant(10*time.Minute, opts...).Retry(func() error {

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -375,7 +375,7 @@ func (e *Etcd) args(config runtime.Configurator) ([]string, error) {
 		if ok {
 			initialCluster := fmt.Sprintf("%s=https://%s:2380", hostname, ips[0].String())
 
-			existing := config.Machine().Type() == machine.ControlPlane || metadata.Upgraded
+			existing := config.Machine().Type() == machine.TypeControlPlane || metadata.Upgraded
 			if existing {
 				blackListArgs.Set("initial-cluster-state", "existing")
 

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -61,7 +61,7 @@ func (o *OSD) Condition(config runtime.Configurator) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *OSD) DependsOn(config runtime.Configurator) []string {
-	if config.Machine().Type() == machine.Worker {
+	if config.Machine().Type() == machine.TypeWorker {
 		return []string{"system-containerd", "containerd"}
 	}
 

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -81,7 +81,7 @@ func ValidateForUpgrade() error {
 		return err
 	}
 
-	if config.Machine().Type() != machine.Worker {
+	if config.Machine().Type() != machine.TypeWorker {
 		client, err := NewClientFromControlPlaneIPs(config.Cluster().CA(), config.Cluster().Endpoint())
 		if err != nil {
 			return err

--- a/internal/pkg/provision/check/default.go
+++ b/internal/pkg/provision/check/default.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/pkg/conditions"
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // DefaultClusterChecks returns a set of default Talos cluster readiness checks.
@@ -19,7 +19,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		// wait for etcd to be healthy on all control plane nodes
 		func(cluster provision.ClusterAccess) conditions.Condition {
 			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(generate.TypeInit, generate.TypeControlPlane))
+				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
 			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for bootkube to finish on init node

--- a/internal/pkg/provision/check/kubernetes.go
+++ b/internal/pkg/provision/check/kubernetes.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // K8sAllNodesReportedAssertion checks whether all the nodes show up in node list.
@@ -68,7 +68,7 @@ func K8sFullControlPlaneAssertion(ctx context.Context, cluster provision.Cluster
 	var expectedNodes []string
 
 	for _, node := range cluster.Info().Nodes {
-		if node.Type == generate.TypeInit || node.Type == generate.TypeControlPlane {
+		if node.Type == machine.TypeInit || node.Type == machine.TypeControlPlane {
 			expectedNodes = append(expectedNodes, node.PrivateIP.String())
 		}
 	}

--- a/internal/pkg/provision/check/options.go
+++ b/internal/pkg/provision/check/options.go
@@ -4,15 +4,13 @@
 
 package check
 
-import (
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
-)
+import "github.com/talos-systems/talos/pkg/config/machine"
 
 // Option represents functional option.
 type Option func(o *Options) error
 
 // WithNodeTypes sets the node types for a check.
-func WithNodeTypes(t ...generate.Type) Option {
+func WithNodeTypes(t ...machine.Type) Option {
 	return func(o *Options) error {
 		o.Types = t
 
@@ -22,7 +20,7 @@ func WithNodeTypes(t ...generate.Type) Option {
 
 // Options describes ClusterCheck parameters.
 type Options struct {
-	Types []generate.Type
+	Types []machine.Type
 }
 
 // DefaultOptions returns the default options.

--- a/internal/pkg/provision/providers/docker/reflect.go
+++ b/internal/pkg/provision/providers/docker/reflect.go
@@ -9,7 +9,7 @@ import (
 	"net"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 func (p *provisioner) Reflect(ctx context.Context, clusterName string) (provision.Cluster, error) {
@@ -46,7 +46,7 @@ func (p *provisioner) Reflect(ctx context.Context, clusterName string) (provisio
 	}
 
 	for _, node := range nodes {
-		t, err := generate.ParseType(node.Labels["talos.type"])
+		t, err := machine.ParseType(node.Labels["talos.type"])
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // ClusterRequest is the root object describing cluster to be provisioned.
@@ -37,7 +38,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 	found := false
 
 	for i := range reqs {
-		if reqs[i].Type == generate.TypeInit {
+		if reqs[i].Config.Machine().Type() == machine.TypeInit {
 			if found {
 				err = fmt.Errorf("duplicate init node in requests")
 				return
@@ -58,7 +59,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 // MasterNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Type == generate.TypeInit || reqs[i].Type == generate.TypeControlPlane {
+		if reqs[i].Config.Machine().Type() == machine.TypeInit || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -69,7 +70,7 @@ func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 // WorkerNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Type == generate.TypeJoin {
+		if reqs[i].Config.Machine().Type() == machine.TypeWorker {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -79,10 +80,9 @@ func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 
 // NodeRequest describes a request for a node.
 type NodeRequest struct {
-	Type       generate.Type
-	Name       string
-	IP         net.IP
-	ConfigData string
+	Name   string
+	IP     net.IP
+	Config runtime.Configurator
 
 	// Share of CPUs, in 1e-9 fractions
 	NanoCPUs int64

--- a/internal/pkg/provision/result.go
+++ b/internal/pkg/provision/result.go
@@ -7,7 +7,7 @@ package provision
 import (
 	"net"
 
-	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // Cluster describes the provisioned Cluster.
@@ -33,7 +33,7 @@ type NetworkInfo struct {
 type NodeInfo struct {
 	ID   string
 	Name string
-	Type generate.Type
+	Type machine.Type
 
 	PublicIP  net.IP
 	PrivateIP net.IP

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
@@ -45,7 +46,7 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		}
 
 		// Pull existing machine configs of each type
-		for _, configType := range []generate.Type{generate.TypeInit, generate.TypeControlPlane, generate.TypeJoin} {
+		for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
 			data, err := ioutil.ReadFile(filepath.Join(options.ExistingConfigs, strings.ToLower(configType.String())+".yaml"))
 			if err != nil {
 				return bundle, err
@@ -57,11 +58,11 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 			}
 
 			switch configType {
-			case generate.TypeInit:
+			case machine.TypeInit:
 				bundle.InitCfg = unmarshalledConfig
-			case generate.TypeControlPlane:
+			case machine.TypeControlPlane:
 				bundle.ControlPlaneCfg = unmarshalledConfig
-			case generate.TypeJoin:
+			case machine.TypeWorker:
 				bundle.JoinCfg = unmarshalledConfig
 			}
 		}
@@ -95,7 +96,7 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		return bundle, err
 	}
 
-	for _, configType := range []generate.Type{generate.TypeInit, generate.TypeControlPlane, generate.TypeJoin} {
+	for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
 		var generatedConfig *v1alpha1.Config
 
 		generatedConfig, err = generate.Config(configType, input)
@@ -104,11 +105,11 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		}
 
 		switch configType {
-		case generate.TypeInit:
+		case machine.TypeInit:
 			bundle.InitCfg = generatedConfig
-		case generate.TypeControlPlane:
+		case machine.TypeControlPlane:
 			bundle.ControlPlaneCfg = generatedConfig
-		case generate.TypeJoin:
+		case machine.TypeWorker:
 			bundle.JoinCfg = generatedConfig
 		}
 	}

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -5,6 +5,7 @@
 package machine
 
 import (
+	"fmt"
 	"os"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -12,17 +13,36 @@ import (
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
-// Type represents the node type.
+// Type represents a machine type.
 type Type int
 
 const (
-	// Bootstrap represents a bootstrap node.
-	Bootstrap Type = iota
-	// ControlPlane represents a control plane node.
-	ControlPlane
-	// Worker represents a worker node.
-	Worker
+	// TypeInit represents an init node.
+	TypeInit Type = iota
+	// TypeControlPlane represents a control plane node.
+	TypeControlPlane
+	// TypeWorker represents a worker node.
+	TypeWorker
 )
+
+// String returns the string representation of Type.
+func (t Type) String() string {
+	return [...]string{"Init", "ControlPlane", "Join"}[t]
+}
+
+// ParseType parses string constant as Type
+func ParseType(t string) (Type, error) {
+	switch t {
+	case "Init":
+		return TypeInit, nil
+	case "ControlPlane":
+		return TypeControlPlane, nil
+	case "Join":
+		return TypeWorker, nil
+	default:
+		return 0, fmt.Errorf("unknown type %q", t)
+	}
+}
 
 // Machine defines the requirements for a config that pertains to machine
 // related options.

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -10,12 +10,12 @@ import (
 	stdlibx509 "crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net"
 	"net/url"
 	"time"
 
 	"github.com/talos-systems/talos/internal/pkg/cis"
+	"github.com/talos-systems/talos/pkg/config/machine"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	tnet "github.com/talos-systems/talos/pkg/net"
@@ -33,54 +33,19 @@ const DefaultIPv6PodNet = "fc00:db8:10::/56"
 // DefaultIPv6ServiceNet is the network to be used for kubernetes Services when using IPv6-based master nodes
 const DefaultIPv6ServiceNet = "fc00:db8:20::/112"
 
-// Type represents a config type.
-type Type int
-
-const (
-	// TypeInit indicates a config type should correspond to the kubeadm
-	// InitConfiguration type.
-	TypeInit Type = iota
-	// TypeControlPlane indicates a config type should correspond to the
-	// kubeadm JoinConfiguration type that has the ControlPlane field
-	// defined.
-	TypeControlPlane
-	// TypeJoin indicates a config type should correspond to the kubeadm
-	// JoinConfiguration type.
-	TypeJoin
-)
-
-// String returns the string representation of Type.
-func (t Type) String() string {
-	return [...]string{"Init", "ControlPlane", "Join"}[t]
-}
-
-// ParseType parses string constant as Type
-func ParseType(t string) (Type, error) {
-	switch t {
-	case "Init":
-		return TypeInit, nil
-	case "ControlPlane":
-		return TypeControlPlane, nil
-	case "Join":
-		return TypeJoin, nil
-	default:
-		return 0, fmt.Errorf("unknown type %q", t)
-	}
-}
-
 // Config returns the talos config for a given node type.
 // nolint: gocyclo
-func Config(t Type, in *Input) (c *v1alpha1.Config, err error) {
+func Config(t machine.Type, in *Input) (c *v1alpha1.Config, err error) {
 	switch t {
-	case TypeInit:
+	case machine.TypeInit:
 		if c, err = initUd(in); err != nil {
 			return c, err
 		}
-	case TypeControlPlane:
+	case machine.TypeControlPlane:
 		if c, err = controlPlaneUd(in); err != nil {
 			return c, err
 		}
-	case TypeJoin:
+	case machine.TypeWorker:
 		if c, err = workerUd(in); err != nil {
 			return c, err
 		}

--- a/pkg/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/config/types/v1alpha1/generate/generate_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/talos-systems/talos/pkg/config/machine"
 	genv1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/constants"
 )
@@ -30,17 +31,17 @@ func (suite *GenerateSuite) SetupSuite() {
 }
 
 func (suite *GenerateSuite) TestGenerateInitSuccess() {
-	_, err := genv1alpha1.Config(genv1alpha1.TypeInit, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeInit, suite.input)
 	suite.Require().NoError(err)
 }
 
 func (suite *GenerateSuite) TestGenerateControlPlaneSuccess() {
-	_, err := genv1alpha1.Config(genv1alpha1.TypeControlPlane, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeControlPlane, suite.input)
 	suite.Require().NoError(err)
 }
 
 func (suite *GenerateSuite) TestGenerateWorkerSuccess() {
-	_, err := genv1alpha1.Config(genv1alpha1.TypeJoin, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeWorker, suite.input)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -110,11 +110,11 @@ func (m *MachineConfig) Files() []machine.File {
 func (m *MachineConfig) Type() machine.Type {
 	switch m.MachineType {
 	case "init":
-		return machine.Bootstrap
+		return machine.TypeInit
 	case "controlplane":
-		return machine.ControlPlane
+		return machine.TypeControlPlane
 	default:
-		return machine.Worker
+		return machine.TypeWorker
 	}
 }
 

--- a/pkg/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_validation.go
@@ -77,7 +77,7 @@ func (c *Config) Validate(mode runtime.Mode) error {
 		}
 	}
 
-	if c.Machine().Type() == machine.Bootstrap {
+	if c.Machine().Type() == machine.TypeInit {
 		switch c.Cluster().Network().CNI().Name() {
 		case "custom":
 			if len(c.Cluster().Network().CNI().URLs()) == 0 {


### PR DESCRIPTION
We have been using two packages that define a config type and a machine
type, when really they are one and the same. This unifies the types down
to one set.