### PR TITLE
fix: install sequence stuck on event bus

### DIFF
--- a/internal/pkg/runtime/errors.go
+++ b/internal/pkg/runtime/errors.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package runtime
+
+import "errors"
+
+// ErrReboot is raised to initiate early reboot sequence via panic.
+var ErrReboot = errors.New("reboot")

--- a/internal/pkg/runtime/initializer/metal/metal.go
+++ b/internal/pkg/runtime/initializer/metal/metal.go
@@ -7,7 +7,6 @@ package metal
 import (
 	"errors"
 
-	"github.com/talos-systems/talos/internal/pkg/event"
 	"github.com/talos-systems/talos/internal/pkg/install"
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
@@ -36,11 +35,7 @@ func (b *Metal) Initialize(r runtime.Runtime) (err error) {
 			return err
 		}
 
-		event.Bus().Notify(event.Event{Type: event.Reboot})
-
-		// Prevent the task from returning to prevent the next phase from
-		// running.
-		select {}
+		panic(runtime.ErrReboot)
 	}
 
 	m := manager.NewManager(mountpoints)


### PR DESCRIPTION
machined's main.go waits for boot sequence to finish, while metal
platform initializer tries to send a message to the event bus without
any listeners, so this is pure deadlock.

Resolve that by panicking from initializer, this aborts phase and
sequence, and leads to reboot on panic. Not really clean as it leaves
scary stacktraces in the dmesg, but it works. Cleanup might be done by
introducing error value for reboot, and ignoring it when printing the
errors.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>