### PR TITLE
chore: update timeout values for e2e tests

### DIFF
--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -59,7 +59,7 @@ func (suite *RebootSuite) TestRebootNodeByNode() {
 
 		func(node string) {
 			// timeout for single node reboot
-			ctx, ctxCancel := context.WithTimeout(suite.ctx, 5*time.Minute)
+			ctx, ctxCancel := context.WithTimeout(suite.ctx, 10*time.Minute)
 			defer ctxCancel()
 
 			nodeCtx := client.WithNodes(ctx, node)
@@ -72,7 +72,7 @@ func (suite *RebootSuite) TestRebootNodeByNode() {
 
 			var uptimeAfter float64
 
-			suite.Require().NoError(retry.Constant(3 * time.Minute).Retry(func() error {
+			suite.Require().NoError(retry.Constant(10 * time.Minute).Retry(func() error {
 				uptimeAfter, err = suite.ReadUptime(nodeCtx)
 				if err != nil {
 					// API might be unresponsive during reboot
@@ -147,7 +147,7 @@ func (suite *RebootSuite) TestRebootAllNodes() {
 
 				nodeCtx := client.WithNodes(suite.ctx, node)
 
-				return retry.Constant(3 * time.Minute).Retry(func() error {
+				return retry.Constant(10 * time.Minute).Retry(func() error {
 					uptimeAfter, err := suite.ReadUptime(nodeCtx)
 					if err != nil {
 						// API might be unresponsive during reboot


### PR DESCRIPTION
This PR will update the values for timeout when testing e2e. We were
hitting issues in GCP on the reboot test, as the nodes seemed to be
taking a few minutes to become responsive again. I also moved the
"cluster health" check in the node-by-node reboot test to use the
default suite context, so it'll have a timeout of 30m instead of the 5
that it had initially. This seems to solve the node-by-node bailing as
well.