### PR TITLE
fix: leave etcd after draining node

### DIFF
--- a/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
@@ -211,6 +211,9 @@ func (d *Sequencer) Upgrade(req *machineapi.UpgradeRequest) error {
 		phase.NewPhase(
 			"cordon and drain node",
 			kubernetes.NewCordonAndDrainTask(),
+		),
+		phase.NewPhase(
+			"handle control plane requirements",
 			upgrade.NewLeaveEtcdTask(),
 		),
 		phase.NewPhase(


### PR DESCRIPTION
This fixes an edge case where etcd can potentially become unresponsive,
and prevent a draining of a node. We drain the node, and then leave etcd
since all subsequent tasks do not depend on etcd in any way, and will
reduce the chances of an upgrade failure.