### PR TITLE
fix(networkd): Set hostname properly for dhcp when no hostname option is returned

### DIFF
--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -135,6 +135,10 @@ func (d *DHCP) Hostname() string {
 		return fmt.Sprintf("%s.%s", shortHostname, d.Ack.DomainName())
 	}
 
+	if d.Ack.HostName() == "" {
+		return fmt.Sprintf("%s-%s", "talos", strings.ReplaceAll(d.Address().IP.String(), ".", "-"))
+	}
+
 	return d.Ack.HostName()
 }
 


### PR DESCRIPTION
This fixes a condition where a dhcp response does not provide a hostname. Previously
this would cause the default hostname ( talos-127-0-1-1 ) to be used. This catches
the condition and changes it to compute the hostname via talos-ip.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>