### PR TITLE
chore: implement reboot test

### DIFF
--- a/cmd/osctl/cmd/read.go
+++ b/cmd/osctl/cmd/read.go
@@ -34,6 +34,8 @@ var readCmd = &cobra.Command{
 				return fmt.Errorf("error reading file: %w", err)
 			}
 
+			defer r.Close() //nolint: errcheck
+
 			var wg sync.WaitGroup
 
 			wg.Add(1)
@@ -51,7 +53,7 @@ var readCmd = &cobra.Command{
 				return fmt.Errorf("error reading: %w", err)
 			}
 
-			return nil
+			return r.Close()
 		})
 	},
 }

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -533,7 +533,7 @@ func (c *Client) TimeCheck(ctx context.Context, server string, callOptions ...gr
 }
 
 // Read reads a file.
-func (c *Client) Read(ctx context.Context, path string) (io.Reader, <-chan error, error) {
+func (c *Client) Read(ctx context.Context, path string) (io.ReadCloser, <-chan error, error) {
 	stream, err := c.MachineClient.Read(ctx, &machineapi.ReadRequest{Path: path})
 	if err != nil {
 		return nil, nil, err

--- a/internal/app/machined/internal/api/reg/reg.go
+++ b/internal/app/machined/internal/api/reg/reg.go
@@ -78,7 +78,9 @@ func (r *Registrator) Register(s *grpc.Server) {
 // Reboot implements the machineapi.MachineServer interface.
 func (r *Registrator) Reboot(ctx context.Context, in *empty.Empty) (reply *machineapi.RebootResponse, err error) {
 	reply = &machineapi.RebootResponse{
-		Messages: []*machineapi.Reboot{},
+		Messages: []*machineapi.Reboot{
+			{},
+		},
 	}
 
 	log.Printf("reboot via API received")
@@ -90,7 +92,9 @@ func (r *Registrator) Reboot(ctx context.Context, in *empty.Empty) (reply *machi
 // Shutdown implements the machineapi.MachineServer interface.
 func (r *Registrator) Shutdown(ctx context.Context, in *empty.Empty) (reply *machineapi.ShutdownResponse, err error) {
 	reply = &machineapi.ShutdownResponse{
-		Messages: []*machineapi.Shutdown{},
+		Messages: []*machineapi.Shutdown{
+			{},
+		},
 	}
 
 	log.Printf("shutdown via API received")
@@ -135,7 +139,9 @@ func (r *Registrator) Reset(ctx context.Context, in *empty.Empty) (data *machine
 	}
 
 	return &machineapi.ResetResponse{
-		Messages: []*machineapi.Reset{},
+		Messages: []*machineapi.Reset{
+			{},
+		},
 	}, err
 }
 

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -1,0 +1,131 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_api
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"time"
+
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
+	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/retry"
+)
+
+type RebootSuite struct {
+	base.APISuite
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+// SuiteName ...
+func (suite *RebootSuite) SuiteName() string {
+	return "api.RebootSuite"
+}
+
+// SetupTest ...
+func (suite *RebootSuite) SetupTest() {
+	// make sure we abort at some point in time, but give enough room for reboots
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 30*time.Minute)
+}
+
+// TearDownTest ...
+func (suite *RebootSuite) TearDownTest() {
+	suite.ctxCancel()
+}
+
+func (suite *RebootSuite) readUptime(ctx context.Context) (float64, error) {
+	reader, errCh, err := suite.Client.Read(ctx, "/proc/uptime")
+	if err != nil {
+		return 0, err
+	}
+
+	defer reader.Close() //nolint: errcheck
+
+	var uptime float64
+
+	n, err := fmt.Fscanf(reader, "%f", &uptime)
+	if err != nil {
+		return 0, err
+	}
+
+	if n != 1 {
+		return 0, fmt.Errorf("not all fields scanned: %d", n)
+	}
+
+	_, err = io.Copy(ioutil.Discard, reader)
+	if err != nil {
+		return 0, err
+	}
+
+	for err = range errCh {
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return uptime, reader.Close()
+}
+
+// TestRebootNodeByNode reboots cluster node by node, waiting for health between reboots.
+func (suite *RebootSuite) TestRebootNodeByNode() {
+	if !suite.Capabilities().SupportsReboot {
+		suite.T().Skip("cluster doesn't support reboots")
+	}
+
+	nodes := suite.DiscoverNodes()
+	suite.Require().NotEmpty(nodes)
+
+	for _, node := range nodes {
+		suite.T().Log("rebooting node", node)
+
+		func(node string) {
+			// timeout for single node reboot
+			ctx, ctxCancel := context.WithTimeout(suite.ctx, 5*time.Minute)
+			defer ctxCancel()
+
+			nodeCtx := client.WithNodes(ctx, node)
+
+			// read uptime before reboot
+			uptimeBefore, err := suite.readUptime(nodeCtx)
+			suite.Require().NoError(err)
+
+			suite.Assert().NoError(suite.Client.Reboot(nodeCtx))
+
+			var uptimeAfter float64
+
+			suite.Require().NoError(retry.Constant(3 * time.Minute).Retry(func() error {
+				uptimeAfter, err = suite.readUptime(nodeCtx)
+				if err != nil {
+					// API might be unresponsive during reboot
+					return retry.ExpectedError(err)
+				}
+
+				if uptimeAfter >= uptimeBefore {
+					// uptime should go down after reboot
+					return retry.ExpectedError(fmt.Errorf("uptime didn't go down: before %f, after %f", uptimeBefore, uptimeAfter))
+				}
+
+				return nil
+			}))
+
+			if suite.Cluster != nil {
+				// without cluster state we can't do deep checks, but basic reboot test still works
+				// NB: using `ctx` here to have client talking to init node by default
+				suite.AssertClusterHealthy(ctx)
+			}
+		}(node)
+
+	}
+}
+
+func init() {
+	allSuites = append(allSuites, new(RebootSuite))
+}

--- a/internal/integration/k8s/version.go
+++ b/internal/integration/k8s/version.go
@@ -7,13 +7,11 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/talos-systems/talos/internal/integration/base"
-	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -36,10 +34,7 @@ func (suite *VersionSuite) TestExpectedVersion() {
 	expectedApiServerVersion := fmt.Sprintf("v%s", constants.DefaultKubernetesVersion)
 	suite.Assert().Equal(expectedApiServerVersion, apiServerVersion.GitVersion)
 
-	v, err := suite.Client.Version(context.Background())
-	suite.Require().NoError(err)
-
-	checkKernelVersion := v.Messages[0].Platform != nil && v.Messages[0].Platform.Mode != runtime.Container.String()
+	checkKernelVersion := suite.Capabilities().RunsTalosKernel
 
 	// verify each node (kubelet version, Talos version, etc.)
 	nodes, err := suite.Clientset.CoreV1().Nodes().List(metav1.ListOptions{})

--- a/internal/pkg/provision/check/default.go
+++ b/internal/pkg/provision/check/default.go
@@ -25,7 +25,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		// wait for bootkube to finish on init node
 		func(cluster provision.ClusterAccess) conditions.Condition {
 			return conditions.PollingCondition("bootkube to finish", func(ctx context.Context) error {
-				return ServiceStateAssertion(ctx, cluster, "bootkube", "Finished")
+				return ServiceStateAssertion(ctx, cluster, "bootkube", "Finished", "Skipped")
 			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for apid to be ready on all the nodes

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/talos-systems/talos/cmd/osctl/pkg/client"
 	"github.com/talos-systems/talos/cmd/osctl/pkg/client/config"
 )
 
@@ -41,10 +42,20 @@ func WithTalosConfig(talosConfig *config.Config) Option {
 	}
 }
 
+// WithTalosClient specifies client to use when acessing Talos cluster.
+func WithTalosClient(client *client.Client) Option {
+	return func(o *Options) error {
+		o.TalosClient = client
+
+		return nil
+	}
+}
+
 // Options describes Provisioner parameters.
 type Options struct {
 	LogWriter     io.Writer
 	TalosConfig   *config.Config
+	TalosClient   *client.Client
 	ForceEndpoint string
 }
 


### PR DESCRIPTION
Reboot test does node-by-node reboots followed by cluster health checks
(same as done by provisioner).

Fixed bug with `Read()` returning `Reader` instead of `ReadCloser`
(minor).

Allowed `bootkube` to be `Skipped` (for rebooted node).

Added support for doing checks via provided client instance.

Implemented generic capabilities to skip tests based on cluster
platform.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>