### PR TITLE
feat: add usb storage support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,29 +268,29 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:08adc10 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:08adc10 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:00d8397 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:00d8397 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/containerd:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/eudev:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/iptables:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/libressl:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/musl:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/runc:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/socat:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:08adc10 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:08adc10 /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:08adc10 /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:08adc10 /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:08adc10 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/containerd:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/eudev:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/iptables:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/libressl:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/musl:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/runc:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/socat:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:00d8397 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:00d8397 /lib/libblkid.* /rootfs/lib
+COPY --from=docker.io/autonomy/util-linux:00d8397 /lib/libuuid.* /rootfs/lib
+COPY --from=docker.io/autonomy/kmod:00d8397 /usr/lib/libkmod.* /rootfs/lib
+COPY --from=docker.io/autonomy/kernel:00d8397 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=ntpd-image /ntpd.tar /rootfs/usr/images/

--- a/internal/pkg/kernel/vmlinuz/vmlinuz.go
+++ b/internal/pkg/kernel/vmlinuz/vmlinuz.go
@@ -24,15 +24,15 @@ var bzImageMagic = []struct {
 	reader decompressFunc
 }{
 	{
-		magic: []byte("\037\213\010"),
-		reader: func(r io.Reader) (io.ReadCloser, error) {
-			return gzip.NewReader(r)
-		},
-	},
-	{
 		magic: []byte("\3757zXZ\000"),
 		reader: func(r io.Reader) (io.ReadCloser, error) {
 			return xz.NewReader(r)
+		},
+	},
+	{
+		magic: []byte("\037\213\010"),
+		reader: func(r io.Reader) (io.ReadCloser, error) {
+			return gzip.NewReader(r)
 		},
 	},
 	{


### PR DESCRIPTION
This PR will pull in a newer kernel config that enables the
`CONFIG_USB_STORAGE` options for folks wanting to interact with USB
storage devices from talos.

Will close #1967 