### PR TITLE
chore: update upgrade tests for new version, split into two tracks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -496,11 +496,11 @@ steps:
   - kernel
   - push-local
 
-- name: provision-tests
+- name: provision-tests-prepare
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make provision-tests
+  - make provision-tests-prepare
   environment:
     REGISTRY: registry.ci.svc:5000
   privileged: true
@@ -520,6 +520,50 @@ steps:
   - talosctl-linux
   - kernel
   - push-local
+
+- name: provision-tests-track-0
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-0
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
+
+- name: provision-tests-track-1
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-1
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
 
 - name: push
   pull: always
@@ -1116,11 +1160,11 @@ steps:
   - kernel
   - push-local
 
-- name: provision-tests
+- name: provision-tests-prepare
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make provision-tests
+  - make provision-tests-prepare
   environment:
     REGISTRY: registry.ci.svc:5000
   privileged: true
@@ -1140,6 +1184,50 @@ steps:
   - talosctl-linux
   - kernel
   - push-local
+
+- name: provision-tests-track-0
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-0
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
+
+- name: provision-tests-track-1
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-1
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
 
 - name: push
   pull: always
@@ -1828,11 +1916,11 @@ steps:
   - kernel
   - push-local
 
-- name: provision-tests
+- name: provision-tests-prepare
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make provision-tests
+  - make provision-tests-prepare
   environment:
     REGISTRY: registry.ci.svc:5000
   privileged: true
@@ -1852,6 +1940,50 @@ steps:
   - talosctl-linux
   - kernel
   - push-local
+
+- name: provision-tests-track-0
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-0
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
+
+- name: provision-tests-track-1
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-1
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
 
 - name: push
   pull: always
@@ -2570,11 +2702,11 @@ steps:
   - kernel
   - push-local
 
-- name: provision-tests
+- name: provision-tests-prepare
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make provision-tests
+  - make provision-tests-prepare
   environment:
     REGISTRY: registry.ci.svc:5000
   privileged: true
@@ -2594,6 +2726,50 @@ steps:
   - talosctl-linux
   - kernel
   - push-local
+
+- name: provision-tests-track-0
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-0
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
+
+- name: provision-tests-track-1
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-1
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
 
 - name: push
   pull: always
@@ -3312,11 +3488,11 @@ steps:
   - kernel
   - push-local
 
-- name: provision-tests
+- name: provision-tests-prepare
   pull: always
   image: autonomy/build-container:latest
   commands:
-  - make provision-tests
+  - make provision-tests-prepare
   environment:
     REGISTRY: registry.ci.svc:5000
   privileged: true
@@ -3336,6 +3512,50 @@ steps:
   - talosctl-linux
   - kernel
   - push-local
+
+- name: provision-tests-track-0
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-0
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
+
+- name: provision-tests-track-1
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make provision-tests-track-1
+  environment:
+    REGISTRY: registry.ci.svc:5000
+  privileged: true
+  volumes:
+  - name: dockersock
+    path: /var/run
+  - name: docker
+    path: /root/.docker/buildx
+  - name: kube
+    path: /root/.kube
+  - name: dev
+    path: /dev
+  - name: tmp
+    path: /tmp
+  depends_on:
+  - provision-tests-prepare
 
 - name: push
   pull: always
@@ -3574,6 +3794,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: ce26e0c326108f56e6e30eb0094e42e74746851b92ed37ea95a6afff16648cfb
+hmac: 0faf410cbb2e500b5fc1957aa894c6cd8064b8b2bf9ef22f1802501c167ac1a5
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ KUBECTL_URL ?= https://storage.googleapis.com/kubernetes-release/release/v1.17.3
 SONOBUOY_VERSION ?= 0.17.1
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= ./...
-RELEASES ?= v0.3.2 v0.4.0-alpha.5
+RELEASES ?= v0.3.2 v0.4.0-alpha.7
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64
@@ -200,11 +200,20 @@ e2e-%: $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64 $(ARTIFACTS)/sonobu
 		KUBECTL=$(PWD)/$(ARTIFACTS)/kubectl \
 		SONOBUOY=$(PWD)/$(ARTIFACTS)/sonobuoy
 
