### PR TITLE
feat: make `--wait` default option to `talosctl cluster create`

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -327,7 +327,7 @@ func init() {
 	createCmd.Flags().StringVar(&clusterCpus, "cpus", "1.5", "the share of CPUs as fraction (each container)")
 	createCmd.Flags().IntVar(&clusterMemory, "memory", 1024, "the limit on memory usage in MB (each container)")
 	createCmd.Flags().IntVar(&clusterDiskSize, "disk", 4*1024, "the limit on disk size in MB (each VM)")
-	createCmd.Flags().BoolVar(&clusterWait, "wait", false, "wait for the cluster to be ready before returning")
+	createCmd.Flags().BoolVar(&clusterWait, "wait", true, "wait for the cluster to be ready before returning")
 	createCmd.Flags().DurationVar(&clusterWaitTimeout, "wait-timeout", 20*time.Minute, "timeout to wait for the cluster to be ready")
 	createCmd.Flags().BoolVar(&forceInitNodeAsEndpoint, "init-node-as-endpoint", false, "use init node as endpoint instead of any load balancer endpoint")
 	createCmd.Flags().StringVar(&forceEndpoint, "endpoint", "", "use endpoint instead of provider defaults")

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -34,7 +34,7 @@ talosctl cluster create [flags]
       --nameservers strings         list of nameservers to use (VM only) (default [8.8.8.8,1.1.1.1])
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
       --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
-      --wait                        wait for the cluster to be ready before returning
+      --wait                        wait for the cluster to be ready before returning (default true)
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
       --with-bootloader-emulation   enable bootloader emulation to load kernel and initramfs from disk image
       --with-debug                  enable debug in Talos config to send service logs to the console

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -25,7 +25,6 @@ function create_cluster {
     --mtu 1500 \
     --memory 2048 \
     --cpus 4.0 \
-    --wait \
     --endpoint "${ENDPOINT}"
 }
 

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -28,7 +28,6 @@ function create_cluster {
     --memory 2048 \
     --cpus 2.0 \
     --cidr 172.20.0.0/24 \
-    --wait \
     --install-image ${REGISTRY:-docker.io}/autonomy/installer:${INSTALLER_TAG} \
     ${FIRECRACKER_FLAGS}
 }


### PR DESCRIPTION
It seems to be useful enough to be the default one and it prevents
simple mistakes while trying to access the cluster which is not ready
yet.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>