### PR TITLE
refactor: use tls.Config as client credentials

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/grpc/tls"
 )
 
 // APISuite is a base suite for API tests
@@ -31,7 +32,16 @@ func (apiSuite *APISuite) SetupSuite() {
 		endpoints = []string{apiSuite.Endpoint}
 	}
 
-	apiSuite.Client, err = client.NewClient(creds, endpoints, constants.ApidPort)
+	tlsconfig, err := tls.New(
+		tls.WithKeypair(creds.Crt),
+		tls.WithClientAuthType(tls.Mutual),
+		tls.WithCACertPEM(creds.CA),
+	)
+	if err != nil {
+		apiSuite.Require().NoError(err)
+	}
+
+	apiSuite.Client, err = client.NewClient(tlsconfig, endpoints, constants.ApidPort)
 	apiSuite.Require().NoError(err)
 }
 

--- a/internal/pkg/provision/access/adapter.go
+++ b/internal/pkg/provision/access/adapter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/internal/pkg/provision"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/grpc/tls"
 )
 
 // NewAdapter returns ClusterAccess object from Cluster.
@@ -60,7 +61,16 @@ func (a *adapter) Client(endpoints ...string) (*client.Client, error) {
 		endpoints = configContext.Endpoints
 	}
 
-	client, err := client.NewClient(creds, endpoints, constants.ApidPort)
+	tlsconfig, err := tls.New(
+		tls.WithKeypair(creds.Crt),
+		tls.WithClientAuthType(tls.Mutual),
+		tls.WithCACertPEM(creds.CA),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := client.NewClient(tlsconfig, endpoints, constants.ApidPort)
 	if err == nil {
 		a.clients[key] = client
 	}


### PR DESCRIPTION
The `client.Creds` struct was not used very often, and made using the
`client.NewClient` function impossible to use in combination with the
`RemoteRenewingFileCertificateProvider`. This modifies
`client.NewClient` to accept a `tls.Config` instead of `client.Creds`,
allowing for the use of `RemoteRenewingFileCertificateProvider` with
`client.NewClient`.