### PR TITLE
feat: respect panic kernel flag

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -34,6 +34,9 @@ const (
 	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos
 	KernelParamNetworkInterfaceIgnore = "talos.network.interface.ignore"
 
+	// KernelParamPanic is the kernel parameter name for specifying the time to wait until rebooting after kernel panic (0 disables reboot).
+	KernelParamPanic = "panic"
+
 	// KernelCurrentRoot is the kernel parameter name for specifying the
 	// current root partition.
 	KernelCurrentRoot = "talos.root"


### PR DESCRIPTION
This PR allows Talos to respect the panic=0 flag if users pass that in
their kernel args. Doing this makes it easier to catch kernel panics in
debug scenarios and allows the user to manually trigger a restart with
ctrl+alt+del when they're ready.