### PR TITLE
refactor: change machine type names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 bin
 _out
 .vscode
-init.yaml
+bootstrap.yaml
 controlplane.yaml
-join.yaml
+worker.yaml
 docgen
 talosconfig
 kubeconfig

--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -219,14 +219,14 @@ func genV1Alpha1Config(args []string) error {
 		return fmt.Errorf("failed to generate config bundle: %w", err)
 	}
 
-	for _, t := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
+	for _, t := range []machine.Type{machine.TypeBootstrap, machine.TypeControlPlane, machine.TypeWorker} {
 		name = strings.ToLower(t.String()) + ".yaml"
 		fullFilePath := filepath.Join(outputDir, name)
 
 		var configString string
 
 		switch t {
-		case machine.TypeInit:
+		case machine.TypeBootstrap:
 			configString, err = configBundle.Init().String()
 			if err != nil {
 				return err

--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -14,7 +14,7 @@ osctl config generate --version v1alpha1 <cluster name> <cluster endpoint>
 ````
 
 This will generate a machine config for each node type, and a talosconfig.
-The following is an example of an `init.yaml`:
+The following is an example of an `bootstrap.yaml`:
 
 ```yaml
 version: v1alpha1

--- a/docs/website/content/v0.3/en/guides/cloud/aws.md
+++ b/docs/website/content/v0.3/en/guides/cloud/aws.md
@@ -141,9 +141,9 @@ Using the DNS name of the loadbalancer created earlier, generate the base config
 
 ```bash
 $ osctl config generate talos-k8s-aws-tutorial https://<load balancer IP or DNS>
-created init.yaml
+created bootstrap.yaml
 created controlplane.yaml
-created join.yaml
+created worker.yaml
 created talosconfig
 ```
 
@@ -152,12 +152,12 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
+$ osctl validate --config bootstrap.yaml --mode cloud
+bootstrap.yaml is valid for cloud mode
 $ osctl validate --config controlplane.yaml --mode cloud
 controlplane.yaml is valid for cloud mode
-$ osctl validate --config join.yaml --mode cloud
-join.yaml is valid for cloud mode
+$ osctl validate --config worker.yaml --mode cloud
+worker.yaml is valid for cloud mode
 ```
 
 ### Create the EC2 Instances
@@ -173,7 +173,7 @@ aws ec2 run-instances \
     --image-id $AMI \
     --count 1 \
     --instance-type t3.small \
-    --user-data file://init.yaml \
+    --user-data file://bootstrap.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
 ```
@@ -199,7 +199,7 @@ aws ec2 run-instances \
     --image-id $AMI \
     --count 3 \
     --instance-type t3.small \
-    --user-data file://join.yaml \
+    --user-data file://worker.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/azure.md
+++ b/docs/website/content/v0.3/en/guides/cloud/azure.md
@@ -211,7 +211,7 @@ az vm availability-set create \
 az vm create \
   --name talos-controlplane-0 \
   --image talos \
-  --custom-data ./init.yaml \
+  --custom-data ./bootstrap.yaml \
   -g $GROUP \
   --admin-username talos \
   --generate-ssh-keys \
@@ -243,7 +243,7 @@ done
   az vm create \
     --name talos-worker-0 \
     --image talos \
-    --custom-data ./join.yaml \
+    --custom-data ./worker.yaml \
     -g $GROUP \
     --admin-username talos \
     --generate-ssh-keys \

--- a/docs/website/content/v0.3/en/guides/cloud/digitalocean.md
+++ b/docs/website/content/v0.3/en/guides/cloud/digitalocean.md
@@ -54,9 +54,9 @@ Using the DNS name of the loadbalancer created earlier, generate the base config
 
 ```bash
 $ osctl config generate talos-k8s-digital-ocean-tutorial https://<load balancer IP or DNS>
-created init.yaml
+created bootstrap.yaml
 created controlplane.yaml
-created join.yaml
+created worker.yaml
 created talosconfig
 ```
 
@@ -65,12 +65,12 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
+$ osctl validate --config bootstrap.yaml --mode cloud
+bootstrap.yaml is valid for cloud mode
 $ osctl validate --config controlplane.yaml --mode cloud
 controlplane.yaml is valid for cloud mode
-$ osctl validate --config join.yaml --mode cloud
-join.yaml is valid for cloud mode
+$ osctl validate --config worker.yaml --mode cloud
+worker.yaml is valid for cloud mode
 ```
 
 ### Create the Droplets
@@ -84,7 +84,7 @@ doctl compute droplet create \
     --size s-2vcpu-4gb \
     --enable-private-networking \
     --tag-names talos-digital-ocean-tutorial-control-plane \
-    --user-data-file init.yaml \
+    --user-data-file bootstrap.yaml \
     --ssh-keys <ssh key fingerprint> \
     talos-control-plane-1
 ```
@@ -127,7 +127,7 @@ doctl compute droplet create \
     --image <image ID> \
     --size s-2vcpu-4gb \
     --enable-private-networking \
-    --user-data-file join.yaml \
+    --user-data-file worker.yaml \
     --ssh-keys <ssh key fingerprint> \
     talos-worker-1
 ```

--- a/docs/website/content/v0.3/en/guides/cloud/gcp.md
+++ b/docs/website/content/v0.3/en/guides/cloud/gcp.md
@@ -123,7 +123,7 @@ gcloud compute instances create talos-controlplane-0 \
   --zone $REGION-b \
   --tags talos-controlplane \
   --boot-disk-size 20GB \
-  --metadata-from-file=user-data=./init.yaml
+  --metadata-from-file=user-data=./bootstrap.yaml
 
 # Create control plane 1/2
 for i in $( seq 1 2 ); do
@@ -147,7 +147,7 @@ gcloud compute instances create talos-worker-0 \
   --image talos \
   --zone $REGION-b \
   --boot-disk-size 20GB \
-  --metadata-from-file=user-data=./join.yaml
+  --metadata-from-file=user-data=./worker.yaml
 ```
 
 ### Retrieve the `kubeconfig`
@@ -164,3 +164,4 @@ CONTROL_PLANE_0_IP=$(gcloud compute instances describe talos-controlplane-0 \
 osctl --talosconfig ./talosconfig config endpoint $CONTROL_PLANE_0_IP
 osctl --talosconfig ./talosconfig kubeconfig .
 kubectl --kubeconfig ./kubeconfig get nodes
+```

--- a/docs/website/content/v0.3/en/guides/cloud/vmware.md
+++ b/docs/website/content/v0.3/en/guides/cloud/vmware.md
@@ -24,9 +24,9 @@ Using the DNS name or name of the loadbalancer used in the prereq steps, generat
 
 ```bash
 $ osctl config generate talos-k8s-vmware-tutorial https://<load balancer IP or DNS>
-created init.yaml
+created bootstrap.yaml
 created controlplane.yaml
-created join.yaml
+created worker.yaml
 created talosconfig
 ```
 
@@ -34,9 +34,9 @@ created talosconfig
 
 ```bash
 $ osctl config generate talos-k8s-vmware-tutorial https://<DNS name>:6443
-created init.yaml
+created bootstrap.yaml
 created controlplane.yaml
-created join.yaml
+created worker.yaml
 created talosconfig
 ```
 
@@ -45,12 +45,12 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
+$ osctl validate --config bootstrap.yaml --mode cloud
+bootstrap.yaml is valid for cloud mode
 $ osctl validate --config controlplane.yaml --mode cloud
 controlplane.yaml is valid for cloud mode
-$ osctl validate --config join.yaml --mode cloud
-join.yaml is valid for cloud mode
+$ osctl validate --config worker.yaml --mode cloud
+worker.yaml is valid for cloud mode
 ```
 
 ### Set Environment Variables
@@ -108,7 +108,7 @@ To facilitate persistent storage using the vSphere cloud provider integration wi
 
 ```bash
 govc vm.change \
-  -e "guestinfo.talos.config=$(cat init.yaml | base64)" \
+  -e "guestinfo.talos.config=$(cat bootstrap.yaml | base64)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/control-plane-1
 ```
@@ -176,12 +176,12 @@ govc vm.power -on control-plane-3
 ```bash
 govc vm.clone -on=false -vm talos-$TALOS_VERSION worker-1
 govc vm.change \
-  -e "guestinfo.talos.config=$(base64 join.yaml)" \
+  -e "guestinfo.talos.config=$(base64 worker.yaml)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/worker-1
 govc vm.clone -on=false -vm talos-$TALOS_VERSION worker-2
 govc vm.change \
-  -e "guestinfo.talos.config=$(base64 join.yaml)" \
+  -e "guestinfo.talos.config=$(base64 worker.yaml)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/worker-2
 ```

--- a/docs/website/content/v0.3/en/guides/metal/matchbox.md
+++ b/docs/website/content/v0.3/en/guides/metal/matchbox.md
@@ -18,9 +18,9 @@ Using the DNS name of the load balancer, generate the base configuration files f
 
 ```bash
 $ osctl config generate talos-k8s-metal-tutorial https://<load balancer IP or DNS>
-created init.yaml
+created bootstrap.yaml
 created controlplane.yaml
-created join.yaml
+created worker.yaml
 created talosconfig
 ```
 
@@ -29,19 +29,19 @@ At this point, you can modify the generated configs to your liking.
 #### Validate the Configuration Files
 
 ```bash
-$ osctl validate --config init.yaml --mode metal
-init.yaml is valid for metal mode
+$ osctl validate --config bootstrap.yaml --mode metal
+bootstrap.yaml is valid for metal mode
 $ osctl validate --config controlplane.yaml --mode metal
 controlplane.yaml is valid for metal mode
-$ osctl validate --config join.yaml --mode metal
-join.yaml is valid for metal mode
+$ osctl validate --config worker.yaml --mode metal
+worker.yaml is valid for metal mode
 ```
 
 #### Publishing the Machine Configuration Files
 
 In bare-metal setups it is up to the user to provide the configuration files over HTTP(S).
 A special kernel parameter (`talos.config`) must be used to inform Talos about _where_ it should retreive its' configuration file.
-To keep things simple we will place `init.yaml`, `controlplane.yaml`, and `join.yaml` into Matchbox's `assets` directory.
+To keep things simple we will place `bootstrap.yaml`, `controlplane.yaml`, and `worker.yaml` into Matchbox's `assets` directory.
 This directory is automatically served by Matchbox.
 
 ### Create the Matchbox Configuration Files
@@ -71,7 +71,7 @@ Download these files from the [release](https://github.com/talos-systems/talos/r
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev/assets/init.yaml"
+      "talos.config=http://matchbox.talos.dev/assets/bootstrap.yaml"
     ]
   }
 }
@@ -125,7 +125,7 @@ Download these files from the [release](https://github.com/talos-systems/talos/r
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev/assets/join.yaml"
+      "talos.config=http://matchbox.talos.dev/assets/worker.yaml"
     ]
   }
 }

--- a/hack/test/integration/libvirt.sh
+++ b/hack/test/integration/libvirt.sh
@@ -55,11 +55,11 @@ function up {
     cp $PWD/../../../${ARTIFACTS}/vmlinuz ./matchbox/assets/
     cd ./matchbox/assets
     $PWD/../../../../../${ARTIFACTS}/osctl-linux-amd64 config generate --install-image ${INSTALLER} integration-test https://kubernetes.talos.dev:6443
-    yq w -i init.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
-    yq w -i init.yaml cluster.network.cni.name 'custom'
-    yq w -i init.yaml cluster.network.cni.urls[+] "${CNI_URL}"
+    yq w -i bootstrap.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    yq w -i bootstrap.yaml cluster.network.cni.name 'custom'
+    yq w -i bootstrap.yaml cluster.network.cni.urls[+] "${CNI_URL}"
     yq w -i controlplane.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
-    yq w -i join.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
+    yq w -i worker.yaml machine.install.extraKernelArgs[+] 'console=ttyS0'
     cd -
     virt-install --name $CONTROL_PLANE_1_NAME --network=bridge:talos0,model=e1000,mac=$CONTROL_PLANE_1_MAC $COMMON_VIRT_OPTS --boot=hd,network
     virt-install --name $CONTROL_PLANE_2_NAME --network=bridge:talos0,model=e1000,mac=$CONTROL_PLANE_2_MAC $COMMON_VIRT_OPTS --boot=hd,network

--- a/hack/test/integration/matchbox/profiles/default.json
+++ b/hack/test/integration/matchbox/profiles/default.json
@@ -18,7 +18,7 @@
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev:8080/assets/join.yaml"
+      "talos.config=http://matchbox.talos.dev:8080/assets/worker.yaml"
     ]
   }
 }

--- a/hack/test/integration/matchbox/profiles/init.json
+++ b/hack/test/integration/matchbox/profiles/init.json
@@ -18,7 +18,7 @@
       "console=ttyS0",
       "printk.devkmsg=on",
       "talos.platform=metal",
-      "talos.config=http://matchbox.talos.dev:8080/assets/init.yaml"
+      "talos.config=http://matchbox.talos.dev:8080/assets/bootstrap.yaml"
     ]
   }
 }

--- a/internal/app/machined/internal/phase/services/start_services.go
+++ b/internal/app/machined/internal/phase/services/start_services.go
@@ -58,7 +58,7 @@ func (task *StartServices) loadSystemServices(r runtime.Runtime) {
 	// Start the services common to all control plane nodes.
 
 	switch r.Config().Machine().Type() {
-	case machine.TypeInit:
+	case machine.TypeBootstrap:
 		fallthrough
 	case machine.TypeControlPlane:
 		svcs.Load(
@@ -74,7 +74,7 @@ func (task *StartServices) loadKubernetesServices(r runtime.Runtime) {
 		&services.Kubelet{},
 	)
 
-	if r.Config().Machine().Type() == machine.TypeInit {
+	if r.Config().Machine().Type() == machine.TypeBootstrap {
 		svcs.Load(
 			&services.Bootkube{},
 		)

--- a/internal/app/machined/internal/phase/services/stop_services.go
+++ b/internal/app/machined/internal/phase/services/stop_services.go
@@ -34,7 +34,7 @@ func (task *StopServices) standard(r runtime.Runtime) (err error) {
 	if task.upgrade {
 		services := []string{"containerd", "networkd", "ntpd", "udevd"}
 
-		if r.Config().Machine().Type() == machine.TypeInit || r.Config().Machine().Type() == machine.TypeControlPlane {
+		if r.Config().Machine().Type() == machine.TypeBootstrap || r.Config().Machine().Type() == machine.TypeControlPlane {
 			services = append(services, "trustd")
 		}
 

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 // ValidateSuite verifies dmesg command
@@ -46,8 +47,8 @@ func (suite *ValidateSuite) TearDownTest() {
 func (suite *ValidateSuite) TestValidate() {
 	suite.RunOsctl([]string{"config", "generate", "foobar", "https://10.0.0.1"})
 
-	for _, configFile := range []string{"init.yaml", "controlplane.yaml", "join.yaml"} {
-		for _, mode := range []string{"Cloud", "Container", "Interactive", "Metal"} {
+	for _, configFile := range []string{machine.TypeBootstrap.String() + ".yaml", machine.TypeControlPlane.String() + ".yaml", machine.TypeWorker.String() + ".yaml"} {
+		for _, mode := range []string{"cloud", "container", "interactive", "metal"} {
 			suite.RunOsctl([]string{"validate", "-m", mode, "-c", configFile})
 		}
 	}

--- a/internal/pkg/provision/check/default.go
+++ b/internal/pkg/provision/check/default.go
@@ -19,7 +19,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		// wait for etcd to be healthy on all control plane nodes
 		func(cluster provision.ClusterAccess) conditions.Condition {
 			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
+				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeBootstrap, machine.TypeControlPlane))
 			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for bootkube to finish on init node

--- a/internal/pkg/provision/check/kubernetes.go
+++ b/internal/pkg/provision/check/kubernetes.go
@@ -68,7 +68,7 @@ func K8sFullControlPlaneAssertion(ctx context.Context, cluster provision.Cluster
 	var expectedNodes []string
 
 	for _, node := range cluster.Info().Nodes {
-		if node.Type == machine.TypeInit || node.Type == machine.TypeControlPlane {
+		if node.Type == machine.TypeBootstrap || node.Type == machine.TypeControlPlane {
 			expectedNodes = append(expectedNodes, node.PrivateIP.String())
 		}
 	}

--- a/internal/pkg/provision/providers/docker/node.go
+++ b/internal/pkg/provision/providers/docker/node.go
@@ -104,7 +104,7 @@ func (p *provisioner) createNode(ctx context.Context, clusterReq provision.Clust
 	// Mutate the container configurations based on the node type.
 
 	switch nodeReq.Config.Machine().Type() {
-	case machine.TypeInit:
+	case machine.TypeBootstrap:
 		var apidPort nat.Port
 
 		apidPort, err = nat.NewPort("tcp", "50000")

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -57,7 +57,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 	found := false
 
 	for i := range reqs {
-		if reqs[i].Config.Machine().Type() == machine.TypeInit {
+		if reqs[i].Config.Machine().Type() == machine.TypeBootstrap {
 			if found {
 				err = fmt.Errorf("duplicate init node in requests")
 				return
@@ -78,7 +78,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 // MasterNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Config.Machine().Type() == machine.TypeInit || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
+		if reqs[i].Config.Machine().Type() == machine.TypeBootstrap || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
 			nodes = append(nodes, reqs[i])
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,7 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		}
 
 		// Pull existing machine configs of each type
-		for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
+		for _, configType := range []machine.Type{machine.TypeBootstrap, machine.TypeControlPlane, machine.TypeWorker} {
 			data, err := ioutil.ReadFile(filepath.Join(options.ExistingConfigs, strings.ToLower(configType.String())+".yaml"))
 			if err != nil {
 				return bundle, err
@@ -58,7 +58,7 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 			}
 
 			switch configType {
-			case machine.TypeInit:
+			case machine.TypeBootstrap:
 				bundle.InitCfg = unmarshalledConfig
 			case machine.TypeControlPlane:
 				bundle.ControlPlaneCfg = unmarshalledConfig
@@ -96,7 +96,7 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		return bundle, err
 	}
 
-	for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
+	for _, configType := range []machine.Type{machine.TypeBootstrap, machine.TypeControlPlane, machine.TypeWorker} {
 		var generatedConfig *v1alpha1.Config
 
 		generatedConfig, err = generate.Config(configType, input)
@@ -105,7 +105,7 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		}
 
 		switch configType {
-		case machine.TypeInit:
+		case machine.TypeBootstrap:
 			bundle.InitCfg = generatedConfig
 		case machine.TypeControlPlane:
 			bundle.ControlPlaneCfg = generatedConfig

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -17,27 +17,36 @@ import (
 type Type int
 
 const (
-	// TypeInit represents an init node.
-	TypeInit Type = iota
+	// TypeBootstrap represents a bootstrap node.
+	TypeBootstrap Type = iota
 	// TypeControlPlane represents a control plane node.
 	TypeControlPlane
 	// TypeWorker represents a worker node.
 	TypeWorker
 )
 
+const (
+	// TypeBootstrapString is the string representation of TypeBootstrap.
+	TypeBootstrapString = "bootstrap"
+	// TypeControlPlaneString is the string representation of TypeControlPlane.
+	TypeControlPlaneString = "controlplane"
+	// TypeWorkerString is the string representation of TypeWorker.
+	TypeWorkerString = "worker"
+)
+
 // String returns the string representation of Type.
 func (t Type) String() string {
-	return [...]string{"Init", "ControlPlane", "Join"}[t]
+	return [...]string{TypeBootstrapString, TypeControlPlaneString, TypeWorkerString}[t]
 }
 
 // ParseType parses string constant as Type
 func ParseType(t string) (Type, error) {
 	switch t {
-	case "Init":
-		return TypeInit, nil
-	case "ControlPlane":
+	case TypeBootstrap.String():
+		return TypeBootstrap, nil
+	case TypeControlPlane.String():
 		return TypeControlPlane, nil
-	case "Join":
+	case TypeWorker.String():
 		return TypeWorker, nil
 	default:
 		return 0, fmt.Errorf("unknown type %q", t)

--- a/pkg/config/types/v1alpha1/doc.go
+++ b/pkg/config/types/v1alpha1/doc.go
@@ -13,7 +13,7 @@ osctl config generate --version v1alpha1 <cluster name> <cluster endpoint>
 ````
 
 This will generate a machine config for each node type, and a talosconfig.
-The following is an example of an `init.yaml`:
+The following is an example of an `bootstrap.yaml`:
 
 ```yaml
 version: v1alpha1

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -7,6 +7,7 @@ package generate
 import (
 	"net/url"
 
+	"github.com/talos-systems/talos/pkg/config/machine"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -14,7 +15,7 @@ func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
 	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
 
 	machine := &v1alpha1.MachineConfig{
-		MachineType:     "controlplane",
+		MachineType:     machine.TypeControlPlane.String(),
 		MachineToken:    in.TrustdInfo.Token,
 		MachineCA:       in.Certs.OS,
 		MachineCertSANs: in.AdditionalMachineCertSANs,

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -37,7 +37,7 @@ const DefaultIPv6ServiceNet = "fc00:db8:20::/112"
 // nolint: gocyclo
 func Config(t machine.Type, in *Input) (c *v1alpha1.Config, err error) {
 	switch t {
-	case machine.TypeInit:
+	case machine.TypeBootstrap:
 		if c, err = initUd(in); err != nil {
 			return c, err
 		}

--- a/pkg/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/config/types/v1alpha1/generate/generate_test.go
@@ -31,7 +31,7 @@ func (suite *GenerateSuite) SetupSuite() {
 }
 
 func (suite *GenerateSuite) TestGenerateInitSuccess() {
-	_, err := genv1alpha1.Config(machine.TypeInit, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeBootstrap, suite.input)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/config/types/v1alpha1/generate/worker.go
+++ b/pkg/config/types/v1alpha1/generate/worker.go
@@ -7,19 +7,20 @@ package generate
 import (
 	"net/url"
 
+	"github.com/talos-systems/talos/pkg/config/machine"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
-func initUd(in *Input) (*v1alpha1.Config, error) {
+func workerUd(in *Input) (*v1alpha1.Config, error) {
 	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
 
 	machine := &v1alpha1.MachineConfig{
-		MachineType:     "init",
+		MachineType:     machine.TypeWorker.String(),
+		MachineToken:    in.TrustdInfo.Token,
+		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  &v1alpha1.NetworkConfig{},
-		MachineCA:       in.Certs.OS,
-		MachineCertSANs: in.AdditionalMachineCertSANs,
-		MachineToken:    in.TrustdInfo.Token,
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,
@@ -27,34 +28,22 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		},
 	}
 
-	certSANs := in.GetAPIServerSANs()
-
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)
 	if err != nil {
 		return config, err
 	}
 
 	cluster := &v1alpha1.ClusterConfig{
-		ClusterName: in.ClusterName,
+		ClusterCA:      &x509.PEMEncodedCertificateAndKey{Crt: in.Certs.K8s.Crt},
+		BootstrapToken: in.Secrets.BootstrapToken,
 		ControlPlane: &v1alpha1.ControlPlaneConfig{
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
-		},
-		APIServer: &v1alpha1.APIServerConfig{
-			CertSANs: certSANs,
-		},
-		ControllerManager: &v1alpha1.ControllerManagerConfig{},
-		Scheduler:         &v1alpha1.SchedulerConfig{},
-		EtcdConfig: &v1alpha1.EtcdConfig{
-			RootCA: in.Certs.Etcd,
 		},
 		ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
 			DNSDomain:     in.ServiceDomain,
 			PodSubnet:     in.PodNet,
 			ServiceSubnet: in.ServiceNet,
 		},
-		ClusterCA:                     in.Certs.K8s,
-		BootstrapToken:                in.Secrets.BootstrapToken,
-		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
 	}
 
 	config.MachineConfig = machine

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -109,14 +109,12 @@ func (m *MachineConfig) Files() []machine.File {
 
 // Type implements the Configurator interface.
 func (m *MachineConfig) Type() machine.Type {
-	switch m.MachineType {
-	case "init":
-		return machine.TypeInit
-	case "controlplane":
-		return machine.TypeControlPlane
-	default:
+	t, err := machine.ParseType(m.MachineType)
+	if err != nil {
 		return machine.TypeWorker
 	}
+
+	return t
 }
 
 // Server implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_validation.go
@@ -77,7 +77,7 @@ func (c *Config) Validate(mode runtime.Mode) error {
 		}
 	}
 
-	if c.Machine().Type() == machine.TypeInit {
+	if c.Machine().Type() == machine.TypeBootstrap {
 		switch c.Cluster().Network().CNI().Name() {
 		case "custom":
 			if len(c.Cluster().Network().CNI().URLs()) == 0 {


### PR DESCRIPTION
BREAKING CHANGE: A machine type of "join" is no longer valid. Use
"worker" instead.