### PR TITLE
test: firecracker provisioner fixes, implement cluster destroy 

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/machine"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -203,12 +204,14 @@ func genV1Alpha1Config(args []string) error {
 	configBundle, err := config.NewConfigBundle(
 		config.WithInputOptions(
 			&config.InputOptions{
-				ClusterName:               args[0],
-				Endpoint:                  args[1],
-				KubeVersion:               kubernetesVersion,
-				AdditionalSubjectAltNames: additionalSANs,
-				InstallDisk:               installDisk,
-				InstallImage:              installImage,
+				ClusterName: args[0],
+				Endpoint:    args[1],
+				KubeVersion: kubernetesVersion,
+				GenOptions: []generate.GenOption{
+					generate.WithInstallDisk(installDisk),
+					generate.WithInstallImage(installImage),
+					generate.WithAdditionalSubjectAltNames(additionalSANs),
+				},
 			},
 		),
 	)

--- a/cmd/osctl/cmd/firecracker_launch_linux.go
+++ b/cmd/osctl/cmd/firecracker_launch_linux.go
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/internal/pkg/provision/providers/firecracker"
+)
+
+// firecrackerLaunchCmd represents the firecracker-launch command
+var firecrackerLaunchCmd = &cobra.Command{
+	Use:    "firecracker-launch",
+	Short:  "Intneral command used by Firecracker provisioner",
+	Long:   ``,
+	Args:   cobra.NoArgs,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return firecracker.Launch()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(firecrackerLaunchCmd)
+}

--- a/cmd/osctl/cmd/root.go
+++ b/cmd/osctl/cmd/root.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/helpers"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/version"
@@ -51,18 +51,9 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() error {
-	var (
-		defaultTalosConfig string
-		ok                 bool
-	)
-
-	if defaultTalosConfig, ok = os.LookupEnv(constants.TalosConfigEnvVar); !ok {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return err
-		}
-
-		defaultTalosConfig = path.Join(home, ".talos", "config")
+	defaultTalosConfig, err := config.GetDefaultPath()
+	if err != nil {
+		return err
 	}
 
 	rootCmd.PersistentFlags().StringVar(&talosconfig, "talosconfig", defaultTalosConfig, "The path to the Talos configuration file")

--- a/cmd/osctl/pkg/client/config/path.go
+++ b/cmd/osctl/pkg/client/config/path.go
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+// GetTalosDirectory returns path to Talos directory (~/.talos).
+func GetTalosDirectory() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".talos"), nil
+}
+
+// GetDefaultPath returns default path to Talos config.
+func GetDefaultPath() (string, error) {
+	if path, ok := os.LookupEnv(constants.TalosConfigEnvVar); ok {
+		return path, nil
+	}
+
+	talosDir, err := GetTalosDirectory()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(talosDir, "config"), nil
+}

--- a/docs/osctl/osctl.md
+++ b/docs/osctl/osctl.md
@@ -19,7 +19,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 
 ### SEE ALSO
 
-* [osctl cluster](osctl_cluster.md)	 - A collection of commands for managing local docker-based clusters
+* [osctl cluster](osctl_cluster.md)	 - A collection of commands for managing local docker-based or firecracker-based clusters
 * [osctl completion](osctl_completion.md)	 - Output shell completion code for the specified shell (bash or zsh)
 * [osctl config](osctl_config.md)	 - Manage the client configuration
 * [osctl containers](osctl_containers.md)	 - List containers

--- a/docs/osctl/osctl_cluster.md
+++ b/docs/osctl/osctl_cluster.md
@@ -1,17 +1,19 @@
 <!-- markdownlint-disable -->
 ## osctl cluster
 
-A collection of commands for managing local docker-based clusters
+A collection of commands for managing local docker-based or firecracker-based clusters
 
 ### Synopsis
 
-A collection of commands for managing local docker-based clusters
+A collection of commands for managing local docker-based or firecracker-based clusters
 
 ### Options
 
 ```
-  -h, --help          help for cluster
-      --name string   the name of the cluster (default "talos-default")
+  -h, --help                 help for cluster
+      --name string          the name of the cluster (default "talos-default")
+      --provisioner string   Talos cluster provisioner to use (default "docker")
+      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
 ```
 
 ### Options inherited from parent commands
@@ -26,6 +28,7 @@ A collection of commands for managing local docker-based clusters
 ### SEE ALSO
 
 * [osctl](osctl.md)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
