### PR TITLE
feat: Add support for VLAN devices on Talos

### DIFF
--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -16,8 +16,10 @@ import (
 
 // Static implements the Addressing interface
 type Static struct {
-	Device      *machine.Device
+	CIDR        string
+	Mtu         int
 	FQDN        string
+	RouteList   []machine.Route
 	NetIf       *net.Interface
 	NameServers []net.IP
 }
@@ -37,7 +39,7 @@ func (s *Static) Name() string {
 // Address returns the IP address
 func (s *Static) Address() *net.IPNet {
 	// nolint: errcheck
-	ip, ipn, _ := net.ParseCIDR(s.Device.CIDR)
+	ip, ipn, _ := net.ParseCIDR(s.CIDR)
 	ipn.IP = ip
 
 	return ipn
@@ -46,13 +48,13 @@ func (s *Static) Address() *net.IPNet {
 // Mask returns the netmask.
 func (s *Static) Mask() net.IPMask {
 	// nolint: errcheck
-	_, ipnet, _ := net.ParseCIDR(s.Device.CIDR)
+	_, ipnet, _ := net.ParseCIDR(s.CIDR)
 	return ipnet.Mask
 }
 
 // MTU returns the specified MTU.
 func (s *Static) MTU() uint32 {
-	mtu := uint32(s.Device.MTU)
+	mtu := uint32(s.Mtu)
 	if mtu == 0 {
 		mtu = uint32(s.NetIf.MTU)
 	}
@@ -83,7 +85,7 @@ func (s *Static) Scope() uint8 {
 // Routes aggregates the specified routes for a given device configuration
 // TODO: do we need to be explicit on route vs gateway?
 func (s *Static) Routes() (routes []*Route) {
-	for _, route := range s.Device.Routes {
+	for _, route := range s.RouteList {
 		// nolint: errcheck
 		_, ipnet, _ := net.ParseCIDR(route.Network)
 

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/runtime/platform"
-	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -128,10 +127,8 @@ func New(config runtime.Configurator) (*Networkd, error) {
 		if strings.HasPrefix(device.Name, "lo") {
 			netconf[device.Name] = append(netconf[device.Name], nic.WithAddressing(
 				&address.Static{
-					Device: &machine.Device{
-						CIDR: "127.0.0.1/8",
-						MTU:  nic.MaximumMTU,
-					},
+					CIDR: "127.0.0.1/8",
+					Mtu:  nic.MaximumMTU,
 				},
 			))
 		}
@@ -385,11 +382,19 @@ func (n *Networkd) configureLinks(bonded bool) error {
 					return fmt.Errorf("error creating nic %q: %w", netif.Name, err)
 				}
 
+				if err := netif.CreateSub(); err != nil {
+					return fmt.Errorf("error creating sub interface nic %q: %w", netif.Name, err)
+				}
+
 				if err := netif.Configure(); err != nil {
 					return fmt.Errorf("error configuring nic %q: %w", netif.Name, err)
 				}
 
 				if err := netif.Addressing(); err != nil {
+					return fmt.Errorf("error configuring addressing %q: %w", netif.Name, err)
+				}
+
+				if err := netif.AddressingSub(); err != nil {
 					return fmt.Errorf("error configuring addressing %q: %w", netif.Name, err)
 				}
 

--- a/internal/app/networkd/pkg/nic/netlink.go
+++ b/internal/app/networkd/pkg/nic/netlink.go
@@ -13,19 +13,28 @@ import (
 )
 
 // createLink creates an interface
-func (n *NetworkInterface) createLink() error {
-	var info *rtnetlink.LinkInfo
-
-	if n.Bonded {
-		info = &rtnetlink.LinkInfo{Kind: "bond"}
-	}
-
+func (n *NetworkInterface) createLink(name string, info *rtnetlink.LinkInfo) error {
 	err := n.rtConn.Link.New(&rtnetlink.LinkMessage{
 		Family: unix.AF_UNSPEC,
 		Type:   0,
 		Attributes: &rtnetlink.LinkAttributes{
-			Name: n.Name,
+			Name: name,
 			Info: info,
+		},
+	})
+
+	return err
+}
+
+// createLink creates an interface
+func (n *NetworkInterface) createSubLink(name string, info *rtnetlink.LinkInfo, master *uint32) error {
+	err := n.rtConn.Link.New(&rtnetlink.LinkMessage{
+		Family: unix.AF_UNSPEC,
+		Type:   0,
+		Attributes: &rtnetlink.LinkAttributes{
+			Name: name,
+			Info: info,
+			Type: *master,
 		},
 	})
 

--- a/internal/app/networkd/pkg/nic/nic_test.go
+++ b/internal/app/networkd/pkg/nic/nic_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
+	"github.com/talos-systems/talos/pkg/config/machine"
 )
 
 type NicSuite struct {
@@ -103,5 +104,24 @@ func (suite *NicSuite) TestBond() {
 		mynic, err := New(test...)
 		suite.Require().NoError(err)
 		suite.Assert().True(mynic.Bonded)
+	}
+}
+
+func (suite *NicSuite) TestVlan() {
+	testSettings := [][]Option{
+		{
+			WithName("eth0"),
+			WithVlan(100),
+		},
+		{
+			WithName("eth0"),
+			WithVlan(100),
+			WithVlanCIDR(100, "172.21.10.101/28", []machine.Route{}),
+		},
+	}
+	for _, test := range testSettings {
+		mynic, err := New(test...)
+		suite.Require().NoError(err)
+		suite.Assert().True(len(mynic.Vlans) > 0)
 	}
 }

--- a/internal/app/networkd/pkg/nic/options.go
+++ b/internal/app/networkd/pkg/nic/options.go
@@ -47,3 +47,12 @@ func WithAddressing(a address.Addressing) Option {
 		return err
 	}
 }
+
+// WithNoAddressing defines how the addressing for a given interface
+// should be configured
+func WithNoAddressing() Option {
+	return func(n *NetworkInterface) (err error) {
+		n.AddressMethod = []address.Addressing{}
+		return err
+	}
+}

--- a/internal/app/networkd/pkg/nic/vars.go
+++ b/internal/app/networkd/pkg/nic/vars.go
@@ -303,3 +303,20 @@ func FailOverMACByName(f string) (fo FailOverMAC, err error) {
 
 	return fo, err
 }
+
+const (
+	IFLA_VLAN_UNSPEC = iota
+	IFLA_VLAN_ID
+	IFLA_VLAN_FLAGS
+	IFLA_VLAN_EGRESS_QOS
+	IFLA_VLAN_INGRESS_QOS
+	IFLA_VLAN_PROTOCOL
+	IFLA_VLAN_MAX = IFLA_VLAN_PROTOCOL
+)
+
+// VlanProtocol possible values
+const (
+	VLAN_PROTOCOL_UNKNOWN = 0
+	VLAN_PROTOCOL_8021Q   = 0x8100
+	VLAN_PROTOCOL_8021AD  = 0x88A8
+)

--- a/internal/app/networkd/pkg/nic/vlan_options.go
+++ b/internal/app/networkd/pkg/nic/vlan_options.go
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package nic
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/mdlayher/netlink"
+
+	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
+	"github.com/talos-systems/talos/pkg/config/machine"
+)
+
+// Vlan contins interface related parameters to a VLAN device
+type Vlan struct {
+	Parent        string
+	ID            uint16
+	Link          *net.Interface
+	VlanSettings  *netlink.AttributeEncoder
+	AddressMethod []address.Addressing
+}
+
+// WithVlan defines the VLAN id to use
+func WithVlan(id uint16) Option {
+	return func(n *NetworkInterface) (err error) {
+		for _, vlan := range n.Vlans {
+			if vlan.ID == id {
+				return fmt.Errorf("duplicate VLAN id  %v given", vlan)
+			}
+		}
+
+		vlan := &Vlan{
+			ID:           id,
+			VlanSettings: netlink.NewAttributeEncoder(),
+		}
+
+		vlan.VlanSettings.Uint16(uint16(IFLA_VLAN_ID), vlan.ID)
+		n.Vlans = append(n.Vlans, vlan)
+
+		return nil
+	}
+}
+
+// WithVlanDhcp sets a VLAN device with DHCP
+func WithVlanDhcp(id uint16) Option {
+	return func(n *NetworkInterface) (err error) {
+		for _, vlan := range n.Vlans {
+			if vlan.ID == id {
+				vlan.AddressMethod = append(vlan.AddressMethod, &address.DHCP{})
+				return nil
+			}
+		}
+
+		return fmt.Errorf("VLAN id not found for DHCP. Vlan ID  %v given", id)
+	}
+}
+
+// WithVlanCIDR defines if the interface have static CIDRs added
+func WithVlanCIDR(id uint16, cidr string, routeList []machine.Route) Option {
+	return func(n *NetworkInterface) (err error) {
+		for _, vlan := range n.Vlans {
+			if vlan.ID == id {
+				vlan.AddressMethod = append(vlan.AddressMethod, &address.Static{CIDR: cidr, RouteList: routeList})
+				return nil
+			}
+		}
+
+		return fmt.Errorf("VLAN id not found for CIDR setting  %v given", id)
+	}
+}

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -98,6 +98,7 @@ type Device struct {
 	CIDR      string  `yaml:"cidr"`
 	Routes    []Route `yaml:"routes"`
 	Bond      *Bond   `yaml:"bond"`
+	Vlans     []*Vlan `yaml:"vlans"`
 	MTU       int     `yaml:"mtu"`
 	DHCP      bool    `yaml:"dhcp"`
 	Ignore    bool    `yaml:"ignore"`
@@ -133,6 +134,14 @@ type Bond struct {
 	ADActorSysPrio  uint16   `yaml:"adActorSysPrio"`
 	ADUserPortKey   uint16   `yaml:"adUserPortKey"`
 	PeerNotifyDelay uint32   `yaml:"peerNotifyDelay"`
+}
+
+// Vlan represents vlan settings for a device
+type Vlan struct {
+	CIDR   string  `ỳaml:"cidr"`
+	Routes []Route `yaml:"routes"`
+	DHCP   bool    `yaml:"dhcp"`
+	ID     uint16  `yaml:"vlanId"`
 }
 
 // Route represents a network route.

--- a/pkg/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_validation.go
@@ -149,7 +149,7 @@ func CheckDeviceAddressing(d machine.Device) error {
 	}
 
 	// test for neither dhcp nor cidr specified
-	if !d.DHCP && d.CIDR == "" {
+	if !d.DHCP && d.CIDR == "" && len(d.Vlans) == 0 {
 		result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device", "", ErrBadAddressing))
 	}
 


### PR DESCRIPTION
- Creates VLAN devices that are configured under a certain master device
- Address and routes are added to VLAN devices
- Allows a physical device to be created without Addressing if VLANs are defined for a network interface.