### PR TITLE
feat: implement registry mirror & config for image pull

### DIFF
--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -32,6 +32,7 @@ osctl cluster create [flags]
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
       --mtu int                     MTU of the docker bridge network (default 1500)
       --nameservers strings         list of nameservers to use (VM only) (default [8.8.8.8,1.1.1.1])
+      --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
       --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --wait                        wait for the cluster to be ready before returning
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)

--- a/docs/osctl/osctl_config_generate.md
+++ b/docs/osctl/osctl_config_generate.md
@@ -20,6 +20,7 @@ osctl config generate <cluster name> https://<load balancer IP or DNS name> [fla
       --install-image string        the image used to perform an installation (default "docker.io/autonomy/installer:latest")
       --kubernetes-version string   desired kubernetes version to run (default "1.17.1")
   -o, --output-dir string           destination to output generated files
+      --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
       --version string              the desired machine config version to generate (default "v1alpha1")
 ```
 

--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -331,6 +331,49 @@ sysctls:
 
 ```
 
+#### registries
+
+Used to configure the machine's container image registry mirrors.
+
+Automatically generates matching CRI configuration for registry mirrors.
+
+Section `mirrors` allows to redirect requests for images to non-default registry,
+which might be local registry or caching mirror.
+
+Section `config` provides a way to authenticate to the registry with TLS client
+identity, provide registry CA, or authentication information.
+Authentication information has same meaning with the corresponding field in `.docker/config.json`.
+
+See also matching configuration for [CRI containerd plugin](https://github.com/containerd/cri/blob/master/docs/registry.md).
+
+Type: `RegistriesConfig`
+
+Examples:
+
+```yaml
+registries:
+  mirrors:
+    docker.io:
+      endpoints:
+        - https://registry-1.docker.io
+    '*':
+      endpoints:
+        - http://some.host:123/
+ config:
+  "some.host:123":
+    tls:
+      CA: ... # base64-encoded CA certificate in PEM format
+      clientIdentity:
+        cert: ...  # base64-encoded client certificate in PEM format
+        key: ...  # base64-encoded client key in PEM format
+    auth:
+      username: ...
+      password: ...
+      auth: ...
+      identityToken: ...
+
+```
+
 ---
 
 ### ClusterConfig
@@ -736,6 +779,32 @@ Defaults to `pool.ntp.org`
 > Note: This parameter only supports a single time server
 
 Type: `array`
+
+---
+
+### RegistriesConfig
+
+#### mirrors
+
+Specifies mirror configuration for each registry.
+This setting allows to use local pull-through caching registires,
+air-gapped installations, etc.
+
+Registry name is the first segment of image identifier, with 'docker.io'
+being default one.
+Name '*' catches any registry names not specified explicitly.
+
+Type: `map`
+
+#### config
+
+Specifies TLS & auth configuration for HTTPS image registries.
+Mutual TLS can be enabled with 'clientIdentity' option.
+
+TLS configuration can be skipped if registry has trusted
+server certificate.
+
+Type: `map`
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace (
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20180906201452-2aa6f33b730c
+	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
 	github.com/beevik/ntp v0.2.0

--- a/internal/app/machined/internal/phase/config/extra_files.go
+++ b/internal/app/machined/internal/phase/config/extra_files.go
@@ -35,7 +35,12 @@ func (task *ExtraFiles) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 func (task *ExtraFiles) runtime(r runtime.Runtime) (err error) {
 	var result *multierror.Error
 
-	for _, f := range r.Config().Machine().Files() {
+	files, err := r.Config().Machine().Files()
+	if err != nil {
+		return fmt.Errorf("error generating extra files: %w", err)
+	}
+
+	for _, f := range files {
 		content := f.Content
 
 		switch f.Op {

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -69,7 +69,7 @@ func (e *Etcd) PreFunc(ctx context.Context, config runtime.Configurator) (err er
 	// Pull the image and unpack it.
 
 	containerdctx := namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
-	if _, err = image.Pull(containerdctx, client, config.Cluster().Etcd().Image()); err != nil {
+	if _, err = image.Pull(containerdctx, config.Machine().Registries(), client, config.Cluster().Etcd().Image()); err != nil {
 		return fmt.Errorf("failed to pull image %q: %w", config.Cluster().Etcd().Image(), err)
 	}
 

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -114,7 +114,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, config runtime.Configurator) erro
 	// Pull the image and unpack it.
 	containerdctx := namespaces.WithNamespace(ctx, "k8s.io")
 
-	_, err = image.Pull(containerdctx, client, config.Machine().Kubelet().Image())
+	_, err = image.Pull(containerdctx, config.Machine().Registries(), client, config.Machine().Kubelet().Image())
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/containers/cri/containerd/config.go
+++ b/internal/pkg/containers/cri/containerd/config.go
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package containerd
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/talos-systems/talos/pkg/config/machine"
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+// config structures to generate TOML containerd CRI plugin config
+type mirror struct {
+	Endpoints []string `toml:"endpoint"`
+}
+
+type authConfig struct {
+	Username      string `toml:"username"`
+	Password      string `toml:"password"`
+	Auth          string `toml:"auth"`
+	IdentityToken string `toml:"identitytoken"`
+}
+
+type tlsConfig struct {
+	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
+	CAFile             string `toml:"ca_file"`
+	CertFile           string `toml:"cert_file"`
+	KeyFile            string `toml:"key_file"`
+}
+
+type registryConfig struct {
+	Auth *authConfig `toml:"auth"`
+	TLS  *tlsConfig  `toml:"tls"`
+}
+
+type registry struct {
+	Mirrors map[string]mirror         `toml:"mirrors"`
+	Configs map[string]registryConfig `toml:"configs"`
+}
+
+type criConfig struct {
+	Registry registry `toml:"registry"`
+}
+
+type pluginsConfig struct {
+	CRI criConfig `toml:"cri"`
+}
+
+type containerdConfig struct {
+	Plugins pluginsConfig `toml:"plugins"`
+}
+
+// GenerateRegistriesConfig for containerd CRI plugin (TOML format).
+//
+//nolint: gocyclo
+func GenerateRegistriesConfig(input machine.Registries) ([]machine.File, error) {
+	caPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "ca")
+	clientPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "client")
+
+	var config containerdConfig
+	config.Plugins.CRI.Registry.Mirrors = make(map[string]mirror)
+	config.Plugins.CRI.Registry.Configs = make(map[string]registryConfig)
+
+	for mirrorName, mirrorConfig := range input.Mirrors() {
+		config.Plugins.CRI.Registry.Mirrors[mirrorName] = mirror{Endpoints: mirrorConfig.Endpoints}
+	}
+
+	var extraFiles []machine.File
+
+	for registryHost, hostConfig := range input.Config() {
+		cfg := registryConfig{}
+
+		if hostConfig.Auth != nil {
+			cfg.Auth = &authConfig{
+				Username:      hostConfig.Auth.Username,
+				Password:      hostConfig.Auth.Password,
+				Auth:          hostConfig.Auth.Auth,
+				IdentityToken: hostConfig.Auth.IdentityToken,
+			}
+		}
+
+		if hostConfig.TLS != nil {
+			cfg.TLS = &tlsConfig{
+				InsecureSkipVerify: hostConfig.TLS.InsecureSkipVerify,
+			}
+
+			if hostConfig.TLS.CA != nil {
+				path := filepath.Join(caPath, fmt.Sprintf("%s.crt", registryHost))
+
+				extraFiles = append(extraFiles, machine.File{
+					Content:     string(hostConfig.TLS.CA),
+					Permissions: 0600,
+					Path:        path,
+					Op:          "create",
+				})
+
+				cfg.TLS.CAFile = path
+			}
+
+			if hostConfig.TLS.ClientIdentity.Crt != nil {
+				path := filepath.Join(clientPath, fmt.Sprintf("%s.crt", registryHost))
+
+				extraFiles = append(extraFiles, machine.File{
+					Content:     string(hostConfig.TLS.ClientIdentity.Crt),
+					Permissions: 0600,
+					Path:        path,
+					Op:          "create",
+				})
+
+				cfg.TLS.CertFile = path
+			}
+
+			if hostConfig.TLS.ClientIdentity.Key != nil {
+				path := filepath.Join(clientPath, fmt.Sprintf("%s.key", registryHost))
+
+				extraFiles = append(extraFiles, machine.File{
+					Content:     string(hostConfig.TLS.ClientIdentity.Key),
+					Permissions: 0600,
+					Path:        path,
+					Op:          "create",
+				})
+
+				cfg.TLS.KeyFile = path
+			}
+		}
+
+		if cfg.Auth != nil || cfg.TLS != nil {
+			config.Plugins.CRI.Registry.Configs[registryHost] = cfg
+		}
+	}
+
+	var buf bytes.Buffer
+
+	if err := toml.NewEncoder(&buf).Encode(&config); err != nil {
+		return nil, err
+	}
+
+	// CRI plugin doesn't support merging configs for plugins across files,
+	// so we have to append CRI plugin to the main config, as it already contains
+	// configuration pieces for CRI plugin
+	return append(extraFiles, machine.File{
+		Content:     buf.String(),
+		Permissions: 0644,
+		Path:        constants.CRIContainerdConfig,
+		Op:          "append",
+	}), nil
+}

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -1,0 +1,117 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package containerd_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/pkg/containers/cri/containerd"
+	"github.com/talos-systems/talos/pkg/config/machine"
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
+)
+
+type mockConfig struct {
+	mirrors map[string]machine.RegistryMirrorConfig
+	config  map[string]machine.RegistryConfig
+}
+
+func (c *mockConfig) Mirrors() map[string]machine.RegistryMirrorConfig {
+	return c.mirrors
+}
+
+func (c *mockConfig) Config() map[string]machine.RegistryConfig {
+	return c.config
+}
+
+func (c *mockConfig) ExtraFiles() ([]machine.File, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type ConfigSuite struct {
+	suite.Suite
+}
+
+func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
+	cfg := &mockConfig{
+		mirrors: map[string]machine.RegistryMirrorConfig{
+			"docker.io": {
+				Endpoints: []string{"https://registry-1.docker.io", "https://registry-2.docker.io"},
+			},
+		},
+		config: map[string]machine.RegistryConfig{
+			"some.host:123": {
+				Auth: &machine.RegistryAuthConfig{
+					Username:      "root",
+					Password:      "secret",
+					Auth:          "auth",
+					IdentityToken: "token",
+				},
+				TLS: &machine.RegistryTLSConfig{
+					InsecureSkipVerify: true,
+					CA:                 []byte("cacert"),
+					ClientIdentity: &x509.PEMEncodedCertificateAndKey{
+						Crt: []byte("clientcert"),
+						Key: []byte("clientkey"),
+					},
+				},
+			},
+		},
+	}
+
+	files, err := containerd.GenerateRegistriesConfig(cfg)
+	suite.Require().NoError(err)
+	suite.Assert().Equal([]machine.File{
+		{
+			Content:     `cacert`,
+			Permissions: 0600,
+			Path:        "/etc/cri/ca/some.host:123.crt",
+			Op:          "create",
+		},
+		{
+			Content:     `clientcert`,
+			Permissions: 0600,
+			Path:        "/etc/cri/client/some.host:123.crt",
+			Op:          "create",
+		},
+		{
+			Content:     `clientkey`,
+			Permissions: 0600,
+			Path:        "/etc/cri/client/some.host:123.key",
+			Op:          "create",
+		},
+		{
+			Content: `[plugins]
+  [plugins.cri]
+    [plugins.cri.registry]
+      [plugins.cri.registry.mirrors]
+        [plugins.cri.registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io", "https://registry-2.docker.io"]
+      [plugins.cri.registry.configs]
+        [plugins.cri.registry.configs."some.host:123"]
+          [plugins.cri.registry.configs."some.host:123".auth]
+            username = "root"
+            password = "secret"
+            auth = "auth"
+            identitytoken = "token"
+          [plugins.cri.registry.configs."some.host:123".tls]
+            insecure_skip_verify = true
+            ca_file = "/etc/cri/ca/some.host:123.crt"
+            cert_file = "/etc/cri/client/some.host:123.crt"
+            key_file = "/etc/cri/client/some.host:123.key"
+`,
+			Permissions: 0644,
+			Path:        constants.CRIContainerdConfig,
+			Op:          "append",
+		},
+	}, files)
+}
+
+func TestConfigSuite(t *testing.T) {
+	suite.Run(t, new(ConfigSuite))
+}

--- a/internal/pkg/containers/cri/containerd/containerd.go
+++ b/internal/pkg/containers/cri/containerd/containerd.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package containerd provides support for containerd CRI plugin
+package containerd

--- a/internal/pkg/containers/image/resolver.go
+++ b/internal/pkg/containers/image/resolver.go
@@ -1,0 +1,167 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/remotes/docker"
+
+	"github.com/talos-systems/talos/pkg/config/machine"
+)
+
+// NewResolver builds registry resolver based on Talos configuration.
+func NewResolver(config machine.Registries) remotes.Resolver {
+	return docker.NewResolver(docker.ResolverOptions{
+		Hosts: RegistryHosts(config),
+	})
+}
+
+// RegistryHosts returns host configuration per registry.
+func RegistryHosts(config machine.Registries) docker.RegistryHosts {
+	return func(host string) ([]docker.RegistryHost, error) {
+		var registries []docker.RegistryHost
+
+		endpoints, err := RegistryEndpoints(config, host)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, endpoint := range endpoints {
+			u, err := url.Parse(endpoint)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing endpoint %q for host %q: %w", endpoint, host, err)
+			}
+
+			transport := newTransport()
+			client := &http.Client{Transport: transport}
+
+			registryConfig := config.Config()[u.Host]
+
+			if u.Scheme != "https" && registryConfig.TLS != nil {
+				return nil, fmt.Errorf("TLS config specified for non-HTTPS registry: %q", u.Host)
+			}
+
+			if registryConfig.TLS != nil {
+				transport.TLSClientConfig, err = registryConfig.TLS.GetTLSConfig()
+				if err != nil {
+					return nil, fmt.Errorf("error preparing TLS config for %q: %w", u.Host, err)
+				}
+			}
+
+			if u.Path == "" {
+				u.Path = "/v2"
+			}
+
+			uu := u
+
+			registries = append(registries, docker.RegistryHost{
+				Client: client,
+				Authorizer: docker.NewDockerAuthorizer(
+					docker.WithAuthClient(client),
+					docker.WithAuthCreds(func(host string) (string, string, error) {
+						return PrepareAuth(registryConfig.Auth, uu.Host, host)
+					})),
+				Host:         uu.Host,
+				Scheme:       uu.Scheme,
+				Path:         uu.Path,
+				Capabilities: docker.HostCapabilityResolve | docker.HostCapabilityPull,
+			})
+		}
+
+		return registries, nil
+	}
+}
+
+// RegistryEndpoints returns registry endpoints per host using config.
+func RegistryEndpoints(config machine.Registries, host string) ([]string, error) {
+	var endpoints []string
+
+	if hostConfig, ok := config.Mirrors()[host]; ok {
+		endpoints = hostConfig.Endpoints
+	}
+
+	if endpoints == nil {
+		if catchAllConfig, ok := config.Mirrors()["*"]; ok {
+			endpoints = catchAllConfig.Endpoints
+		}
+	}
+
+	if len(endpoints) == 0 {
+		// still no endpoints, use default
+		defaultHost, err := docker.DefaultHost(host)
+		if err != nil {
+			return nil, fmt.Errorf("error getting default host for %q: %w", host, err)
+		}
+
+		endpoints = append(endpoints, "https://"+defaultHost)
+	}
+
+	return endpoints, nil
+}
+
+// PrepareAuth returns authentication info in the format expected by containerd.
+func PrepareAuth(auth *machine.RegistryAuthConfig, host, expectedHost string) (string, string, error) {
+	if auth == nil {
+		return "", "", nil
+	}
+
+	if expectedHost != host {
+		// don't pass auth to unknown hosts
+		return "", "", nil
+	}
+
+	if auth.Username != "" {
+		return auth.Username, auth.Password, nil
+	}
+
+	if auth.IdentityToken != "" {
+		return "", auth.IdentityToken, nil
+	}
+
+	if auth.Auth != "" {
+		decLen := base64.StdEncoding.DecodedLen(len(auth.Auth))
+		decoded := make([]byte, decLen)
+
+		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.Auth))
+		if err != nil {
+			return "", "", fmt.Errorf("error parsing auth for %q: %w", host, err)
+		}
+
+		fields := strings.SplitN(string(decoded), ":", 2)
+		if len(fields) != 2 {
+			return "", "", fmt.Errorf("invalid decoded auth for %q: %q", host, decoded)
+		}
+
+		user, password := fields[0], fields[1]
+
+		return user, strings.Trim(password, "\x00"), nil
+	}
+
+	return "", "", fmt.Errorf("invalid auth config for %q", host)
+}
+
+// newTransport creates HTTP transport with default settings.
+func newTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 5 * time.Second,
+	}
+}

