### PR TITLE
feat: make admin kubeconfig cert lifetime configurable

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -570,6 +570,21 @@ extraManifests:
 
 ```
 
+#### adminKubeconfig
+
+Settings for admin kubeconfig generation.
+Certificate lifetime can be configured.
+
+Type: `AdminKubeconfigConfig`
+
+Examples:
+
+```yaml
+adminKubeconfig:
+  certLifetime: 1h
+
+```
+
 ---
 
 ### KubeletConfig
@@ -1045,5 +1060,16 @@ Type: `string`
 URLs containing manifests to apply for CNI.
 
 Type: `array`
+
+---
+
+### AdminKubeconfigConfig
+
+#### certLifetime
+
+Admin kubeconfig certificate lifetime (default is 1 year).
+Field format accepts any Go time.Duration format ('1h' for one hour, '10m' for ten minutes).
+
+Type: `Duration`
 
 ---

--- a/internal/pkg/kubeconfig/admin.go
+++ b/internal/pkg/kubeconfig/admin.go
@@ -36,15 +36,8 @@ contexts:
 current-context: admin@{{ .Cluster }}
 `
 
-// Cluster defines minimal interface for certificate generation.
-type Cluster interface {
-	cluster.Name
-	cluster.CA
-	cluster.Endpoint
-}
-
 // GenerateAdmin generates admin kubeconfig for the cluster.
