### PR TITLE
chore: update golangci-lint-1.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.21.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.23.3
 RUN cd $(mktemp -d) \
     && go mod init tmp \
     && go get mvdan.cc/gofumpt/gofumports \

--- a/cmd/osctl/pkg/client/client.go
+++ b/cmd/osctl/pkg/client/client.go
@@ -566,6 +566,7 @@ func ReadStream(stream MachineStream) (io.ReadCloser, <-chan error, error) {
 				}
 				//nolint: errcheck
 				pw.CloseWithError(err)
+
 				return
 			}
 

--- a/hack/golang/golangci-lint.yaml
+++ b/hack/golang/golangci-lint.yaml
@@ -111,6 +111,7 @@ linters:
     - funlen
     - godox
     - gocognit
+    - gomnd
   disable-all: false
   fast: false
 

--- a/internal/app/machined/pkg/system/runner/containerd/opts.go
+++ b/internal/app/machined/pkg/system/runner/containerd/opts.go
@@ -19,6 +19,7 @@ func WithMemoryLimit(limit int64) oci.SpecOpts {
 			Limit: &limit,
 			// DisableOOMKiller: &disable,
 		}
+
 		return nil
 	}
 }

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -146,6 +146,7 @@ func (o *APID) Runner(config runtime.Configurator) (runner.Runner, error) {
 func (o *APID) HealthFunc(runtime.Configurator) health.Check {
 	return func(ctx context.Context) error {
 		var d net.Dialer
+
 		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "127.0.0.1", constants.ApidPort))
 		if err != nil {
 			return err

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -209,6 +209,7 @@ func (k *Kubelet) HealthFunc(runtime.Configurator) health.Check {
 		if err != nil {
 			return err
 		}
+
 		req = req.WithContext(ctx)
 
 		resp, err := http.DefaultClient.Do(req)

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -129,6 +129,7 @@ func (o *OSD) HealthFunc(runtime.Configurator) health.Check {
 		if err != nil {
 			return err
 		}
+
 		return conn.Close()
 	}
 }

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -103,6 +103,7 @@ func (t *Trustd) Runner(config runtime.Configurator) (runner.Runner, error) {
 func (t *Trustd) HealthFunc(runtime.Configurator) health.Check {
 	return func(ctx context.Context) error {
 		var d net.Dialer
+
 		conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%d", "127.0.0.1", constants.TrustdPort))
 		if err != nil {
 			return err

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -194,7 +194,9 @@ func (s *singleton) Shutdown() {
 
 		go func(svcrunner *ServiceRunner, reverseDeps []string) {
 			defer shutdownWg.Done()
+
 			conds := make([]conditions.Condition, len(reverseDeps))
+
 			for i := range reverseDeps {
 				conds[i] = WaitForService(StateEventDown, reverseDeps[i])
 			}

--- a/internal/app/networkd/pkg/nic/bond_options.go
+++ b/internal/app/networkd/pkg/nic/bond_options.go
@@ -47,6 +47,7 @@ func WithSubInterface(o ...string) Option {
 
 			n.SubInterfaces = append(n.SubInterfaces, iface)
 		}
+
 		return err
 	}
 }
@@ -55,6 +56,7 @@ func WithSubInterface(o ...string) Option {
 func WithBondMode(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var mode BondMode
+
 		if mode, err = BondModeByName(o); err != nil {
 			return err
 		}
@@ -69,6 +71,7 @@ func WithBondMode(o string) Option {
 func WithHashPolicy(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var policy BondXmitHashPolicy
+
 		if policy, err = BondXmitHashPolicyByName(o); err != nil {
 			return err
 		}
@@ -83,6 +86,7 @@ func WithHashPolicy(o string) Option {
 func WithLACPRate(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var rate LACPRate
+
 		if rate, err = LACPRateByName(o); err != nil {
 			return err
 		}
@@ -131,6 +135,7 @@ func WithUseCarrier(o bool) Option {
 		}
 
 		n.BondSettings.Uint8(uint16(IFLA_BOND_USE_CARRIER), carrier)
+
 		return err
 	}
 }
@@ -148,6 +153,7 @@ func WithARPInterval(o uint32) Option {
 func WithARPValidate(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var valid ARPValidate
+
 		if valid, err = ARPValidateByName(o); err != nil {
 			return err
 		}
@@ -163,6 +169,7 @@ func WithARPValidate(o string) Option {
 func WithARPAllTargets(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var target ARPAllTargets
+
 		if target, err = ARPAllTargetsByName(o); err != nil {
 			return err
 		}
@@ -177,11 +184,13 @@ func WithARPAllTargets(o string) Option {
 func WithPrimary(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var iface *net.Interface
+
 		if iface, err = net.InterfaceByName(o); err != nil {
 			return err
 		}
 
 		n.BondSettings.Uint8(uint16(IFLA_BOND_PRIMARY_RESELECT), uint8(iface.Index))
+
 		return err
 	}
 }
@@ -190,10 +199,13 @@ func WithPrimary(o string) Option {
 func WithPrimaryReselect(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var primary PrimaryReselect
+
 		if primary, err = PrimaryReselectByName(o); err != nil {
 			return err
 		}
+
 		n.BondSettings.Uint8(uint16(IFLA_BOND_PRIMARY_RESELECT), uint8(primary))
+
 		return err
 	}
 }
@@ -203,10 +215,13 @@ func WithPrimaryReselect(o string) Option {
 func WithFailOverMAC(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var fo FailOverMAC
+
 		if fo, err = FailOverMACByName(o); err != nil {
 			return err
 		}
+
 		n.BondSettings.Uint8(uint16(IFLA_BOND_FAIL_OVER_MAC), uint8(fo))
+
 		return err
 	}
 }
@@ -269,10 +284,13 @@ func WithPacketsPerSlave(o uint32) Option {
 func WithADSelect(o string) Option {
 	return func(n *NetworkInterface) (err error) {
 		var sel ADSelect
+
 		if sel, err = ADSelectByName(o); err != nil {
 			return err
 		}
+
 		n.BondSettings.Uint8(uint16(IFLA_BOND_AD_SELECT), uint8(sel))
+
 		return err
 	}
 }

--- a/internal/app/ntpd/pkg/ntp/options.go
+++ b/internal/app/ntpd/pkg/ntp/options.go
@@ -44,7 +44,9 @@ func WithMaxPoll(o int) Option {
 		if o > MaxAllowablePoll {
 			return fmt.Errorf("MaxPoll(%d) is larger than maximum allowed value(%d)", o, MaxAllowablePoll)
 		}
+
 		n.MaxPoll = time.Duration(o) * time.Second
+
 		return err
 	}
 }
@@ -55,7 +57,9 @@ func WithMinPoll(o int) Option {
 		if o < MinAllowablePoll {
 			return fmt.Errorf("MinPoll(%d) is smaller than minimum allowed value(%d)", o, MinAllowablePoll)
 		}
+
 		n.MinPoll = time.Duration(o) * time.Second
+
 		return err
 	}
 }

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -65,9 +65,11 @@ func WithAnnotations(annotations map[string]string) oci.SpecOpts {
 		if s.Annotations == nil {
 			s.Annotations = make(map[string]string)
 		}
+
 		for k, v := range annotations {
 			s.Annotations[k] = v
 		}
+
 		return nil
 	}
 }

--- a/pkg/chunker/stream/stream.go
+++ b/pkg/chunker/stream/stream.go
@@ -65,6 +65,7 @@ func (c *Stream) Read(ctx context.Context) <-chan []byte {
 		defer c.source.Close()
 
 		buf := make([]byte, c.options.Size)
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -77,8 +78,10 @@ func (c *Stream) Read(ctx context.Context) <-chan []byte {
 				if err != io.EOF {
 					fmt.Printf("read error: %s\n", err.Error())
 				}
+
 				break
 			}
+
 			if n != 0 {
 				// Copy the buffer since we will modify it in the next loop.
 				b := make([]byte, n)

--- a/pkg/grpc/tls/tls.go
+++ b/pkg/grpc/tls/tls.go
@@ -37,6 +37,7 @@ func WithClientAuthType(t Type) func(*tls.Config) error {
 		default:
 			return fmt.Errorf("unhandled client auth type %+v", t)
 		}
+
 		return nil
 	}
 }
@@ -51,8 +52,10 @@ func WithServerCertificateProvider(p CertificateProvider) func(*tls.Config) erro
 		if p == nil {
 			return errors.New("no provider")
 		}
+
 		cfg.Certificates = nil
 		cfg.GetCertificate = p.GetCertificate
+
 		return nil
 	}
 }
@@ -67,8 +70,10 @@ func WithClientCertificateProvider(p CertificateProvider) func(*tls.Config) erro
 		if p == nil {
 			return errors.New("no provider")
 		}
+
 		cfg.Certificates = nil
 		cfg.GetClientCertificate = p.GetClientCertificate
+
 		return nil
 	}
 }
@@ -88,12 +93,15 @@ func WithCACertPEM(ca []byte) func(*tls.Config) error {
 		if len(ca) == 0 {
 			return errors.New("no CA cert provided")
 		}
+
 		if ok := cfg.ClientCAs.AppendCertsFromPEM(ca); !ok {
 			return errors.New("failed to append CA certificate to ClientCAs pool")
 		}
+
 		if ok := cfg.RootCAs.AppendCertsFromPEM(ca); !ok {
 			return errors.New("failed to append CA certificate to RootCAs pool")
 		}
+
 		return nil
 	}
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -275,12 +275,14 @@ func (h *Client) Drain(node string) error {
 	for _, pod := range pods.Items {
 		go func(p corev1.Pod) {
 			defer wg.Done()
+
 			for _, ref := range p.ObjectMeta.OwnerReferences {
 				if ref.Kind == "DaemonSet" {
 					log.Printf("skipping DaemonSet pod %s\n", p.GetName())
 					return
 				}
 			}
+
 			if err := h.evict(p, int64(60)); err != nil {
 				log.Printf("WARNING: failed to evict pod: %v", err)
 			}


### PR DESCRIPTION
`gomnd` disabled, as it complains about every number used in the code,
and `wsl` became much more thorough.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>