### PR TITLE
feat(networkd): Make healthcheck perform a check

### DIFF
--- a/internal/app/networkd/pkg/reg/reg_test.go
+++ b/internal/app/networkd/pkg/reg/reg_test.go
@@ -118,7 +118,9 @@ func (suite *NetworkdSuite) TestHealthAPI() {
 	nClient := healthapi.NewHealthClient(conn)
 	hcResp, err := nClient.Check(context.Background(), &empty.Empty{})
 	suite.Assert().NoError(err)
-	suite.Assert().Equal(healthapi.HealthCheck_SERVING, hcResp.Messages[0].Status)
+	// Can only check against unknown since its not guaranteed that
+	// the host the tests will run on will have an arp table populated.
+	suite.Assert().NotEqual(healthapi.HealthCheck_UNKNOWN, hcResp.Messages[0].Status)
 
 	rResp, err := nClient.Ready(context.Background(), &empty.Empty{})
 	suite.Assert().NoError(err)
@@ -139,7 +141,7 @@ func (suite *NetworkdSuite) TestHealthAPI() {
 	for i := 0; i < 2; i++ {
 		hcResp, err = stream.Recv()
 		suite.Assert().NoError(err)
-		suite.Assert().Equal(healthapi.HealthCheck_SERVING, hcResp.Messages[0].Status)
+		suite.Assert().NotEqual(healthapi.HealthCheck_UNKNOWN, hcResp.Messages[0].Status)
 	}
 
 	cancel()


### PR DESCRIPTION
This implements an actual health check for networkd. We use the arp table ( ip neighbors )
to determine if the machine is actively sending traffic. We should see at least one entry
with a REACHABLE state during normal operating conditions.

Signed-off-by: Brad Beam <brad.beam@talos-systems.com>