### PR TITLE
feat: allow for exposing ports on docker clusters

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/cluster.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/cluster.go
@@ -21,9 +21,9 @@ var Cmd = &cobra.Command{
 }
 
 var (
-	provisioner string
-	stateDir    string
-	clusterName string
+	provisionerName string
+	stateDir        string
+	clusterName     string
 )
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 		defaultStateDir = filepath.Join(defaultStateDir, "clusters")
 	}
 
-	Cmd.PersistentFlags().StringVar(&provisioner, "provisioner", "docker", "Talos cluster provisioner to use")
+	Cmd.PersistentFlags().StringVar(&provisionerName, "provisioner", "docker", "Talos cluster provisioner to use")
 	Cmd.PersistentFlags().StringVar(&stateDir, "state", defaultStateDir, "directory path to store cluster state")
 	Cmd.PersistentFlags().StringVar(&clusterName, "name", "talos-default", "the name of the cluster")
 }

--- a/cmd/talosctl/cmd/mgmt/cluster/destroy.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/destroy.go
@@ -25,7 +25,7 @@ var destroyCmd = &cobra.Command{
 }
 
 func destroy(ctx context.Context) error {
-	provisioner, err := providers.Factory(ctx, provisioner)
+	provisioner, err := providers.Factory(ctx, provisionerName)
 	if err != nil {
 		return err
 	}

--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -30,7 +30,7 @@ var showCmd = &cobra.Command{
 }
 
 func show(ctx context.Context) error {
-	provisioner, err := providers.Factory(ctx, provisioner)
+	provisioner, err := providers.Factory(ctx, provisionerName)
 	if err != nil {
 		return err
 	}

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -21,6 +21,7 @@ talosctl cluster create [flags]
       --cpus string                 the share of CPUs as fraction (each container) (default "1.5")
       --disk int                    the limit on disk size in MB (each VM) (default 4096)
       --endpoint string             use endpoint instead of provider defaults
+  -p, --exposed-ports string        Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
   -h, --help                        help for create
       --image string                the image to use (default "docker.io/autonomy/talos:latest")
       --init-node-as-endpoint       use init node as endpoint instead of any load balancer endpoint

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -60,6 +60,15 @@ func WithBootladerEmulation() Option {
 	}
 }
 
+// WithDockerPorts allows docker provisioner to expose ports on workers
+func WithDockerPorts(ports []string) Option {
+	return func(o *Options) error {
+		o.DockerPorts = ports
+
+		return nil
+	}
+}
+
 // Options describes Provisioner parameters.
 type Options struct {
 	LogWriter     io.Writer
@@ -69,6 +78,9 @@ type Options struct {
 
 	// Enable bootloader by booting from disk image assets.
 	BootloaderEmulation bool
+
+	// Expose ports to worker machines in docker provisioner
+	DockerPorts []string
 }
 
 // DefaultOptions returns default options.

--- a/internal/pkg/provision/providers/docker/create.go
+++ b/internal/pkg/provision/providers/docker/create.go
@@ -39,7 +39,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	fmt.Fprintln(options.LogWriter, "creating master nodes")
 
-	if nodeInfo, err = p.createNodes(ctx, request, request.Nodes.MasterNodes()); err != nil {
+	if nodeInfo, err = p.createNodes(ctx, request, request.Nodes.MasterNodes(), &options); err != nil {
 		return nil, err
 	}
 
@@ -47,7 +47,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	var workerNodeInfo []provision.NodeInfo
 
-	if workerNodeInfo, err = p.createNodes(ctx, request, request.Nodes.WorkerNodes()); err != nil {
+	if workerNodeInfo, err = p.createNodes(ctx, request, request.Nodes.WorkerNodes(), &options); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR will introduce a `-p/--exposed-ports` flag to talosctl. This
flag will allow us to enable port forwards on worker nodes only. This
will allow for ingresses on docker clusters so we can hopefully use
ingress for Arges initial bootstrapping. I modeled this after how KIND allows ingresses
[here](https://kind.sigs.k8s.io/docs/user/ingress/)

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>