### PR TITLE
docs: remove invalid field from docs

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -230,7 +230,6 @@ Examples:
 ```yaml
 install:
   disk:
-  extraDiskArgs:
   extraKernelArgs:
   image:
   bootloader:

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -118,7 +118,6 @@ type MachineConfig struct {
 	//     - |
 	//       install:
 	//         disk:
-	//         extraDiskArgs:
 	//         extraKernelArgs:
 	//         image:
 	//         bootloader:


### PR DESCRIPTION
This removes `extraDiskArgs` from the kubelet configuration field. This
never really was a thing.