### PR TITLE
fix: add reboot flag to reset command

### DIFF
--- a/cmd/osctl/cmd/reset.go
+++ b/cmd/osctl/cmd/reset.go
@@ -37,5 +37,6 @@ var resetCmd = &cobra.Command{
 
 func init() {
 	resetCmd.Flags().BoolVar(&graceful, "graceful", true, "if true, attempt to cordon/drain node and leave etcd (if applicable)")
+	resetCmd.Flags().BoolVar(&reboot, "reboot", true, "if true, reboot the node after resetting (default is to shutdown)")
 	rootCmd.AddCommand(resetCmd)
 }

--- a/docs/osctl/osctl_reset.md
+++ b/docs/osctl/osctl_reset.md
@@ -16,6 +16,7 @@ osctl reset [flags]
 ```
       --graceful   if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
   -h, --help       help for reset
+      --reboot     if true, reboot the node after resetting (default is to shutdown) (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
This exposes the reboot option for thee reset API by adding a `--reboot`
flag to the CLI.