### PR TITLE
[wip] chore: remove install from output when running gen config

### DIFF
--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
-	"github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/machine"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
@@ -156,8 +155,8 @@ func genV1Alpha1Config(args []string) error {
 
 func init() {
 	genCmd.AddCommand(genConfigCmd)
-	genConfigCmd.Flags().StringVar(&installDisk, "install-disk", "/dev/sda", "the disk to install to")
-	genConfigCmd.Flags().StringVar(&installImage, "install-image", helpers.DefaultImage(constants.DefaultInstallerImageRepository), "the image used to perform an installation") // nolint: lll
+	genConfigCmd.Flags().StringVar(&installDisk, "install-disk", "", "the disk to install to")
+	genConfigCmd.Flags().StringVar(&installImage, "install-image", "", "the image used to perform an installation") // nolint: lll
 	genConfigCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
 	genConfigCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	genConfigCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")

--- a/docs/talosctl/talosctl_gen_config.md
+++ b/docs/talosctl/talosctl_gen_config.md
@@ -17,8 +17,8 @@ talosctl gen config <cluster name> https://<load balancer IP or DNS name> [flags
       --additional-sans strings     additional Subject-Alt-Names for the APIServer certificate
       --dns-domain string           the dns domain to use for cluster (default "cluster.local")
   -h, --help                        help for config
-      --install-disk string         the disk to install to (default "/dev/sda")
-      --install-image string        the image used to perform an installation (default "docker.io/autonomy/installer:latest")
+      --install-disk string         the disk to install to
+      --install-image string        the image used to perform an installation
       --kubernetes-version string   desired kubernetes version to run (default "1.18.0")
   -o, --output-dir string           destination to output generated files
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>

--- a/pkg/config/types/v1alpha1/generate/controlplane.go
+++ b/pkg/config/types/v1alpha1/generate/controlplane.go
@@ -24,9 +24,8 @@ func controlPlaneUd(in *Input) (*v1alpha1.Config, error) {
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  in.NetworkConfig,
 		MachineInstall: &v1alpha1.InstallConfig{
-			InstallDisk:       in.InstallDisk,
-			InstallImage:      in.InstallImage,
-			InstallBootloader: true,
+			InstallDisk:  in.InstallDisk,
+			InstallImage: in.InstallImage,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -24,15 +24,13 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineToken:    in.TrustdInfo.Token,
 		MachineInstall: &v1alpha1.InstallConfig{
-			InstallDisk:       in.InstallDisk,
-			InstallImage:      in.InstallImage,
-			InstallBootloader: true,
+			InstallDisk:  in.InstallDisk,
+			InstallImage: in.InstallImage,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,
 		},
 	}
-
 	certSANs := in.GetAPIServerSANs()
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -24,9 +24,8 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 		MachineKubelet:  &v1alpha1.KubeletConfig{},
 		MachineNetwork:  in.NetworkConfig,
 		MachineInstall: &v1alpha1.InstallConfig{
-			InstallDisk:       in.InstallDisk,
-			InstallImage:      in.InstallImage,
-			InstallBootloader: true,
+			InstallDisk:  in.InstallDisk,
+			InstallImage: in.InstallImage,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -487,7 +487,7 @@ type InstallConfig struct {
 	//     - yes
 	//     - false
 	//     - no
-	InstallWipe bool `yaml:"wipe"`
+	InstallWipe bool `yaml:"wipe,omitempty"`
 	//   description: |
 	//     Indicates if filesystems should be forcefully created.
 	//   values:
@@ -495,7 +495,7 @@ type InstallConfig struct {
 	//     - yes
 	//     - false
 	//     - no
-	InstallForce bool `yaml:"force"`
+	InstallForce bool `yaml:"force,omitempty"`
 }
 
 // TimeConfig represents the options for configuring time on a node.


### PR DESCRIPTION
## What? (description)
chore: remove install from output when running gen config

## Why? (reasoning)
This PR will remove the output of all the various keys under
`machine.install{}` in the output when `talosctl gen config` is issued.
Install section only applies for bare metal, so this should clean up the
config some for the average use case. Users that are doing bare metal
will still have these options available if needed.

Will close #1729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2028)
<!-- Reviewable:end -->
