### PR TITLE
feat: allow additional manifests to be provided to bootkube

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -484,6 +484,22 @@ etcd:
 
 ```
 
+#### extraManifests
+
+A list of urls that point to additional manifests.
+These will get automatically deployed by bootkube.
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraManifests:
+  - "https://www.mysweethttpserver.com/manifest1.yaml"
+  - "https://www.mysweethttpserver.com/manifest2.yaml"
+
+```
+
 ---
 
 ### KubeletConfig

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -24,6 +24,7 @@ type Cluster interface {
 	Etcd() Etcd
 	Network() Network
 	LocalAPIServerPort() int
+	ExtraManifestURLs() []string
 }
 
 // Network defines the requirements for a config that pertains to cluster

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -323,6 +323,11 @@ func (c *ClusterConfig) ServiceCIDR() string {
 	return c.ClusterNetwork.ServiceSubnet[0]
 }
 
+// ExtraManifestURLs implements the Configurator interface.
+func (c *ClusterConfig) ExtraManifestURLs() []string {
+	return c.ExtraManifests
+}
+
 // Name implements the Configurator interface.
 func (c *CNIConfig) Name() string {
 	return c.CNIName

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -264,6 +264,15 @@ type ClusterConfig struct {
 	//           key: LS0tLS1CRUdJTiBSU0...
 	//         image: ...
 	EtcdConfig *EtcdConfig `yaml:"etcd,omitempty"`
+	//   description: |
+	//     A list of urls that point to additional manifests.
+	//     These will get automatically deployed by bootkube.
+	//   examples:
+	//     - |
+	//       extraManifests:
+	//         - "https://www.mysweethttpserver.com/manifest1.yaml"
+	//         - "https://www.mysweethttpserver.com/manifest2.yaml"
+	ExtraManifests []string `yaml:"extraManifests,omitempty"`
 }
 
 // KubeletConfig reperesents the kubelet config values


### PR DESCRIPTION
This PR will add an `additionalManifests` field to the config data that
allows users to specify a list of URLs that they'd like to fetch
manifests from. These manifests will then be added to the bootkube asset
directory and applied during the bootkube service.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>