### PR TITLE
docs: add missing docs

### DIFF
--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -15,16 +15,24 @@ osctl cluster create [flags]
 
 ```
       --cidr string                 CIDR of the docker bridge network (default "10.5.0.0/24")
+      --cni-bin-path strings        search path for CNI binaries (default [/opt/cni/bin])
+      --cni-cache-dir string        CNI cache directory path (default "/var/lib/cni")
+      --cni-conf-dir string         CNI config directory path (default "/etc/cni/conf.d")
       --cpus string                 the share of CPUs as fraction (each container) (default "1.5")
+      --disk int                    the limit on disk size in MB (each VM) (default 4096)
       --endpoint string             use endpoint instead of provider defaults
   -h, --help                        help for create
       --image string                the image to use (default "docker.io/autonomy/talos:latest")
       --init-node-as-endpoint       use init node as endpoint instead of any load balancer endpoint
+      --initrd-path string          the uncompressed kernel image to use (default "_out/initramfs.xz")
   -i, --input-dir string            location of pre-generated config files
+      --install-image string        the installer image to use (default "docker.io/autonomy/installer:latest")
       --kubernetes-version string   desired kubernetes version to run (default "1.17.0")
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
       --mtu int                     MTU of the docker bridge network (default 1500)
+      --provisioner string          Talos cluster provisioner to use (default "docker")
+      --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --wait                        wait for the cluster to be ready before returning
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
       --workers int                 the number of workers to create (default 1)


### PR DESCRIPTION
The `docs` target needed to be ran.