### PR TITLE
chore: update pkgs tag to v0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,31 +287,31 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:a5eeee0 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:a5eeee0 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/containerd:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/eudev:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/iptables:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/libressl:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:a5eeee0 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:a5eeee0 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/musl:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/runc:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/socat:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:a5eeee0 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:a5eeee0 /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:a5eeee0 /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:a5eeee0 /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:a5eeee0 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/musl:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0 /lib/libblkid.* /rootfs/lib
+COPY --from=docker.io/autonomy/util-linux:v0.2.0 /lib/libuuid.* /rootfs/lib
+COPY --from=docker.io/autonomy/kmod:v0.2.0 /usr/lib/libkmod.* /rootfs/lib
+COPY --from=docker.io/autonomy/kernel:v0.2.0 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/


### PR DESCRIPTION
This change updates the pkgs tag to v0.2.0. There is no difference in
the content of the packages.
> See `make help` for a description of the available targets.