### PR TITLE
chore: build app container images skipping export to host 

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -49,120 +49,6 @@ steps:
   - name: tmp
     path: /tmp
 
-- name: machined
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make machined
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: osd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make osd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: apid
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make apid
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: trustd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make trustd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: ntpd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make ntpd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: networkd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make networkd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
 - name: osctl-linux
   pull: always
   image: autonomy/build-container:latest
@@ -256,12 +142,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - apid
-  - machined
-  - networkd
-  - ntpd
-  - osd
-  - trustd
+  - setup-ci
 
 - name: installer
   pull: always
@@ -299,7 +180,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - installer
+  - initramfs
 
 - name: lint-go
   pull: always
@@ -470,7 +351,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - talos
+  - initramfs
 
 - name: unit-tests-race
   pull: always
@@ -522,7 +403,6 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
   - talos
   - osctl-linux
 
@@ -544,7 +424,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
+  - initramfs
   - osctl-linux
   - kernel
 
@@ -695,120 +575,6 @@ steps:
   - name: tmp
     path: /tmp
 
-- name: machined
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make machined
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: osd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make osd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: apid
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make apid
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: trustd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make trustd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: ntpd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make ntpd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: networkd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make networkd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
 - name: osctl-linux
   pull: always
   image: autonomy/build-container:latest
@@ -902,12 +668,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - apid
-  - machined
-  - networkd
-  - ntpd
-  - osd
-  - trustd
+  - setup-ci
 
 - name: installer
   pull: always
@@ -945,7 +706,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - installer
+  - initramfs
 
 - name: lint-go
   pull: always
@@ -1116,7 +877,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - talos
+  - initramfs
 
 - name: unit-tests-race
   pull: always
@@ -1168,7 +929,6 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
   - talos
   - osctl-linux
 
@@ -1190,7 +950,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
+  - initramfs
   - osctl-linux
   - kernel
 
@@ -1433,120 +1193,6 @@ steps:
   - name: tmp
     path: /tmp
 
-- name: machined
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make machined
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: osd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make osd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: apid
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make apid
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: trustd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make trustd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: ntpd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make ntpd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: networkd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make networkd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
 - name: osctl-linux
   pull: always
   image: autonomy/build-container:latest
@@ -1640,12 +1286,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - apid
-  - machined
-  - networkd
-  - ntpd
-  - osd
-  - trustd
+  - setup-ci
 
 - name: installer
   pull: always
@@ -1683,7 +1324,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - installer
+  - initramfs
 
 - name: lint-go
   pull: always
@@ -1854,7 +1495,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - talos
+  - initramfs
 
 - name: unit-tests-race
   pull: always
@@ -1906,7 +1547,6 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
   - talos
   - osctl-linux
 
@@ -1928,7 +1568,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
+  - initramfs
   - osctl-linux
   - kernel
 
@@ -2201,120 +1841,6 @@ steps:
   - name: tmp
     path: /tmp
 
-- name: machined
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make machined
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: osd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make osd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: apid
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make apid
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: trustd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make trustd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: ntpd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make ntpd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: networkd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make networkd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
 - name: osctl-linux
   pull: always
   image: autonomy/build-container:latest
@@ -2408,12 +1934,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - apid
-  - machined
-  - networkd
-  - ntpd
-  - osd
-  - trustd
+  - setup-ci
 
 - name: installer
   pull: always
@@ -2451,7 +1972,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - installer
+  - initramfs
 
 - name: lint-go
   pull: always
@@ -2622,7 +2143,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - talos
+  - initramfs
 
 - name: unit-tests-race
   pull: always
@@ -2674,7 +2195,6 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
   - talos
   - osctl-linux
 
@@ -2696,7 +2216,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
+  - initramfs
   - osctl-linux
   - kernel
 
@@ -2969,120 +2489,6 @@ steps:
   - name: tmp
     path: /tmp
 
-- name: machined
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make machined
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: osd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make osd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: apid
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make apid
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: trustd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make trustd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: ntpd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make ntpd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
-- name: networkd
-  pull: always
-  image: autonomy/build-container:latest
-  commands:
-  - make networkd
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: docker
-    path: /root/.docker/buildx
-  - name: kube
-    path: /root/.kube
-  - name: dev
-    path: /dev
-  - name: tmp
-    path: /tmp
-  depends_on:
-  - setup-ci
-
 - name: osctl-linux
   pull: always
   image: autonomy/build-container:latest
