### PR TITLE
fix: correctly split lines with /dev/kmsg output

### DIFF
--- a/internal/app/machined/internal/phase/phase.go
+++ b/internal/app/machined/internal/phase/phase.go
@@ -146,7 +146,7 @@ func (r *Runner) runTask(task Task, errCh chan<- error) {
 				return
 			}
 
-			buf := make([]byte, 512) // using small buffer here, as kmsg has its limits
+			buf := make([]byte, 8192)
 			n := goruntime.Stack(buf, false)
 			err = fmt.Errorf("panic recovered: %v\n%s", r, string(buf[:n]))
 		}

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -7,6 +7,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
@@ -37,6 +38,8 @@ func RunInstallerContainer(r runtime.Runtime, opts ...Option) error {
 	if err != nil {
 		return err
 	}
+
+	log.Printf("pulling installer container image: %q", r.Config().Machine().Install().Image())
 
 	var img containerd.Image
 

--- a/internal/pkg/kmsg/kmsg.go
+++ b/internal/pkg/kmsg/kmsg.go
@@ -25,7 +25,7 @@ func Setup(prefix string, withLogFile bool) error {
 		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
 	}
 
-	var writer io.Writer = kmsg
+	var writer io.Writer = &Writer{KmsgWriter: kmsg}
 
 	if withLogFile {
 		if err := os.MkdirAll(constants.DefaultLogPath, 0700); err != nil {
@@ -39,7 +39,7 @@ func Setup(prefix string, withLogFile bool) error {
 			return fmt.Errorf("failed to open %s: %w", logPath, err)
 		}
 
-		writer = io.MultiWriter(kmsg, f)
+		writer = io.MultiWriter(writer, f)
 	}
 
 	log.SetOutput(writer)

--- a/internal/pkg/kmsg/writer.go
+++ b/internal/pkg/kmsg/writer.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kmsg
+
+import (
+	"bytes"
+	"io"
+)
+
+// MaxLineLength to be passed to kmsg, see https://github.com/torvalds/linux/blob/master/kernel/printk/printk.c#L450.
+const MaxLineLength = 1024 - 48
+
+// Writer ensures writes by line and limits each line to maxLineLength characters.
+//
+// This workarounds kmsg limits.
+type Writer struct {
+	KmsgWriter io.Writer
+}
+
+// Writer implements io.Writer interface.
+func (w *Writer) Write(p []byte) (n int, err error) {
+	// split writes by `\n`, and limit each line to MaxLineLength
+	for len(p) > 0 {
+		i := bytes.IndexByte(p, '\n')
+		if i == -1 {
+			i = len(p) - 1
+		}
+
+		line := p[:i+1]
+		if len(line) > MaxLineLength {
+			line = append(line[:MaxLineLength-4], []byte("...\n")...)
+		}
+
+		var nn int
+		nn, err = w.KmsgWriter.Write(line)
+
+		if nn == len(line) {
+			n += i + 1
+		} else {
+			n += nn
+		}
+
+		if err != nil {
+			return
+		}
+
+		p = p[i+1:]
+	}
+
+	return
+}

--- a/internal/pkg/kmsg/writer_test.go
+++ b/internal/pkg/kmsg/writer_test.go
@@ -1,0 +1,58 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kmsg_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/pkg/kmsg"
+)
+
+type fakeWriter struct {
+	lines [][]byte
+}
+
+func (w *fakeWriter) Write(p []byte) (n int, err error) {
+	w.lines = append(w.lines, append([]byte(nil), p...))
+
+	return len(p), nil
+}
+
+func TestWriter(t *testing.T) {
+	fakeW := &fakeWriter{}
+	kmsgW := &kmsg.Writer{KmsgWriter: fakeW}
+
+	n, err := kmsgW.Write([]byte("foo"))
+	assert.Equal(t, 3, n)
+	assert.NoError(t, err)
+
+	n, err = kmsgW.Write([]byte("bar\n"))
+	assert.Equal(t, 4, n)
+	assert.NoError(t, err)
+
+	n, err = kmsgW.Write([]byte("foo\nbar\n"))
+	assert.Equal(t, 8, n)
+	assert.NoError(t, err)
+
+	n, err = kmsgW.Write(append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength-1), '\n'))
+	assert.Equal(t, kmsg.MaxLineLength, n)
+	assert.NoError(t, err)
+
+	n, err = kmsgW.Write(append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength), '\n', 'a', 'b', '\n'))
+	assert.Equal(t, kmsg.MaxLineLength+4, n)
+	assert.NoError(t, err)
+
+	assert.Len(t, fakeW.lines, 7)
+	assert.Equal(t, fakeW.lines[0], []byte("foo"))
+	assert.Equal(t, fakeW.lines[1], []byte("bar\n"))
+	assert.Equal(t, fakeW.lines[2], []byte("foo\n"))
+	assert.Equal(t, fakeW.lines[3], []byte("bar\n"))
+	assert.Equal(t, fakeW.lines[4], append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength-1), '\n'))
+	assert.Equal(t, fakeW.lines[5], append(bytes.Repeat([]byte{0xce}, kmsg.MaxLineLength-4), '.', '.', '.', '\n'))
+	assert.Equal(t, fakeW.lines[6], []byte("ab\n"))
+}


### PR DESCRIPTION
This fixes cases when large `log.Printf()` was simply lost as it exceeds
max line length (despite being multi-line string with each line below
1KB). Now console logging should be much more reliable.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>