### PR TITLE
feat: disable kubelet ro port

### DIFF
--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -249,7 +249,6 @@ func newKubeletConfiguration(clusterDNS []string, dnsDomain string) *kubeletconf
 		StaticPodPath:      "/etc/kubernetes/manifests",
 		Address:            "0.0.0.0",
 		Port:               10250,
-		ReadOnlyPort:       10255, // TODO(andrewrynhard): Disable this.
 		RotateCertificates: true,
 		Authentication: kubeletconfig.KubeletAuthentication{
 			X509: kubeletconfig.KubeletX509Authentication{


### PR DESCRIPTION
## What? (description)
feat: disable kubelet ro port

## Why? (reasoning)
This PR will remove the kubelet read only port, using the default of 0
(disabled). This will bring us closer to CIS alignment.

Will close #1731 