### PR TITLE
docs: remove pre-release from v0.3 docs

### DIFF
--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -32,7 +32,7 @@ export default {
 
   data() {
     return {
-      options: [{ version: 'v0.3', url: '/docs/v0.3', prerelease: true }]
+      options: [{ version: 'v0.3', url: '/docs/v0.3', prerelease: false }]
     }
   },
 


### PR DESCRIPTION
This change updates the docs toggle menu to remove "pre-release" from
the v0.3 option.