### PR TITLE
chore: update bootkube config to include cluster name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 replace (
 	github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
 	github.com/firecracker-microvm/firecracker-go-sdk v0.19.0 => github.com/smira/firecracker-go-sdk v0.19.1-0.20200110185541-4fce8cba9f84
-	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20200114174616-69b2e9624d84
+	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20200121212854-f29021689bee
 	github.com/opencontainers/runtime-spec v1.0.1 => github.com/opencontainers/runtime-spec v0.1.2-0.20180301181910-fa4b36aa9c99
 )
 

--- a/go.sum
+++ b/go.sum
@@ -524,8 +524,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/bootkube v0.14.1-0.20200114174616-69b2e9624d84 h1:KRx1oVRoUHA312/osjM0iFdCFG5mfI+mEzSRSMBoCNE=
-github.com/talos-systems/bootkube v0.14.1-0.20200114174616-69b2e9624d84/go.mod h1:zLrZfPQ49k0O6x6QN0pDSJn9iD0EMyj6J+5x1vqJSFw=
+github.com/talos-systems/bootkube v0.14.1-0.20200121212854-f29021689bee h1:Grx/Ut3pPr+ZaBF/TdqmeEw5RLuX7e0m93yMpSOth1E=
+github.com/talos-systems/bootkube v0.14.1-0.20200121212854-f29021689bee/go.mod h1:zLrZfPQ49k0O6x6QN0pDSJn9iD0EMyj6J+5x1vqJSFw=
 github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1LNzuMEs9Pw=
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -309,6 +309,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 	images.PodCheckpointer = config.Cluster().PodCheckpointer().Image()
 
 	conf := asset.Config{
+		ClusterName:            config.Cluster().Name(),
 		CACert:                 k8sCA,
 		CAPrivKey:              k8sKey,
 		EtcdCACert:             ca,

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -14,6 +14,7 @@ import (
 // Cluster defines the requirements for a config that pertains to cluster
 // related options.
 type Cluster interface {
+	Name() string
 	Endpoint() *url.URL
 	Token() Token
 	CertSANs() []string

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -182,6 +182,11 @@ func (k *KubeletConfig) ExtraMounts() []specs.Mount {
 	return nil
 }
 
+// Name implements the Configurator interface.
+func (c *ClusterConfig) Name() string {
+	return c.ClusterName
+}
+
 // Endpoint implements the Configurator interface.
 func (c *ClusterConfig) Endpoint() *url.URL {
 	return c.ControlPlane.Endpoint.URL


### PR DESCRIPTION
This PR will add the new cluster name field to our bootkube options.
This allows for the generated kubeconfig to include the context-name for
the default context.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>