### PR TITLE
chore: get correct drone status in github actions

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -35,7 +35,7 @@ jobs:
           STATUS_URL=$(echo $PR_INFO | jq -r .statuses_url)
 
           ## Discover previous drone build number and send it a post to retrigger
-          DRONE_BUILD_URL=$(curl -s $STATUS_URL | jq -r .[0].target_url )
+          DRONE_BUILD_URL=$(curl -s $STATUS_URL | jq -r '[.[] | select(.context == "continuous-integration/drone/pr")][0].target_url')
           DRONE_BUILD_NUM=${DRONE_BUILD_URL##*/}
 
           docker run -e "DRONE_SERVER=$DRONE_SERVER" -e "DRONE_TOKEN=$DRONE_TOKEN" drone/cli:1.2.1 build restart $GITHUB_REPOSITORY $DRONE_BUILD_NUM

--- a/.github/workflows/promote-e2e.yml
+++ b/.github/workflows/promote-e2e.yml
@@ -36,7 +36,7 @@ jobs:
           STATUS_URL=$(echo $PR_INFO | jq -r .statuses_url)
 
           ## Discover previous drone build number and send it a post to promote
-          DRONE_BUILD_URL=$(curl -s $STATUS_URL | jq -r .[0].target_url )
+          DRONE_BUILD_URL=$(curl -s $STATUS_URL | jq -r '[.[] | select(.context == "continuous-integration/drone/pr")][0].target_url')
           DRONE_BUILD_NUM=${DRONE_BUILD_URL##*/}
 
           docker run  -e "DRONE_SERVER=$DRONE_SERVER" -e "DRONE_TOKEN=$DRONE_TOKEN" drone/cli:1.2.1 build promote $GITHUB_REPOSITORY $DRONE_BUILD_NUM e2e


### PR DESCRIPTION
This PR fixes a small bug I found yesterday to make sure we're fetching
the latest drone build number always.