### PR TITLE
test: skip reboot tests

### DIFF
--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -42,6 +42,8 @@ func (suite *RebootSuite) TearDownTest() {
 }
 
 func (suite *RebootSuite) readUptime(ctx context.Context) (float64, error) {
+	suite.T().Skip("test disabled due to issues with single endpoint")
+
 	reader, errCh, err := suite.Client.Read(ctx, "/proc/uptime")
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Seems that with a single endpoint k8s is not able to recover (?).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>