### PR TITLE
feat: allow for persistence of config data

### DIFF
--- a/cmd/installer/cmd/install.go
+++ b/cmd/installer/cmd/install.go
@@ -54,14 +54,7 @@ func runInstallCmd() (err error) {
 			return err
 		}
 
-		var content machineconfig.Content
-
-		content, err = machineconfig.FromBytes(b)
-		if err != nil {
-			return err
-		}
-
-		config, err = machineconfig.New(content)
+		config, err = machineconfig.NewFromBytes(b)
 		if err != nil {
 			return err
 		}

--- a/cmd/osctl/cmd/validate.go
+++ b/cmd/osctl/cmd/validate.go
@@ -26,11 +26,7 @@ var validateCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		content, err := config.FromFile(validateConfigArg)
-		if err != nil {
-			return err
-		}
-		config, err := config.New(content)
+		config, err := config.NewFromFile(validateConfigArg)
 		if err != nil {
 			return err
 		}

--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -72,6 +72,19 @@ Valid Values:
 
 - ``v1alpha1``
 
+#### persist
+
+Indicates whether to pull the machine config upon every boot.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
 #### machine
 
 Provides machine specific configuration options.

--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -106,10 +106,5 @@ func main() {
 }
 
 func loadConfig() (runtime.Configurator, error) {
-	content, err := config.FromFile(*configPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return config.New(content)
+	return config.NewFromFile(*configPath)
 }

--- a/internal/app/machined/internal/phase/config/save_config.go
+++ b/internal/app/machined/internal/phase/config/save_config.go
@@ -29,12 +29,12 @@ func (task *SaveConfig) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 func (task *SaveConfig) runtime(r runtime.Runtime) (err error) {
 	log.Printf("saving config %s to disk\n", r.Config().Version())
 
-	s, err := r.Config().String()
+	b, err := r.Config().Bytes()
 	if err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(constants.ConfigPath, []byte(s), 0644); err != nil {
+	if err = ioutil.WriteFile(constants.ConfigPath, b, 0644); err != nil {
 		return err
 	}
 

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -28,14 +28,9 @@ func init() {
 func main() {
 	log.Println("starting initial network configuration")
 
-	content, err := config.FromFile(*configPath)
+	config, err := config.NewFromFile(*configPath)
 	if err != nil {
-		log.Fatalf("failed to open config: %v", err)
-	}
-
-	config, err := config.New(content)
-	if err != nil {
-		log.Fatalf("failed to create config: %v", err)
+		log.Fatalf("failed to create config from file: %v", err)
 	}
 
 	nwd, err := networkd.New(config)

--- a/internal/app/ntpd/main.go
+++ b/internal/app/ntpd/main.go
@@ -44,14 +44,9 @@ func main() {
 
 	server := DefaultServer
 
-	content, err := config.FromFile(*configPath)
+	config, err := config.NewFromFile(*configPath)
 	if err != nil {
-		log.Fatalf("open config: %v", err)
-	}
-
-	config, err := config.New(content)
-	if err != nil {
-		log.Fatalf("open config: %v", err)
+		log.Fatalf("failed to create config from file: %v", err)
 	}
 
 	// Check if ntp servers are defined

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -40,14 +40,9 @@ func main() {
 		log.Fatalf("startup: %s", err)
 	}
 
-	content, err := config.FromFile(*configPath)
+	config, err := config.NewFromFile(*configPath)
 	if err != nil {
-		log.Fatalf("open config: %v", err)
-	}
-
-	config, err := config.New(content)
-	if err != nil {
-		log.Fatalf("open config: %v", err)
+		log.Fatalf("failed to create config from file: %v", err)
 	}
 
 	ips, err := net.IPAddrs()

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -71,12 +71,7 @@ func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpo
 // ValidateForUpgrade validates the etcd cluster state to ensure that performing
 // an upgrade is safe.
 func ValidateForUpgrade() error {
-	content, err := config.FromFile(constants.ConfigPath)
-	if err != nil {
-		return err
-	}
-
-	config, err := config.New(content)
+	config, err := config.NewFromFile(constants.ConfigPath)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/mount/manager/owned/owned.go
+++ b/internal/pkg/mount/manager/owned/owned.go
@@ -56,9 +56,7 @@ func MountPointsForDevice(devpath string) (mountpoints *mount.Points, err error)
 }
 
 // MountPointForLabel returns a mount point for the specified device and label.
-func MountPointForLabel(label string) (mountpoint *mount.Point, err error) {
-	opts := []mount.Option{}
-
+func MountPointForLabel(label string, opts ...mount.Option) (mountpoint *mount.Point, err error) {
 	var target string
 
 	switch label {
@@ -89,26 +87,4 @@ func MountPointForLabel(label string) (mountpoint *mount.Point, err error) {
 	mountpoint = mount.NewMountPoint(dev.Path, target, dev.SuperBlock.Type(), unix.MS_NOATIME, "", opts...)
 
 	return mountpoint, nil
-}
-
-// MountPointsFromLabels returns the mountpoints required to boot the system.
-// Since this function is called exclusively during boot time, this is when
-// we want to grow the data filesystem.
-func MountPointsFromLabels() (mountpoints *mount.Points, err error) {
-	mountpoints = mount.NewMountPoints()
-
-	for _, label := range []string{constants.EphemeralPartitionLabel, constants.BootPartitionLabel} {
-		mountpoint, err := MountPointForLabel(label)
-		if err != nil {
-			return nil, err
-		}
-
-		if mountpoint == nil {
-			continue
-		}
-
-		mountpoints.Set(label, mountpoint)
-	}
-
-	return mountpoints, nil
 }

--- a/internal/pkg/runtime/configurator.go
+++ b/internal/pkg/runtime/configurator.go
@@ -14,10 +14,12 @@ import (
 type Configurator interface {
 	Version() string
 	Debug() bool
+	Persist() bool
 	Machine() machine.Machine
 	Cluster() cluster.Cluster
 	Validate(Mode) error
 	String() (string, error)
+	Bytes() ([]byte, error)
 }
 
 // ConfiguratorBundle defines the configuration bundle interface.

--- a/internal/pkg/runtime/initializer/cloud/cloud.go
+++ b/internal/pkg/runtime/initializer/cloud/cloud.go
@@ -9,6 +9,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // Cloud is an initializer that mounts an existing installation.
@@ -16,12 +17,14 @@ type Cloud struct{}
 
 // Initialize implements the Initializer interface.
 func (c *Cloud) Initialize(r runtime.Runtime) (err error) {
-	var mountpoints *mount.Points
+	mountpoints := mount.NewMountPoints()
 
-	mountpoints, err = owned.MountPointsFromLabels()
+	mountpoint, err := owned.MountPointForLabel(constants.EphemeralPartitionLabel)
 	if err != nil {
 		return err
 	}
+
+	mountpoints.Set(constants.EphemeralPartitionLabel, mountpoint)
 
 	m := manager.NewManager(mountpoints)
 	if err = m.MountAll(); err != nil {

--- a/internal/pkg/runtime/initializer/metal/metal.go
+++ b/internal/pkg/runtime/initializer/metal/metal.go
@@ -12,6 +12,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager"
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/owned"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // Metal represents an initializer that performs a full installation to a
@@ -23,9 +24,9 @@ func (b *Metal) Initialize(r runtime.Runtime) (err error) {
 	// Attempt to discover a previous installation
 	// An err case should only happen if no partitions
 	// with matching labels were found
-	var mountpoints *mount.Points
+	mountpoints := mount.NewMountPoints()
 
-	mountpoints, err = owned.MountPointsFromLabels()
+	mountpoint, err := owned.MountPointForLabel(constants.EphemeralPartitionLabel)
 	if err != nil {
 		if r.Config().Machine().Install().Image() == "" {
 			return errors.New("an install image is required")
@@ -37,6 +38,8 @@ func (b *Metal) Initialize(r runtime.Runtime) (err error) {
 
 		panic(runtime.ErrReboot)
 	}
+
+	mountpoints.Set(constants.EphemeralPartitionLabel, mountpoint)
 
 	m := manager.NewManager(mountpoints)
 	if err = m.MountAll(); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,8 +122,8 @@ func NewConfigBundle(opts ...BundleOption) (*v1alpha1.ConfigBundle, error) {
 	return bundle, nil
 }
 
-// New initializes and returns a Configurator.
-func New(c Content) (config runtime.Configurator, err error) {
+// newConfig initializes and returns a Configurator.
+func newConfig(c Content) (config runtime.Configurator, err error) {
 	switch c.Version {
 	case v1alpha1.Version:
 		config = &v1alpha1.Config{}
@@ -137,9 +137,29 @@ func New(c Content) (config runtime.Configurator, err error) {
 	}
 }
 
-// FromFile is a convenience function that reads the config from disk, and
+// NewFromFile will take a filepath and attempt to parse a config file from it
+func NewFromFile(filepath string) (runtime.Configurator, error) {
+	content, err := fromFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	return newConfig(content)
+}
+
+// NewFromBytes will take a byteslice and attempt to parse a config file from it
+func NewFromBytes(in []byte) (runtime.Configurator, error) {
+	content, err := fromBytes(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return newConfig(content)
+}
+
+// fromFile is a convenience function that reads the config from disk, and
 // unmarshals it.
-func FromFile(p string) (c Content, err error) {
+func fromFile(p string) (c Content, err error) {
 	b, err := ioutil.ReadFile(p)
 	if err != nil {
 		return c, fmt.Errorf("read config: %w", err)
@@ -148,9 +168,9 @@ func FromFile(p string) (c Content, err error) {
 	return unmarshal(b)
 }
 
-// FromBytes is a convenience function that reads the config from a string, and
+// fromBytes is a convenience function that reads the config from a string, and
 // unmarshals it.
-func FromBytes(b []byte) (c Content, err error) {
+func fromBytes(b []byte) (c Content, err error) {
 	return unmarshal(b)
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -30,7 +30,7 @@ func (suite *Suite) TestNew() {
 		{Content{Version: v1alpha1.Version}, false},
 		{Content{Version: ""}, true},
 	} {
-		_, err := New(t.content)
+		_, err := newConfig(t.content)
 
 		if t.errExpected {
 			suite.Require().Error(err)

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -37,6 +37,11 @@ func (c *Config) Debug() bool {
 	return false
 }
 
+// Persist implements the Configurator interface.
+func (c *Config) Persist() bool {
+	return c.ConfigPersist
+}
+
 // Machine implements the Configurator interface.
 func (c *Config) Machine() machine.Machine {
 	return c.MachineConfig
@@ -49,12 +54,22 @@ func (c *Config) Cluster() cluster.Cluster {
 
 // String implements the Configurator interface.
 func (c *Config) String() (string, error) {
-	b, err := yaml.Marshal(c)
+	b, err := c.Bytes()
 	if err != nil {
 		return "", err
 	}
 
 	return string(b), nil
+}
+
+// Bytes implements the Configurator interface.
+func (c *Config) Bytes() ([]byte, error) {
+	b, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }
 
 // Install implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -24,6 +24,14 @@ type Config struct {
 	//     - "`v1alpha1`"
 	ConfigVersion string `yaml:"version"`
 	//   description: |
+	//     Indicates whether to pull the machine config upon every boot.
+	//   values:
+	//     - true
+	//     - yes
+	//     - false
+	//     - no
+	ConfigPersist bool `yaml:"persist"`
+	//   description: |
 	//     Provides machine specific configuration options.
 	MachineConfig *MachineConfig `yaml:"machine"`
 	//   description: |

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -168,7 +168,7 @@ const (
 	EtcdDataPath = "/var/lib/etcd"
 
 	// ConfigPath is the path to the downloaded config.
-	ConfigPath = "/run/config.yaml"
+	ConfigPath = "/boot/config.yaml"
 
 	// MetalConfigISOLabel is the volume label for ISO based configuration.
 	MetalConfigISOLabel = "metal-iso"


### PR DESCRIPTION
This PR will allow users to set the `persist: true` value in their
config data to tell talos not to re-pull the config data at each reboot.
The default will still remain as a "pull every time" methodology in order
to encourage immutability by default.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>