-* [osctl cluster create](osctl_cluster_create.md)	 - Creates a local docker-based kubernetes cluster
-* [osctl cluster destroy](osctl_cluster_destroy.md)	 - Destroys a local docker-based kubernetes cluster
+* [osctl cluster create](osctl_cluster_create.md)	 - Creates a local docker-based or firecracker-based kubernetes cluster
+* [osctl cluster destroy](osctl_cluster_destroy.md)	 - Destroys a local docker-based or firecracker-based kubernetes cluster
+* [osctl cluster show](osctl_cluster_show.md)	 - Shows info about a local provisioned kubernetes cluster
 

--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable -->
 ## osctl cluster create
 
-Creates a local docker-based kubernetes cluster
+Creates a local docker-based or firecracker-based kubernetes cluster
 
 ### Synopsis
 
-Creates a local docker-based kubernetes cluster
+Creates a local docker-based or firecracker-based kubernetes cluster
 
 ```
 osctl cluster create [flags]
@@ -31,7 +31,6 @@ osctl cluster create [flags]
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
       --mtu int                     MTU of the docker bridge network (default 1500)
-      --provisioner string          Talos cluster provisioner to use (default "docker")
       --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --wait                        wait for the cluster to be ready before returning
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
@@ -45,10 +44,12 @@ osctl cluster create [flags]
   -e, --endpoints strings    override default endpoints in Talos configuration
       --name string          the name of the cluster (default "talos-default")
   -n, --nodes strings        target the specified nodes
+      --provisioner string   Talos cluster provisioner to use (default "docker")
+      --state string         directory path to store cluster state (default "/home/user/.talos/clusters")
       --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
 ```
 
 ### SEE ALSO
 
-* [osctl cluster](osctl_cluster.md)	 - A collection of commands for managing local docker-based clusters
+* [osctl cluster](osctl_cluster.md)	 - A collection of commands for managing local docker-based or firecracker-based clusters
 

--- a/docs/osctl/osctl_cluster_show.md
+++ b/docs/osctl/osctl_cluster_show.md
@@ -1,20 +1,20 @@
 <!-- markdownlint-disable -->
-## osctl cluster destroy
+## osctl cluster show
 
-Destroys a local docker-based or firecracker-based kubernetes cluster
+Shows info about a local provisioned kubernetes cluster
 
 ### Synopsis
 
-Destroys a local docker-based or firecracker-based kubernetes cluster
+Shows info about a local provisioned kubernetes cluster
 
 ```
-osctl cluster destroy [flags]
+osctl cluster show [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for destroy
+  -h, --help   help for show
 ```
 
 ### Options inherited from parent commands

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -9,17 +9,15 @@ package integration_test
 
 import (
 	"flag"
-	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 	"github.com/talos-systems/talos/internal/integration/api"
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/internal/integration/cli"
 	"github.com/talos-systems/talos/internal/integration/k8s"
-	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/version"
 )
 
@@ -65,17 +63,7 @@ func TestIntegration(t *testing.T) {
 }
 
 func init() {
-	var (
-		defaultTalosConfig string
-		ok                 bool
-	)
-
-	if defaultTalosConfig, ok = os.LookupEnv(constants.TalosConfigEnvVar); !ok {
-		home, err := os.UserHomeDir()
-		if err == nil {
-			defaultTalosConfig = path.Join(home, ".talos", "config")
-		}
-	}
+	defaultTalosConfig, _ := config.GetDefaultPath() //nolint: errcheck
 
 	flag.StringVar(&talosConfig, "talos.config", defaultTalosConfig, "The path to the Talos configuration file")
 	flag.StringVar(&endpoint, "talos.endpoint", "", "endpoint to use (overrides config)")

--- a/internal/pkg/provision/providers/docker/create.go
+++ b/internal/pkg/provision/providers/docker/create.go
@@ -57,8 +57,10 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		clusterInfo: provision.ClusterInfo{
 			ClusterName: request.Name,
 			Network: provision.NetworkInfo{
-				Name: request.Network.Name,
-				CIDR: request.Network.CIDR,
+				Name:        request.Network.Name,
+				CIDR:        request.Network.CIDR,
+				GatewayAddr: request.Network.GatewayAddr,
+				MTU:         request.Network.MTU,
 			},
 			Nodes: nodeInfo,
 		},

--- a/internal/pkg/provision/providers/docker/node.go
+++ b/internal/pkg/provision/providers/docker/node.go
@@ -175,6 +175,9 @@ func (p *provisioner) createNode(ctx context.Context, clusterReq provision.Clust
 		Name: info.Name,
 		Type: nodeReq.Config.Machine().Type(),
 
+		NanoCPUs: nodeReq.NanoCPUs,
+		Memory:   nodeReq.Memory,
+
 		PrivateIP: net.ParseIP(info.NetworkSettings.Networks[clusterReq.Network.Name].IPAddress),
 	}
 

--- a/internal/pkg/provision/providers/docker/result.go
+++ b/internal/pkg/provision/providers/docker/result.go
@@ -5,6 +5,8 @@
 package docker
 
 import (
+	"fmt"
+
 	"github.com/talos-systems/talos/internal/pkg/provision"
 )
 
@@ -12,6 +14,14 @@ type result struct {
 	clusterInfo provision.ClusterInfo
 }
 
+func (res *result) Provisioner() string {
+	return "docker"
+}
+
 func (res *result) Info() provision.ClusterInfo {
 	return res.clusterInfo
+}
+
+func (res *result) StatePath() (string, error) {
+	return "", fmt.Errorf("state path is not used for docker provisioner")
 }

--- a/internal/pkg/provision/providers/firecracker/destroy.go
+++ b/internal/pkg/provision/providers/firecracker/destroy.go
@@ -6,6 +6,8 @@ package firecracker
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
 )
