### PR TITLE
chore: support bootloader emulation in firecracker provisioner

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -39,6 +39,7 @@ var (
 	nodeInstallImage        string
 	nodeVmlinuxPath         string
 	nodeInitramfsPath       string
+	bootloaderEmulation     bool
 	networkCIDR             string
 	networkMTU              int
 	nameservers             []string
@@ -183,6 +184,10 @@ func create(ctx context.Context) (err error) {
 
 	provisionOptions := []provision.Option{}
 	configBundleOpts := []config.BundleOption{}
+
+	if bootloaderEmulation {
+		provisionOptions = append(provisionOptions, provision.WithBootladerEmulation())
+	}
 
 	if inputDir != "" {
 		configBundleOpts = append(configBundleOpts, config.WithExistingConfigs(inputDir))
@@ -412,6 +417,7 @@ func init() {
 	clusterUpCmd.Flags().StringVar(&nodeInstallImage, "install-image", defaultImage(constants.DefaultInstallerImageRepository), "the installer image to use")
 	clusterUpCmd.Flags().StringVar(&nodeVmlinuxPath, "vmlinux-path", helpers.ArtifactPath(constants.KernelUncompressedAsset), "the uncompressed kernel image to use")
 	clusterUpCmd.Flags().StringVar(&nodeInitramfsPath, "initrd-path", helpers.ArtifactPath(constants.InitramfsAsset), "the uncompressed kernel image to use")
+	clusterUpCmd.Flags().BoolVar(&bootloaderEmulation, "with-bootloader-emulation", false, "enable bootloader emulation to load kernel and initramfs from disk image")
 	clusterUpCmd.Flags().IntVar(&networkMTU, "mtu", 1500, "MTU of the docker bridge network")
 	clusterUpCmd.Flags().StringVar(&networkCIDR, "cidr", "10.5.0.0/24", "CIDR of the docker bridge network")
 	clusterUpCmd.Flags().StringSliceVar(&nameservers, "nameservers", []string{"8.8.8.8", "1.1.1.1"}, "list of nameservers to use (VM only)")

--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -35,6 +35,7 @@ osctl cluster create [flags]
       --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --wait                        wait for the cluster to be ready before returning
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
+      --with-bootloader-emulation   enable bootloader emulation to load kernel and initramfs from disk image
       --workers int                 the number of workers to create (default 1)
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/pin/tftp v2.1.0+incompatible
 	github.com/prometheus/procfs v0.0.8
 	github.com/ryanuber/columnize v2.1.0+incompatible
+	github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,8 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014 h1:tne8XW3soRDJn4DIiqBc4jw+DPashtFMTSC9G0pC3ug=
+github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014/go.mod h1:smSuTvETRIkX95VAIWBdKoGJuUxif7NT7FgbkpVqOiA=
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c h1:gqEdF4VwBu3lTKGHS9rXE9x1/pEaSwCXRLOZRF6qtlw=

--- a/internal/pkg/kernel/vmlinuz/vmlinuz.go
+++ b/internal/pkg/kernel/vmlinuz/vmlinuz.go
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package vmlinuz provides utilities for reading bzImage kernel format.
+package vmlinuz
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/smira/go-xz"
+)
+
+type decompressFunc func(io.Reader) (io.ReadCloser, error)
+
+// Based on https://github.com/torvalds/linux/blob/master/scripts/extract-vmlinux.
+var bzImageMagic = []struct {
+	magic  []byte
+	reader decompressFunc
+}{
+	{
+		magic: []byte("\037\213\010"),
+		reader: func(r io.Reader) (io.ReadCloser, error) {
+			return gzip.NewReader(r)
+		},
+	},
+	{
+		magic: []byte("\3757zXZ\000"),
+		reader: func(r io.Reader) (io.ReadCloser, error) {
+			return xz.NewReader(r)
+		},
+	},
+	{
+		magic: []byte("BZh"),
+		reader: func(r io.Reader) (io.ReadCloser, error) {
+			return ioutil.NopCloser(bzip2.NewReader(r)), nil
+		},
+	},
+}
+
+// Decompress the bzImage Linux kernel format and extract vmlinux kernel.
+//
+// Only following formats are supported: gzip, xz and bzip2.
+func Decompress(r io.Reader) (io.ReadCloser, error) {
+	// read first 64Kb and look for signature
+	head := make([]byte, 65536)
+
+	if _, err := io.ReadFull(r, head); err != nil {
+		return nil, fmt.Errorf("error reading 64Kb vmlinuz head: %w", err)
+	}
+
+	start := -1
+
+	var decompress decompressFunc
+
+	for _, matcher := range bzImageMagic {
+		start = bytes.Index(head, matcher.magic)
+		if start != -1 {
+			decompress = matcher.reader
+			break
+		}
+	}
+
+	if start == -1 {
+		return nil, fmt.Errorf("error looking for vmlinuz magic")
+	}
+
+	return decompress(io.MultiReader(bytes.NewReader(head[start:]), r))
+}

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -51,12 +51,24 @@ func WithTalosClient(client *client.Client) Option {
 	}
 }
 
+// WithBootladerEmulation enables bootloader emulation.
+func WithBootladerEmulation() Option {
+	return func(o *Options) error {
+		o.BootloaderEmulation = true
+
+		return nil
+	}
+}
+
 // Options describes Provisioner parameters.
 type Options struct {
 	LogWriter     io.Writer
 	TalosConfig   *config.Config
 	TalosClient   *client.Client
 	ForceEndpoint string
+
+	// Enable bootloader by booting from disk image assets.
+	BootloaderEmulation bool
 }
 
 // DefaultOptions returns default options.

--- a/internal/pkg/provision/providers/firecracker/bootloader.go
+++ b/internal/pkg/provision/providers/firecracker/bootloader.go
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package firecracker
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/talos-systems/talos/internal/pkg/kernel/vmlinuz"
+	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/vfat"
+	"github.com/talos-systems/talos/pkg/blockdevice/table"
+	"github.com/talos-systems/talos/pkg/blockdevice/table/gpt"
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+const diskImageSectorSize = 512
+
+// BootLoader extracts kernel (vmlinux) and initrd (initramfs.xz) from Talos disk image.
+type BootLoader struct {
+	diskF *os.File
+
+	bootPartitionReader *io.SectionReader
+
+	bootFs *vfat.FileSystem
+
+	kernelTempPath, initrdTempPath string
+}
+
+// BootAssets is what BootLoader extracts from the disk image.
+type BootAssets struct {
+	KernelPath string
+	InitrdPath string
+}
+
+// NewBootLoader creates boot loader for the disk image.
+func NewBootLoader(diskImage string) (*BootLoader, error) {
+	b := &BootLoader{}
+
+	var err error
+
+	b.diskF, err = os.Open(diskImage)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// ExtractAssets from disk image.
+func (b *BootLoader) ExtractAssets() (BootAssets, error) {
+	if err := b.findBootPartition(); err != nil {
+		return BootAssets{}, err
+	}
+
+	if err := b.openFilesystem(); err != nil {
+		return BootAssets{}, err
+	}
+
+	if err := b.extractKernel(); err != nil {
+		return BootAssets{}, err
+	}
+
+	if err := b.extractInitrd(); err != nil {
+		return BootAssets{}, err
+	}
+
+	return BootAssets{
+		KernelPath: b.kernelTempPath,
+		InitrdPath: b.initrdTempPath,
+	}, nil
+}
+
+// Close the bootloader.
+func (b *BootLoader) Close() error {
+	if b.kernelTempPath != "" {
+		os.Remove(b.kernelTempPath) //nolint: errcheck
+		b.kernelTempPath = ""
+	}
+
+	if b.initrdTempPath != "" {
+		os.Remove(b.initrdTempPath) //nolint: errcheck
+		b.initrdTempPath = ""
+	}
+
+	if b.diskF != nil {
+		if err := b.diskF.Close(); err != nil {
+			return err
+		}
+
+		b.diskF = nil
+	}
+
+	return nil
+}
+
+func (b *BootLoader) findBootPartition() error {
+	diskTable, err := gpt.NewGPT("vda", b.diskF)
+	if err != nil {
+		return fmt.Errorf("error creating GPT object: %w", err)
+	}
+
+	if err = diskTable.Read(); err != nil {
+		return fmt.Errorf("error reading GPT: %w", err)
+	}
+
+	var bootPartition table.Partition
+
+	for _, part := range diskTable.Partitions() {
+		// TODO: should we do better matching here
+		if part.No() == 1 {
+			bootPartition = part
+			break
+		}
+	}
+
+	if bootPartition == nil {
+		return fmt.Errorf("no boot partition found")
+	}
+
+	b.bootPartitionReader = io.NewSectionReader(b.diskF, bootPartition.Start()*diskImageSectorSize, bootPartition.Length()*diskImageSectorSize)
+
+	return nil
+}
+
+func (b *BootLoader) openFilesystem() error {
+	sb := &vfat.SuperBlock{}
+
+	if _, err := b.bootPartitionReader.Seek(sb.Offset(), io.SeekStart); err != nil {
+		return fmt.Errorf("error seeking boot partition: %w", err)
+	}
+
+	err := binary.Read(b.bootPartitionReader, binary.BigEndian, sb)
+	if err != nil {
+		return fmt.Errorf("error reading vfat superblock: %w", err)
+	}
+
+	if !sb.Is() {
+		return fmt.Errorf("corrupt vfat superblock")
+	}
+
+	b.bootFs, err = vfat.NewFileSystem(b.bootPartitionReader, sb)
+	if err != nil {
+		return fmt.Errorf("error initializing FAT32 filesystem: %w", err)
+	}
+
+	return nil
+}
+
+func (b *BootLoader) extractKernel() error {
+	r, err := b.bootFs.Open(filepath.Join("default", constants.KernelAsset))
+	if err != nil {
+		return fmt.Errorf("error opening kernel asset: %w", err)
+	}
+
+	kernelR, err := vmlinuz.Decompress(bufio.NewReader(r))
+	if err != nil {
+		return fmt.Errorf("error decompressing kernel: %w", err)
+	}
+
+	defer kernelR.Close() //nolint: errcheck
+
+	tempF, err := ioutil.TempFile("", "talos")
+	if err != nil {
+		return fmt.Errorf("error creating temporary kernel image file: %w", err)
+	}
+
+	defer tempF.Close() //nolint: errcheck
+
+	if _, err = io.Copy(tempF, kernelR); err != nil {
+		return fmt.Errorf("error extracting kernel: %w", err)
+	}
+
+	b.kernelTempPath = tempF.Name()
+
+	return nil
+}
+
+func (b *BootLoader) extractInitrd() error {
+	r, err := b.bootFs.Open(filepath.Join("default", constants.InitramfsAsset))
+	if err != nil {
+		return fmt.Errorf("error opening initrd: %w", err)
+	}
+
+	tempF, err := ioutil.TempFile("", "talos")
+	if err != nil {
+		return fmt.Errorf("error creating temporary initrd file: %w", err)
+	}
+
+	defer tempF.Close() //nolint: errcheck
+
+	if _, err = io.Copy(tempF, r); err != nil {
+		return fmt.Errorf("error extracting initrd: %w", err)
+	}
+
+	b.initrdTempPath = tempF.Name()
+
+	return nil
+}

--- a/internal/pkg/provision/providers/firecracker/create.go
+++ b/internal/pkg/provision/providers/firecracker/create.go
@@ -67,7 +67,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	fmt.Fprintln(options.LogWriter, "creating master nodes")
 
-	if nodeInfo, err = p.createNodes(state, request, request.Nodes.MasterNodes()); err != nil {
+	if nodeInfo, err = p.createNodes(state, request, request.Nodes.MasterNodes(), &options); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	var workerNodeInfo []provision.NodeInfo
 
-	if workerNodeInfo, err = p.createNodes(state, request, request.Nodes.WorkerNodes()); err != nil {
+	if workerNodeInfo, err = p.createNodes(state, request, request.Nodes.WorkerNodes(), &options); err != nil {
 		return nil, err
 	}
 

--- a/pkg/blockdevice/filesystem/vfat/filesystem.go
+++ b/pkg/blockdevice/filesystem/vfat/filesystem.go
@@ -1,0 +1,288 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vfat
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// FileSystem provides simple way to read files from FAT32 filesystems.
+//
+// This code is far from being production quality, it might break if filesystem
+// is corrupted or is not actually FAT32.
+type FileSystem struct {
+	sb *SuperBlock
+	f  io.ReaderAt
+
+	sectorSize  uint16
+	clusterSize uint32
+	fatSize     uint64
+	fatOffset   uint32
+	dataStart   uint64
+
+	fat map[uint32]uint32
+}
+
+// NewFileSystem initializes Filesystem, reads FAT.
+func NewFileSystem(f io.ReaderAt, sb *SuperBlock) (*FileSystem, error) {
+	fs := &FileSystem{
+		sb: sb,
+		f:  f,
+	}
+
+	fs.sectorSize = binary.LittleEndian.Uint16(sb.SectorSize[:])
+	fs.clusterSize = uint32(sb.ClusterSize) * uint32(fs.sectorSize)
+	fs.fatSize = uint64(fs.sectorSize) * uint64(binary.LittleEndian.Uint32(sb.Fat32Length[:]))
+	fs.fatOffset = uint32(binary.LittleEndian.Uint16(sb.Reserved[:])) * uint32(fs.sectorSize)
+	fs.dataStart = uint64(fs.fatOffset) + 2*fs.fatSize
+
+	rawFat := make([]byte, fs.fatSize)
+
+	if err := readAtFull(fs.f, int64(fs.fatOffset), rawFat); err != nil {
+		return nil, fmt.Errorf("error reading FAT: %w", err)
+	}
+
+	fs.fat = make(map[uint32]uint32)
+
+	for i := uint32(2); i < uint32(fs.fatSize/4); i++ {
+		c := binary.LittleEndian.Uint32(rawFat[i*4 : i*4+4])
+
+		if c != 0 {
+			fs.fat[i] = c
+		}
+	}
+
+	return fs, nil
+}
+
+// Open the file as read-only stream on the filesystem.
+func (fs *FileSystem) Open(path string) (io.Reader, error) {
+	components := strings.Split(path, string(os.PathSeparator))
+
+	// start with rootDirectory
+	dir := &directory{
+		fs:           fs,
+		firstCluster: binary.LittleEndian.Uint32(fs.sb.RootCluster[:]),
+	}
+
+	for i, component := range components {
+		if component == "" {
+			continue
+		}
+
+		entries, err := dir.scan()
+		if err != nil {
+			return nil, err
+		}
+
+		found := false
+
+		for _, entry := range entries {
+			if entry.filename == component {
+				found = true
+
+				if i == len(components)-1 {
+					// should be a file
+					if entry.isDirectory {
+						return nil, fmt.Errorf("expected file entry, but directory found")
+					}
+
+					return &file{
+						fs:    fs,
+						chain: fs.fatChain(entry.firstCluster),
+						size:  entry.size,
+					}, nil
+				}
+
+				if !entry.isDirectory {
+					return nil, fmt.Errorf("expected directory, but file found")
+				}
+
+				dir = &directory{
+					fs:           fs,
+					firstCluster: entry.firstCluster,
+				}
+
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("path not found")
+		}
+	}
+
+	return nil, fmt.Errorf("path not found")
+}
+
+// fatChain results list of clusters for a file (or directory) based on first
+// cluster number and FAT.
+func (fs *FileSystem) fatChain(firstCluster uint32) (chain []uint32) {
+	chain = []uint32{firstCluster}
+
+	for {
+		next := fs.fat[firstCluster]
+		if next == 0 || next&0xFFFFFF8 == 0xFFFFFF8 {
+			return
+		}
+
+		chain = append(chain, next)
+		firstCluster = next
+	}
+}
+
+type directory struct {
+	fs           *FileSystem
+	firstCluster uint32
+}
+
+type directoryEntry struct {
+	filename    string
+	isDirectory bool
+
+	size         uint32
+	firstCluster uint32
+}
+
+// scan a directory building list of entries.
+//
+// Only LFN are supported, entries without LFN are ignored.
+func (d *directory) scan() ([]directoryEntry, error) {
+	// read whole directory into memory
+	chain := d.fs.fatChain(d.firstCluster)
+	raw := make([]byte, uint32(len(chain))*d.fs.clusterSize)
+
+	for i, cluster := range chain {
+		if err := readAtFull(d.fs.f, int64(d.fs.dataStart)+int64(cluster-2)*int64(d.fs.clusterSize), raw[uint32(i)*d.fs.clusterSize:uint32(i+1)*d.fs.clusterSize]); err != nil {
+			return nil, fmt.Errorf("error reading directory contents: %w", err)
+		}
+	}
+
+	var (
+		entries []directoryEntry
+		lfn     string
+	)
+
+	for i := 0; i < len(raw); i += 32 {
+		entry := raw[i : i+32]
+
+		if entry[0] == 0 {
+			return entries, nil
+		}
+
+		if entry[0] == 0xe5 {
+			continue
+		}
+
+		if entry[11] == 0x0f {
+			if entry[0]&0x40 == 0x40 {
+				lfn = ""
+			}
+
+			lfn = parseLfn(entry) + lfn
+
+			continue
+		}
+
+		if lfn == "" {
+			// no lfn, skip directory entry
+			continue
+		}
+
+		entries = append(entries, directoryEntry{
+			filename:     lfn,
+			isDirectory:  entry[11]&0x10 == 0x10,
+			size:         binary.LittleEndian.Uint32(entry[28:32]),
+			firstCluster: binary.LittleEndian.Uint32(append(entry[26:28], entry[20:22]...)),
+		})
+	}
+
+	return entries, nil
+}
+
+type file struct {
+	fs     *FileSystem
+	chain  []uint32
+	offset uint32
+	size   uint32
+}
+
+func (f *file) Read(p []byte) (n int, err error) {
+	remaining := len(p)
+	if uint32(remaining) > f.size-f.offset {
+		remaining = int(f.size - f.offset)
+		if remaining == 0 {
+			err = io.EOF
+			return
+		}
+	}
+
+	for remaining > 0 {
+		clusterIdx := f.offset / f.fs.clusterSize
+		clusterOffset := f.offset % f.fs.clusterSize
+
+		if clusterIdx > uint32(len(f.chain)) {
+			err = fmt.Errorf("FAT chain overrun")
+			return
+		}
+
+		cluster := f.chain[clusterIdx]
+		readLen := f.fs.clusterSize - clusterOffset
+
+		if readLen > uint32(remaining) {
+			readLen = uint32(remaining)
+		}
+
+		if err = readAtFull(f.fs.f, int64(f.fs.dataStart)+int64(cluster-2)*int64(f.fs.clusterSize)+int64(clusterOffset), p[:readLen]); err != nil {
+			return
+		}
+
+		remaining -= int(readLen)
+		n += int(readLen)
+		f.offset += readLen
+
+		p = p[readLen:]
+	}
+
+	return n, err
+}
+
+func readAtFull(r io.ReaderAt, off int64, buf []byte) error {
+	remaining := len(buf)
+
+	for remaining > 0 {
+		n, err := r.ReadAt(buf, off)
+		if err != nil {
+			return err
+		}
+
+		remaining -= n
+		off += int64(n)
+		buf = buf[n:]
+	}
+
+	return nil
+}
+
+func parseLfn(entry []byte) string {
+	raw := append(entry[1:11], append(entry[14:26], entry[28:32]...)...)
+
+	parsed := []rune{}
+
+	for i := 0; i < len(raw); i += 2 {
+		val := binary.LittleEndian.Uint16(raw[i : i+2])
+		if val == 0 {
+			break
+		}
+
+		parsed = append(parsed, rune(val))
+	}
+
+	return string(parsed)
+}

--- a/pkg/blockdevice/filesystem/vfat/superblock.go
+++ b/pkg/blockdevice/filesystem/vfat/superblock.go
@@ -19,7 +19,7 @@ type SuperBlock struct {
 	Sysid        [8]uint8
 	SectorSize   [2]uint8
 	ClusterSize  uint8
-	Reserved     uint16
+	Reserved     [2]uint8
 	Fats         uint8
 	DirEntries   [2]uint8
 	Sectors      [2]uint8
@@ -29,10 +29,10 @@ type SuperBlock struct {
 	Heads        uint16
 	Hidden       uint32
 	TotalSect    uint32
-	Fat32Length  uint32
+	Fat32Length  [4]uint8
 	Flags        uint16
 	Version      [2]uint8
-	RootCluster  uint32
+	RootCluster  [4]uint8
 	FsinfoSector uint16
 	BackupBoot   uint16
 	Reserved2    [6]uint16


### PR DESCRIPTION
Firecracker launches tries to open VM disk image before every boot,
parses partition table, finds boot partition, tries to read it as FAT32
filesystem, extracts uncompressed kernel from `bzImage` (firecracker
doesn't support `bzImage` yet), extracts initramfs and passes it to
firecracker binary.

This flow allows for extended tests, e.g. testing installer, upgrade and
downgrade tests, etc.

Bootloader emulation is disabled by default for now, can be enabled via
`--with-bootloader-emulation` flag to `osctl cluster create`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>