### PR TITLE
chore: implement loadbalancer for firecracker provisioner

### DIFF
--- a/cmd/osctl/cmd/firecracker_launch_linux.go
+++ b/cmd/osctl/cmd/firecracker_launch_linux.go
@@ -13,7 +13,7 @@ import (
 // firecrackerLaunchCmd represents the firecracker-launch command
 var firecrackerLaunchCmd = &cobra.Command{
 	Use:    "firecracker-launch",
-	Short:  "Intneral command used by Firecracker provisioner",
+	Short:  "Internal command used by Firecracker provisioner",
 	Long:   ``,
 	Args:   cobra.NoArgs,
 	Hidden: true,

--- a/cmd/osctl/cmd/loadbalancer_launch.go
+++ b/cmd/osctl/cmd/loadbalancer_launch.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/internal/pkg/loadbalancer"
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+var loadbalancerLaunchCmdFlags struct {
+	addr      string
+	upstreams []string
+}
+
+// loadbalancerLaunchCmd represents the loadbalancer-launch command
+var loadbalancerLaunchCmd = &cobra.Command{
+	Use:    "loadbalancer-launch",
+	Short:  "Intneral command used by Firecracker provisioner",
+	Long:   ``,
+	Args:   cobra.NoArgs,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var lb loadbalancer.TCP
+
+		for _, port := range []int{constants.ApidPort, 6443} { // TODO: need to put 6443 as constant or use config?
+			upstreams := make([]string, len(loadbalancerLaunchCmdFlags.upstreams))
+			for i := range upstreams {
+				upstreams[i] = fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.upstreams[i], port)
+			}
+
+			// for apid, add only init node for now (first item)
+			if port == constants.ApidPort && len(upstreams) > 1 {
+				upstreams = upstreams[:1]
+			}
+
+			if err := lb.AddRoute(fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.addr, port), upstreams); err != nil {
+				return err
+			}
+		}
+
+		return lb.Run()
+	},
+}
+
+func init() {
+	loadbalancerLaunchCmd.Flags().StringVar(&loadbalancerLaunchCmdFlags.addr, "loadbalancer-addr", "localhost", "load balancer listen address (IP or host)")
+	loadbalancerLaunchCmd.Flags().StringSliceVar(&loadbalancerLaunchCmdFlags.upstreams, "loadbalancer-upstreams", []string{}, "load balancer upstreams (nodes to proxy to)")
+	rootCmd.AddCommand(loadbalancerLaunchCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/yaml.v2 v2.2.7
 	gotest.tools v2.2.0+incompatible
+	inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -793,6 +793,9 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+inet.af v0.0.0-20181218191229-53da77bc832c h1:U3RoiyEF5b3Y1SVL6NNvpkgqUz2qS3a0OJh9kpSCN04=
+inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252 h1:gmJCKidOfjKDUHF1jjke+I+2iQIyE3HNNxu2OKO/FUI=
+inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252/go.mod h1:zq+R+tLcdHugi7Jt+FtIQY6m6wtX34lr2CdQVH2fhW0=
 k8s.io/api v0.17.0 h1:H9d/lw+VkZKEVIUc8F3wgiQ+FUXTTr21M87jXLU7yqM=
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/apiextensions-apiserver v0.17.0 h1:+XgcGxqaMztkbbvsORgCmHIb4uImHKvTjNyu7b8gRnA=

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -42,8 +42,6 @@ func (suite *RebootSuite) TearDownTest() {
 }
 
 func (suite *RebootSuite) readUptime(ctx context.Context) (float64, error) {
-	suite.T().Skip("test disabled due to issues with single endpoint")
-
 	reader, errCh, err := suite.Client.Read(ctx, "/proc/uptime")
 	if err != nil {
 		return 0, err

--- a/internal/pkg/loadbalancer/loadbalancer.go
+++ b/internal/pkg/loadbalancer/loadbalancer.go
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package loadbalancer provides simple TCP loadbalancer.
+package loadbalancer
+
+import (
+	"context"
+	"log"
+	"net"
+
+	"inet.af/tcpproxy"
+
+	"github.com/talos-systems/talos/internal/pkg/loadbalancer/upstream"
+)
+
+// TCP is a simple loadbalancer for TCP connections across a set of upstreams.
+//
+// Healthcheck is defined as TCP dial attempt by default.
+//
+// Zero value of TCP is a valid proxy, use `AddRoute` to install load balancer for
+// address.
+//
+// Usage: call Run() to start lb and wait for shutdown, call Close() to shutdown lb.
+type TCP struct {
+	tcpproxy.Proxy
+}
+
+type lbUpstream string
+
+func (upstream lbUpstream) HealthCheck(ctx context.Context) error {
+	d := net.Dialer{}
+
+	c, err := d.DialContext(ctx, "tcp", string(upstream))
+	if err != nil {
+		log.Printf("healhcheck failed for %q: %s", string(upstream), err)
+
+		return err
+	}
+
+	return c.Close()
+}
+
+type lbTarget struct {
+	list *upstream.List
+}
+
+func (target *lbTarget) HandleConn(conn net.Conn) {
+	upstreamBackend, err := target.list.Pick()
+	if err != nil {
+		log.Printf("no upstreams available, closing connection from %s", conn.RemoteAddr())
+		conn.Close() //nolint: errcheck
+
+		return
+	}
+
+	upstreamAddr := upstreamBackend.(lbUpstream) //nolint: errcheck
+
+	log.Printf("proxying connection %s -> %s", conn.RemoteAddr(), string(upstreamAddr))
+
+	upstreamTarget := tcpproxy.To(string(upstreamAddr))
+	upstreamTarget.OnDialError = func(src net.Conn, dstDialErr error) {
+		src.Close() //nolint: errcheck
+
+		log.Printf("error dialing upstream %s: %s", string(upstreamAddr), dstDialErr)
+
+		target.list.Down(upstreamBackend)
+	}
+
+	upstreamTarget.HandleConn(conn)
+}
+
+// AddRoute installs load balancer route from listen address ipAddr to list of upstreams.
+//
+// TCP automatically does background health checks for the upstreams and picks only healthy
+// ones. Healthcheck is simple Dial attempt.
+func (t *TCP) AddRoute(ipPort string, upstreamAddrs []string, options ...upstream.ListOption) error {
+	upstreams := make([]upstream.Backend, len(upstreamAddrs))
+	for i := range upstreams {
+		upstreams[i] = lbUpstream(upstreamAddrs[i])
+	}
+
+	list, err := upstream.NewList(upstreams, options...)
+	if err != nil {
+		return err
+	}
+
+	t.Proxy.AddRoute(ipPort, &lbTarget{list: list})
+
+	return nil
+}

--- a/internal/pkg/loadbalancer/loadbalancer_test.go
+++ b/internal/pkg/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,177 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package loadbalancer_test
+
+import (
+	"io/ioutil"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/pkg/loadbalancer"
+	"github.com/talos-systems/talos/internal/pkg/loadbalancer/upstream"
+)
+
+type mockUpstream struct {
+	identity string
+
+	addr string
+	l    net.Listener
+}
+
+func (u *mockUpstream) Start() error {
+	var err error
+
+	u.l, err = net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return err
+	}
+
+	u.addr = u.l.Addr().String()
+
+	go u.serve()
+
+	return nil
+}
+
+func (u *mockUpstream) serve() {
+	for {
+		c, err := u.l.Accept()
+		if err != nil {
+			return
+		}
+
+		c.Write([]byte(u.identity)) //nolint: errcheck
+		c.Close()                   //nolint: errcheck
+	}
+}
+
+func (u *mockUpstream) Close() {
+	u.l.Close() //nolint: errcheck
+}
+
+func findListenAddress() (string, error) {
+	u := mockUpstream{}
+
+	if err := u.Start(); err != nil {
+		return "", err
+	}
+
+	u.Close()
+
+	return u.addr, nil
+}
+
+type TCPSuite struct {
+	suite.Suite
+}
+
+func (suite *TCPSuite) TestBalancer() {
+	const (
+		upstreamCount   = 5
+		failingUpstream = 1
+	)
+
+	upstreams := make([]mockUpstream, upstreamCount)
+	for i := range upstreams {
+		upstreams[i].identity = strconv.Itoa(i)
+		suite.Require().NoError(upstreams[i].Start())
+	}
+
+	upstreamAddrs := make([]string, len(upstreams))
+	for i := range upstreamAddrs {
+		upstreamAddrs[i] = upstreams[i].addr
+	}
+
+	listenAddr, err := findListenAddress()
+	suite.Require().NoError(err)
+
+	lb := &loadbalancer.TCP{}
+	suite.Require().NoError(lb.AddRoute(
+		listenAddr,
+		upstreamAddrs,
+		upstream.WithLowHighScores(-3, 3),
+		upstream.WithInitialScore(1),
+		upstream.WithScoreDeltas(-1, 1),
+		upstream.WithHealthcheckInterval(time.Second),
+		upstream.WithHealthcheckTimeout(100*time.Millisecond),
+	))
+
+	suite.Require().NoError(lb.Start())
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		lb.Wait() //nolint: errcheck
+	}()
+
+	for i := 0; i < 2*upstreamCount; i++ {
+		c, err := net.Dial("tcp", listenAddr)
+		suite.Require().NoError(err)
+
+		id, err := ioutil.ReadAll(c)
+		suite.Require().NoError(err)
+
+		// load balancer should go round-robin across all the upstreams
+		suite.Assert().Equal([]byte(strconv.Itoa(i%upstreamCount)), id)
+
+		suite.Require().NoError(c.Close())
+	}
+
+	// bring down one upstream
+	upstreams[failingUpstream].Close()
+
+	j := 0
+	failedRequests := 0
+
+	for i := 0; i < 10*upstreamCount; i++ {
+		c, err := net.Dial("tcp", listenAddr)
+		suite.Require().NoError(err)
+
+		id, err := ioutil.ReadAll(c)
+		suite.Require().NoError(err)
+
+		if len(id) == 0 {
+			// hit failing upstream
+			suite.Assert().Equal(failingUpstream, j%upstreamCount)
+
+			failedRequests++
+
+			continue
+		}
+
+		if j%upstreamCount == failingUpstream {
+			j++
+		}
+
+		// load balancer should go round-robin across all the upstreams
+		suite.Assert().Equal([]byte(strconv.Itoa(j%upstreamCount)), id)
+		j++
+
+		suite.Require().NoError(c.Close())
+	}
+
+	// worst case: score = 3 (highScore) to go to -1 requires 5 requests
+	suite.Assert().Less(failedRequests, 5) // no more than 5 requests should fail
+
+	suite.Require().NoError(lb.Close())
+	wg.Wait()
+
+	for i := range upstreams {
+		upstreams[i].Close()
+	}
+}
+
+func TestTCPSuite(t *testing.T) {
+	suite.Run(t, new(TCPSuite))
+}

--- a/internal/pkg/loadbalancer/upstream/upstream.go
+++ b/internal/pkg/loadbalancer/upstream/upstream.go
@@ -1,0 +1,256 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package upstream provides utilities for choosing upstream backends based on score.
+package upstream
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Backend is an interface which should be implemented for a Pick entry.
+type Backend interface {
+	HealthCheck(ctx context.Context) error
+}
+
+type node struct {
+	backend Backend
+	score   float64
+}
+
+// ListOption allows to configure List.
+type ListOption func(*List) error
+
+// WithLowHighScores configures low and high score.
+func WithLowHighScores(lowScore, highScore float64) ListOption {
+	return func(l *List) error {
+		if l.lowScore > 0 {
+			return fmt.Errorf("lowScore should be non-positive")
+		}
+
+		if l.highScore < 0 {
+			return fmt.Errorf("highScore should be non-positive")
+		}
+
+		if l.lowScore > l.highScore {
+			return fmt.Errorf("lowScore should be less or equal to highScore")
+		}
+
+		l.lowScore, l.highScore = lowScore, highScore
+
+		return nil
+	}
+}
+
+// WithScoreDeltas configures fail and success score delta.
+func WithScoreDeltas(failScoreDelta, successScoreDelta float64) ListOption {
+	return func(l *List) error {
+		if l.failScoreDelta >= 0 {
+			return fmt.Errorf("failScoreDelta should be negative")
+		}
+
+		if l.successScoreDelta <= 0 {
+			return fmt.Errorf("successScoreDelta should be positive")
+		}
+
+		l.failScoreDelta, l.successScoreDelta = failScoreDelta, successScoreDelta
+
+		return nil
+	}
+}
+
+// WithInitialScore configures initial backend score.
+func WithInitialScore(initialScore float64) ListOption {
+	return func(l *List) error {
+		l.initialScore = initialScore
+
+		return nil
+	}
+}
+
+// WithHealthcheckInterval configures healthcheck interval.
+func WithHealthcheckInterval(interval time.Duration) ListOption {
+	return func(l *List) error {
+		l.healthcheckInterval = interval
+
+		return nil
+	}
+}
+
+// WithHealthcheckTimeout configures healthcheck timeout (for each backend).
+func WithHealthcheckTimeout(timeout time.Duration) ListOption {
+	return func(l *List) error {
+		l.healthcheckTimeout = timeout
+
+		return nil
+	}
+}
+
+// List of upstream Backends with healthchecks and different strategies to pick a node.
+//
+// List keeps track of Backends with score. Score is updated on health checks, and via external
+// interface (e.g. when actual connection fails).
+//
+// Initial score is set via options (default is +1). Low and high scores defaults are (-3, +3).
+// Backend score is limited by low and high scores. Each time healthcheck fails score is adjusted
+// by fail delta score, and every successful check updates score by success score delta (defaults are -1/+1).
+//
+// Backend might be used if its score is not negative.
+type List struct {
+	lowScore, highScore               float64
+	failScoreDelta, successScoreDelta float64
+	initialScore                      float64
+
+	healthcheckInterval time.Duration
+	healthcheckTimeout  time.Duration
+
+	healthWg        sync.WaitGroup
+	healthCtx       context.Context
+	healthCtxCancel context.CancelFunc
+
+	// Following fields are protected by mutex
+	mu sync.Mutex
+
+	nodes   []node
+	current int
+}
+
+// NewList initializes new list with upstream backends and options and starts health checks.
+//
+// List should be stopped with `.Shutdown()`.
+func NewList(upstreams []Backend, options ...ListOption) (*List, error) {
+	// initialize with defaults
+	list := &List{
+		lowScore:          -3.0,
+		highScore:         3.0,
+		failScoreDelta:    -1.0,
+		successScoreDelta: 1.0,
+		initialScore:      1.0,
+
+		healthcheckInterval: 1 * time.Second,
+		healthcheckTimeout:  100 * time.Millisecond,
+
+		current: -1,
+	}
+
+	list.healthCtx, list.healthCtxCancel = context.WithCancel(context.Background())
+
+	for _, opt := range options {
+		if err := opt(list); err != nil {
+			return nil, err
+		}
+	}
+
+	list.nodes = make([]node, len(upstreams))
+
+	for i := range list.nodes {
+		list.nodes[i].backend = upstreams[i]
+		list.nodes[i].score = list.initialScore
+	}
+
+	list.healthWg.Add(1)
+
+	go list.healthcheck()
+
+	return list, nil
+}
+
+// Shutdown stops healthchecks.
+func (list *List) Shutdown() {
+	list.healthCtxCancel()
+
+	list.healthWg.Wait()
+}
+
+// Up increases backend score by success score delta.
+func (list *List) Up(upstream Backend) {
+	list.mu.Lock()
+	defer list.mu.Unlock()
+
+	for i := range list.nodes {
+		if list.nodes[i].backend == upstream {
+			list.nodes[i].score += list.successScoreDelta
+			if list.nodes[i].score > list.highScore {
+				list.nodes[i].score = list.highScore
+			}
+		}
+	}
+}
+
+// Down decreases backend score by fail score delta.
+func (list *List) Down(upstream Backend) {
+	list.mu.Lock()
+	defer list.mu.Unlock()
+
+	for i := range list.nodes {
+		if list.nodes[i].backend == upstream {
+			list.nodes[i].score += list.failScoreDelta
+			if list.nodes[i].score < list.lowScore {
+				list.nodes[i].score = list.lowScore
+			}
+		}
+	}
+}
+
+// Pick returns next backend to be used.
+//
+// Default policy is to pick healthy (non-negative score) backend in
+// round-robin fashion.
+func (list *List) Pick() (Backend, error) {
+	list.mu.Lock()
+	defer list.mu.Unlock()
+
+	for j := 0; j < len(list.nodes); j++ {
+		i := (list.current + 1 + j) % len(list.nodes)
+
+		if list.nodes[i].score >= 0 {
+			list.current = i
+
+			return list.nodes[list.current].backend, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no upstreams available")
+}
+
+func (list *List) healthcheck() {
+	defer list.healthWg.Done()
+
+	ticker := time.NewTicker(list.healthcheckInterval)
+	defer ticker.Stop()
+
+	for {
+		list.mu.Lock()
+		nodes := append([]node(nil), list.nodes...)
+		list.mu.Unlock()
+
+		for _, node := range nodes {
+			select {
+			case <-list.healthCtx.Done():
+				return
+			default:
+			}
+
+			func() {
+				ctx, ctxCancel := context.WithTimeout(list.healthCtx, list.healthcheckTimeout)
+				defer ctxCancel()
+
+				if err := node.backend.HealthCheck(ctx); err != nil {
+					list.Down(node.backend)
+				} else {
+					list.Up(node.backend)
+				}
+			}()
+		}
+
+		select {
+		case <-ticker.C:
+		case <-list.healthCtx.Done():
+			return
+		}
+	}
+}

--- a/internal/pkg/loadbalancer/upstream/upstream_test.go
+++ b/internal/pkg/loadbalancer/upstream/upstream_test.go
@@ -1,0 +1,192 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package upstream_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/internal/pkg/loadbalancer/upstream"
+	"github.com/talos-systems/talos/pkg/retry"
+)
+
+type mockBackend string
+
+func (b mockBackend) HealthCheck(ctx context.Context) error {
+	switch string(b) {
+	case "fail":
+		return errors.New("fail")
+	case "success":
+		return nil
+	default:
+		<-ctx.Done()
+
+		return ctx.Err()
+	}
+}
+
+type ListSuite struct {
+	suite.Suite
+}
+
+func (suite *ListSuite) TestEmpty() {
+	l, err := upstream.NewList(nil)
+	suite.Require().NoError(err)
+
+	defer l.Shutdown()
+
+	backend, err := l.Pick()
+	suite.Assert().Nil(backend)
+	suite.Assert().EqualError(err, "no upstreams available")
+}
+
+func (suite *ListSuite) TestRoundRobin() {
+	l, err := upstream.NewList([]upstream.Backend{mockBackend("one"), mockBackend("two"), mockBackend("three")})
+	suite.Require().NoError(err)
+
+	defer l.Shutdown()
+
+	backend, err := l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("two"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("three"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+}
+
+func (suite *ListSuite) TestDownUp() {
+	l, err := upstream.NewList(
+		[]upstream.Backend{
+			mockBackend("one"),
+			mockBackend("two"),
+			mockBackend("three"),
+		},
+		upstream.WithLowHighScores(-3, 3),
+		upstream.WithInitialScore(1),
+		upstream.WithScoreDeltas(-1, 1),
+		upstream.WithHealthcheckInterval(time.Hour),
+	)
+	suite.Require().NoError(err)
+
+	defer l.Shutdown()
+
+	backend, err := l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	l.Down(mockBackend("two"))   // score == 0
+	l.Down(mockBackend("two"))   // score == -1
+	l.Down(mockBackend("three")) // score == 0
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("three"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("three"), backend)
+	suite.Assert().NoError(err)
+
+	l.Down(mockBackend("three")) // score == -1
+	l.Up(mockBackend("two"))     // score == 0
+	l.Up(mockBackend("two"))     // score == 1
+	l.Up(mockBackend("two"))     // score == 2
+	l.Up(mockBackend("two"))     // score == 3
+	l.Up(mockBackend("two"))     // score == 3 (capped at highScore)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("two"), backend)
+	suite.Assert().NoError(err)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	l.Down(mockBackend("two")) // score == 2
+	l.Down(mockBackend("two")) // score == 1
+	l.Down(mockBackend("two")) // score == 0
+	l.Down(mockBackend("two")) // score == -1
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	l.Down(mockBackend("two")) // score == -2
+	l.Down(mockBackend("two")) // score == -3
+	l.Down(mockBackend("two")) // score == -3 (capped at lowScore)
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("one"), backend)
+	suite.Assert().NoError(err)
+
+	l.Up(mockBackend("two")) // score == -2
+	l.Up(mockBackend("two")) // score == -1
+	l.Up(mockBackend("two")) // score == 0
+
+	backend, err = l.Pick()
+	suite.Assert().Equal(mockBackend("two"), backend)
+	suite.Assert().NoError(err)
+}
+
+func (suite *ListSuite) TestHealthcheck() {
+	l, err := upstream.NewList(
+		[]upstream.Backend{
+			mockBackend("success"),
+			mockBackend("fail"),
+			mockBackend("timeout"),
+		},
+		upstream.WithLowHighScores(-1, 1),
+		upstream.WithInitialScore(1),
+		upstream.WithScoreDeltas(-1, 1),
+		upstream.WithHealthcheckInterval(10*time.Millisecond),
+		upstream.WithHealthcheckTimeout(time.Millisecond),
+	)
+	suite.Require().NoError(err)
+
+	defer l.Shutdown()
+
+	time.Sleep(20 * time.Millisecond) // let healthchecks run
+
+	// when health info converges, "success" should be the only backend left
+	suite.Require().NoError(retry.Constant(time.Second, retry.WithUnits(time.Millisecond)).Retry(func() error {
+		for i := 0; i < 10; i++ {
+			backend, err := l.Pick()
+			if err != nil {
+				return retry.UnexpectedError(err)
+			}
+
+			if backend.(mockBackend) != mockBackend("success") {
+				return retry.ExpectedError(fmt.Errorf("unexpected %v", backend))
+			}
+		}
+
+		return nil
+	}))
+}
+
+func TestListSuite(t *testing.T) {
+	suite.Run(t, new(ListSuite))
+}

--- a/internal/pkg/provision/providers/docker/docker.go
+++ b/internal/pkg/provision/providers/docker/docker.go
@@ -45,3 +45,10 @@ func (p *provisioner) Close() error {
 func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.GenOption {
 	return nil
 }
+
+// GetLoadBalancers returns internal/external loadbalancer endpoints.
+func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
+	// docker doesn't provide internal LB, so return empty string
+	// external LB is always localhost where docker exposes ports
+	return "", "127.0.0.1"
+}

--- a/internal/pkg/provision/providers/firecracker/create.go
+++ b/internal/pkg/provision/providers/firecracker/create.go
@@ -57,6 +57,12 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		return nil, fmt.Errorf("unable to provision CNI network: %w", err)
 	}
 
+	fmt.Fprintln(options.LogWriter, "creating load balancer")
+
+	if err = p.createLoadBalancer(state, request); err != nil {
+		return nil, fmt.Errorf("error creating loadbalancer: %w", err)
+	}
+
 	var nodeInfo []provision.NodeInfo
 
 	fmt.Fprintln(options.LogWriter, "creating master nodes")

--- a/internal/pkg/provision/providers/firecracker/destroy.go
+++ b/internal/pkg/provision/providers/firecracker/destroy.go
@@ -28,12 +28,18 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 		return err
 	}
 
-	fmt.Fprintln(options.LogWriter, "removing network")
-
 	state, ok := cluster.(*state)
 	if !ok {
 		return fmt.Errorf("error inspecting firecracker state, %#+v", cluster)
 	}
+
+	fmt.Fprintln(options.LogWriter, "removing load balancer")
+
+	if err := p.destroyLoadBalancer(state); err != nil {
+		return fmt.Errorf("error stopping loadbalancer: %w", err)
+	}
+
+	fmt.Fprintln(options.LogWriter, "removing network")
 
 	if err := p.destroyNetwork(state); err != nil {
 		return err

--- a/internal/pkg/provision/providers/firecracker/firecracker.go
+++ b/internal/pkg/provision/providers/firecracker/firecracker.go
@@ -52,3 +52,9 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 		}),
 	}
 }
