### PR TITLE
fix: resolve race condition in createNodes

### DIFF
--- a/internal/pkg/provision/providers/docker/node.go
+++ b/internal/pkg/provision/providers/docker/node.go
@@ -36,11 +36,11 @@ func (p *provisioner) createNodes(ctx context.Context, clusterReq provision.Clus
 	for _, nodeReq := range nodeReqs {
 		go func(nodeReq provision.NodeRequest) {
 			nodeInfo, err := p.createNode(ctx, clusterReq, nodeReq, options)
-			errCh <- err
-
 			if err == nil {
 				nodeCh <- nodeInfo
 			}
+
+			errCh <- err
 		}(nodeReq)
 	}
 

--- a/internal/pkg/provision/providers/firecracker/node.go
+++ b/internal/pkg/provision/providers/firecracker/node.go
@@ -49,11 +49,11 @@ func (p *provisioner) createNodes(state *state, clusterReq provision.ClusterRequ
 	for _, nodeReq := range nodeReqs {
 		go func(nodeReq provision.NodeRequest) {
 			nodeInfo, err := p.createNode(state, clusterReq, nodeReq, opts)
-			errCh <- err
-
 			if err == nil {
 				nodeCh <- nodeInfo
 			}
+
+			errCh <- err
 		}(nodeReq)
 	}
 


### PR DESCRIPTION
Due to the race, main goroutine might consume all the errors from
`errCh` and close `nodesCh`, so node goroutine might hit panic on send
to closed channel.

```
panic: send on closed channel

goroutine 40 [running]:
github.com/talos-systems/talos/internal/pkg/provision/providers/firecracker.(*provisioner).createNodes.func1(0x26ab668, 0xc00025a000, 0xc0005a83c0, 0xc00029d540, 0xc000536120, 0xc000464540, 0xc000041d80, 0x18, 0xc0006d406c, 0x4, ...)
	/src/internal/pkg/provision/providers/firecracker/node.go:55 +0x1fa
created by github.com/talos-systems/talos/internal/pkg/provision/providers/firecracker.(*provisioner).createNodes
	/src/internal/pkg/provision/providers/firecracker/node.go:50 +0x1ca
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

