### PR TITLE
docs: add note about API server port to metal/matchbox guide

### DIFF
--- a/docs/website/content/v0.3/en/guides/metal/matchbox.md
+++ b/docs/website/content/v0.3/en/guides/metal/matchbox.md
@@ -24,6 +24,17 @@ created join.yaml
 created talosconfig
 ```
 
+> Note: If you are using a DNS record, you will want to specify the port for the API Server (`tcp/6443`)
+
+```bash
+$ osctl config generate talos-k8s-metal-tutorial https://<DNS name>:6443
+created init.yaml
+created controlplane.yaml
+created join.yaml
+created talosconfig
+```
+
+
 At this point, you can modify the generated configs to your liking.
 
 #### Validate the Configuration Files


### PR DESCRIPTION
copied from the guide for VMware (https://github.com/talos-systems/talos/blob/master/docs/website/content/v0.3/en/guides/cloud/vmware.md#generating-base-configurations)

see #1784 