### PR TITLE
fix: ignore link-local and other non routable addresses

### DIFF
--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -24,7 +24,7 @@ func IPAddrs() (ips []net.IP, err error) {
 	}
 
 	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.IsGlobalUnicast() {
 			if ipnet.IP.To4() != nil {
 				ips = append(ips, ipnet.IP)
 			}


### PR DESCRIPTION
This is backport of
https://github.com/talos-systems/talos/commit/fae5e6915d32c41b464978baf7ba335264963e58#diff-da3509c3f67d46ea31daf53392216e68.

This fixes `etcd` bootstrap with firecracker provisioner, as firecracker
provisions link-local addresses on each node and `etcd` code might pick
them up instead of real interface address.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>