### PR TITLE
fix: move empty label check

### DIFF
--- a/cmd/installer/pkg/bootloader/syslinux/syslinux.go
+++ b/cmd/installer/pkg/bootloader/syslinux/syslinux.go
@@ -263,10 +263,6 @@ func update() (err error) {
 }
 
 func setADV(ldlinux, fallback string) (err error) {
-	if fallback == "" {
-		return nil
-	}
-
 	var f *os.File
 
 	if f, err = os.OpenFile(ldlinux, os.O_RDWR, 0700); err != nil {

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -127,6 +127,10 @@ func revert() (err error) {
 		return nil
 	}
 
+	if label == "" {
+		return nil
+	}
+
 	log.Printf("reverting default boot to %q", label)
 
 	var b []byte


### PR DESCRIPTION
We should always set the fallback tag on an upgrade, and only revert if
the tag value is not an empty string.