### PR TITLE
chore: support slash commands in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,11 @@ platform:
   arch: amd64
 
 steps:
+- name: ok-to-test
+  image: autonomy/build-container:latest
+  commands:
+  - curl --request GET "https://api.github.com/repos/$DRONE_REPO/issues/$DRONE_PULL_REQUEST" | jq -e '.labels[]|select(.name == "ok-to-test")'
+
 - name: setup-ci
   image: autonomy/build-container:latest
   commands:

--- a/.github/workflows/promote-e2e.yml
+++ b/.github/workflows/promote-e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@master
 
-      - name: Apply ok-to-test Label
+      - name: Apply needs-e2e Label
         uses: actions/github@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -90,6 +90,20 @@ local volumes = {
   ],
 };
 
+// TODO(rsmitty): figure out how we can keep docker and setup-ci from running while also supporting 
+// times when we're not using those in the default pipeline (e2e and conformance for ex.)
+// Sets up the CI environment
+local check_ok_test = {
+  name: 'ok-to-test',
+  image: 'autonomy/build-container:latest',
+  privileged: false,
+  environment: {},
+  commands: [
+      'curl --request GET "https://api.github.com/repos/$DRONE_REPO/issues/$DRONE_PULL_REQUEST" | jq -e \'.labels[]|select(.name == "ok-to-test")\''
+  ],
+  volumes: [],
+};
+
 // This provides the docker service.
 local docker = {
   name: 'docker',
@@ -302,7 +316,7 @@ local default_trigger = {
   },
 };
 
-local default_pipeline = Pipeline('default', default_steps) + default_trigger;
+local default_pipeline = Pipeline('default', [check_ok_test] + default_steps) + default_trigger;
 
 // E2E pipeline.
 


### PR DESCRIPTION
This PR adds the necessary drone step to check for the `ok-to-test`
label before running any testing against a PR.