### PR TITLE
feat: make machine config persist by default

### DIFF
--- a/internal/pkg/provision/providers/docker/docker.go
+++ b/internal/pkg/provision/providers/docker/docker.go
@@ -43,7 +43,9 @@ func (p *provisioner) Close() error {
 
 // GenOptions provides a list of additional config generate options.
 func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.GenOption {
-	return nil
+	return []generate.GenOption{
+		generate.WithPersist(false),
+	}
 }
 
 // GetLoadBalancers returns internal/external loadbalancer endpoints.

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -14,6 +14,7 @@ func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
 	config := &v1alpha1.Config{
 		ConfigVersion: "v1alpha1",
 		ConfigDebug:   in.Debug,
+		ConfigPersist: in.Persist,
 	}
 
 	machine := &v1alpha1.MachineConfig{

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -89,7 +89,8 @@ type Input struct {
 
 	RegistryMirrors map[string]machine.RegistryMirrorConfig
 
-	Debug bool
+	Debug   bool
+	Persist bool
 }
 
 // GetAPIServerEndpoint returns the formatted host:port of the API server endpoint
@@ -329,6 +330,7 @@ func NewInput(clustername string, endpoint string, kubernetesVersion string, opt
 		NetworkConfig:             options.NetworkConfig,
 		RegistryMirrors:           options.RegistryMirrors,
 		Debug:                     options.Debug,
+		Persist:                   options.Persist,
 	}
 
 	return input, nil

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -14,6 +14,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 	config := &v1alpha1.Config{
 		ConfigVersion: "v1alpha1",
 		ConfigDebug:   in.Debug,
+		ConfigPersist: in.Persist,
 	}
 
 	machine := &v1alpha1.MachineConfig{

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -15,6 +15,7 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 	config := &v1alpha1.Config{
 		ConfigVersion: "v1alpha1",
 		ConfigDebug:   in.Debug,
+		ConfigPersist: in.Persist,
 	}
 
 	machine := &v1alpha1.MachineConfig{

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -88,6 +88,15 @@ func WithDebug(enable bool) GenOption {
 	}
 }
 
+// WithPersist enables persistence of machine config across reboots.
+func WithPersist(enable bool) GenOption {
+	return func(o *GenOptions) error {
+		o.Persist = enable
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
@@ -98,9 +107,12 @@ type GenOptions struct {
 	RegistryMirrors           map[string]machine.RegistryMirrorConfig
 	DNSDomain                 string
 	Debug                     bool
+	Persist                   bool
 }
 
 // DefaultGenOptions returns default options.
 func DefaultGenOptions() GenOptions {
-	return GenOptions{}
+	return GenOptions{
+		Persist: true,
+	}
 }


### PR DESCRIPTION
## What? (description) 

feat: make machine config persist by default

## Why? (reasoning)
This PR will change the default behavior for machine configs to
`persist: true`. This seems to be expected behavior from our users so
we'll move to this method for v0.5

Will close #2023 