### PR TITLE
feat: allow ability to customize containerd

### DIFF
--- a/docs/website/content/v0.3.en.json
+++ b/docs/website/content/v0.3.en.json
@@ -70,12 +70,16 @@
     "path": "v0.3/en/customization",
     "items": [
       {
-        "title": "Kernel",
-        "path": "v0.3/en/customization/kernel"
+        "title": "Containerd",
+        "path": "v0.3/en/customization/containerd"
       },
       {
         "title": "Corporate Proxy",
         "path": "v0.3/en/customization/proxy"
+      },
+      {
+        "title": "Kernel",
+        "path": "v0.3/en/customization/kernel"
       }
     ]
   },

--- a/docs/website/content/v0.3/en/customization/containerd.md
+++ b/docs/website/content/v0.3/en/customization/containerd.md
@@ -1,0 +1,33 @@
+---
+title: 'Customizing containerd'
+---
+
+We offer the ability to use custom configuration files for containerd.
+The base containerd configuration expects to merge in any additional configs present in `/var/cri/conf.d/*.toml`.
+
+## An example of exposing metrics
+
+Into each machine config, add the following:
+
+```yaml
+machine:
+  ...
+  files:
+    - content: |
+        [metrics]
+          address = "0.0.0.0:11234"
+      path: /var/cri/conf.d/metrics.toml
+      op: create
+```
+
+Create cluster like normal and see that metrics are now present on this port:
+
+```bash
+$ curl 127.0.0.1:11234/v1/metrics
+# HELP container_blkio_io_service_bytes_recursive_bytes The blkio io service bytes recursive
+# TYPE container_blkio_io_service_bytes_recursive_bytes gauge
+container_blkio_io_service_bytes_recursive_bytes{container_id="0677d73196f5f4be1d408aab1c4125cf9e6c458a4bea39e590ac779709ffbe14",device="/dev/dm-0",major="253",minor="0",namespace="k8s.io",op="Async"} 0
+container_blkio_io_service_bytes_recursive_bytes{container_id="0677d73196f5f4be1d408aab1c4125cf9e6c458a4bea39e590ac779709ffbe14",device="/dev/dm-0",major="253",minor="0",namespace="k8s.io",op="Discard"} 0
+...
+...
+```

--- a/hack/containerd.toml
+++ b/hack/containerd.toml
@@ -1,2 +1,4 @@
+imports = ["/var/cri/conf.d/*.toml"]
+
 [plugins.cri.containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"


### PR DESCRIPTION
This PR will allow for any toml files added into `/var/cri/conf.d` to be
picked up and parsed as a containerd config. This should allow users a
nice way to add additional configs by passing extra files in machine
config like:

```
machine:
  ...
  files:
    - content: |
        [metrics]
          address = "0.0.0.0:11234"
      path: /var/cri/conf.d/metrics.toml
      op: create
```

Will close #1718.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>