### PR TITLE
chore: remove Firecracker bridge interface in osctl cluster destroy

### DIFF
--- a/internal/pkg/provision/providers/firecracker/destroy.go
+++ b/internal/pkg/provision/providers/firecracker/destroy.go
@@ -28,6 +28,17 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
+	fmt.Fprintln(options.LogWriter, "removing network")
+
+	state, ok := cluster.(*state)
+	if !ok {
+		return fmt.Errorf("error inspecting firecracker state, %#+v", cluster)
+	}
+
+	if err := p.destroyNetwork(state); err != nil {
+		return err
+	}
+
 	fmt.Fprintln(options.LogWriter, "removing state directory")
 
 	stateDirectoryPath, err := cluster.StatePath()


### PR DESCRIPTION
Cleaning things up so that IP network can be re-used with another
network name (and inteface name).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>