@@ -3176,12 +2582,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - apid
-  - machined
-  - networkd
-  - ntpd
-  - osd
-  - trustd
+  - setup-ci
 
 - name: installer
   pull: always
@@ -3219,7 +2620,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - installer
+  - initramfs
 
 - name: lint-go
   pull: always
@@ -3390,7 +2791,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - talos
+  - initramfs
 
 - name: unit-tests-race
   pull: always
@@ -3442,7 +2843,6 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
   - talos
   - osctl-linux
 
@@ -3464,7 +2864,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - unit-tests
+  - initramfs
   - osctl-linux
   - kernel
 
@@ -3702,6 +3102,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 6e1cb951c820c10c2b05d40cfb5577b8395b79d751b2c4246734de03c8a76422
+hmac: 84131ac5504f383563cba78fdadbf8f21721bc9a2e46991f236944c533137850
 
 ...

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -90,7 +90,7 @@ local volumes = {
   ],
 };
 
-// TODO(rsmitty): figure out how we can keep docker and setup-ci from running while also supporting 
+// TODO(rsmitty): figure out how we can keep docker and setup-ci from running while also supporting
 // times when we're not using those in the default pipeline (e2e and conformance for ex.)
 // Sets up the CI environment
 local check_ok_test = {
@@ -188,19 +188,13 @@ local Pipeline(name, steps=[], depends_on=[], with_docker=true, disable_clone=fa
 
 // Default pipeline.
 
-local machined = Step("machined", depends_on=[setup_ci]);
-local osd = Step("osd", depends_on=[setup_ci]);
-local trustd = Step("trustd", depends_on=[setup_ci]);
-local ntpd = Step("ntpd", depends_on=[setup_ci]);
-local networkd = Step("networkd", depends_on=[setup_ci]);
-local apid = Step("apid", depends_on=[setup_ci]);
 local osctl_linux = Step("osctl-linux", depends_on=[setup_ci]);
 local osctl_darwin = Step("osctl-darwin", depends_on=[setup_ci]);
 local docs = Step("docs", depends_on=[osctl_linux]);
 local kernel = Step('kernel', depends_on=[setup_ci]);
-local initramfs = Step("initramfs", depends_on=[apid, machined, networkd, ntpd, osd, trustd]);
+local initramfs = Step("initramfs", depends_on=[setup_ci]);
 local installer = Step("installer", depends_on=[initramfs]);
-local talos = Step("talos", depends_on=[installer]);
+local talos = Step("talos", depends_on=[initramfs]);
 local golint = Step("lint-go", depends_on=[setup_ci]);
 local protobuflint = Step("lint-protobuf", depends_on=[setup_ci]);
 local markdownlint = Step("lint-markdown", depends_on=[setup_ci]);
@@ -209,10 +203,10 @@ local image_azure = Step("image-azure", depends_on=[installer]);
 local image_digital_ocean = Step("image-digital-ocean", depends_on=[installer]);
 local image_gcp = Step("image-gcp", depends_on=[installer]);
 local image_vmware = Step("image-vmware", depends_on=[installer]);
-local unit_tests = Step("unit-tests", depends_on=[talos]);
+local unit_tests = Step("unit-tests", depends_on=[initramfs]);
 local unit_tests_race = Step("unit-tests-race", depends_on=[golint]);
-local e2e_docker = Step("e2e-docker", depends_on=[unit_tests, talos, osctl_linux]);
-local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[unit_tests, osctl_linux, kernel]);
+local e2e_docker = Step("e2e-docker", depends_on=[talos, osctl_linux]);
+local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, osctl_linux, kernel]);
 
 local coverage = {
   name: 'coverage',
@@ -275,12 +269,6 @@ local push_latest = {
 
 local default_steps = [
   setup_ci,
-  machined,
-  osd,
-  apid,
-  trustd,
-  ntpd,
-  networkd,
   osctl_linux,
   osctl_darwin,
   docs,


### PR DESCRIPTION
Container images for `apid`, `networkd`, etc. are now built inside the
buildkit using the `img` tool. This means that all the dependencies are
now controlled in `buildkit` and many more stages can run in parallel
without problems (overwriting content in `_out/images`).

This also simplifies Drone configuration, as we can let buildkit handle
the dependencies. I also enabled more stages to run in parallel.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>