### PR TITLE
refactor: improve upgrade image validation logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ KUBECTL_URL ?= https://storage.googleapis.com/kubernetes-release/release/v1.18.0
 SONOBUOY_VERSION ?= 0.17.1
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= ./...
-RELEASES ?= v0.3.2 v0.4.0-alpha.7
+RELEASES ?= v0.3.2 v0.4.0-alpha.8
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64

--- a/internal/app/machined/internal/api/reg/reg.go
+++ b/internal/app/machined/internal/api/reg/reg.go
@@ -110,6 +110,8 @@ func (r *Registrator) Shutdown(ctx context.Context, in *empty.Empty) (reply *mac
 
 // Upgrade initiates an upgrade.
 func (r *Registrator) Upgrade(ctx context.Context, in *machineapi.UpgradeRequest) (data *machineapi.UpgradeResponse, err error) {
+	log.Printf("validating %q", in.GetImage())
+
 	if err = pullAndValidateInstallerImage(ctx, r.config.Machine().Registries(), in.GetImage()); err != nil {
 		return nil, err
 	}
@@ -643,7 +645,7 @@ func pullAndValidateInstallerImage(ctx context.Context, config machinecfg.Regist
 	//nolint: errcheck
 	defer container.Delete(containerdctx, containerd.WithSnapshotCleanup)
 
-	task, err := container.NewTask(containerdctx, cio.NewCreator(cio.WithStdio))
+	task, err := container.NewTask(containerdctx, cio.NullIO)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -57,6 +57,8 @@ func (b *Bootkube) PreFunc(ctx context.Context, config runtime.Configurator) (er
 
 		if resp, err = client.Get(clientv3.WithRequireLeader(attemptCtx), constants.InitializedKey); err != nil {
 			if errors.Is(err, rpctypes.ErrGRPCKeyNotFound) {
+				log.Println("no key found, assuming cluster needs to be bootstrapped")
+
 				// no key set yet, treat as not provisioned yet
 				return nil
 			}
@@ -66,10 +68,14 @@ func (b *Bootkube) PreFunc(ctx context.Context, config runtime.Configurator) (er
 
 		if len(resp.Kvs) == 0 {
 			// no key/values in the range, treat as not provisioned yet
+			log.Printf("response for key %q is empty, assuming cluster needs to be bootstrapped", constants.InitializedKey)
+
 			return nil
 		}
 
 		if string(resp.Kvs[0].Value) == "true" {
+			log.Println("cluster is already bootstrapped")
+
 			b.provisioned = true
 		}
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -57,7 +57,7 @@ type upgradeSpec struct {
 
 const (
 	talos03Version = "v0.3.2-1-g71ac6696"
-	talos04Version = "v0.4.0-alpha.7"
+	talos04Version = "v0.4.0-alpha.8-9-g3b189c8c"
 )
 
 var (


### PR DESCRIPTION
This prevents the validation test from printing to stdout. An
additional log message was added to the beginning of the upgrade API
method to indicate that the image wil be validated.