### PR TITLE
fix: follow symlinks

### DIFF
--- a/pkg/archiver/walker.go
+++ b/pkg/archiver/walker.go
@@ -55,9 +55,16 @@ func Walker(ctx context.Context, rootPath string, options ...WalkerOption) (<-ch
 		o(&opts)
 	}
 
-	_, err := os.Stat(rootPath)
+	info, err := os.Lstat(rootPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+		rootPath, err = filepath.EvalSymlinks(rootPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	ch := make(chan FileItem)


### PR DESCRIPTION
This fixes the list API to check if the requested path is a symlink, and
to follow the symlink if so.

Fixes #1823.