### PR TITLE
test: mark long tests as !short

### DIFF
--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/client"
@@ -31,6 +32,10 @@ func (suite *RebootSuite) SuiteName() string {
 
 // SetupTest ...
 func (suite *RebootSuite) SetupTest() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
 	// make sure we abort at some point in time, but give enough room for reboots
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 30*time.Minute)
 }

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"testing"
 	"time"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/client"
@@ -31,6 +32,10 @@ func (suite *ResetSuite) SuiteName() string {
 
 // SetupTest ...
 func (suite *ResetSuite) SetupTest() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
 	// make sure we abort at some point in time, but give enough room for Resets
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 30*time.Minute)
 }

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -8,6 +8,7 @@ package cli
 
 import (
 	"regexp"
+	"testing"
 	"time"
 
 	"github.com/talos-systems/talos/internal/integration/base"
@@ -25,6 +26,10 @@ func (suite *RestartSuite) SuiteName() string {
 
 // TestSystem restarts system containerd process.
 func (suite *RestartSuite) TestSystem() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
 	suite.RunOsctl([]string{"restart", "trustd"},
 		base.StdoutEmpty())
 
@@ -35,6 +40,10 @@ func (suite *RestartSuite) TestSystem() {
 
 // TestKubernetes restarts K8s container.
 func (suite *RestartSuite) TestK8s() {
+	if testing.Short() {
+		suite.T().Skip("skipping in short mode")
+	}
+
 	suite.RunOsctl([]string{"restart", "-k", "kubelet"},
 		base.StdoutEmpty())
 


### PR DESCRIPTION
This skips long-running integration tests if `-test.short` mode is
enabled.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>