### PR TITLE
fix: make sure Close() is called on every path

### DIFF
--- a/internal/app/machined/internal/api/reg/reg.go
+++ b/internal/app/machined/internal/api/reg/reg.go
@@ -583,12 +583,12 @@ func (r *Registrator) Read(in *machineapi.ReadRequest, srv machineapi.MachineSer
 			return err
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		defer f.Close() //nolint: errcheck
 
+		ctx, cancel := context.WithCancel(srv.Context())
 		defer cancel()
 
 		chunker := stream.NewChunker(f)
-
 		chunkCh := chunker.Read(ctx)
 
 		for data := range chunkCh {

--- a/internal/app/machined/internal/phase/security/ima.go
+++ b/internal/app/machined/internal/phase/security/ima.go
@@ -66,6 +66,8 @@ func (task *IMA) runtime(r runtime.Runtime) (err error) {
 		return err
 	}
 
+	defer f.Close() //nolint: errcheck
+
 	for _, line := range rules {
 		if _, err = f.WriteString(line + "\n"); err != nil {
 			return fmt.Errorf("rule %q is invalid", err)

--- a/internal/app/machined/pkg/system/runner/containerd/import.go
+++ b/internal/app/machined/pkg/system/runner/containerd/import.go
@@ -88,6 +88,8 @@ func (i *Importer) Import(reqs ...*ImportRequest) (err error) {
 					return fmt.Errorf("error opening %s: %w", r.Path, err)
 				}
 
+				defer tarball.Close() //nolint: errcheck
+
 				imgs, err := client.Import(ctx, tarball, r.Options...)
 				if err != nil {
 					return fmt.Errorf("error importing %s: %w", r.Path, err)

--- a/internal/pkg/containers/container.go
+++ b/internal/pkg/containers/container.go
@@ -78,6 +78,7 @@ func (c *Container) GetLogChunker(follow bool, tailLines int) (chunker.Chunker, 
 		if tailLines >= 0 {
 			err = tail.SeekLines(f, tailLines)
 			if err != nil {
+				f.Close() //nolint: errcheck
 				return nil, nil, fmt.Errorf("error tailing log: %w", err)
 			}
 		}


### PR DESCRIPTION
For some places `.Close()` was clearly missing, for some of them I wanted
to be 200% sure it gets called on every code path.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>