### PR TITLE
refactor: rename system-containerd and containerd services

### DIFF
--- a/internal/app/machined/internal/phase/services/start_containerd.go
+++ b/internal/app/machined/internal/phase/services/start_containerd.go
@@ -14,21 +14,21 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/runtime"
 )
 
-// StartSystemContainerd represents the task to start system containerd.
-type StartSystemContainerd struct{}
+// StartContainerd represents the task to start system containerd.
+type StartContainerd struct{}
 
-// NewStartSystemContainerdTask initializes and returns an Services task.
-func NewStartSystemContainerdTask() phase.Task {
-	return &StartSystemContainerd{}
+// NewStartContainerdTask initializes and returns an Services task.
+func NewStartContainerdTask() phase.Task {
+	return &StartContainerd{}
 }
 
 // TaskFunc returns the runtime function.
-func (task *StartSystemContainerd) TaskFunc(mode runtime.Mode) phase.TaskFunc {
+func (task *StartContainerd) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 	return task.standard
 }
 
-func (task *StartSystemContainerd) standard(r runtime.Runtime) (err error) {
-	svc := &services.SystemContainerd{}
+func (task *StartContainerd) standard(r runtime.Runtime) (err error) {
+	svc := &services.Containerd{}
 
 	system.Services(r.Config()).LoadAndStart(svc)
 

--- a/internal/app/machined/internal/phase/services/start_services.go
+++ b/internal/app/machined/internal/phase/services/start_services.go
@@ -43,7 +43,7 @@ func (task *StartServices) loadSystemServices(r runtime.Runtime) {
 	// Start the services common to all nodes.
 	svcs.Load(
 		&services.MachinedAPI{},
-		&services.Containerd{},
+		&services.CRI{},
 		&services.APID{},
 		&services.OSD{},
 		&services.Networkd{},

--- a/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
@@ -104,8 +104,8 @@ func (d *Sequencer) Boot() error {
 			network.NewInitialNetworkSetupTask(),
 		),
 		phase.NewPhase(
-			"start system-containerd",
-			services.NewStartSystemContainerdTask(),
+			"start containerd",
+			services.NewStartContainerdTask(),
 		),
 		phase.NewPhase(
 			"platform tasks",
@@ -245,7 +245,7 @@ func (d *Sequencer) Upgrade(req *machineapi.UpgradeRequest) error {
 		),
 		phase.NewPhase(
 			"stop services",
-			services.NewStopServicesTask("containerd", "udevd"),
+			services.NewStopServicesTask("cri", "udevd"),
 		),
 		phase.NewPhase(
 			"unmount system disk submounts",

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -67,7 +67,7 @@ func (o *APID) Condition(config runtime.Configurator) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *APID) DependsOn(config runtime.Configurator) []string {
-	return []string{"system-containerd", "containerd"}
+	return []string{"containerd", "cri"}
 }
 
 func (o *APID) Runner(config runtime.Configurator) (runner.Runner, error) {

--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -23,37 +23,37 @@ import (
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
-// Containerd implements the Service interface. It serves as the concrete type with
+// CRI implements the Service interface. It serves as the concrete type with
 // the required methods.
-type Containerd struct{}
+type CRI struct{}
 
 // ID implements the Service interface.
-func (c *Containerd) ID(config runtime.Configurator) string {
-	return "containerd"
+func (c *CRI) ID(config runtime.Configurator) string {
+	return "cri"
 }
 
 // PreFunc implements the Service interface.
-func (c *Containerd) PreFunc(ctx context.Context, config runtime.Configurator) error {
+func (c *CRI) PreFunc(ctx context.Context, config runtime.Configurator) error {
 	return os.MkdirAll(defaults.DefaultRootDir, os.ModeDir)
 }
 
 // PostFunc implements the Service interface.
-func (c *Containerd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
+func (c *CRI) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 
 // Condition implements the Service interface.
-func (c *Containerd) Condition(config runtime.Configurator) conditions.Condition {
+func (c *CRI) Condition(config runtime.Configurator) conditions.Condition {
 	return nil
 }
 
 // DependsOn implements the Service interface.
-func (c *Containerd) DependsOn(config runtime.Configurator) []string {
+func (c *CRI) DependsOn(config runtime.Configurator) []string {
 	return nil
 }
 
 // Runner implements the Service interface.
-func (c *Containerd) Runner(config runtime.Configurator) (runner.Runner, error) {
+func (c *CRI) Runner(config runtime.Configurator) (runner.Runner, error) {
 	// Set the process arguments.
 	args := &runner.Args{
 		ID: c.ID(config),
@@ -81,7 +81,7 @@ func (c *Containerd) Runner(config runtime.Configurator) (runner.Runner, error) 
 }
 
 // HealthFunc implements the HealthcheckedService interface
-func (c *Containerd) HealthFunc(runtime.Configurator) health.Check {
+func (c *CRI) HealthFunc(runtime.Configurator) health.Check {
 	return func(ctx context.Context) error {
 		client, err := containerd.New(constants.ContainerdAddress)
 		if err != nil {
@@ -104,6 +104,6 @@ func (c *Containerd) HealthFunc(runtime.Configurator) health.Check {
 }
 
 // HealthSettings implements the HealthcheckedService interface
-func (c *Containerd) HealthSettings(runtime.Configurator) *health.Settings {
+func (c *CRI) HealthSettings(runtime.Configurator) *health.Settings {
 	return &health.DefaultSettings
 }

--- a/internal/app/machined/pkg/system/services/cri_test.go
+++ b/internal/app/machined/pkg/system/services/cri_test.go
@@ -14,5 +14,5 @@ import (
 )
 
 func TestContainerdInterfaces(t *testing.T) {
-	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Containerd))
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.CRI))
 }

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -66,7 +66,7 @@ func (n *Networkd) Condition(config runtime.Configurator) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (n *Networkd) DependsOn(config runtime.Configurator) []string {
-	return []string{"system-containerd"}
+	return []string{"containerd"}
 }
 
 func (n *Networkd) Runner(config runtime.Configurator) (runner.Runner, error) {

--- a/internal/app/machined/pkg/system/services/ntpd.go
+++ b/internal/app/machined/pkg/system/services/ntpd.go
@@ -59,7 +59,7 @@ func (n *NTPd) Condition(config runtime.Configurator) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (n *NTPd) DependsOn(config runtime.Configurator) []string {
-	return []string{"system-containerd", "networkd"}
+	return []string{"containerd", "networkd"}
 }
 
 func (n *NTPd) Runner(config runtime.Configurator) (runner.Runner, error) {

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -25,7 +25,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
 	"github.com/talos-systems/talos/internal/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
 )
@@ -63,11 +62,7 @@ func (o *OSD) Condition(config runtime.Configurator) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *OSD) DependsOn(config runtime.Configurator) []string {
-	if config.Machine().Type() == machine.TypeWorker {
-		return []string{"system-containerd", "containerd"}
-	}
-
-	return []string{"system-containerd", "containerd"}
+	return []string{"containerd", "cri"}
 }
 
 func (o *OSD) Runner(config runtime.Configurator) (runner.Runner, error) {

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -61,7 +61,7 @@ func (o *Routerd) Condition(config runtime.Configurator) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *Routerd) DependsOn(config runtime.Configurator) []string {
-	return []string{"system-containerd"}
+	return []string{"containerd"}
 }
 
 func (o *Routerd) Runner(config runtime.Configurator) (runner.Runner, error) {

--- a/internal/app/machined/pkg/system/services/system-containerd.go
+++ b/internal/app/machined/pkg/system/services/system-containerd.go
@@ -21,37 +21,37 @@ import (
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
-// SystemContainerd implements the Service interface. It serves as the concrete type with
+// Containerd implements the Service interface. It serves as the concrete type with
 // the required methods.
-type SystemContainerd struct{}
+type Containerd struct{}
 
 // ID implements the Service interface.
-func (c *SystemContainerd) ID(config runtime.Configurator) string {
-	return "system-containerd"
+func (c *Containerd) ID(config runtime.Configurator) string {
+	return "containerd"
 }
 
 // PreFunc implements the Service interface.
-func (c *SystemContainerd) PreFunc(ctx context.Context, config runtime.Configurator) error {
+func (c *Containerd) PreFunc(ctx context.Context, config runtime.Configurator) error {
 	return nil
 }
 
 // PostFunc implements the Service interface.
-func (c *SystemContainerd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
+func (c *Containerd) PostFunc(config runtime.Configurator, state events.ServiceState) (err error) {
 	return nil
 }
 
 // Condition implements the Service interface.
-func (c *SystemContainerd) Condition(config runtime.Configurator) conditions.Condition {
+func (c *Containerd) Condition(config runtime.Configurator) conditions.Condition {
 	return nil
 }
 
 // DependsOn implements the Service interface.
-func (c *SystemContainerd) DependsOn(config runtime.Configurator) []string {
+func (c *Containerd) DependsOn(config runtime.Configurator) []string {
 	return nil
 }
 
 // Runner implements the Service interface.
-func (c *SystemContainerd) Runner(config runtime.Configurator) (runner.Runner, error) {
+func (c *Containerd) Runner(config runtime.Configurator) (runner.Runner, error) {
 	// Set the process arguments.
 	args := &runner.Args{
 		ID: c.ID(config),
@@ -78,7 +78,7 @@ func (c *SystemContainerd) Runner(config runtime.Configurator) (runner.Runner, e
 }
 
 // HealthFunc implements the HealthcheckedService interface
-func (c *SystemContainerd) HealthFunc(runtime.Configurator) health.Check {
+func (c *Containerd) HealthFunc(runtime.Configurator) health.Check {
 	return func(ctx context.Context) error {
 		client, err := containerd.New(constants.SystemContainerdAddress)
 		if err != nil {
@@ -101,6 +101,6 @@ func (c *SystemContainerd) HealthFunc(runtime.Configurator) health.Check {
 }
 
 // HealthSettings implements the HealthcheckedService interface
-func (c *SystemContainerd) HealthSettings(runtime.Configurator) *health.Settings {
+func (c *Containerd) HealthSettings(runtime.Configurator) *health.Settings {
 	return &health.DefaultSettings
 }

--- a/internal/app/machined/pkg/system/services/system-containerd_test.go
+++ b/internal/app/machined/pkg/system/services/system-containerd_test.go
@@ -14,5 +14,5 @@ import (
 )
 
 func TestSystemContainerdInterfaces(t *testing.T) {
-	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.SystemContainerd))
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Containerd))
 }


### PR DESCRIPTION
This changes the name of the `system-containerd` service to `containerd`
and the `containerd` service to `cri`. This is so that the CRI service
is a little more generic. In the future, when we add support for other
CRIs, it will be better to refer to this service generically as "cri."