### PR TITLE
fix: block when handling bus event

### DIFF
--- a/internal/pkg/event/event.go
+++ b/internal/pkg/event/event.go
@@ -52,17 +52,17 @@ type ObserveNotifier interface {
 
 // Embeddable is a type that implements sane defaults as an observer.
 type Embeddable struct {
-	channel Channel
-	types   []Type
+	Chan  Channel
+	types []Type
 }
 
 // Channel implements the Observer interface.
 func (e *Embeddable) Channel() Channel {
-	if cap(e.channel) == 0 {
-		e.channel = make(Channel, 20)
+	if e.Chan == nil {
+		e.Chan = make(Channel)
 	}
 
-	return e.channel
+	return e.Chan
 }
 
 // Types implements the Observer interface.

--- a/internal/pkg/event/event_test.go
+++ b/internal/pkg/event/event_test.go
@@ -23,12 +23,12 @@ func (suite *EventSuite) TestBus() {
 	subscriber1 := struct {
 		*event.Embeddable
 	}{
-		&event.Embeddable{},
+		&event.Embeddable{Chan: make(event.Channel, 20)},
 	}
 	subscriber2 := struct {
 		*event.Embeddable
 	}{
-		&event.Embeddable{},
+		&event.Embeddable{Chan: make(event.Channel, 20)},
 	}
 
 	event.Bus().Register(subscriber1)


### PR DESCRIPTION
If we don't block, there is the potential for multiple shutdown,
reboot, and upgrade requests to be processed.