### PR TITLE
docs: add bare-metal install example yaml

### DIFF
--- a/docs/website/content/v0.4/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.4/en/configuration/v1alpha1.md
@@ -255,12 +255,13 @@ Examples:
 
 ```yaml
 install:
-  disk:
+  disk: /dev/sda
   extraKernelArgs:
-  image:
-  bootloader:
-  wipe:
-  force:
+    - option=value
+  image: docker.io/autonomy/installer:latest
+  bootloader: true
+  wipe: false
+  force: false
 
 ```
 

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -134,12 +134,13 @@ type MachineConfig struct {
 	//   examples:
 	//     - |
 	//       install:
-	//         disk:
+	//         disk: /dev/sda
 	//         extraKernelArgs:
-	//         image:
-	//         bootloader:
-	//         wipe:
-	//         force:
+	//           - option=value
+	//         image: docker.io/autonomy/installer:latest
+	//         bootloader: true
+	//         wipe: false
+	//         force: false
 	MachineInstall *InstallConfig `yaml:"install,omitempty"`
 	//   description: |
 	//     Allows the addition of user specified files.


### PR DESCRIPTION
I know there is an example at the top of the page but the example mid-page was empty yaml