### PR TITLE
feat: add support for `--with-debug` to osctl cluster create

### DIFF
--- a/cmd/osctl/cmd/mgmt/cluster/create.go
+++ b/cmd/osctl/cmd/mgmt/cluster/create.go
@@ -39,6 +39,7 @@ var (
 	nodeVmlinuxPath         string
 	nodeInitramfsPath       string
 	bootloaderEmulation     bool
+	configDebug             bool
 	networkCIDR             string
 	networkMTU              int
 	nameservers             []string
@@ -162,6 +163,7 @@ func create(ctx context.Context) (err error) {
 	} else {
 		genOptions := []generate.GenOption{
 			generate.WithInstallImage(nodeInstallImage),
+			generate.WithDebug(configDebug),
 		}
 
 		for _, registryMirror := range registryMirrors {
@@ -316,6 +318,7 @@ func init() {
 	createCmd.Flags().StringVar(&nodeInitramfsPath, "initrd-path", helpers.ArtifactPath(constants.InitramfsAsset), "the uncompressed kernel image to use")
 	createCmd.Flags().BoolVar(&bootloaderEmulation, "with-bootloader-emulation", false, "enable bootloader emulation to load kernel and initramfs from disk image")
 	createCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
+	createCmd.Flags().BoolVar(&configDebug, "with-debug", false, "enable debug in Talos config to send service logs to the console")
 	createCmd.Flags().IntVar(&networkMTU, "mtu", 1500, "MTU of the docker bridge network")
 	createCmd.Flags().StringVar(&networkCIDR, "cidr", "10.5.0.0/24", "CIDR of the docker bridge network")
 	createCmd.Flags().StringSliceVar(&nameservers, "nameservers", []string{"8.8.8.8", "1.1.1.1"}, "list of nameservers to use (VM only)")

--- a/docs/osctl/osctl_cluster_create.md
+++ b/docs/osctl/osctl_cluster_create.md
@@ -37,6 +37,7 @@ osctl cluster create [flags]
       --wait                        wait for the cluster to be ready before returning
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
       --with-bootloader-emulation   enable bootloader emulation to load kernel and initramfs from disk image
+      --with-debug                  enable debug in Talos config to send service logs to the console
       --workers int                 the number of workers to create (default 1)
 ```
 

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -11,7 +11,10 @@ import (
 )
 
 func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
-	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
+	config := &v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		ConfigDebug:   in.Debug,
+	}
 
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "controlplane",

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -58,6 +58,8 @@ func Config(t machine.Type, in *Input) (c *v1alpha1.Config, err error) {
 }
 
 // Input holds info about certs, ips, and node type.
+//
+//nolint: maligned
 type Input struct {
 	Certs *Certs
 
@@ -86,6 +88,8 @@ type Input struct {
 	NetworkConfig *v1alpha1.NetworkConfig
 
 	RegistryMirrors map[string]machine.RegistryMirrorConfig
+
+	Debug bool
 }
 
 // GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
@@ -324,6 +328,7 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 		InstallImage:              options.InstallImage,
 		NetworkConfig:             options.NetworkConfig,
 		RegistryMirrors:           options.RegistryMirrors,
+		Debug:                     options.Debug,
 	}
 
 	return input, nil

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -11,7 +11,10 @@ import (
 )
 
 func initUd(in *Input) (*v1alpha1.Config, error) {
-	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
+	config := &v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		ConfigDebug:   in.Debug,
+	}
 
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "init",

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -12,7 +12,10 @@ import (
 )
 
 func workerUd(in *Input) (*v1alpha1.Config, error) {
-	config := &v1alpha1.Config{ConfigVersion: "v1alpha1"}
+	config := &v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		ConfigDebug:   in.Debug,
+	}
 
 	machine := &v1alpha1.MachineConfig{
 		MachineType:     "worker",

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -79,6 +79,15 @@ func WithDNSDomain(dnsDomain string) GenOption {
 	}
 }
 
+// WithDebug enables verbose logging to console for all services.
+func WithDebug(enable bool) GenOption {
+	return func(o *GenOptions) error {
+		o.Debug = enable
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
@@ -88,6 +97,7 @@ type GenOptions struct {
 	NetworkConfig             *v1alpha1.NetworkConfig
 	RegistryMirrors           map[string]machine.RegistryMirrorConfig
 	DNSDomain                 string
+	Debug                     bool
 }
 
 // DefaultGenOptions returns default options.


### PR DESCRIPTION
This enables config option 'debug: yes' which redirects service logs to
console which helps debugging cases when API is not available.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>