### PR TITLE
fix: implement kubelet extra mounts

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -558,6 +558,25 @@ extraArgs:
 
 ```
 
+#### extraMounts
+
+The `extraMounts` field is used to add additional mounts to the kubelet container.
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraMounts:
+  - source: /var/lib/example
+    destination: /var/lib/example
+    type: bind
+    options:
+      - rshared
+      - ro
+
+```
+
 ---
 
 ### NetworkConfig

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -179,7 +179,7 @@ func (k *KubeletConfig) ExtraArgs() map[string]string {
 
 // ExtraMounts implements the Configurator interface.
 func (k *KubeletConfig) ExtraMounts() []specs.Mount {
-	return nil
+	return k.KubeletExtraMounts
 }
 
 // Name implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -9,6 +9,8 @@ package v1alpha1
 import (
 	"net/url"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
@@ -303,6 +305,18 @@ type KubeletConfig struct {
 	//       extraArgs:
 	//         key: value
 	KubeletExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+	//   description: |
+	//     The `extraMounts` field is used to add additional mounts to the kubelet container.
+	//   examples:
+	//     - |
+	//       extraMounts:
+	//         - source: /var/lib/example
+	//           destination: /var/lib/example
+	//           type: bind
+	//           options:
+	//             - rshared
+	//             - ro
+	KubeletExtraMounts []specs.Mount `yaml:"extraMounts,omitempty"`
 }
 
 // NetworkConfig reperesents the machine's networking config values.


### PR DESCRIPTION
This implements old behavior from our initial config that allows for
specifying extra mounts for the kubelet container.