+
+// GetLoadBalancers returns internal/external loadbalancer endpoints.
+func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
+	// firecracker runs loadbalancer on the bridge, which is good for both internal & external access
+	return networkReq.GatewayAddr.String(), networkReq.GatewayAddr.String()
+}

--- a/internal/pkg/provision/providers/firecracker/loadbalancer.go
+++ b/internal/pkg/provision/providers/firecracker/loadbalancer.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package firecracker
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/talos-systems/talos/internal/pkg/provision"
+)
+
+const (
+	lbPid = "lb.pid"
+	lbLog = "lb.log"
+)
+
+func (p *provisioner) createLoadBalancer(state *state, clusterReq provision.ClusterRequest) error {
+	pidPath := filepath.Join(state.statePath, lbPid)
+
+	logFile, err := os.OpenFile(filepath.Join(state.statePath, lbLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return err
+	}
+
+	defer logFile.Close() //nolint: errcheck
+
+	masterNodes := clusterReq.Nodes.MasterNodes()
+	masterIPs := make([]string, len(masterNodes))
+
+	for i := range masterIPs {
+		masterIPs[i] = masterNodes[i].IP.String()
+	}
+
+	cmd := exec.Command(clusterReq.SelfExecutable, "loadbalancer-launch",
+		"--loadbalancer-addr", clusterReq.Network.GatewayAddr.String(),
+		"--loadbalancer-upstreams", strings.Join(masterIPs, ","),
+	)
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // daemonize
+	}
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), os.ModePerm); err != nil {
+		return fmt.Errorf("error writing LB PID file: %w", err)
+	}
+
+	return nil
+}
+
+func (p *provisioner) destroyLoadBalancer(state *state) error {
+	pidPath := filepath.Join(state.statePath, lbPid)
+
+	return stopProcessByPidfile(pidPath)
+}

