### PR TITLE
fix: mount TLS certs into bootkube container

### DIFF
--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -160,6 +160,7 @@ func (b *Bootkube) Runner(config runtime.Configurator) (runner.Runner, error) {
 
 	// Set the required kubelet mounts.
 	mounts := []specs.Mount{
+		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: constants.ConfigPath, Source: constants.ConfigPath, Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: "/etc/kubernetes", Source: "/etc/kubernetes", Options: []string{"bind", "rshared", "rw"}},
 	}


### PR DESCRIPTION
Bootkube needs TLS certs to fetch TLS-protected resources (or to use
custom TLS certifcates).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>