### PR TITLE
feat: add debug logs to networkd health check

### DIFF
--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,7 +124,7 @@ func (n *Networkd) Runner(config runtime.Configurator) (runner.Runner, error) {
 }
 
 // HealthFunc implements the HealthcheckedService interface
-func (n *Networkd) HealthFunc(runtime.Configurator) health.Check {
+func (n *Networkd) HealthFunc(cfg runtime.Configurator) health.Check {
 	return func(ctx context.Context) error {
 		var (
 			conn      *grpc.ClientConn
@@ -159,7 +160,13 @@ func (n *Networkd) HealthFunc(runtime.Configurator) health.Check {
 			return nil
 		}
 
-		return errors.New("networkd is unhealthy")
+		msg := fmt.Sprintf("networkd is unhealthy: %s", hcResp.Messages[0].Status.String())
+
+		if cfg.Debug() {
+			log.Printf("DEBUG: %s", msg)
+		}
+
+		return errors.New(msg)
 	}
 }
 


### PR DESCRIPTION
We need better logging on why networkd is failing the health check. This
adds logging if the debug option is set to true in the machine config.