### PR TITLE
fix: PodCIDR, ServiceCIDR should be comma sets

### DIFF
--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -379,7 +379,7 @@ func (c *ClusterConfig) PodCIDR() string {
 		return constants.DefaultPodCIDR
 	}
 
-	return c.ClusterNetwork.PodSubnet[0]
+	return strings.Join(c.ClusterNetwork.PodSubnet, ",")
 }
 
 // ServiceCIDR implements the Configurator interface.
@@ -391,7 +391,7 @@ func (c *ClusterConfig) ServiceCIDR() string {
 		return constants.DefaultServiceCIDR
 	}
 
-	return c.ClusterNetwork.ServiceSubnet[0]
+	return strings.Join(c.ClusterNetwork.ServiceSubnet, ",")
 }
 
 // ExtraManifestURLs implements the Configurator interface.


### PR DESCRIPTION
PodCIDRs and ServiceCIDRs are now returned as comma-delimited set of
their slices, as per the documenation for kube-api-server and
kube-controller-manager in dual-stack configurations.

Ref: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#enable-ipv4-ipv6-dual-stack

Fixes #1883

Signed-off-by: Seán C McCord <ulexus@gmail.com>