### PR TITLE
fix: add debug option to v1alpha1 config

### DIFF
--- a/docs/website/content/v0.3/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.3/en/configuration/v1alpha1.md
@@ -72,6 +72,19 @@ Valid Values:
 
 - ``v1alpha1``
 
+#### debug
+
+Enable verbose logging.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
 #### persist
 
 Indicates whether to pull the machine config upon every boot.

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -34,7 +34,7 @@ func (c *Config) Version() string {
 
 // Debug implements the Configurator interface.
 func (c *Config) Debug() bool {
-	return false
+	return c.ConfigDebug
 }
 
 // Persist implements the Configurator interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -24,6 +24,14 @@ type Config struct {
 	//     - "`v1alpha1`"
 	ConfigVersion string `yaml:"version"`
 	//   description: |
+	//     Enable verbose logging.
+	//   values:
+	//     - true
+	//     - yes
+	//     - false
+	//     - no
+	ConfigDebug bool `yaml:"debug"`
+	//   description: |
 	//     Indicates whether to pull the machine config upon every boot.
 	//   values:
 	//     - true


### PR DESCRIPTION
This PR fixes the `debug` option in the config.