-func GenerateAdmin(config Cluster, out io.Writer) error {
+func GenerateAdmin(config cluster.Cluster, out io.Writer) error {
 	tpl, err := template.New("kubeconfig").Parse(adminKubeConfigTemplate)
 	if err != nil {
 		return fmt.Errorf("error parsing kubeconfig template: %w", err)
@@ -64,7 +57,7 @@ func GenerateAdmin(config Cluster, out io.Writer) error {
 		x509.RSA(true),
 		x509.CommonName(constants.KubernetesAdminCertCommonName),
 		x509.Organization(constants.KubernetesAdminCertOrganization),
-		x509.NotAfter(time.Now().Add(constants.KubernetesAdminCertDefaultLifetime)))
+		x509.NotAfter(time.Now().Add(config.AdminKubeconfig().CertLifetime())))
 	if err != nil {
 		return fmt.Errorf("error generating admin certificate: %w", err)
 	}

--- a/internal/pkg/kubeconfig/admin_test.go
+++ b/internal/pkg/kubeconfig/admin_test.go
@@ -9,32 +9,15 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/talos-systems/talos/internal/pkg/kubeconfig"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
-
-type mockClusterConfig struct {
-	name string
-	ca   *x509.PEMEncodedCertificateAndKey
-}
-
-func (c mockClusterConfig) Name() string {
-	return c.name
-}
-
-func (c mockClusterConfig) CA() *x509.PEMEncodedCertificateAndKey {
-	return c.ca
-}
-
-func (c mockClusterConfig) Endpoint() *url.URL {
-	u, _ := url.Parse("http://localhost:6443/api/") //nolint: errcheck
-
-	return u
-}
 
 type AdminSuite struct {
 	suite.Suite
@@ -44,11 +27,22 @@ func (suite *AdminSuite) TestGenerate() {
 	ca, err := x509.NewSelfSignedCertificateAuthority(x509.RSA(true))
 	suite.Require().NoError(err)
 
-	cfg := mockClusterConfig{
-		name: "talos1",
-		ca: &x509.PEMEncodedCertificateAndKey{
+	u, err := url.Parse("http://localhost:3333/api")
+	suite.Require().NoError(err)
+
+	cfg := &v1alpha1.ClusterConfig{
+		ClusterName: "talos1",
+		ClusterCA: &x509.PEMEncodedCertificateAndKey{
 			Crt: ca.CrtPEM,
 			Key: ca.KeyPEM,
+		},
+		ControlPlane: &v1alpha1.ControlPlaneConfig{
+			Endpoint: &v1alpha1.Endpoint{
+				URL: u,
+			},
+		},
+		AdminKubeconfigConfig: v1alpha1.AdminKubeconfigConfig{
+			AdminKubeconfigCertLifetime: time.Hour,
 		},
 	}
 
@@ -60,7 +54,7 @@ func (suite *AdminSuite) TestGenerate() {
 	config, err := clientcmd.Load(buf.Bytes())
 	suite.Require().NoError(err)
 
-	suite.Assert().NoError(clientcmd.ConfirmUsable(*config, fmt.Sprintf("admin@%s", cfg.name)))
+	suite.Assert().NoError(clientcmd.ConfirmUsable(*config, fmt.Sprintf("admin@%s", cfg.ClusterName)))
 }
 
 func TestAdminSuite(t *testing.T) {

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -6,38 +6,24 @@ package cluster
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
-// Name defines subset of Cluster to provide cluster name.
-type Name interface {
-	Name() string
-}
-
-// CA defines subset of Cluster to provide cluster CA certificate and key.
-type CA interface {
-	CA() *x509.PEMEncodedCertificateAndKey
-}
-
-// Endpoint defines subset of Cluster to provide API endpoint.
-type Endpoint interface {
-	Endpoint() *url.URL
-}
-
 // Cluster defines the requirements for a config that pertains to cluster
 // related options.
 type Cluster interface {
-	Name
+	Name() string
 	APIServer() APIServer
 	ControllerManager() ControllerManager
 	Scheduler() Scheduler
-	Endpoint
+	Endpoint() *url.URL
 	Token() Token
 	CertSANs() []string
 	SetCertSANs([]string)
-	CA
+	CA() *x509.PEMEncodedCertificateAndKey
 	AESCBCEncryptionSecret() string
 	Config(machine.Type) (string, error)
 	Etcd() Etcd
@@ -46,6 +32,7 @@ type Cluster interface {
 	PodCheckpointer() PodCheckpointer
 	CoreDNS() CoreDNS
 	ExtraManifestURLs() []string
+	AdminKubeconfig() AdminKubeconfig
 }
 
 // Network defines the requirements for a config that pertains to cluster
@@ -106,4 +93,9 @@ type PodCheckpointer interface {
 // coredns options.
 type CoreDNS interface {
 	Image() string
+}
+
+// AdminKubeconfig defines settings for admin kubeconfig.
+type AdminKubeconfig interface {
+	CertLifetime() time.Duration
 }

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v2"
 
@@ -275,6 +276,11 @@ func (c *ClusterConfig) Scheduler() cluster.Scheduler {
 	return c.SchedulerConfig
 }
 
+// AdminKubeconfig implements the Configurator interface.
+func (c *ClusterConfig) AdminKubeconfig() cluster.AdminKubeconfig {
+	return c.AdminKubeconfigConfig
+}
+
 // ExtraArgs implements the Configurator interface.
 func (s *SchedulerConfig) ExtraArgs() map[string]string {
 	return s.ExtraArgsConfig
@@ -502,4 +508,13 @@ func (p *PodCheckpointer) Image() string {
 	}
 
 	return checkpointerImage
+}
+
+// CertLifetime implements the Configurator interface.
+func (a AdminKubeconfigConfig) CertLifetime() time.Duration {
+	if a.AdminKubeconfigCertLifetime == 0 {
+		return constants.KubernetesAdminCertDefaultLifetime
+	}
+
+	return a.AdminKubeconfigCertLifetime
 }

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -8,6 +8,7 @@ package v1alpha1
 
 import (
 	"net/url"
+	"time"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 
@@ -324,6 +325,14 @@ type ClusterConfig struct {
 	//         - "https://www.mysweethttpserver.com/manifest1.yaml"
 	//         - "https://www.mysweethttpserver.com/manifest2.yaml"
 	ExtraManifests []string `yaml:"extraManifests,omitempty"`
+	//   description: |
+	//     Settings for admin kubeconfig generation.
+	//     Certificate lifetime can be configured.
+	//   examples:
+	//     - |
+	//       adminKubeconfig:
+	//         certLifetime: 1h
+	AdminKubeconfigConfig AdminKubeconfigConfig `yaml:"adminKubeconfig,omitempty"`
 }
 
 // KubeletConfig reperesents the kubelet config values
@@ -658,4 +667,12 @@ type CNIConfig struct {
 	//   description: |
 	//     URLs containing manifests to apply for CNI.
 	CNIUrls []string `yaml:"urls,omitempty"`
+}
+
+// AdminKubeconfigConfig contains admin kubeconfig settings.
+type AdminKubeconfigConfig struct {
+	//   description: |
+	//     Admin kubeconfig certificate lifetime (default is 1 year).
+	//     Field format accepts any Go time.Duration format ('1h' for one hour, '10m' for ten minutes).
+	AdminKubeconfigCertLifetime time.Duration `yaml:"certLifetime,omitempty"`
 }


### PR DESCRIPTION
Fixes #1906

This provides lifetime as duration relative to kubeconfig generation
time (the moment `osctl kubeconfig` was called).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>