### PR TITLE
feat: allow for bootkube images to be customized

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -484,6 +484,34 @@ etcd:
 
 ```
 
+#### podCheckpointer
+
+Pod Checkpointer specific configuration options.
+
+Type: `PodCheckpointer`
+
+Examples:
+
+```yaml
+podCheckpointer:
+  image: ...
+
+```
+
+#### coreDNS
+
+Core DNS specific configuration options.
+
+Type: `CoreDNS`
+
+Examples:
+
+```yaml
+coreDNS:
+  image: ...
+
+```
+
 #### extraManifests
 
 A list of urls that point to additional manifests.
@@ -690,6 +718,26 @@ Defaults to `pool.ntp.org`
 > Note: This parameter only supports a single time server
 
 Type: `array`
+
+---
+
+### PodCheckpointer
+
+#### image
+
+The `image` field is an override to the default pod-checkpointer image.
+
+Type: `string`
+
+---
+
+### CoreDNS
+
+#### image
+
+The `image` field is an override to the default coredns image.
+
+Type: `string`
 
 ---
 

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -19,12 +19,11 @@ import (
 	"path/filepath"
 	"time"
 
+	getter "github.com/hashicorp/go-getter"
+	"github.com/hashicorp/go-multierror"
 	"github.com/kubernetes-sigs/bootkube/pkg/asset"
 	"github.com/kubernetes-sigs/bootkube/pkg/tlsutil"
 	"go.etcd.io/etcd/clientv3"
-
-	getter "github.com/hashicorp/go-getter"
-	"github.com/hashicorp/go-multierror"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/bootkube"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
@@ -305,9 +304,9 @@ func generateAssets(config runtime.Configurator) (err error) {
 
 	images.Hyperkube = config.Machine().Kubelet().Image()
 
-	// TODO(andrewrynhard): This is a hack workaround for now. Update this once
-	// there is an official image.
-	images.PodCheckpointer = "docker.io/autonomy/pod-checkpointer:51fba9528e96d3be488562574c288b2fb82a1e3b"
+	// Allow for overriding by users via config data
+	images.CoreDNS = config.Cluster().CoreDNS().Image()
+	images.PodCheckpointer = config.Cluster().PodCheckpointer().Image()
 
 	conf := asset.Config{
 		CACert:                 k8sCA,

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -24,6 +24,8 @@ type Cluster interface {
 	Etcd() Etcd
 	Network() Network
 	LocalAPIServerPort() int
+	PodCheckpointer() PodCheckpointer
+	CoreDNS() CoreDNS
 	ExtraManifestURLs() []string
 }
 
@@ -55,4 +57,16 @@ type Etcd interface {
 type Token interface {
 	ID() string
 	Secret() string
+}
+
+// PodCheckpointer defines the requirements for a config that pertains to bootkube
+// pod-checkpointer options.
+type PodCheckpointer interface {
+	Image() string
+}
+
+// CoreDNS defines the requirements for a config that pertains to bootkube
+// coredns options.
+type CoreDNS interface {
+	Image() string
 }

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/kubernetes-sigs/bootkube/pkg/asset"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/talos-systems/talos/pkg/config/cluster"
@@ -328,6 +329,24 @@ func (c *ClusterConfig) ExtraManifestURLs() []string {
 	return c.ExtraManifests
 }
 
+// PodCheckpointer implements the Configurator interface.
+func (c *ClusterConfig) PodCheckpointer() cluster.PodCheckpointer {
+	if c.PodCheckpointerConfig == nil {
+		return &PodCheckpointer{}
+	}
+
+	return c.PodCheckpointerConfig
+}
+
+// CoreDNS implements the Configurator interface.
+func (c *ClusterConfig) CoreDNS() cluster.CoreDNS {
+	if c.CoreDNSConfig == nil {
+		return &CoreDNS{}
+	}
+
+	return c.CoreDNSConfig
+}
+
 // Name implements the Configurator interface.
 func (c *CNIConfig) Name() string {
 	return c.CNIName
@@ -391,4 +410,26 @@ func (i *InstallConfig) Force() bool {
 // WithBootloader implements the Configurator interface.
 func (i *InstallConfig) WithBootloader() bool {
 	return i.InstallBootloader
+}
+
+// Image implements the Configurator interface.
+func (c *CoreDNS) Image() string {
+	coreDNSImage := asset.DefaultImages.CoreDNS
+
+	if c.CoreDNSImage != "" {
+		coreDNSImage = c.CoreDNSImage
+	}
+
+	return coreDNSImage
+}
+
+// Image implements the Configurator interface.
+func (p *PodCheckpointer) Image() string {
+	checkpointerImage := constants.PodCheckpointerImage
+
+	if p.PodCheckpointerImage != "" {
+		checkpointerImage = p.PodCheckpointerImage
+	}
+
+	return checkpointerImage
 }

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -265,6 +265,20 @@ type ClusterConfig struct {
 	//         image: ...
 	EtcdConfig *EtcdConfig `yaml:"etcd,omitempty"`
 	//   description: |
+	//     Pod Checkpointer specific configuration options.
+	//   examples:
+	//     - |
+	//       podCheckpointer:
+	//         image: ...
+	PodCheckpointerConfig *PodCheckpointer `yaml:"podCheckpointer,omitempty"`
+	//   description: |
+	//     Core DNS specific configuration options.
+	//   examples:
+	//     - |
+	//       coreDNS:
+	//         image: ...
+	CoreDNSConfig *CoreDNS `yaml:"coreDNS,omitempty"`
+	//   description: |
 	//     A list of urls that point to additional manifests.
 	//     These will get automatically deployed by bootkube.
 	//   examples:
@@ -399,6 +413,20 @@ type TimeConfig struct {
 	//
 	//     > Note: This parameter only supports a single time server
 	TimeServers []string `yaml:"servers,omitempty"`
+}
+
+// PodCheckpointer represents the pod-checkpointer config values
+type PodCheckpointer struct {
+	//   description: |
+	//     The `image` field is an override to the default pod-checkpointer image.
+	PodCheckpointerImage string `yaml:"image,omitempty"`
+}
+
+// CoreDNS represents the coredns config values
+type CoreDNS struct {
+	//   description: |
+	//     The `image` field is an override to the default coredns image.
+	CoreDNSImage string `yaml:"image,omitempty"`
 }
 
 // Endpoint struct holds the endpoint url parsed out of machine config.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -132,6 +132,11 @@ const (
 	// KubernetesImage is the enforced hyperkube image to use for the control plane.
 	KubernetesImage = "k8s.gcr.io/hyperkube"
 
+	// PodCheckpointerImage is the enforced pod checkpointer for bootkube to use
+	// TODO(andrewrynhard): This is a hack workaround for now. Update this once
+	// there is an official image.
+	PodCheckpointerImage = "docker.io/autonomy/pod-checkpointer:51fba9528e96d3be488562574c288b2fb82a1e3b"
+
 	// LabelNodeRoleMaster is the node label required by a control plane node.
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
 


### PR DESCRIPTION
This PR allows for pod checkpointer and coredns images to be customized
for bootkube. We can already customize the hyperkube image and all other
images used by bootkube are CNI-related and can be customized with the
"custom" CNI setup.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>