### PR TITLE
fix: respect dns domain from machine config

### DIFF
--- a/cmd/osctl/cmd/config.go
+++ b/cmd/osctl/cmd/config.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	configVersion     string
+	dnsDomain         string
 	kubernetesVersion string
 	installDisk       string
 	installImage      string
@@ -222,6 +223,7 @@ func genV1Alpha1Config(args []string) error {
 					generate.WithInstallDisk(installDisk),
 					generate.WithInstallImage(installImage),
 					generate.WithAdditionalSubjectAltNames(additionalSANs),
+					generate.WithDNSDomain(dnsDomain),
 				),
 			},
 		),
@@ -288,6 +290,7 @@ func init() {
 	configGenerateCmd.Flags().StringVar(&installDisk, "install-disk", "/dev/sda", "the disk to install to")
 	configGenerateCmd.Flags().StringVar(&installImage, "install-image", defaultImage(constants.DefaultInstallerImageRepository), "the image used to perform an installation") // nolint: lll
 	configGenerateCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
+	configGenerateCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	configGenerateCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")
 	configGenerateCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 	configGenerateCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "destination to output generated files")

--- a/docs/osctl/osctl_config_generate.md
+++ b/docs/osctl/osctl_config_generate.md
@@ -15,6 +15,7 @@ osctl config generate <cluster name> https://<load balancer IP or DNS name> [fla
 
 ```
       --additional-sans strings     additional Subject-Alt-Names for the APIServer certificate
+      --dns-domain string           the dns domain to use for cluster (default "cluster.local")
   -h, --help                        help for generate
       --install-disk string         the disk to install to (default "/dev/sda")
       --install-image string        the image used to perform an installation (default "docker.io/autonomy/installer:latest")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 replace (
 	github.com/docker/distribution v2.7.1+incompatible => github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible
-	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20200131192519-720c01d02032
+	github.com/kubernetes-sigs/bootkube => github.com/talos-systems/bootkube v0.14.1-0.20200319175557-2bd6f456a124
 	github.com/opencontainers/runtime-spec v1.0.1 => github.com/opencontainers/runtime-spec v0.1.2-0.20180301181910-fa4b36aa9c99
 )
 

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/bootkube v0.14.1-0.20200131192519-720c01d02032 h1:Ruxuw1AX8iarsbGiQQsDRwqtrGN0ZTRBqWf5xFXVtec=
-github.com/talos-systems/bootkube v0.14.1-0.20200131192519-720c01d02032/go.mod h1:zLrZfPQ49k0O6x6QN0pDSJn9iD0EMyj6J+5x1vqJSFw=
+github.com/talos-systems/bootkube v0.14.1-0.20200319175557-2bd6f456a124 h1:u4qEgc01PKGgZ7i+1ldl2A7a9jkEv6vhk0q4xNvbXX0=
+github.com/talos-systems/bootkube v0.14.1-0.20200319175557-2bd6f456a124/go.mod h1:zLrZfPQ49k0O6x6QN0pDSJn9iD0EMyj6J+5x1vqJSFw=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
 github.com/talos-systems/go-smbios v0.0.0-20200219201045-94b8c4e489ee h1:9i0ZFsjZ0wY8UUn/tk2MQshLBC0PNFJe3+84AUqzzyw=

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -340,6 +340,7 @@ func generateAssets(config runtime.Configurator) (err error) {
 		BootstrapTokenID:           config.Cluster().Token().ID(),
 		BootstrapTokenSecret:       config.Cluster().Token().Secret(),
 		AESCBCEncryptionSecret:     config.Cluster().AESCBCEncryptionSecret(),
+		ClusterDomain:              config.Cluster().Network().DNSDomain(),
 	}
 
 	as, err := asset.NewDefaultAssets(conf)

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -237,7 +237,7 @@ func (k *Kubelet) HealthSettings(runtime.Configurator) *health.Settings {
 	return &settings
 }
 
-func newKubeletConfiguration(clusterDNS []string) *kubeletconfig.KubeletConfiguration {
+func newKubeletConfiguration(clusterDNS []string, dnsDomain string) *kubeletconfig.KubeletConfiguration {
 	f := false
 	t := true
 
@@ -265,7 +265,7 @@ func newKubeletConfiguration(clusterDNS []string) *kubeletconfig.KubeletConfigur
 		Authorization: kubeletconfig.KubeletAuthorization{
 			Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
 		},
-		ClusterDomain:       "cluster.local",
+		ClusterDomain:       dnsDomain,
 		ClusterDNS:          clusterDNS,
 		SerializeImagePulls: &f,
 		FailSwapOn:          &f,
@@ -314,7 +314,7 @@ func writeKubeletConfig(config runtime.Configurator) error {
 		dnsServiceIPs = append(dnsServiceIPs, dnsIP.String())
 	}
 
-	kubeletConfiguration := newKubeletConfiguration(dnsServiceIPs)
+	kubeletConfiguration := newKubeletConfiguration(dnsServiceIPs, config.Cluster().Network().DNSDomain())
 
 	serializer := json.NewSerializerWithOptions(
 		json.DefaultMetaFactory,

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -41,6 +41,7 @@ type Network interface {
 	CNI() CNI
 	PodCIDR() string
 	ServiceCIDR() string
+	DNSDomain() string
 }
 
 // CNI defines the requirements for a config that pertains to Kubernetes

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -313,7 +313,7 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 		ControlPlaneEndpoint:      endpoint,
 		PodNet:                    []string{podNet},
 		ServiceNet:                []string{serviceNet},
-		ServiceDomain:             "cluster.local",
+		ServiceDomain:             options.DNSDomain,
 		ClusterName:               clustername,
 		KubernetesVersion:         kubernetesVersion,
 		Secrets:                   kubeadmTokens,

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -70,6 +70,15 @@ func WithRegistryMirror(host string, endpoints ...string) GenOption {
 	}
 }
 
+// WithDNSDomain specifies domain name to use in Talos cluster.
+func WithDNSDomain(dnsDomain string) GenOption {
+	return func(o *GenOptions) error {
+		o.DNSDomain = dnsDomain
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
@@ -78,6 +87,7 @@ type GenOptions struct {
 	AdditionalSubjectAltNames []string
 	NetworkConfig             *v1alpha1.NetworkConfig
 	RegistryMirrors           map[string]machine.RegistryMirrorConfig
+	DNSDomain                 string
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -376,6 +376,15 @@ func (c *ClusterConfig) Network() cluster.Network {
 	return c
 }
 
+// DNSDomain implements the Configurator interface.
+func (c *ClusterConfig) DNSDomain() string {
+	if c.ClusterNetwork == nil {
+		return constants.DefaultDNSDomain
+	}
+
+	return c.ClusterNetwork.DNSDomain
+}
+
 // CNI implements the Configurator interface.
 func (c *ClusterConfig) CNI() cluster.CNI {
 	switch {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -286,6 +286,9 @@ const (
 	// DefaultServiceCIDR is the default service CIDR block.
 	DefaultServiceCIDR = "10.96.0.0/12"
 
+	// DefaultDNSDomain is the default DNS domain.
+	DefaultDNSDomain = "cluster.local"
+
 	// InitializedKey is the key used to indicate if the cluster has been
 	// initialized.
 	InitializedKey = "initialized"


### PR DESCRIPTION
BREAKING CHANGE: This PR fixes a bug where we were only passing `cluster.local` to the
kubelet configuration. It will also pull in a new version of the
bootkube fork to ensure that custom domains got propogated down to the
API Server certs, as well as the CoreDNS configuration for a cluster.

Existing users should be aware that, if they were previously trying to
use this option in machine configs, that an upgrade will may break
their cluster. It will update a kubelet flag with the new domain, but
CoreDNS and API Server certs will not change since bootkube has already
run. One option may be to change these values manually inside the
Kubernetes cluster. However, it may prove easier to rebuild the cluster
if necessary.

Additionally, this PR also exposes a flag to `osctl config generate`
to allow tweaking this domain value as well.