### PR TITLE
fix: bind etcd to IPv6 if available

### DIFF
--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -218,7 +218,7 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 
 	var loopback, podNet, serviceNet string
 
-	if isIPv6(endpoint) {
+	if tnet.IsIPv6(net.ParseIP(endpoint)) {
 		loopback = "::1"
 		podNet = DefaultIPv6PodNet
 		serviceNet = DefaultIPv6ServiceNet
@@ -379,16 +379,4 @@ func genToken(lenFirst int, lenSecond int) (string, error) {
 	}
 
 	return tokenTemp[0] + "." + tokenTemp[1], nil
-}
-
-func isIPv6(addrs ...string) bool {
-	for _, a := range addrs {
-		if ip := net.ParseIP(a); ip != nil {
-			if ip.To4() == nil {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -118,3 +118,21 @@ func DomainName() (domainname string, err error) {
 
 	return strings.TrimSuffix(domainname, "\n"), nil
 }
+
+// IsIPv6 indicates whether any IP address within the provided set is an IPv6
+// address
+func IsIPv6(addrs ...net.IP) bool {
+	for _, a := range addrs {
+		if a == nil || a.IsLoopback() || a.IsUnspecified() {
+			continue
+		}
+
+		if a.To4() == nil {
+			if a.To16() != nil {
+				return true
+			}
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
If an IPv6 address is available, etcd should bind to `[::]` instead of
`0.0.0.0`.  This will cause etcd to listen on both IPv4 and IPv6
interfaces.

Additionally, this fixes the SAN list for the etcd certificate
generation to include the FQDN of the host.

Fixes #1842
Fixes #1843

Signed-off-by: Seán C McCord <ulexus@gmail.com>