### PR TITLE
chore: rework firecracker code around upstream Go SDK + PRs

### DIFF
--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -31,6 +31,7 @@ osctl cluster create [flags]
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
       --mtu int                     MTU of the docker bridge network (default 1500)
+      --nameservers strings         list of nameservers to use (VM only) (default [8.8.8.8,1.1.1.1])
       --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --wait                        wait for the cluster to be ready before returning
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 replace (
 	github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
-	github.com/firecracker-microvm/firecracker-go-sdk v0.19.0 => github.com/smira/firecracker-go-sdk v0.19.1-0.20200110185541-4fce8cba9f84
+	github.com/firecracker-microvm/firecracker-go-sdk v0.19.0 => github.com/smira/firecracker-go-sdk v0.19.1-0.20200124123725-fb8b25794e34
 	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20200123150754-82cbbbe2c4de
 	github.com/opencontainers/runtime-spec v1.0.1 => github.com/opencontainers/runtime-spec v0.1.2-0.20180301181910-fa4b36aa9c99
 )

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/smira/firecracker-go-sdk v0.19.1-0.20200110185541-4fce8cba9f84 h1:PNu2CXmtEYf8o56YXuRt92lMQT0OuCMnHdmKobGRX+A=
-github.com/smira/firecracker-go-sdk v0.19.1-0.20200110185541-4fce8cba9f84/go.mod h1:kW0gxvPpPvMukUxxTO9DrpSlScrtrTDGY3VgjAj/Qwc=
+github.com/smira/firecracker-go-sdk v0.19.1-0.20200124123725-fb8b25794e34 h1:Tgxf84uXZM2R+NSFX1TVWlHw3Ka7SM39/NMmUZTG92U=
+github.com/smira/firecracker-go-sdk v0.19.1-0.20200124123725-fb8b25794e34/go.mod h1:kW0gxvPpPvMukUxxTO9DrpSlScrtrTDGY3VgjAj/Qwc=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c h1:gqEdF4VwBu3lTKGHS9rXE9x1/pEaSwCXRLOZRF6qtlw=

--- a/internal/pkg/provision/providers/docker/docker.go
+++ b/internal/pkg/provision/providers/docker/docker.go
@@ -42,6 +42,6 @@ func (p *provisioner) Close() error {
 }
 
 // GenOptions provides a list of additional config generate options.
