### PR TITLE
fix: do not add empty netconf

### DIFF
--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -62,8 +62,9 @@ func New(config runtime.Configurator) (*Networkd, error) {
 	netconf := make(map[string][]nic.Option)
 
 	if option = kernel.ProcCmdline().Get("ip").First(); option != nil {
-		name, opts := buildKernelOptions(*option)
-		netconf[name] = opts
+		if name, opts := buildKernelOptions(*option); name != "" {
+			netconf[name] = opts
+		}
 	}
 
 	// Gather settings for all config driven interfaces


### PR DESCRIPTION
When `ip=dhcp` (as well as a few other conditions), the
buildKernelOptions function returns empty.  In these cases, this empty
network config should not be added to the common list for iteration.

fixes #1869

Signed-off-by: Seán C McCord <ulexus@gmail.com>