### PR TITLE
chore: enable slash commands in github PRs

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,45 @@
+name: Check OK To Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_ok_to_test:
+    runs-on: ubuntu-latest
+    name: "Check comments for /test"
+    steps:
+      - name: Check for test slash command
+        uses: xt0rted/slash-command-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: "test"
+          permission-level: "write"
+          reaction: "true"
+          reaction-type: "rocket"
+
+      - uses: actions/checkout@master
+
+      - name: Apply ok-to-test Label
+        uses: actions/github@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: label ok-to-test
+
+      - name: Retrigger drone
+        run: |
+          ## Fetch PR number and github status URL
+          PULL_NUMBER=$(jq -r .issue.number "$GITHUB_EVENT_PATH")
+          PR_INFO=$(curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER")
+          STATUS_URL=$(echo $PR_INFO | jq -r .statuses_url)
+
+          ## Discover previous drone build number and send it a post to retrigger
+          DRONE_BUILD_URL=$(curl -s $STATUS_URL | jq -r .[0].target_url )
+          DRONE_BUILD_NUM=${DRONE_BUILD_URL##*/}
+
+          docker run -e "DRONE_SERVER=$DRONE_SERVER" -e "DRONE_TOKEN=$DRONE_TOKEN" drone/cli:1.2.1 build restart $GITHUB_REPOSITORY $DRONE_BUILD_NUM
+        env:
+          GITHUB_EVENT_PATH: $GITHUB_EVENT_PATH
+          DRONE_SERVER: "https://ci.dev.talos-systems.io"
+          DRONE_TOKEN: ${{ secrets.DRONE_TOKEN }}

--- a/.github/workflows/promote-e2e.yml
+++ b/.github/workflows/promote-e2e.yml
@@ -1,0 +1,46 @@
+name: Promote E2E
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  check_ok_to_test:
+    runs-on: ubuntu-latest
+    name: "Check comments for /e2e"
+    steps:
+      - name: Check for test slash command
+        uses: xt0rted/slash-command-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: "e2e"
+          permission-level: "write"
+          reaction: "true"
+          reaction-type: "rocket"
+
+      - name: Checkout repo
+        uses: actions/checkout@master
+
+      - name: Apply ok-to-test Label
+        uses: actions/github@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: label needs-e2e
+
+      - name: Retrigger drone
+        run: |
+          ## Fetch PR number and github status URL
+          PULL_NUMBER=$(jq -r .issue.number "$GITHUB_EVENT_PATH")
+          PR_INFO=$(curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER")
+          STATUS_URL=$(echo $PR_INFO | jq -r .statuses_url)
+
+          ## Discover previous drone build number and send it a post to promote
+          DRONE_BUILD_URL=$(curl -s $STATUS_URL | jq -r .[0].target_url )
+          DRONE_BUILD_NUM=${DRONE_BUILD_URL##*/}
+
+          docker run  -e "DRONE_SERVER=$DRONE_SERVER" -e "DRONE_TOKEN=$DRONE_TOKEN" drone/cli:1.2.1 build promote $GITHUB_REPOSITORY $DRONE_BUILD_NUM e2e
+        env:
+          GITHUB_EVENT_PATH: $GITHUB_EVENT_PATH
+          DRONE_SERVER: "https://ci.dev.talos-systems.io"
+          DRONE_TOKEN: ${{ secrets.DRONE_TOKEN }}


### PR DESCRIPTION
This PR will allow us to start building out checks for slash commands,
with /test and /e2e both supported initially. I'll eventually want some
dashes in those commands, but they're not supported in the upstream
regex yet. I'll PR that later.