### PR TITLE
chore: use v0.1.0 tools and pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,29 +202,29 @@ COPY --from=osctl-darwin-build /osctl-darwin-amd64 /osctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:1e63ad5 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:1e63ad5 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.1.0 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.1.0 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/containerd:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/eudev:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/iptables:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/libressl:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/musl:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/runc:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/socat:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:1e63ad5 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:1e63ad5 /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:1e63ad5 /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:1e63ad5 /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:1e63ad5 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/musl:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.1.0 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.1.0 /lib/libblkid.* /rootfs/lib
+COPY --from=docker.io/autonomy/util-linux:v0.1.0 /lib/libuuid.* /rootfs/lib
+COPY --from=docker.io/autonomy/kmod:v0.1.0 /usr/lib/libkmod.* /rootfs/lib
+COPY --from=docker.io/autonomy/kernel:v0.1.0 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 ARG IMAGES
 COPY ${IMAGES}/apid.tar /rootfs/usr/images/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 
 ARTIFACTS := _out
 IMAGES := $(ARTIFACTS)/images
-TOOLS ?= autonomy/tools:b1b5672
+TOOLS ?= autonomy/tools:v0.1.0
 GO_VERSION ?= 1.13
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 OSCTL_DEFAULT_TARGET := osctl-$(OPERATING_SYSTEM)


### PR DESCRIPTION
This brings in the official v0.1.0 releases of tools and pkgs.