@@ -20,7 +22,18 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		}
 	}
 
-	// TODO: implement me
+	fmt.Fprintln(options.LogWriter, "stopping VMs")
 
-	return nil
+	if err := p.destroyNodes(cluster.Info(), &options); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(options.LogWriter, "removing state directory")
+
+	stateDirectoryPath, err := cluster.StatePath()
+	if err != nil {
+		return err
+	}
+
+	return os.RemoveAll(stateDirectoryPath)
 }

--- a/internal/pkg/provision/providers/firecracker/firecracker.go
+++ b/internal/pkg/provision/providers/firecracker/firecracker.go
@@ -12,6 +12,8 @@ import (
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
 
+const stateFileName = "state.yaml"
+
 type provisioner struct {
 }
 

--- a/internal/pkg/provision/providers/firecracker/launch.go
+++ b/internal/pkg/provision/providers/firecracker/launch.go
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package firecracker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/firecracker-microvm/firecracker-go-sdk"
+
+	"github.com/talos-systems/talos/internal/pkg/provision/providers/firecracker/inmemhttp"
+)
+
+// LaunchConfig is passed in to the Launch function over stdin.
+type LaunchConfig struct {
+	GatewayAddr       string
+	Config            string
+	FirecrackerConfig firecracker.Config
+}
+
+// Launch a control process around firecracker VM manager.
+//
+// This function is invoked from 'osctl firecracker-launch' hidden command
+// and wraps starting, controlling and restarting 'firecracker' VM process.
+//
+// Launch restarts VM forever until control process is stopped itself with a signal.
+//
+// Process is expected to receive configuration on stdin. Current working directory
+// should be cluster state directory, process output should be redirected to the
+// logfile in state directory.
+//
+// When signals SIGINT, SIGTERM are received, control process stops firecracker and exits.
+//
+//nolint: gocyclo
+func Launch() error {
+	var config LaunchConfig
+
+	d := json.NewDecoder(os.Stdin)
+
+	if err := d.Decode(&config); err != nil {
+		return fmt.Errorf("error decoding config from stdin: %w", err)
+	}
+
+	if d.More() {
+		return fmt.Errorf("extra unexpected input on stdin")
+	}
+
+	if err := os.Stdin.Close(); err != nil {
+		return err
+	}
+
+	signal.Ignore(syscall.SIGHUP)
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM, syscall.SIGINT)
+
+	ctx := context.Background()
+
+	httpServer, err := inmemhttp.NewServer(fmt.Sprintf("%s:0", config.GatewayAddr))
+	if err != nil {
+		return fmt.Errorf("error launching in-memory HTTP server: %w", err)
+	}
+
+	if err = httpServer.AddFile("config.yaml", []byte(config.Config)); err != nil {
+		return err
+	}
+
+	// patch kernel args
+	config.FirecrackerConfig.KernelArgs = strings.ReplaceAll(config.FirecrackerConfig.KernelArgs, "{TALOS_CONFIG_URL}", fmt.Sprintf("http://%s/config.yaml", httpServer.GetAddr()))
+
+	httpServer.Serve()
+	defer httpServer.Shutdown(ctx) //nolint: errcheck
+
+	for {
+		cmd := firecracker.VMCommandBuilder{}.
+			WithBin("firecracker").
+			WithSocketPath(config.FirecrackerConfig.SocketPath).
+			WithStdin(os.Stdin).
+			WithStdout(os.Stdout).
+			WithStderr(os.Stderr).
+			Build(ctx)
+
+		m, err := firecracker.NewMachine(ctx, config.FirecrackerConfig, firecracker.WithProcessRunner(cmd))
+		if err != nil {
+			return fmt.Errorf("failed to create new machine: %w", err)
+		}
+
+		if err := m.Start(ctx); err != nil {
+			return fmt.Errorf("failed to initialize machine: %w", err)
+		}
+
+		waitCh := make(chan error)
+
+		go func() {
+			waitCh <- m.Wait(ctx)
+		}()
+
+		select {
+		case err := <-waitCh:
+			if err != nil {
+				return fmt.Errorf("failed running VM: %w", err)
+			}
+
+			select {
+			case sig := <-c:
+				fmt.Fprintf(os.Stderr, "exiting VM as signal %s was received\n", sig)
+
+				return nil
+
+			case <-time.After(500 * time.Millisecond): // wait a bit to prevent crash loop
+			}
+		case sig := <-c:
+			fmt.Fprintf(os.Stderr, "stopping VM as signal %s was received\n", sig)
+
+			m.StopVMM() //nolint: errcheck
+
+			<-waitCh // wait for process to exit
+
+			return nil
+		}
+
+		// restart the vm by proceeding with the for loop
+		os.Remove(config.FirecrackerConfig.SocketPath) //nolint: errcheck
+	}
+}

