### PR TITLE
chore: add service state to postfunc

### DIFF
--- a/internal/app/machined/pkg/system/mocks_test.go
+++ b/internal/app/machined/pkg/system/mocks_test.go
@@ -52,7 +52,7 @@ func (m *MockService) Runner(runtime.Configurator) (runner.Runner, error) {
 	return &MockRunner{exitCh: make(chan error)}, m.runnerError
 }
 
-func (m *MockService) PostFunc(runtime.Configurator) error {
+func (m *MockService) PostFunc(runtime.Configurator, events.ServiceState) error {
 	return m.postError
 }
 

--- a/internal/app/machined/pkg/system/service.go
+++ b/internal/app/machined/pkg/system/service.go
@@ -7,6 +7,7 @@ package system
 import (
 	"context"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
@@ -22,7 +23,7 @@ type Service interface {
 	// Runner creates runner for the service
 	Runner(runtime.Configurator) (runner.Runner, error)
 	// PostFunc is invoked after a runner is closed.
-	PostFunc(runtime.Configurator) error
+	PostFunc(runtime.Configurator, events.ServiceState) error
 	// Condition describes the conditions under which a service should
 	// start.
 	Condition(runtime.Configurator) conditions.Condition

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -51,7 +52,7 @@ func (o *APID) PreFunc(ctx context.Context, config runtime.Configurator) error {
 }
 
 // PostFunc implements the Service interface.
-func (o *APID) PostFunc(config runtime.Configurator) (err error) {
+func (o *APID) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/containerd/containerd/defaults"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
@@ -37,7 +38,7 @@ func (c *Containerd) PreFunc(ctx context.Context, config runtime.Configurator) e
 }
 
 // PostFunc implements the Service interface.
-func (c *Containerd) PostFunc(config runtime.Configurator) (err error) {
+func (c *Containerd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -23,6 +23,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"go.etcd.io/etcd/clientv3"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -77,7 +78,7 @@ func (e *Etcd) PreFunc(ctx context.Context, config runtime.Configurator) (err er
 }
 
 // PostFunc implements the Service interface.
-func (e *Etcd) PostFunc(config runtime.Configurator) (err error) {
+func (e *Etcd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -29,6 +29,7 @@ import (
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
 
 	internalcni "github.com/talos-systems/talos/internal/app/machined/internal/cni"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -124,7 +125,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, config runtime.Configurator) erro
 }
 
 // PostFunc implements the Service interface.
-func (k *Kubelet) PostFunc(config runtime.Configurator) (err error) {
+func (k *Kubelet) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/machined_api.go
+++ b/internal/app/machined/pkg/system/services/machined_api.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/talos-systems/talos/internal/app/machined/internal/api"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/goroutine"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
@@ -29,7 +30,7 @@ func (c *MachinedAPI) PreFunc(ctx context.Context, config runtime.Configurator) 
 }
 
 // PostFunc implements the Service interface.
-func (c *MachinedAPI) PostFunc(config runtime.Configurator) (err error) {
+func (c *MachinedAPI) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc"
 
 	healthapi "github.com/talos-systems/talos/api/health"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -53,7 +54,7 @@ func (n *Networkd) PreFunc(ctx context.Context, config runtime.Configurator) err
 }
 
 // PostFunc implements the Service interface.
-func (n *Networkd) PostFunc(config runtime.Configurator) (err error) {
+func (n *Networkd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -17,6 +17,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/syndtr/gocapability/capability"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
@@ -47,7 +48,7 @@ func (n *NTPd) PreFunc(ctx context.Context, config runtime.Configurator) error {
 }
 
 // PostFunc implements the Service interface.
-func (n *NTPd) PostFunc(config runtime.Configurator) (err error) {
+func (n *NTPd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/syndtr/gocapability/capability"
 	"google.golang.org/grpc"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -51,7 +52,7 @@ func (o *OSD) PreFunc(ctx context.Context, config runtime.Configurator) error {
 }
 
 // PostFunc implements the Service interface.
-func (o *OSD) PostFunc(config runtime.Configurator) (err error) {
+func (o *OSD) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -17,6 +17,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"google.golang.org/grpc"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -49,7 +50,7 @@ func (o *Routerd) PreFunc(ctx context.Context, config runtime.Configurator) erro
 }
 
 // PostFunc implements the Service interface.
-func (o *Routerd) PostFunc(config runtime.Configurator) (err error) {
+func (o *Routerd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
@@ -35,7 +36,7 @@ func (c *SystemContainerd) PreFunc(ctx context.Context, config runtime.Configura
 }
 
 // PostFunc implements the Service interface.
-func (c *SystemContainerd) PostFunc(config runtime.Configurator) (err error) {
+func (c *SystemContainerd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
@@ -45,7 +46,7 @@ func (t *Trustd) PreFunc(ctx context.Context, config runtime.Configurator) error
 }
 
 // PostFunc implements the Service interface.
-func (t *Trustd) PostFunc(config runtime.Configurator) (err error) {
+func (t *Trustd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
@@ -37,7 +38,7 @@ func (c *Udevd) PreFunc(ctx context.Context, config runtime.Configurator) error 
 }
 
 // PostFunc implements the Service interface.
-func (c *Udevd) PostFunc(config runtime.Configurator) (err error) {
+func (c *Udevd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/services/udevd_trigger.go
+++ b/internal/app/machined/pkg/system/services/udevd_trigger.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
@@ -31,7 +32,7 @@ func (c *UdevdTrigger) PreFunc(ctx context.Context, config runtime.Configurator)
 }
 
 // PostFunc implements the Service interface.
-func (c *UdevdTrigger) PostFunc(config runtime.Configurator) (err error) {
+func (c *UdevdTrigger) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 


### PR DESCRIPTION
This PR will allow us to take conditional actions in the postfunc of our
services by passing the state of the service into the postfunc call. We
can use this to do conditional cleanups and finalizers if success.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>