-func (p *provisioner) GenOptions() []generate.GenOption {
+func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.GenOption {
 	return nil
 }

--- a/internal/pkg/provision/providers/firecracker/firecracker.go
+++ b/internal/pkg/provision/providers/firecracker/firecracker.go
@@ -9,6 +9,8 @@ import (
 	"context"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
+	"github.com/talos-systems/talos/pkg/config/machine"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
 
@@ -30,8 +32,23 @@ func (p *provisioner) Close() error {
 }
 
 // GenOptions provides a list of additional config generate options.
-func (p *provisioner) GenOptions() []generate.GenOption {
+func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.GenOption {
+	nameservers := make([]string, len(networkReq.Nameservers))
+	for i := range nameservers {
+		nameservers[i] = networkReq.Nameservers[i].String()
+	}
+
 	return []generate.GenOption{
 		generate.WithInstallDisk("/dev/vda"),
+		generate.WithNetworkConfig(&v1alpha1.NetworkConfig{
+			NameServers: nameservers,
+			NetworkInterfaces: []machine.Device{
+				{
+					Interface: "eth0",
+					CIDR:      "169.254.128.128/32", // link-local IP just to trigger the static networkd config
+					MTU:       networkReq.MTU,
+				},
+			},
+		}),
 	}
 }

--- a/internal/pkg/provision/providers/firecracker/launch.go
+++ b/internal/pkg/provision/providers/firecracker/launch.go
@@ -88,6 +88,9 @@ func Launch() error {
 			WithStderr(os.Stderr).
 			Build(ctx)
 
+		// reset static configuration, as it gets set each time CNI runs
+		config.FirecrackerConfig.NetworkInterfaces[0].StaticConfiguration = nil
+
 		m, err := firecracker.NewMachine(ctx, config.FirecrackerConfig, firecracker.WithProcessRunner(cmd))
 		if err != nil {
 			return fmt.Errorf("failed to create new machine: %w", err)

--- a/internal/pkg/provision/providers/firecracker/state.go
+++ b/internal/pkg/provision/providers/firecracker/state.go
@@ -7,6 +7,8 @@ package firecracker
 import (
 	"fmt"
 
+	"github.com/containernetworking/cni/libcni"
+
 	"github.com/talos-systems/talos/internal/pkg/provision"
 )
 
@@ -16,7 +18,8 @@ type state struct {
 
 	ClusterInfo provision.ClusterInfo
 
-	statePath string
+	vmCNIConfig *libcni.NetworkConfigList
+	statePath   string
 }
 
 func (s *state) Provisioner() string {

--- a/internal/pkg/provision/provision.go
+++ b/internal/pkg/provision/provision.go
@@ -18,7 +18,7 @@ type Provisioner interface {
 
 	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)
 
-	GenOptions() []generate.GenOption
+	GenOptions(NetworkRequest) []generate.GenOption
 
 	Close() error
 }

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -44,6 +44,7 @@ type NetworkRequest struct {
 	CIDR        net.IPNet
 	GatewayAddr net.IP
 	MTU         int
+	Nameservers []net.IP
 
 	// CNI-specific parameters.
 	CNI CNIConfig

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -19,7 +19,7 @@ func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
 		MachineCA:       in.Certs.OS,
 		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
-		MachineNetwork:  &v1alpha1.NetworkConfig{},
+		MachineNetwork:  in.NetworkConfig,
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -81,6 +81,8 @@ type Input struct {
 
 	InstallDisk  string
 	InstallImage string
+
+	NetworkConfig *v1alpha1.NetworkConfig
 }
 
 // GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
@@ -299,6 +301,10 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 
 	additionalSubjectAltNames = append(additionalSubjectAltNames, options.AdditionalSubjectAltNames...)
 
+	if options.NetworkConfig == nil {
+		options.NetworkConfig = &v1alpha1.NetworkConfig{}
+	}
+
 	input = &Input{
 		Certs:                     certs,
 		ControlPlaneEndpoint:      endpoint,
@@ -313,6 +319,7 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 		AdditionalMachineCertSANs: additionalMachineCertSANs,
 		InstallDisk:               options.InstallDisk,
 		InstallImage:              options.InstallImage,
+		NetworkConfig:             options.NetworkConfig,
 	}
 
 	return input, nil

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -16,7 +16,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "init",
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
-		MachineNetwork:  &v1alpha1.NetworkConfig{},
+		MachineNetwork:  in.NetworkConfig,
 		MachineCA:       in.Certs.OS,
 		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineToken:    in.TrustdInfo.Token,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -19,7 +19,7 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 		MachineToken:    in.TrustdInfo.Token,
 		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
-		MachineNetwork:  &v1alpha1.NetworkConfig{},
+		MachineNetwork:  in.NetworkConfig,
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -4,6 +4,8 @@
 
 package generate
 
+import v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+
 // GenOption controls generate options specific to input generation.
 type GenOption func(o *GenOptions) error
 
@@ -43,12 +45,22 @@ func WithInstallImage(imageRef string) GenOption {
 	}
 }
 
+// WithNetworkConfig allows to pass network config to be used.
+func WithNetworkConfig(network *v1alpha1.NetworkConfig) GenOption {
+	return func(o *GenOptions) error {
+		o.NetworkConfig = network
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
 	InstallDisk               string
 	InstallImage              string
 	AdditionalSubjectAltNames []string
+	NetworkConfig             *v1alpha1.NetworkConfig
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -203,9 +203,6 @@ const (
 	// CRIContainerdConfig is the path to the config for the containerd instance that provides the CRI.
 	CRIContainerdConfig = "/etc/cri/containerd.toml"
 
-	// TalosDirectoryEnvVar is the environment variable for setting the Talos directory path.
-	TalosDirectoryEnvVar = "TALOSDIR"
-
 	// TalosConfigEnvVar is the environment variable for setting the Talos configuration file path.
 	TalosConfigEnvVar = "TALOSCONFIG"
 

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -24,7 +24,7 @@ func IPAddrs() (ips []net.IP, err error) {
 	}
 
 	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.IsGlobalUnicast() {
 			if ipnet.IP.To4() != nil {
 				ips = append(ips, ipnet.IP)
 			}


### PR DESCRIPTION
This removes use of private fork with custom `ip=` kernel argument
handling and switches fully to upstream version of it.

Firecracker Go SDK version is `master` + following PRs:

* https://github.com/firecracker-microvm/firecracker-go-sdk/pull/167
* https://github.com/firecracker-microvm/firecracker-go-sdk/pull/177
* https://github.com/firecracker-microvm/firecracker-go-sdk/pull/178

MTU handling support was implemented as well.

Changes:

* hostname to each node is passed via `talos.hostname=` kernel arg
* IP configuration is generated by SDK from CNI result
* fixed bugs with wrong netmask
* nameservers & MTU is passed via Talos config
* network CNI config is now not written to disk (no need to clean it up)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>