### PR TITLE
chore: remove KubernetesVersion from provision request

### DIFF
--- a/cmd/osctl/cmd/cluster.go
+++ b/cmd/osctl/cmd/cluster.go
@@ -175,10 +175,9 @@ func create(ctx context.Context) (err error) {
 			},
 		},
 
-		Image:             nodeImage,
-		KernelPath:        nodeVmlinuxPath,
-		InitramfsPath:     nodeInitramfsPath,
-		KubernetesVersion: kubernetesVersion,
+		Image:         nodeImage,
+		KernelPath:    nodeVmlinuxPath,
+		InitramfsPath: nodeInitramfsPath,
 
 		SelfExecutable: os.Args[0],
 		StateDirectory: stateDir,

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -19,10 +19,9 @@ type ClusterRequest struct {
 	Network NetworkRequest
 	Nodes   NodeRequests
 
-	Image             string
-	KernelPath        string
-	InitramfsPath     string
-	KubernetesVersion string
+	Image         string
+	KernelPath    string
+	InitramfsPath string
 
 	// Path to osctl executable to re-execute itself as needed.
 	SelfExecutable string


### PR DESCRIPTION
Not sure how it got into `ClusterRequest`, but we're not using it.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>