### PR TITLE
chore: add PR template for contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+<!--
+Thank you for contributing to Talos!
+
+Here's a brief list of TODOs that might make your contribution easier to merge:
+
+- Your PR should consist of a single commit. Please squash multiple commits before submitting.
+
+- Ensure your commit is signed. This can be done with the `git commit -s` flag.
+
+- We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) in our repositories. Please make sure your commit is formatted according to this spec (Examples are: `feat: ...`, `fix: ...`, `docs: ...`).
+
+- We use a `rebase and merge` strategy for this repository. In order to make sure your changes are merged quickly, please ensure you are rebased off of the latest commit.
+
+- One of our maintainers will comment on your PR with `/test`. Maintainers are the only ones capable of performing this function. This command will kick off our CI suite against your changes, which must pass before changes are merged. 
+
+- As an extension of the previous bullet, you may wish to run `make lint` and `make unit-tests` locally. These will allow you to catch basic issues before CI.
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #


### PR DESCRIPTION
This PR will add the ability for us to show new contributors some
protips when they open a new PR against Talos.