### PR TITLE
fix: ensure proxy is used when fetching additional manifests for bootkube

### DIFF
--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -403,7 +404,8 @@ func fetchManifests(urls []string) error {
 		// Disable netrc since we don't have getent installed, and most likely
 		// never will.
 		httpGetter := &getter.HttpGetter{
-			Netrc: false,
+			Netrc:  false,
+			Client: http.DefaultClient,
 		}
 
 		getter.Getters["http"] = httpGetter


### PR DESCRIPTION
Http getter library is by default using it's own client. This ensure the default transport is used for fetching additional manifests.

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>

