### PR TITLE
chore: only run ok-to-test when PR

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,9 @@ steps:
   image: autonomy/build-container:latest
   commands:
   - curl --request GET "https://api.github.com/repos/$DRONE_REPO/issues/$DRONE_PULL_REQUEST" | jq -e '.labels[]|select(.name == "ok-to-test")'
+  when:
+    event:
+    - pull_request
 
 - name: setup-ci
   image: autonomy/build-container:latest

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -102,6 +102,9 @@ local check_ok_test = {
       'curl --request GET "https://api.github.com/repos/$DRONE_REPO/issues/$DRONE_PULL_REQUEST" | jq -e \'.labels[]|select(.name == "ok-to-test")\''
   ],
   volumes: [],
+  when: {
+    event: ['pull_request'],
+  },
 };
 
 // This provides the docker service.


### PR DESCRIPTION
This PR fixes a quick bug in CI where the ok-to-test step in drone was
running after a merge to master.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>