### PR TITLE
fix: refuse to upgrade if single master

### DIFF
--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -95,6 +95,10 @@ func ValidateForUpgrade() error {
 			return err
 		}
 
+		if len(resp.Members) == 1 {
+			return fmt.Errorf("only 1 etcd member found. assuming this is not an HA setup and refusing to upgrade")
+		}
+
 		for _, member := range resp.Members {
 			// If the member is not started, the name will be an empty string.
 			if len(member.Name) == 0 {


### PR DESCRIPTION
This PR adds some simple logic to bail early in the upgrade process if
there only seems to be a single etcd node present in the cluster. This
allows us to keep from blowing up non-HA clusters if users issue an
upgrade command.

Will close #1770.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>