--- a/internal/pkg/provision/providers/firecracker/reflect.go
+++ b/internal/pkg/provision/providers/firecracker/reflect.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package firecracker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/talos-systems/talos/internal/pkg/provision"
+)
+
+func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory string) (provision.Cluster, error) {
+	statePath := filepath.Join(stateDirectory, clusterName)
+
+	st, err := os.Stat(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("cluster %q not found: %w", clusterName, err)
+		}
+
+		return nil, err
+	}
+
+	if !st.IsDir() {
+		return nil, fmt.Errorf("state path %q is not a directory: %s", statePath, st.Mode())
+	}
+
+	stateFile, err := os.Open(filepath.Join(statePath, stateFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	defer stateFile.Close() //nolint: errcheck
+
+	state := &state{}
+
+	if err = yaml.NewDecoder(stateFile).Decode(state); err != nil {
+		return nil, fmt.Errorf("error unmarshalling state file: %w", err)
+	}
+
+	if state.ProvisionerName != "firecracker" {
+		return nil, fmt.Errorf("cluster %q was created with different provisioner %q", clusterName, state.ProvisionerName)
+	}
+
+	state.statePath = statePath
+
+	return state, nil
+}

--- a/internal/pkg/provision/providers/firecracker/state.go
+++ b/internal/pkg/provision/providers/firecracker/state.go
@@ -5,24 +5,32 @@
 package firecracker
 
 import (
-	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
+	"fmt"
+
 	"github.com/talos-systems/talos/internal/pkg/provision"
 )
 
 type state struct {
-	tempDir             string
-	baseConfigURL       string
-	bridgeInterfaceName string
+	ProvisionerName string
+	BridgeName      string
 
-	talosConfig *config.Config
+	ClusterInfo provision.ClusterInfo
 
-	clusterInfo provision.ClusterInfo
+	statePath string
 }
 
-func (s *state) TalosConfig() *config.Config {
-	return s.talosConfig
+func (s *state) Provisioner() string {
+	return "firecracker"
 }
 
 func (s *state) Info() provision.ClusterInfo {
-	return s.clusterInfo
+	return s.ClusterInfo
+}
+
+func (s *state) StatePath() (string, error) {
+	if s.statePath == "" {
+		return "", fmt.Errorf("state path is not set")
+	}
+
+	return s.statePath, nil
 }

--- a/internal/pkg/provision/provision.go
+++ b/internal/pkg/provision/provision.go
@@ -16,12 +16,9 @@ type Provisioner interface {
 	Create(context.Context, ClusterRequest, ...Option) (Cluster, error)
 	Destroy(context.Context, Cluster, ...Option) error
 
+	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)
+
 	GenOptions() []generate.GenOption
 
 	Close() error
-}
-
-// ClusterNameReflector rebuilds Cluster information by cluster name.
-type ClusterNameReflector interface {
-	Reflect(ctx context.Context, clusterName string) (Cluster, error)
 }

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -23,6 +23,12 @@ type ClusterRequest struct {
 	KernelPath        string
 	InitramfsPath     string
 	KubernetesVersion string
+
+	// Path to osctl executable to re-execute itself as needed.
+	SelfExecutable string
+
+	// Path to root of state directory (~/.talos/clusters by default).
+	StateDirectory string
 }
 
 // CNIConfig describes CNI part of NetworkRequest.

--- a/internal/pkg/provision/result.go
+++ b/internal/pkg/provision/result.go
@@ -12,6 +12,11 @@ import (
 
 // Cluster describes the provisioned Cluster.
 type Cluster interface {
+	// Provisioner returns name of the provisioner used to build the cluster.
+	Provisioner() string
+	// StatePath returns path to the state directory of the cluster.
+	StatePath() (string, error)
+	// Info returns running cluster information.
 	Info() ClusterInfo
 }
 
@@ -25,8 +30,10 @@ type ClusterInfo struct {
 
 // NetworkInfo describes cluster network.
 type NetworkInfo struct {
-	Name string
-	CIDR net.IPNet
+	Name        string
+	CIDR        net.IPNet
+	GatewayAddr net.IP
+	MTU         int
 }
 
 // NodeInfo describes a node.
@@ -34,6 +41,13 @@ type NodeInfo struct {
 	ID   string
 	Name string
 	Type machine.Type
+
+	// Share of CPUs, in 1e-9 fractions
+	NanoCPUs int64
+	// Memory limit in bytes
+	Memory int64
+	// Disk (volume) size in bytes, if applicable
+	DiskSize int64
 
 	PublicIP  net.IP
 	PrivateIP net.IP

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,10 +96,6 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 		return bundle, err
 	}
 
-	input.AdditionalSubjectAltNames = append(input.AdditionalSubjectAltNames, options.InputOptions.AdditionalSubjectAltNames...)
-	input.InstallDisk = options.InputOptions.InstallDisk
-	input.InstallImage = options.InputOptions.InstallImage
-
 	for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
 		var generatedConfig *v1alpha1.Config
 

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -11,13 +11,10 @@ type BundleOption func(o *BundleOptions) error
 
 // InputOptions holds necessary params for generating an input
 type InputOptions struct {
-	ClusterName               string
-	Endpoint                  string
-	KubeVersion               string
-	AdditionalSubjectAltNames []string
-	InstallDisk               string
-	InstallImage              string
-	GenOptions                []generate.GenOption
+	ClusterName string
+	Endpoint    string
+	KubeVersion string
+	GenOptions  []generate.GenOption
 }
 
 // BundleOptions describes generate parameters.

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -297,6 +297,8 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 		additionalMachineCertSANs = options.EndpointList
 	}
 
+	additionalSubjectAltNames = append(additionalSubjectAltNames, options.AdditionalSubjectAltNames...)
+
 	input = &Input{
 		Certs:                     certs,
 		ControlPlaneEndpoint:      endpoint,

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -25,6 +25,15 @@ func WithInstallDisk(disk string) GenOption {
 	}
 }
 
+// WithAdditionalSubjectAltNames specifies additional SANs.
+func WithAdditionalSubjectAltNames(sans []string) GenOption {
+	return func(o *GenOptions) error {
+		o.AdditionalSubjectAltNames = sans
+
+		return nil
+	}
+}
+
 // WithInstallImage specifies install container image to use in Talos cluster.
 func WithInstallImage(imageRef string) GenOption {
 	return func(o *GenOptions) error {
@@ -36,9 +45,10 @@ func WithInstallImage(imageRef string) GenOption {
 
 // GenOptions describes generate parameters.
 type GenOptions struct {
-	EndpointList []string
-	InstallDisk  string
-	InstallImage string
+	EndpointList              []string
+	InstallDisk               string
+	InstallImage              string
+	AdditionalSubjectAltNames []string
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -203,6 +203,9 @@ const (
 	// CRIContainerdConfig is the path to the config for the containerd instance that provides the CRI.
 	CRIContainerdConfig = "/etc/cri/containerd.toml"
 
+	// TalosDirectoryEnvVar is the environment variable for setting the Talos directory path.
+	TalosDirectoryEnvVar = "TALOSDIR"
+
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 


### PR DESCRIPTION
This implements `osctl cluster destroy` for Firecracker, adds
new utility command `osctl cluser show`.

Firecracker mode now has control process for firecracker VMs, allowing
clean reboots and background operations.

Lots of small fixes to Firecracker mode, clean CNI shutdown, cleaning up
netns, etc.