-provision-tests: release-artifacts $(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64
+provision-tests-prepare: release-artifacts $(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64
+
+provision-tests: provision-tests-prepare
 	@$(MAKE) hack-test-$@ \
 		TAG=$(TAG) \
 		OSCTL=$(PWD)/$(ARTIFACTS)/$(OSCTL_DEFAULT_TARGET)-amd64 \
 		INTEGRATION_TEST=$(PWD)/$(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64
+
+provision-tests-track-%:
+	@$(MAKE) hack-test-provision-tests \
+		TAG=$(TAG) \
+		OSCTL=$(PWD)/$(ARTIFACTS)/$(OSCTL_DEFAULT_TARGET)-amd64 \
+		INTEGRATION_TEST=$(PWD)/$(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64 \
+		INTEGRATION_TEST_RUN="TestIntegration/.+-TR$*"
 
 # Assets for releases
 

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -212,7 +212,9 @@ local unit_tests = Step("unit-tests", depends_on=[initramfs]);
 local unit_tests_race = Step("unit-tests-race", depends_on=[golint]);
 local e2e_docker = Step("e2e-docker", depends_on=[talos, osctl_linux]);
 local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});
-local provision_tests = Step("provision-tests", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});
+local provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});
+local provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry});
+local provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry});
 
 local coverage = {
   name: 'coverage',
@@ -298,7 +300,9 @@ local default_steps = [
   push_local,
   e2e_docker,
   e2e_firecracker,
-  provision_tests,
+  provision_tests_prepare,
+  provision_tests_track_0,
+  provision_tests_track_1,
   push,
   push_latest,
 ];

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -94,11 +94,11 @@ function create_cluster_capi {
 }
 
 function run_talos_integration_test {
-  "${INTEGRATION_TEST}" -test.v -talos.failfast -talos.osctlpath "${OSCTL}" -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}"
+  "${INTEGRATION_TEST}" -test.v -talos.failfast -talos.talosctlpath "${OSCTL}" -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}"
 }
 
 function run_talos_integration_test_docker {
-  "${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}" -talos.k8sendpoint ${ENDPOINT}:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}"
+  "${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${OSCTL}" -talos.k8sendpoint ${ENDPOINT}:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}"
 }
 
 function run_kubernetes_integration_test {

--- a/hack/test/provision-tests.sh
+++ b/hack/test/provision-tests.sh
@@ -12,5 +12,8 @@ case "${REGISTRY:-false}" in
     ;;
 esac
 
+if [ "${INTEGRATION_TEST_RUN:-undefined}" != "undefined" ]; then
+  INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -test.run ${INTEGRATION_TEST_RUN}"
+fi
 
-"${INTEGRATION_TEST}" -test.v -talos.osctlpath "${OSCTL}" -talos.provision.mem 2048 -talos.provision.cpu 2 ${INTEGRATION_TEST_FLAGS}
+"${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${OSCTL}" -talos.provision.mem 2048 -talos.provision.cpu 2 ${INTEGRATION_TEST_FLAGS}

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount/manager/squashfs"
 	"github.com/talos-systems/talos/internal/pkg/mount/switchroot"
 	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 // nolint: gocyclo
@@ -43,6 +44,8 @@ func run() (err error) {
 	if err != nil {
 		return err
 	}
+
+	log.Printf("booting Talos %s", version.Tag)
 
 	// Mount the rootfs.
 	log.Println("mounting the rootfs")

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -23,8 +23,8 @@ type TalosSuite struct {
 	TalosConfig string
 	// Version is the (expected) version of Talos tests are running against
 	Version string
-	// OsctlPath is path to talosctl binary
-	OsctlPath string
+	// TalosctlPath is path to talosctl binary
+	TalosctlPath string
 
 	discoveredNodes []string
 }

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -43,7 +43,7 @@ func (cliSuite *CLISuite) buildOsctlCmd(args []string) *exec.Cmd {
 
 	args = append([]string{"--talosconfig", cliSuite.TalosConfig}, args...)
 
-	return exec.Command(cliSuite.OsctlPath, args...)
+	return exec.Command(cliSuite.TalosctlPath, args...)
 }
 
 // RunOsctl runs talosctl binary with the options provided

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -37,7 +37,7 @@ var (
 	endpoint        string
 	k8sEndpoint     string
 	expectedVersion string
-	osctlPath       string
+	talosctlPath    string
 	provisionerName string
 	clusterName     string
 	stateDir        string
@@ -76,12 +76,12 @@ func TestIntegration(t *testing.T) {
 	for _, s := range allSuites {
 		if configuredSuite, ok := s.(base.ConfiguredSuite); ok {
 			configuredSuite.SetConfig(base.TalosSuite{
-				Endpoint:    endpoint,
-				K8sEndpoint: k8sEndpoint,
-				Cluster:     cluster,
-				TalosConfig: talosConfig,
-				Version:     expectedVersion,
-				OsctlPath:   osctlPath,
+				Endpoint:     endpoint,
+				K8sEndpoint:  k8sEndpoint,
+				Cluster:      cluster,
+				TalosConfig:  talosConfig,
+				Version:      expectedVersion,
+				TalosctlPath: talosctlPath,
 			})
 		}
 
@@ -124,7 +124,7 @@ func init() {
 	flag.StringVar(&stateDir, "talos.state", defaultStateDir, "directory path to store cluster state")
 	flag.StringVar(&clusterName, "talos.name", "talos-default", "the name of the cluster")
 	flag.StringVar(&expectedVersion, "talos.version", version.Tag, "expected Talos version")
-	flag.StringVar(&osctlPath, "talos.osctlpath", "talosctl", "The path to 'talosctl' binary")
+	flag.StringVar(&talosctlPath, "talos.talosctlpath", "talosctl", "The path to 'talosctl' binary")
 
 	flag.StringVar(&provision_test.DefaultSettings.CIDR, "talos.provision.cidr", provision_test.DefaultSettings.CIDR, "CIDR to use to provision clusters (provision tests only)")
 	flag.Var(&provision_test.DefaultSettings.RegistryMirrors, "talos.provision.registry-mirror", "registry mirrors to use (provision tests only)")

--- a/internal/pkg/provision/access/crashdump.go
+++ b/internal/pkg/provision/access/crashdump.go
@@ -1,0 +1,71 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package access
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/talos-systems/talos/api/common"
+	"github.com/talos-systems/talos/cmd/talosctl/pkg/client"
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+// CrashDump produces debug information to help with debugging failures.
+func (a *adapter) CrashDump(ctx context.Context, out io.Writer) {
+	cli, err := a.Client()
+	if err != nil {
+		fmt.Fprintf(out, "error creating crashdump: %s\n", err)
+		return
+	}
+
+	for _, node := range a.Info().Nodes {
+		func(node string) {
+			nodeCtx, nodeCtxCancel := context.WithTimeout(client.WithNodes(ctx, node), 30*time.Second)
+			defer nodeCtxCancel()
+
+			fmt.Fprintf(out, "\n%s\n%s\n\n", node, strings.Repeat("=", len(node)))
+
+			services, err := cli.ServiceList(nodeCtx)
+			if err != nil {
+				fmt.Fprintf(out, "error getting services: %s\n", err)
+				return
+			}
+
+			for _, msg := range services.Messages {
+				for _, svc := range msg.Services {
+					stream, err := cli.Logs(nodeCtx, constants.SystemContainerdNamespace, common.ContainerDriver_CONTAINERD, svc.Id, false, 100)
+					if err != nil {
+						fmt.Fprintf(out, "error getting service logs for %s: %s\n", svc.Id, err)
+						continue
+					}
+
+					r, errCh, err := client.ReadStream(stream)
+					if err != nil {
+						fmt.Fprintf(out, "error getting service logs for %s: %s\n", svc.Id, err)
+						continue
+					}
+
+					fmt.Fprintf(out, "\n> %s\n%s\n\n", svc.Id, strings.Repeat("-", len(svc.Id)+2))
+
+					_, err = io.Copy(out, r)
+					if err != nil {
+						fmt.Fprintf(out, "error streaming service logs: %s\n", err)
+					}
+
+					err = <-errCh
+					if err != nil {
+						fmt.Fprintf(out, "error streaming service logs: %s\n", err)
+					}
+
+					r.Close() //nolint: errcheck
+				}
+			}
+		}(node.PrivateIP.String())
+	}
+}

--- a/internal/pkg/provision/adapters.go
+++ b/internal/pkg/provision/adapters.go
@@ -6,6 +6,7 @@ package provision
 
 import (
 	"context"
+	"io"
 
 	"k8s.io/client-go/kubernetes"
 
@@ -21,6 +22,9 @@ type ClusterAccess interface {
 
 	// K8sClient returns Kubernetes client.
 	K8sClient(context.Context) (*kubernetes.Clientset, error)
+
+	// CrashDump essential info for debugging from Talos node.
+	CrashDump(context.Context, io.Writer)
 
 	// Close shuts down all the clients.
 	Close() error


### PR DESCRIPTION
This updates upgrade tests to run two flows with 3+1 clusters:

1. 0.3 -> current (testing upgrade with partition wiping)
2. 0.4-alpha.7 -> current (testing upgrade without partition wiping,
boot-a/boot-b)

And small upgrade with preserve enabled for single-node cluster.

Provision tests are now split into two parallel tracks in Drone.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>