### PR TITLE
chore: provide provisioned cluster info to integration test

### DIFF
--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -13,11 +13,14 @@ case "${CI:-false}" in
     ;;
 esac
 
+PROVISIONER=docker
+CLUSTER_NAME=e2e-${PROVISIONER}
+
 function create_cluster {
   "${OSCTL}" cluster create \
-    --provisioner docker \
+    --provisioner "${PROVISIONER}" \
+    --name "${CLUSTER_NAME}" \
     --image "${IMAGE}" \
-    --name e2e-docker \
     --masters=3 \
     --mtu 1500 \
     --memory 2048 \

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -4,10 +4,13 @@ set -eou pipefail
 
 source ./hack/test/e2e.sh
 
+PROVISIONER=firecracker
+CLUSTER_NAME=e2e-${PROVISIONER}
+
 function create_cluster {
   "${OSCTL}" cluster create \
-    --provisioner firecracker \
-    --name e2e-firecracker \
+    --provisioner "${PROVISIONER}" \
+    --name "${CLUSTER_NAME}" \
     --masters=3 \
     --mtu 1500 \
     --memory 2048 \

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -31,6 +31,10 @@ export NAME_PREFIX="talos-e2e-${SHA}-${PLATFORM}"
 export TIMEOUT=1200
 export NUM_NODES=6
 
+# default values, overridden by osctl cluster create tests
+PROVISIONER=
+CLUSTER_NAME=
+
 cleanup_capi() {
   ${KUBECTL} --kubeconfig /tmp/e2e/docker/kubeconfig delete cluster ${NAME_PREFIX}
 }
@@ -90,11 +94,11 @@ function create_cluster_capi {
 }
 
 function run_talos_integration_test {
-  "${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}"
+  "${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}" -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}"
 }
 
 function run_talos_integration_test_docker {
-  "${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}" -talos.k8sendpoint ${ENDPOINT}:6443
+  "${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}" -talos.k8sendpoint ${ENDPOINT}:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}"
 }
 
 function run_kubernetes_integration_test {

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -48,7 +48,7 @@ func (apiSuite *APISuite) SetupSuite() {
 // DiscoverNodes provides list of Talos nodes in the cluster.
 //
 // As there's no way to provide this functionality via Talos API, it works the following way:
-// 1. If there's a provided list of nodes, it's used.
+// 1. If there's a provided cluster info, it's used.
 // 2. If integration test was compiled with k8s support, k8s is used.
 func (apiSuite *APISuite) DiscoverNodes() []string {
 	discoveredNodes := apiSuite.TalosSuite.DiscoverNodes()

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -7,14 +7,18 @@
 // Package base provides shared definition of base suites for tests
 package base
 
+import (
+	"github.com/talos-systems/talos/internal/pkg/provision"
+)
+
 // TalosSuite defines most common settings for integration test suites
 type TalosSuite struct {
 	// Endpoint to use to connect, if not set config is used
 	Endpoint string
 	// K8sEndpoint is API server endpoint, if set overrides kubeconfig
 	K8sEndpoint string
-	// Nodes is a list of Talos cluster addresses (overrides discovery if set)
-	Nodes []string
+	// Cluster describes provisioned cluster, used for discovery purposes
+	Cluster provision.Cluster
 	// TalosConfig is a path to talosconfig
 	TalosConfig string
 	// Version is the (expected) version of Talos tests are running against
@@ -30,8 +34,10 @@ type TalosSuite struct {
 // This method is overridden in specific suites to allow for specific discovery.
 func (talosSuite *TalosSuite) DiscoverNodes() []string {
 	if talosSuite.discoveredNodes == nil {
-		if talosSuite.Nodes != nil {
-			talosSuite.discoveredNodes = talosSuite.Nodes
+		if talosSuite.Cluster != nil {
+			for _, node := range talosSuite.Cluster.Info().Nodes {
+				talosSuite.discoveredNodes = append(talosSuite.discoveredNodes, node.PrivateIP.String())
+			}
 		}
 	}
 

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -23,6 +23,21 @@ type CLISuite struct {
 	TalosSuite
 }
 
+// DiscoverNodes provides list of Talos nodes in the cluster.
+//
+// As there's no way to provide this functionality via Talos CLI, it relies on cluster info.
+func (cliSuite *CLISuite) DiscoverNodes() []string {
+	discoveredNodes := cliSuite.TalosSuite.DiscoverNodes()
+	if discoveredNodes != nil {
+		return discoveredNodes
+	}
+
+	// still no nodes, skip the test
+	cliSuite.T().Skip("no nodes were discovered")
+
+	return nil
+}
+
 func (cliSuite *CLISuite) buildOsctlCmd(args []string) *exec.Cmd {
 	// TODO: add support for calling `osctl config endpoint` before running osctl
 


### PR DESCRIPTION
Integration test can optionally consume cluster state as generated by
the call to `osctl cluster create` and use it to discover nodes in
integration tests.

This means that now CLI tests can use that as discovery source, and
API/K8s tests by default as well.

Flat list of nodes is to be replaced by something more complex in the
next iteration, but it's good for this PR.

As a demo, add CLI test with multiple nodes (dmesg).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>