--- a/internal/pkg/containers/image/resolver_test.go
+++ b/internal/pkg/containers/image/resolver_test.go
@@ -1,0 +1,225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package image_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
+	"github.com/talos-systems/talos/pkg/config/machine"
+)
+
+type mockConfig struct {
+	mirrors map[string]machine.RegistryMirrorConfig
+	config  map[string]machine.RegistryConfig
+}
+
+func (c *mockConfig) Mirrors() map[string]machine.RegistryMirrorConfig {
+	return c.mirrors
+}
+
+func (c *mockConfig) Config() map[string]machine.RegistryConfig {
+	return c.config
+}
+
+func (c *mockConfig) ExtraFiles() ([]machine.File, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type ResolverSuite struct {
+	suite.Suite
+}
+
+func (suite *ResolverSuite) TestRegistryEndpoints() {
+	// defaults
+	endpoints, err := image.RegistryEndpoints(&mockConfig{}, "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal([]string{"https://registry-1.docker.io"}, endpoints)
+
+	endpoints, err = image.RegistryEndpoints(&mockConfig{}, "quay.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal([]string{"https://quay.io"}, endpoints)
+
+	// overrides without catch-all
+	cfg := &mockConfig{
+		mirrors: map[string]machine.RegistryMirrorConfig{
+			"docker.io": {
+				Endpoints: []string{"http://127.0.0.1:5000", "https://some.host"},
+			},
+		},
+	}
+
+	endpoints, err = image.RegistryEndpoints(cfg, "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal([]string{"http://127.0.0.1:5000", "https://some.host"}, endpoints)
+
+	endpoints, err = image.RegistryEndpoints(cfg, "quay.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal([]string{"https://quay.io"}, endpoints)
+
+	// overrides with catch-all
+	cfg = &mockConfig{
+		mirrors: map[string]machine.RegistryMirrorConfig{
+			"docker.io": {
+				Endpoints: []string{"http://127.0.0.1:5000", "https://some.host"},
+			},
+			"*": {
+				Endpoints: []string{"http://127.0.0.1:5001"},
+			},
+		},
+	}
+
+	endpoints, err = image.RegistryEndpoints(cfg, "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal([]string{"http://127.0.0.1:5000", "https://some.host"}, endpoints)
+
+	endpoints, err = image.RegistryEndpoints(cfg, "quay.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal([]string{"http://127.0.0.1:5001"}, endpoints)
+}
+
+func (suite *ResolverSuite) TestPrepareAuth() {
+	user, pass, err := image.PrepareAuth(nil, "docker.io", "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal("", user)
+	suite.Assert().Equal("", pass)
+
+	user, pass, err = image.PrepareAuth(&machine.RegistryAuthConfig{
+		Username: "root",
+		Password: "secret",
+	}, "docker.io", "not.docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal("", user)
+	suite.Assert().Equal("", pass)
+
+	user, pass, err = image.PrepareAuth(&machine.RegistryAuthConfig{
+		Username: "root",
+		Password: "secret",
+	}, "docker.io", "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal("root", user)
+	suite.Assert().Equal("secret", pass)
+
+	user, pass, err = image.PrepareAuth(&machine.RegistryAuthConfig{
+		IdentityToken: "xyz",
+	}, "docker.io", "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal("", user)
+	suite.Assert().Equal("xyz", pass)
+
+	user, pass, err = image.PrepareAuth(&machine.RegistryAuthConfig{
+		Auth: "dXNlcjE6c2VjcmV0MQ==",
+	}, "docker.io", "docker.io")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal("user1", user)
+	suite.Assert().Equal("secret1", pass)
+
+	_, _, err = image.PrepareAuth(&machine.RegistryAuthConfig{}, "docker.io", "docker.io")
+	suite.Assert().EqualError(err, "invalid auth config for \"docker.io\"")
+}
+
+func (suite *ResolverSuite) TestRegistryHosts() {
+	registryHosts, err := image.RegistryHosts(&mockConfig{})("docker.io")
+	suite.Require().NoError(err)
+	suite.Assert().Len(registryHosts, 1)
+	suite.Assert().Equal("https", registryHosts[0].Scheme)
+	suite.Assert().Equal("registry-1.docker.io", registryHosts[0].Host)
+	suite.Assert().Equal("/v2", registryHosts[0].Path)
+	suite.Assert().Nil(registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig) //nolint: errcheck
+
+	cfg := &mockConfig{
+		mirrors: map[string]machine.RegistryMirrorConfig{
+			"docker.io": {
+				Endpoints: []string{"http://127.0.0.1:5000/docker.io", "https://some.host"},
+			},
+		},
+	}
+
+	registryHosts, err = image.RegistryHosts(cfg)("docker.io")
+	suite.Require().NoError(err)
+	suite.Assert().Len(registryHosts, 2)
+	suite.Assert().Equal("http", registryHosts[0].Scheme)
+	suite.Assert().Equal("127.0.0.1:5000", registryHosts[0].Host)
+	suite.Assert().Equal("/docker.io", registryHosts[0].Path)
+	suite.Assert().Nil(registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig) //nolint: errcheck
+	suite.Assert().Equal("https", registryHosts[1].Scheme)
+	suite.Assert().Equal("some.host", registryHosts[1].Host)
+	suite.Assert().Equal("/v2", registryHosts[1].Path)
+	suite.Assert().Nil(registryHosts[1].Client.Transport.(*http.Transport).TLSClientConfig) //nolint: errcheck
+
+	cfg = &mockConfig{
+		mirrors: map[string]machine.RegistryMirrorConfig{
+			"docker.io": {
+				Endpoints: []string{"https://some.host:123"},
+			},
+		},
+		config: map[string]machine.RegistryConfig{
+			"some.host:123": {
+				TLS: &machine.RegistryTLSConfig{
+					CA: []byte(caCertMock),
+					// ClientIdentity: &x509.PEMEncodedCertificateAndKey{},
+				},
+				Auth: &machine.RegistryAuthConfig{
+					Username: "root",
+					Password: "secret",
+				},
+			},
+		},
+	}
+
+	registryHosts, err = image.RegistryHosts(cfg)("docker.io")
+	suite.Require().NoError(err)
+	suite.Assert().Len(registryHosts, 1)
+	suite.Assert().Equal("https", registryHosts[0].Scheme)
+	suite.Assert().Equal("some.host:123", registryHosts[0].Host)
+	suite.Assert().Equal("/v2", registryHosts[0].Path)
+
+	tlsClientConfig := registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig //nolint: errcheck
+	suite.Require().NotNil(tlsClientConfig)
+	suite.Require().NotNil(tlsClientConfig.RootCAs)
+	suite.Require().Empty(tlsClientConfig.Certificates)
+
+	suite.Require().NotNil(registryHosts[0].Authorizer)
+
+	req, err := http.NewRequest("GET", "htts://some.host:123/v2", nil)
+	suite.Require().NoError(err)
+
+	resp := &http.Response{}
+	resp.Request = req
+	resp.Header = http.Header{}
+	resp.Header.Add(http.CanonicalHeaderKey("WWW-Authenticate"), "Basic realm=\"Access to the staging site\", charset=\"UTF-8\"")
+
+	suite.Require().NoError(registryHosts[0].Authorizer.AddResponses(context.Background(), []*http.Response{resp}))
+	suite.Require().NoError(registryHosts[0].Authorizer.Authorize(context.Background(), req))
+
+	suite.Assert().Equal("Basic cm9vdDpzZWNyZXQ=", req.Header.Get("Authorization"))
+}
+
+func TestResolverSuite(t *testing.T) {
+	suite.Run(t, new(ResolverSuite))
+}
+
+const caCertMock = `-----BEGIN CERTIFICATE-----
+MIICjTCCAhSgAwIBAgIIdebfy8FoW6gwCgYIKoZIzj0EAwIwfDELMAkGA1UEBhMC
+VVMxDjAMBgNVBAgMBVRleGFzMRAwDgYDVQQHDAdIb3VzdG9uMRgwFgYDVQQKDA9T
+U0wgQ29ycG9yYXRpb24xMTAvBgNVBAMMKFNTTC5jb20gUm9vdCBDZXJ0aWZpY2F0
+aW9uIEF1dGhvcml0eSBFQ0MwHhcNMTYwMjEyMTgxNDAzWhcNNDEwMjEyMTgxNDAz
+WjB8MQswCQYDVQQGEwJVUzEOMAwGA1UECAwFVGV4YXMxEDAOBgNVBAcMB0hvdXN0
+b24xGDAWBgNVBAoMD1NTTCBDb3Jwb3JhdGlvbjExMC8GA1UEAwwoU1NMLmNvbSBS
+b290IENlcnRpZmljYXRpb24gQXV0aG9yaXR5IEVDQzB2MBAGByqGSM49AgEGBSuB
+BAAiA2IABEVuqVDEpiM2nl8ojRfLliJkP9x6jh3MCLOicSS6jkm5BBtHllirLZXI
+7Z4INcgn64mMU1jrYor+8FsPazFSY0E7ic3s7LaNGdM0B9y7xgZ/wkWV7Mt/qCPg
+CemB+vNH06NjMGEwHQYDVR0OBBYEFILRhXMw5zUE044CkvvlpNHEIejNMA8GA1Ud
+EwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAUgtGFczDnNQTTjgKS++Wk0cQh6M0wDgYD
+VR0PAQH/BAQDAgGGMAoGCCqGSM49BAMCA2cAMGQCMG/n61kRpGDPYbCWe+0F+S8T
+kdzt5fxQaxFGRrMcIQBiu77D5+jNB5n5DQtdcj7EqgIwH7y6C+IwJPt8bYBVCpk+
+gA0z5Wajs6O7pdWLjwkspl1+4vAHCGht0nxpbl/f5Wpl
+-----END CERTIFICATE-----
+`

--- a/internal/pkg/install/install.go
+++ b/internal/pkg/install/install.go
@@ -44,7 +44,7 @@ func RunInstallerContainer(r runtime.Runtime, opts ...Option) error {
 	var img containerd.Image
 
 	if options.ImagePull {
-		img, err = image.Pull(ctx, client, r.Config().Machine().Install().Image())
+		img, err = image.Pull(ctx, r.Config().Machine().Registries(), client, r.Config().Machine().Install().Image())
 		if err != nil {
 			return err
 		}

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -25,6 +25,9 @@ func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
 			InstallImage:      in.InstallImage,
 			InstallBootloader: true,
 		},
+		MachineRegistries: v1alpha1.RegistriesConfig{
+			RegistryMirrors: in.RegistryMirrors,
+		},
 	}
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -83,6 +83,8 @@ type Input struct {
 	InstallImage string
 
 	NetworkConfig *v1alpha1.NetworkConfig
+
+	RegistryMirrors map[string]machine.RegistryMirrorConfig
 }
 
 // GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
@@ -320,6 +322,7 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 		InstallDisk:               options.InstallDisk,
 		InstallImage:              options.InstallImage,
 		NetworkConfig:             options.NetworkConfig,
+		RegistryMirrors:           options.RegistryMirrors,
 	}
 
 	return input, nil

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -25,6 +25,9 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			InstallImage:      in.InstallImage,
 			InstallBootloader: true,
 		},
+		MachineRegistries: v1alpha1.RegistriesConfig{
+			RegistryMirrors: in.RegistryMirrors,
+		},
 	}
 
 	certSANs := in.GetAPIServerSANs()

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -25,6 +25,9 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 			InstallImage:      in.InstallImage,
 			InstallBootloader: true,
 		},
+		MachineRegistries: v1alpha1.RegistriesConfig{
+			RegistryMirrors: in.RegistryMirrors,
+		},
 	}
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -4,7 +4,10 @@
 
 package generate
 
-import v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+import (
+	"github.com/talos-systems/talos/pkg/config/machine"
+	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+)
 
 // GenOption controls generate options specific to input generation.
 type GenOption func(o *GenOptions) error
@@ -54,6 +57,19 @@ func WithNetworkConfig(network *v1alpha1.NetworkConfig) GenOption {
 	}
 }
 
+// WithRegistryMirror configures registry mirror endpoint(s).
+func WithRegistryMirror(host string, endpoints ...string) GenOption {
+	return func(o *GenOptions) error {
+		if o.RegistryMirrors == nil {
+			o.RegistryMirrors = make(map[string]machine.RegistryMirrorConfig)
+		}
+
+		o.RegistryMirrors[host] = machine.RegistryMirrorConfig{Endpoints: endpoints}
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
@@ -61,6 +77,7 @@ type GenOptions struct {
 	InstallImage              string
 	AdditionalSubjectAltNames []string
 	NetworkConfig             *v1alpha1.NetworkConfig
+	RegistryMirrors           map[string]machine.RegistryMirrorConfig
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -179,6 +179,42 @@ type MachineConfig struct {
 	//         kernel.domainname: talos.dev
 	//         net.ipv4.ip_forward: "0"
 	MachineSysctls map[string]string `yaml:"sysctls,omitempty"`
+	//   description: |
+	//     Used to configure the machine's container image registry mirrors.
+	//
+	//     Automatically generates matching CRI configuration for registry mirrors.
+	//
+	//     Section `mirrors` allows to redirect requests for images to non-default registry,
+	//     which might be local registry or caching mirror.
+	//
+	//     Section `config` provides a way to authenticate to the registry with TLS client
+	//     identity, provide registry CA, or authentication information.
+	//     Authentication information has same meaning with the corresponding field in `.docker/config.json`.
+	//
+	//     See also matching configuration for [CRI containerd plugin](https://github.com/containerd/cri/blob/master/docs/registry.md).
+	//   examples:
+	//     - |
+	//       registries:
+	//         mirrors:
+	//           docker.io:
+	//             endpoints:
+	//               - https://registry-1.docker.io
+	//           '*':
+	//             endpoints:
+	//               - http://some.host:123/
+	//        config:
+	//         "some.host:123":
+	//           tls:
+	//             CA: ... # base64-encoded CA certificate in PEM format
+	//             clientIdentity:
+	//               cert: ...  # base64-encoded client certificate in PEM format
+	//               key: ...  # base64-encoded client key in PEM format
+	//           auth:
+	//             username: ...
+	//             password: ...
+	//             auth: ...
+	//             identityToken: ...
+	MachineRegistries RegistriesConfig `yaml:"registries,omitempty"`
 }
 
 // ClusterConfig reperesents the cluster-wide config values
@@ -426,6 +462,26 @@ type TimeConfig struct {
 	//
 	//     > Note: This parameter only supports a single time server
 	TimeServers []string `yaml:"servers,omitempty"`
+}
+
+// RegistriesConfig represents the image pull options.
+type RegistriesConfig struct {
+	//   description: |
+	//     Specifies mirror configuration for each registry.
+	//     This setting allows to use local pull-through caching registires,
+	//     air-gapped installations, etc.
+	//
+	//     Registry name is the first segment of image identifier, with 'docker.io'
+	//     being default one.
+	//     Name '*' catches any registry names not specified explicitly.
+	RegistryMirrors map[string]machine.RegistryMirrorConfig `yaml:"mirrors,omitempty"`
+	//   description: |
+	//     Specifies TLS & auth configuration for HTTPS image registries.
+	//     Mutual TLS can be enabled with 'clientIdentity' option.
+	//
+	//     TLS configuration can be skipped if registry has trusted
+	//     server certificate.
+	RegistryConfig map[string]machine.RegistryConfig `yaml:"config,omitempty"`
 }
 
 // PodCheckpointer represents the pod-checkpointer config values


### PR DESCRIPTION
When images are pulled by Talos or via CRI plugin, configuration
for each registry is applied. Mirrors allow to redirect pull request to
either local registry or cached registry. Auth & TLS enable
authentication and TLS authentication for non-public registries.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>