### PR TITLE
fix: parse correctly kernel command line missing DNS config 

### DIFF
--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -225,10 +225,13 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 		// case 6:
 		// Primary DNS Resolver
 		case 7:
-			resolvers = append(resolvers, net.ParseIP(field))
+			fallthrough
 		// Secondary DNS Resolver
 		case 8:
-			resolvers = append(resolvers, net.ParseIP(field))
+			nameserverIP := net.ParseIP(field)
+			if nameserverIP != nil {
+				resolvers = append(resolvers, nameserverIP)
+			}
 		}
 	}
 	// NTP server

--- a/internal/app/networkd/pkg/networkd/netconf_test.go
+++ b/internal/app/networkd/pkg/networkd/netconf_test.go
@@ -52,6 +52,22 @@ func (suite *NetconfSuite) TestKernelNetconf() {
 	suite.Assert().Equal(len(addr.Routes()), 1)
 }
 
+func (suite *NetconfSuite) TestKernelNetconfIncomplete() {
+	name, opts := buildKernelOptions("1.1.1.1::3.3.3.3:255.255.255.0::eth0:none:::")
+
+	iface, err := nic.New(opts...)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(iface.Name, name)
+	suite.Assert().Equal(len(iface.AddressMethod), 1)
+	addr := iface.AddressMethod[0]
+	suite.Assert().Equal(addr.Name(), "static")
+	suite.Assert().Equal(addr.Hostname(), "")
+	suite.Assert().Equal(addr.Address().IP, net.ParseIP("1.1.1.1"))
+	suite.Assert().Len(addr.Resolvers(), 0)
+	suite.Assert().Equal(len(addr.Routes()), 1)
+}
+
 func sampleConfig() []machine.Device {
 	return []machine.Device{
 		{


### PR DESCRIPTION
If nameserver is missing, `net.ParseIP` parses it as `nil` `net.IP` and
later on this `<nil>` address is pushed to `resolv.conf`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>