### PR TITLE
chore: cleanup assets dir after bootkube is done

### DIFF
--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -211,7 +211,7 @@ func (b *Bootkube) Runner(config runtime.Configurator) (runner.Runner, error) {
 
 // nolint: gocyclo
 func generateAssets(config runtime.Configurator) (err error) {
-	if err = os.MkdirAll("/etc/kubernetes/manifests", 0644); err != nil {
+	if err = os.MkdirAll(constants.ManifestsDirectory, 0644); err != nil {
 		return err
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -152,6 +152,9 @@ const (
 	// AssetsDirectory is the directory that contains all bootstrap assets.
 	AssetsDirectory = "/etc/kubernetes/assets"
 
+	// ManifestsDirectory is the directory that contains all static manifests.
+	ManifestsDirectory = "/etc/kubernetes/manifests"
+
 	// KubeletKubeconfig is the generated kubeconfig for kubelet.
 	KubeletKubeconfig = "/etc/kubernetes/kubeconfig-kubelet"
 


### PR DESCRIPTION
This PR will clean up bootkube assets regardless of whether bootkube
succeeds. This will allow for a failed bootkube deployment to retry on
reboot.