### PR TITLE
fix: make upgrades work with UEFI

### DIFF
--- a/cmd/installer/pkg/bootloader/syslinux/constants.go
+++ b/cmd/installer/pkg/bootloader/syslinux/constants.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package syslinux
+
+import "github.com/talos-systems/talos/pkg/constants"
+
+const (
+	// BootA is a syslinux label.
+	BootA = "boot-a"
+
+	// BootB is a syslinux label.
+	BootB = "boot-b"
+
+	// SyslinuxLdlinux is the path to ldlinux.sys.
+	SyslinuxLdlinux = constants.BootMountPoint + "/syslinux/ldlinux.sys"
+
+	// SyslinuxConfig is the path to the Syslinux config.
+	SyslinuxConfig = constants.BootMountPoint + "/syslinux/syslinux.cfg"
+
+	gptmbrbin   = "/usr/lib/syslinux/gptmbr.bin"
+	syslinuxefi = "/usr/lib/syslinux/syslinux.efi"
+	ldlinuxe64  = "/usr/lib/syslinux/ldlinux.e64"
+)

--- a/internal/app/machined/internal/phase/rootfs/syslinux.go
+++ b/internal/app/machined/internal/phase/rootfs/syslinux.go
@@ -5,16 +5,12 @@
 package rootfs
 
 import (
-	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
-	"regexp"
 
 	"github.com/talos-systems/talos/cmd/installer/pkg/bootloader/syslinux"
 	"github.com/talos-systems/talos/internal/app/machined/internal/phase"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // Syslinux represents the Syslinux task.
@@ -36,7 +32,7 @@ func (task *Syslinux) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 }
 
 func (task *Syslinux) standard(r runtime.Runtime) (err error) {
-	f, err := os.OpenFile(constants.SyslinuxLdlinux, os.O_RDWR, 0700)
+	f, err := os.OpenFile(syslinux.SyslinuxLdlinux, os.O_RDWR, 0700)
 	if err != nil {
 		return err
 	}
@@ -49,33 +45,9 @@ func (task *Syslinux) standard(r runtime.Runtime) (err error) {
 		return err
 	}
 
-	once, ok := adv.ReadTag(syslinux.AdvUpgrade)
-	if !ok {
-		return nil
+	if ok := adv.DeleteTag(syslinux.AdvUpgrade); ok {
+		log.Println("removing fallback")
 	}
-
-	log.Printf("updating default boot to %q", once)
-
-	var b []byte
-
-	if b, err = ioutil.ReadFile(constants.SyslinuxConfig); err != nil {
-		return err
-	}
-
-	re := regexp.MustCompile(`^DEFAULT\s(.*)`)
-	matches := re.FindSubmatch(b)
-
-	if len(matches) != 2 {
-		return fmt.Errorf("expected 2 matches, got %d", len(matches))
-	}
-
-	b = re.ReplaceAll(b, []byte(fmt.Sprintf("DEFAULT %s", once)))
-
-	if err = ioutil.WriteFile(constants.SyslinuxConfig, b, 0600); err != nil {
-		return err
-	}
-
-	adv.DeleteTag(syslinux.AdvUpgrade)
 
 	if _, err = f.Write(adv); err != nil {
 		return err

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -349,7 +349,7 @@ func (e *Etcd) args(config runtime.Configurator) ([]string, error) {
 	if p.Mode() != runtime.Container {
 		var f *os.File
 
-		if f, err = os.Open(constants.SyslinuxLdlinux); err != nil {
+		if f, err = os.Open(syslinux.SyslinuxLdlinux); err != nil {
 			return nil, err
 		}
 

--- a/internal/pkg/provision/providers/firecracker/bootloader.go
+++ b/internal/pkg/provision/providers/firecracker/bootloader.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,7 +15,6 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/talos-systems/talos/cmd/installer/pkg/bootloader/syslinux"
 	"github.com/talos-systems/talos/internal/pkg/kernel/vmlinuz"
 	"github.com/talos-systems/talos/pkg/blockdevice/filesystem/vfat"
 	"github.com/talos-systems/talos/pkg/blockdevice/table"
@@ -188,29 +186,6 @@ func (b *BootLoader) findLabel() (label string, err error) {
 	}
 
 	label = string(matches[1])
-
-	// Parse the ADV to support the new upgrade strategy.
-	// This can become the default once v0.3 is deprecated.
-
-	f, err := b.bootFs.Open("/syslinux/ldlinux.sys")
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return label, nil
-		}
-
-		return label, fmt.Errorf("failed to open ldlinux.sys: %w", err)
-	}
-
-	var adv syslinux.ADV
-
-	if adv, err = syslinux.NewADV(f); err != nil {
-		return label, err
-	}
-
-	l, ok := adv.ReadTag(syslinux.AdvUpgrade)
-	if ok {
-		label = l
-	}
 
 	return label, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -292,18 +292,6 @@ const (
 	// InitializedKey is the key used to indicate if the cluster has been
 	// initialized.
 	InitializedKey = "initialized"
-
-	// BootA is a syslinux label.
-	BootA = "boot-a"
-
-	// BootB is a syslinux label.
-	BootB = "boot-b"
-
-	// SyslinuxConfig is the path to the Syslinux config.
-	SyslinuxConfig = "/boot/syslinux/syslinux.cfg"
-
-	// SyslinuxLdlinux is the path to ldlinux.sys.
-	SyslinuxLdlinux = "/boot/syslinux/ldlinux.sys"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Since the `--once` option of `extlinux` seems to only work with BIOS, we
needed to change to remove any reliance on this option. Instead of
booting the upgraded version once, and then making it the default after
a successful boot, we now make it the default, and then revert on any
boot error.