### PR TITLE
chore: update capi-upstream

### DIFF
--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -9,7 +9,7 @@ export KUBECONFIG="/tmp/e2e/docker/kubeconfig"
 
 # CAPI
 
-export CAPI_VERSION="0.2.6"
+export CAPI_VERSION="0.2.9"
 export CAPI_COMPONENTS="https://github.com/kubernetes-sigs/cluster-api/releases/download/v${CAPI_VERSION}/cluster-api-components.yaml"
 
 # CABPT


### PR DESCRIPTION
This PR will bring in the latest v1alpha2-supporting release of the upstream capi provider

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>