### PR TITLE
fix: don't proxy gRPC unix connections

### DIFF
--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/conditions"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/grpc/dialer"
 )
 
 // Networkd implements the Service interface. It serves as the concrete type with
@@ -130,7 +131,12 @@ func (n *Networkd) HealthFunc(runtime.Configurator) health.Check {
 			readyResp *healthapi.ReadyCheckResponse
 		)
 
-		if conn, err = grpc.Dial("unix:"+constants.NetworkSocketPath, grpc.WithInsecure()); err != nil {
+		conn, err = grpc.Dial(
+			fmt.Sprintf("%s://%s", "unix", constants.NetworkSocketPath),
+			grpc.WithInsecure(),
+			grpc.WithContextDialer(dialer.DialUnix()),
+		)
+		if err != nil {
 			return err
 		}
 		defer conn.Close() //nolint: errcheck

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/grpc/dialer"
 )
 
 // OSD implements the Service interface. It serves as the concrete type with
@@ -125,7 +126,11 @@ func (o *OSD) Runner(config runtime.Configurator) (runner.Runner, error) {
 // HealthFunc implements the HealthcheckedService interface
 func (o *OSD) HealthFunc(runtime.Configurator) health.Check {
 	return func(ctx context.Context) error {
-		conn, err := grpc.Dial("unix:"+constants.OSSocketPath, grpc.WithInsecure())
+		conn, err := grpc.Dial(
+			fmt.Sprintf("%s://%s", "unix", constants.OSSocketPath),
+			grpc.WithInsecure(),
+			grpc.WithContextDialer(dialer.DialUnix()),
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/app/networkd/pkg/reg/reg_test.go
+++ b/internal/app/networkd/pkg/reg/reg_test.go
@@ -20,6 +20,7 @@ import (
 	healthapi "github.com/talos-systems/talos/api/health"
 	networkapi "github.com/talos-systems/talos/api/network"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
+	"github.com/talos-systems/talos/pkg/grpc/dialer"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 )
 
@@ -43,7 +44,11 @@ func (suite *NetworkdSuite) TestRoutes() {
 	// nolint: errcheck
 	go server.Serve(listener)
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	conn, err := grpc.Dial(
+		fmt.Sprintf("%s://%s", "unix", listener.Addr().String()),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(dialer.DialUnix()),
+	)
 	suite.Assert().NoError(err)
 
 	nClient := networkapi.NewNetworkServiceClient(conn)
@@ -64,7 +69,11 @@ func (suite *NetworkdSuite) TestInterfaces() {
 	// nolint: errcheck
 	go server.Serve(listener)
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	conn, err := grpc.Dial(
+		fmt.Sprintf("%s://%s", "unix", listener.Addr().String()),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(dialer.DialUnix()),
+	)
 	suite.Assert().NoError(err)
 
 	nClient := networkapi.NewNetworkServiceClient(conn)
@@ -111,7 +120,11 @@ func (suite *NetworkdSuite) TestHealthAPI() {
 	// nolint: errcheck
 	go server.Serve(listener)
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	conn, err := grpc.Dial(
+		fmt.Sprintf("%s://%s", "unix", listener.Addr().String()),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(dialer.DialUnix()),
+	)
 	suite.Assert().NoError(err)
 
 	// Verify base state

--- a/internal/app/ntpd/pkg/reg/reg_test.go
+++ b/internal/app/ntpd/pkg/reg/reg_test.go
@@ -18,6 +18,7 @@ import (
 
 	timeapi "github.com/talos-systems/talos/api/time"
 	"github.com/talos-systems/talos/internal/app/ntpd/pkg/ntp"
+	"github.com/talos-systems/talos/pkg/grpc/dialer"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 )
 
@@ -51,7 +52,11 @@ func (suite *NtpdSuite) TestTime() {
 	// nolint: errcheck
 	go server.Serve(listener)
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	conn, err := grpc.Dial(
+		fmt.Sprintf("%s://%s", "unix", listener.Addr().String()),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(dialer.DialUnix()),
+	)
 	suite.Assert().NoError(err)
 
 	nClient := timeapi.NewTimeServiceClient(conn)
@@ -82,7 +87,11 @@ func (suite *NtpdSuite) TestTimeCheck() {
 	// nolint: errcheck
 	go server.Serve(listener)
 
-	conn, err := grpc.Dial(fmt.Sprintf("%s://%s", "unix", listener.Addr().String()), grpc.WithInsecure())
+	conn, err := grpc.Dial(
+		fmt.Sprintf("%s://%s", "unix", listener.Addr().String()),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(dialer.DialUnix()),
+	)
 	suite.Assert().NoError(err)
 
 	nClient := timeapi.NewTimeServiceClient(conn)

--- a/internal/pkg/cri/client.go
+++ b/internal/pkg/cri/client.go
@@ -11,6 +11,8 @@ import (
 
 	"google.golang.org/grpc"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/talos-systems/talos/pkg/grpc/dialer"
 )
 
 // Client is a lightweight implementation of CRI client.
@@ -34,7 +36,9 @@ func NewClient(endpoint string, connectionTimeout time.Duration) (*Client, error
 		grpc.WithBlock(),
 		grpc.FailOnNonTempDialError(false),
 		grpc.WithBackoffMaxDelay(3*time.Second), //nolint: staticcheck
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)),
+		grpc.WithContextDialer(dialer.DialUnix()),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to CRI: %w", err)
 	}

--- a/pkg/grpc/dialer/dialer.go
+++ b/pkg/grpc/dialer/dialer.go
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package dialer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+)
+
+// DialUnix is used as a parameter for 'grpc.WithContextDialer' to bypass the
+// default dialer of gRPC to ensure that proxy vars are not used.
+func DialUnix() func(context.Context, string) (net.Conn, error) {
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		u, err := url.Parse(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		if u.Scheme != "unix" {
+			return nil, fmt.Errorf("invalid scheme: %q", u.Scheme)
+		}
+
+		return net.Dial(u.Scheme, u.Path)
+	}
+}

--- a/pkg/grpc/dialer/dialer_test.go
+++ b/pkg/grpc/dialer/dialer_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package dialer_test
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	// added for accurate coverage estimation
+	//
+	// please remove it once any unit-test is added
+	// for this package
+}


### PR DESCRIPTION
The default gRPC dialer honors proxy environment variables, which causes
local unix socket connections to attempt to go through the proxy. This
fixes that by using a custom dialer.