### PR TITLE
feat: introduce ability to specify extra hosts in /etc/hosts

### DIFF
--- a/docs/website/content/v0.4/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.4/en/configuration/v1alpha1.md
@@ -722,6 +722,23 @@ Defaults to `1.1.1.1` and `8.8.8.8`
 
 Type: `array`
 
+#### extraHostEntries
+
+Allows for extra entries to be added to /etc/hosts file
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraHostEntries:
+  - ip: 192.168.1.100
+    aliases:
+      - test
+      - test.domain.tld
+
+```
+
 ---
 
 ### InstallConfig

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -247,7 +247,7 @@ func (n *Networkd) Hostname() (err error) {
 		return err
 	}
 
-	if err = writeHosts(hostname, address); err != nil {
+	if err = writeHosts(hostname, address, n.Config); err != nil {
 		return err
 	}
 

--- a/pkg/config/machine/machine.go
+++ b/pkg/config/machine/machine.go
@@ -90,6 +90,13 @@ type Network interface {
 	SetHostname(string)
 	Resolvers() []string
 	Devices() []Device
+	ExtraHosts() []ExtraHost
+}
+
+// ExtraHost represents a host entry in /etc/hosts
+type ExtraHost struct {
+	IP      string   `yaml:"ip"`
+	Aliases []string `yaml:"aliases"`
 }
 
 // Device represents a network interface.

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -477,6 +477,11 @@ func (n *NetworkConfig) Resolvers() []string {
 	return n.NameServers
 }
 
+// ExtraHosts implements the Configurator interface.
+func (n *NetworkConfig) ExtraHosts() []machine.ExtraHost {
+	return n.ExtraHostEntries
+}
+
 // Servers implements the Configurator interface.
 func (t *TimeConfig) Servers() []string {
 	return t.TimeServers

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -430,6 +430,16 @@ type NetworkConfig struct {
 	//     Used to statically set the nameservers for the host.
 	//     Defaults to `1.1.1.1` and `8.8.8.8`
 	NameServers []string `yaml:"nameservers,omitempty"`
+	//   description: |
+	//     Allows for extra entries to be added to /etc/hosts file
+	//   examples:
+	//     - |
+	//       extraHostEntries:
+	//         - ip: 192.168.1.100
+	//           aliases:
+	//             - test
+	//             - test.domain.tld
+	ExtraHostEntries []machine.ExtraHost `yaml:"extraHostEntries,omitempty"`
 }
 
 // InstallConfig represents the installation options for preparing a node.


### PR DESCRIPTION
This PR will allow users to configure /etc/hosts through the network
config section, as opposed to having to use a file append operation.

Example usage might look something like:

```
...
...
machine:
  ...
  ...
  network:
    extraHostEntries:
      - ip: 192.168.1.100
        aliases:
          - test
          - test.wtf.bbq
...
...
```

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>