### PR TITLE
fix: stop race condition between kubelet and networkd

### DIFF
--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/talos-systems/talos/pkg/retry"
+
+	"github.com/containerd/containerd"
+)
+
+// Pull is a convenience function that wraps the containerd image pull func with
+// retry functionality.
+func Pull(ctx context.Context, client *containerd.Client, ref string) (img containerd.Image, err error) {
+	err = retry.Exponential(1*time.Minute, retry.WithUnits(1*time.Second)).Retry(func() error {
+		if img, err = client.Pull(ctx, ref, containerd.WithPullUnpack); err != nil {
+			return retry.ExpectedError(fmt.Errorf("failed to pull image %q: %w", ref, err))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}


### PR DESCRIPTION
The kubelet fails to start if a machine's hostname is not set. If
networkd doesn't set it in time, the kubelet service fails to start.
Addionally, this adds retries to container pulls to ensure that any
temporary network failures don't cause fatal errors if we can't pull
images.