### PR TITLE
chore: use registry mirror for system containerd & CRI

### DIFF
--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -7,18 +7,72 @@ package image
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
-	"github.com/talos-systems/talos/pkg/retry"
-
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/remotes/docker"
+
+	"github.com/talos-systems/talos/pkg/retry"
 )
 
 // Pull is a convenience function that wraps the containerd image pull func with
 // retry functionality.
 func Pull(ctx context.Context, client *containerd.Client, ref string) (img containerd.Image, err error) {
+	var resolver = docker.NewResolver(docker.ResolverOptions{
+		Hosts: func(host string) ([]docker.RegistryHost, error) {
+			switch host {
+			case "docker.io":
+				return []docker.RegistryHost{
+					{
+						Client:       http.DefaultClient,
+						Scheme:       "http",
+						Host:         "172.20.0.1:5000",
+						Path:         "/v2",
+						Capabilities: docker.HostCapabilityResolve | docker.HostCapabilityPull,
+					},
+				}, nil
+			case "k8s.gcr.io":
+				return []docker.RegistryHost{
+					{
+						Client:       http.DefaultClient,
+						Scheme:       "http",
+						Host:         "172.20.0.1:5001",
+						Path:         "/v2",
+						Capabilities: docker.HostCapabilityResolve | docker.HostCapabilityPull,
+					},
+				}, nil
+			case "quay.io":
+				return []docker.RegistryHost{
+					{
+						Client:       http.DefaultClient,
+						Scheme:       "http",
+						Host:         "172.20.0.1:5002",
+						Path:         "/v2",
+						Capabilities: docker.HostCapabilityResolve | docker.HostCapabilityPull,
+					},
+				}, nil
+			default:
+				defaultHost, err := docker.DefaultHost(host)
+				if err != nil {
+					return nil, err
+				}
+
+				return []docker.RegistryHost{
+					{
+						Client:       http.DefaultClient,
+						Scheme:       "https",
+						Host:         defaultHost,
+						Path:         "/v2",
+						Capabilities: docker.HostCapabilityResolve | docker.HostCapabilityPull,
+					},
+				}, nil
+			}
+		},
+	})
+
 	err = retry.Exponential(1*time.Minute, retry.WithUnits(1*time.Second)).Retry(func() error {
-		if img, err = client.Pull(ctx, ref, containerd.WithPullUnpack); err != nil {
+		if img, err = client.Pull(ctx, ref, containerd.WithPullUnpack, containerd.WithResolver(resolver)); err != nil {
 			return retry.ExpectedError(fmt.Errorf("failed to pull image %q: %w", ref, err))
 		}
 

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -7,6 +7,7 @@ package generate
 import (
 	"net/url"
 
+	"github.com/talos-systems/talos/pkg/config/machine"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -24,6 +25,22 @@ func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,
 			InstallBootloader: true,
+		},
+		MachineFiles: []machine.File{
+			{
+				Path:        "/etc/cri/containerd.toml",
+				Permissions: 0644,
+				Op:          "append",
+				Content: `
+				[plugins.cri.registry.mirrors]
+				  [plugins.cri.registry.mirrors."docker.io"]
+					endpoint = ["http://172.20.0.1:5000"]
+  				  [plugins.cri.registry.mirrors."k8s.gcr.io"]
+					endpoint = ["http://172.20.0.1:5001"]
+  				  [plugins.cri.registry.mirrors."quay.io"]
+					endpoint = ["http://172.20.0.1:5002"]
+					`,
+			},
 		},
 	}
 

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -7,6 +7,7 @@ package generate
 import (
 	"net/url"
 
+	"github.com/talos-systems/talos/pkg/config/machine"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -24,6 +25,22 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,
 			InstallBootloader: true,
+		},
+		MachineFiles: []machine.File{
+			{
+				Path:        "/etc/cri/containerd.toml",
+				Permissions: 0644,
+				Op:          "append",
+				Content: `
+				[plugins.cri.registry.mirrors]
+				  [plugins.cri.registry.mirrors."docker.io"]
+					endpoint = ["http://172.20.0.1:5000"]
+  				  [plugins.cri.registry.mirrors."k8s.gcr.io"]
+					endpoint = ["http://172.20.0.1:5001"]
+  				  [plugins.cri.registry.mirrors."quay.io"]
+					endpoint = ["http://172.20.0.1:5002"]
+					`,
+			},
 		},
 	}
 

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -7,6 +7,7 @@ package generate
 import (
 	"net/url"
 
+	"github.com/talos-systems/talos/pkg/config/machine"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
@@ -24,6 +25,22 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,
 			InstallBootloader: true,
+		},
+		MachineFiles: []machine.File{
+			{
+				Path:        "/etc/cri/containerd.toml",
+				Permissions: 0644,
+				Op:          "append",
+				Content: `
+				[plugins.cri.registry.mirrors]
+				  [plugins.cri.registry.mirrors."docker.io"]
+					endpoint = ["http://172.20.0.1:5000"]
+  				  [plugins.cri.registry.mirrors."k8s.gcr.io"]
+					endpoint = ["http://172.20.0.1:5001"]
+  				  [plugins.cri.registry.mirrors."quay.io"]
+					endpoint = ["http://172.20.0.1:5002"]
+					`,
+			},
 		},
 	}
 


### PR DESCRIPTION
This is just PoC, code is hacky.

Requires 3 registry mirrors running on localhost, for `quay.io` you have
to use registry:2.5.2, as recent versions don't support v1 schema.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>