--- a/internal/pkg/provision/providers/firecracker/process.go
+++ b/internal/pkg/provision/providers/firecracker/process.go
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package firecracker
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func stopProcessByPidfile(pidPath string) error {
+	pidFile, err := os.Open(pidPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("error checking PID file %q: %w", pidPath, err)
+	}
+
+	defer pidFile.Close() //nolint: errcheck
+
+	var pid int
+
+	if _, err = fmt.Fscanf(pidFile, "%d", &pid); err != nil {
+		return fmt.Errorf("error reading PID for %q: %w", pidPath, err)
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("error finding process %d for %q: %w", pid, pidPath, err)
+	}
+
+	if err = proc.Signal(syscall.SIGTERM); err != nil {
+		if err.Error() == "os: process already finished" {
+			return nil
+		}
+
+		return fmt.Errorf("error sending SIGTERM to %d (path %q): %w", pid, pidPath, err)
+	}
+
+	if _, err = proc.Wait(); err != nil {
+		if errors.Is(err, syscall.ECHILD) {
+			return nil
+		}
+
+		return fmt.Errorf("error waiting for %d to exit (path %q): %w", pid, pidPath, err)
+	}
+
+	return nil
+}

--- a/internal/pkg/provision/provision.go
+++ b/internal/pkg/provision/provision.go
@@ -19,6 +19,7 @@ type Provisioner interface {
 	Reflect(ctx context.Context, clusterName, stateDirectory string) (Cluster, error)
 
 	GenOptions(NetworkRequest) []generate.GenOption
+	GetLoadBalancers(NetworkRequest) (internalEndpoint, externalEndpoint string)
 
 	Close() error
 }


### PR DESCRIPTION
This PR contains generic simple TCP loadbalancer code, and glue code for
firecracker provisioner to use this loadbalancer.

K8s control plane is passed through the load balancer, and Talos API is
passed only to the init node (for now, as some APIs, including
kubeconfig, don't work with non-init node).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>