### PR TITLE
fix: update newtorkd permissions

### DIFF
--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -106,6 +106,7 @@ func (n *Networkd) Runner(config runtime.Configurator) (runner.Runner, error) {
 			containerd.WithMemoryLimit(int64(1000000*32)),
 			oci.WithCapabilities([]string{
 				strings.ToUpper("CAP_" + capability.CAP_NET_ADMIN.String()),
+				strings.ToUpper("CAP_" + capability.CAP_SYS_ADMIN.String()),
 				strings.ToUpper("CAP_" + capability.CAP_NET_RAW.String()),
 			}),
 			oci.WithHostNamespace(specs.NetworkNamespace),


### PR DESCRIPTION
This adds CAP_SYS_ADMIN to the networkd container so that we can set the
hostname and domainname. Without this we get permission denied.