### PR TITLE
feat: generate kubeconfig on the fly on request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ controlplane.yaml
 join.yaml
 docgen
 talosconfig
-kubeconfig
+/kubeconfig
 hack/test/libvirt/matchbox/assets/*
 !hack/test/libvirt/matchbox/assets/.gitkeep
 

--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -106,7 +106,7 @@ func runImageCmd() (err error) {
 	return nil
 }
 
-//nolint: gocyclo
+//nolint: gocyclo,interfacer
 func finalize(platform runtime.Platform, img string) (err error) {
 	dir := filepath.Dir(img)
 

--- a/cmd/osctl/cmd/loadbalancer_launch.go
+++ b/cmd/osctl/cmd/loadbalancer_launch.go
@@ -14,8 +14,9 @@ import (
 )
 
 var loadbalancerLaunchCmdFlags struct {
-	addr      string
-	upstreams []string
+	addr             string
+	upstreams        []string
+	apidOnlyInitNode bool
 }
 
 // loadbalancerLaunchCmd represents the loadbalancer-launch command
@@ -34,9 +35,11 @@ var loadbalancerLaunchCmd = &cobra.Command{
 				upstreams[i] = fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.upstreams[i], port)
 			}
 
-			// for apid, add only init node for now (first item)
-			if port == constants.ApidPort && len(upstreams) > 1 {
-				upstreams = upstreams[:1]
+			if loadbalancerLaunchCmdFlags.apidOnlyInitNode {
+				// for apid, add only init node for now (first item)
+				if port == constants.ApidPort && len(upstreams) > 1 {
+					upstreams = upstreams[:1]
+				}
 			}
 
 			if err := lb.AddRoute(fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.addr, port), upstreams); err != nil {
@@ -51,5 +54,6 @@ var loadbalancerLaunchCmd = &cobra.Command{
 func init() {
 	loadbalancerLaunchCmd.Flags().StringVar(&loadbalancerLaunchCmdFlags.addr, "loadbalancer-addr", "localhost", "load balancer listen address (IP or host)")
 	loadbalancerLaunchCmd.Flags().StringSliceVar(&loadbalancerLaunchCmdFlags.upstreams, "loadbalancer-upstreams", []string{}, "load balancer upstreams (nodes to proxy to)")
+	loadbalancerLaunchCmd.Flags().BoolVar(&loadbalancerLaunchCmdFlags.apidOnlyInitNode, "apid-only-init-node", false, "use only apid init node for load balancing")
 	rootCmd.AddCommand(loadbalancerLaunchCmd)
 }

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -271,22 +271,12 @@ func generateAssets(config runtime.Configurator) (err error) {
 	urls = append(urls, config.Cluster().CertSANs()...)
 	altNames := altNamesFromURLs(urls)
 
-	block, _ = pem.Decode(config.Cluster().CA().Crt)
-	if block == nil {
-		return errors.New("failed to Kubernetes CA certificate")
-	}
-
-	k8sCA, err := x509.ParseCertificate(block.Bytes)
+	k8sCA, err := config.Cluster().CA().GetCert()
 	if err != nil {
-		return fmt.Errorf("failed to parse Kubernetes CA certificate: %w", err)
+		return fmt.Errorf("failed to get Kubernetes CA certificate: %w", err)
 	}
 
-	block, _ = pem.Decode(config.Cluster().CA().Key)
-	if block == nil {
-		return errors.New("failed to Kubernetes CA key")
-	}
-
-	k8sKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	k8sKey, err := config.Cluster().CA().GetRSAKey()
 	if err != nil {
 		return fmt.Errorf("failed to parse Kubernetes key: %w", err)
 	}
@@ -362,12 +352,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 		}
 	}
 
-	input, err := ioutil.ReadFile(constants.GeneratedKubeconfigAsset)
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(constants.AdminKubeconfig, input, 0600)
+	return nil
 }
 
 func altNamesFromURLs(urls []string) *tlsutil.AltNames {

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -210,6 +210,11 @@ func (suite *UpgradeSuite) setupCluster() {
 				ConfDir:  defaultCNIConfDir,
 				CacheDir: defaultCNICacheDir,
 			},
+			LoadBalancer: provision.LoadBalancerConfig{
+				// as we're upgrading from older versions of Talos,
+				// disable LB to all apid nodes
+				LimitApidOnlyInitNode: true,
+			},
 		},
 
 		KernelPath:    suite.spec.SourceKernelPath,

--- a/internal/pkg/kubeconfig/admin.go
+++ b/internal/pkg/kubeconfig/admin.go
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubeconfig
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"text/template"
+	"time"
+
+	"github.com/talos-systems/talos/pkg/config/cluster"
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
+)
+
+const adminKubeConfigTemplate = `apiVersion: v1
+kind: Config
+clusters:
+- name: {{ .Cluster }}
+  cluster:
+    server: {{ .Server }}
+    certificate-authority-data: {{ .CACert }}
+users:
+- name: admin
+  user:
+    client-certificate-data: {{ .AdminCert }}
+    client-key-data: {{ .AdminKey }}
+contexts:
+- context:
+    cluster: {{ .Cluster }}
+    user: admin
+  name: admin@{{ .Cluster }}
+current-context: admin@{{ .Cluster }}
+`
+
+// Cluster defines minimal interface for certificate generation.
+type Cluster interface {
+	cluster.Name
+	cluster.CA
+	cluster.Endpoint
+}
+
+// GenerateAdmin generates admin kubeconfig for the cluster.
+func GenerateAdmin(config Cluster, out io.Writer) error {
+	tpl, err := template.New("kubeconfig").Parse(adminKubeConfigTemplate)
+	if err != nil {
+		return fmt.Errorf("error parsing kubeconfig template: %w", err)
+	}
+
+	k8sCA, err := config.CA().GetCert()
+	if err != nil {
+		return fmt.Errorf("error getting Kubernetes CA certificate: %w", err)
+	}
+
+	k8sKey, err := config.CA().GetRSAKey()
+	if err != nil {
+		return fmt.Errorf("error parseing Kubernetes key: %w", err)
+	}
+
+	adminCert, err := x509.NewCertficateAndKey(k8sCA, k8sKey,
+		x509.RSA(true),
+		x509.CommonName(constants.KubernetesAdminCertCommonName),
+		x509.Organization(constants.KubernetesAdminCertOrganization),
+		x509.NotAfter(time.Now().Add(constants.KubernetesAdminCertDefaultLifetime)))
+	if err != nil {
+		return fmt.Errorf("error generating admin certificate: %w", err)
+	}
+
+	input := struct {
+		Cluster   string
+		CACert    string
+		AdminCert string
+		AdminKey  string
+		Server    string
+	}{
+		Cluster:   config.Name(),
+		CACert:    base64.StdEncoding.EncodeToString(config.CA().Crt),
+		AdminCert: base64.StdEncoding.EncodeToString(adminCert.Crt),
+		AdminKey:  base64.StdEncoding.EncodeToString(adminCert.Key),
+		Server:    config.Endpoint().String(),
+	}
+
+	return tpl.Execute(out, input)
+}

--- a/internal/pkg/kubeconfig/admin_test.go
+++ b/internal/pkg/kubeconfig/admin_test.go
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubeconfig_test
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/talos-systems/talos/internal/pkg/kubeconfig"
+	"github.com/talos-systems/talos/pkg/crypto/x509"
+)
+
+type mockClusterConfig struct {
+	name string
+	ca   *x509.PEMEncodedCertificateAndKey
+}
+
+func (c mockClusterConfig) Name() string {
+	return c.name
+}
+
+func (c mockClusterConfig) CA() *x509.PEMEncodedCertificateAndKey {
+	return c.ca
+}
+
+func (c mockClusterConfig) Endpoint() *url.URL {
+	u, _ := url.Parse("http://localhost:6443/api/") //nolint: errcheck
+
+	return u
+}
+
+type AdminSuite struct {
+	suite.Suite
+}
+
+func (suite *AdminSuite) TestGenerate() {
+	ca, err := x509.NewSelfSignedCertificateAuthority(x509.RSA(true))
+	suite.Require().NoError(err)
+
+	cfg := mockClusterConfig{
+		name: "talos1",
+		ca: &x509.PEMEncodedCertificateAndKey{
+			Crt: ca.CrtPEM,
+			Key: ca.KeyPEM,
+		},
+	}
+
+	var buf bytes.Buffer
+
+	suite.Require().NoError(kubeconfig.GenerateAdmin(cfg, &buf))
+
+	// verify config via k8s client
+	config, err := clientcmd.Load(buf.Bytes())
+	suite.Require().NoError(err)
+
+	suite.Assert().NoError(clientcmd.ConfirmUsable(*config, fmt.Sprintf("admin@%s", cfg.name)))
+}
+
+func TestAdminSuite(t *testing.T) {
+	suite.Run(t, new(AdminSuite))
+}

--- a/internal/pkg/kubeconfig/kubeconfig.go
+++ b/internal/pkg/kubeconfig/kubeconfig.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package kubeconfig provides Kubernetes config file generation from machine config.
+package kubeconfig

--- a/internal/pkg/provision/providers/firecracker/loadbalancer.go
+++ b/internal/pkg/provision/providers/firecracker/loadbalancer.go
@@ -39,10 +39,17 @@ func (p *provisioner) createLoadBalancer(state *state, clusterReq provision.Clus
 		masterIPs[i] = masterNodes[i].IP.String()
 	}
 
-	cmd := exec.Command(clusterReq.SelfExecutable, "loadbalancer-launch",
+	args := []string{
+		"loadbalancer-launch",
 		"--loadbalancer-addr", clusterReq.Network.GatewayAddr.String(),
 		"--loadbalancer-upstreams", strings.Join(masterIPs, ","),
-	)
+	}
+
+	if clusterReq.Network.LoadBalancer.LimitApidOnlyInitNode {
+		args = append(args, "--apid-only-init-node")
+	}
+
+	cmd := exec.Command(clusterReq.SelfExecutable, args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -37,7 +37,13 @@ type CNIConfig struct {
 	CacheDir string
 }
 
-// NetworkRequest describe cluster network.
+// LoadBalancerConfig describes load balancer provisioned for the cluster.
+type LoadBalancerConfig struct {
+	// Limit apid connection load-balancing to init node
+	LimitApidOnlyInitNode bool
+}
+
+// NetworkRequest describes cluster network.
 type NetworkRequest struct {
 	Name        string
 	CIDR        net.IPNet
@@ -47,6 +53,8 @@ type NetworkRequest struct {
 
 	// CNI-specific parameters.
 	CNI CNIConfig
+
+	LoadBalancer LoadBalancerConfig
 }
 
 // NodeRequests is a list of NodeRequest.

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -11,18 +11,33 @@ import (
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
+// Name defines subset of Cluster to provide cluster name.
+type Name interface {
+	Name() string
+}
+
+// CA defines subset of Cluster to provide cluster CA certificate and key.
+type CA interface {
+	CA() *x509.PEMEncodedCertificateAndKey
+}
+
+// Endpoint defines subset of Cluster to provide API endpoint.
+type Endpoint interface {
+	Endpoint() *url.URL
+}
+
 // Cluster defines the requirements for a config that pertains to cluster
 // related options.
 type Cluster interface {
-	Name() string
+	Name
 	APIServer() APIServer
 	ControllerManager() ControllerManager
 	Scheduler() Scheduler
-	Endpoint() *url.URL
+	Endpoint
 	Token() Token
 	CertSANs() []string
 	SetCertSANs([]string)
-	CA() *x509.PEMEncodedCertificateAndKey
+	CA
 	AESCBCEncryptionSecret() string
 	Config(machine.Type) (string, error)
 	Etcd() Etcd

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -122,6 +122,15 @@ const (
 	// KubernetesAPIServerEtcdClientKey defines apiserver's etcd client key name
 	KubernetesAPIServerEtcdClientKey = DefaultCertificatesDir + "/" + "apiserver-etcd-client.key"
 
+	// KubernetesAdminCertCommonName defines CN property of Kubernetes admin certificate.
+	KubernetesAdminCertCommonName = "apiserver-kubelet-client"
+
+	// KubernetesAdminCertOrganization defines Organization values of Kubernetes admin certificate.
+	KubernetesAdminCertOrganization = "system:masters"
+
+	// KubernetesAdminCertDefaultLifetime defines default lifetime for Kubernetes generated admin certificate.
+	KubernetesAdminCertDefaultLifetime = 365 * 24 * time.Hour
+
 	// KubeletBootstrapKubeconfig is the path to the kubeconfig required to
 	// bootstrap the kubelet.
 	KubeletBootstrapKubeconfig = "/etc/kubernetes/bootstrap-kubeconfig"
@@ -142,12 +151,6 @@ const (
 
 	// AssetsDirectory is the directory that contains all bootstrap assets.
 	AssetsDirectory = "/etc/kubernetes/assets"
-
-	// GeneratedKubeconfigAsset is the directory that contains bootstrap TLS assets.
-	GeneratedKubeconfigAsset = AssetsDirectory + "/auth/kubeconfig"
-
-	// AdminKubeconfig is the generated admin kubeconfig.
-	AdminKubeconfig = "/etc/kubernetes/kubeconfig"
 
 	// KubeletKubeconfig is the generated kubeconfig for kubelet.
 	KubeletKubeconfig = "/etc/kubernetes/kubeconfig-kubelet"

--- a/pkg/crypto/x509/x509.go
+++ b/pkg/crypto/x509/x509.go
@@ -585,6 +585,36 @@ func (p *PEMEncodedCertificateAndKey) MarshalYAML() (interface{}, error) {
 	return aux, nil
 }
 
+// GetCert parses PEM-encoded certificate as x509.Certificate.
+func (p *PEMEncodedCertificateAndKey) GetCert() (*x509.Certificate, error) {
+	block, _ := pem.Decode(p.Crt)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	return cert, nil
+}
+
+// GetRSAKey parses PEM-encoded RSA key.
+func (p *PEMEncodedCertificateAndKey) GetRSAKey() (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(p.Key)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse PEM block")
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse RSA key: %w", err)
+	}
+
+	return key, nil
+}
+
 // NewCertficateAndKey generates a new key and certificate signed by a CA.
 //
 //nolint: gocyclo


### PR DESCRIPTION
This extracts admin kubeconfig generation out of bootkube, now based on
Talos x509 library. On each API request for `kubeconfig`, config is
generated on the fly and sent back on the wire.

This fixes two issues:

* any master node can now generate `kubeconfig` (worker nodes can do
that too, but that should probably change in the future)
* after upgrade-and-wipe the disk scenario, `osctl kubeconfig` still
works

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>