### PR TITLE
feat: add extra headers to fetch of extraManifests

### DIFF
--- a/docs/website/content/v0.4/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.4/en/configuration/v1alpha1.md
@@ -597,6 +597,21 @@ extraManifests:
 
 ```
 
+#### extraManifestHeaders
+
+A map of key value pairs that will be added while fetching the ExtraManifests.
+
+Type: `map`
+
+Examples:
+
+```yaml
+extraManifestHeaders:
+  Token: "1234567"
+  X-ExtraInfo: info
+
+```
+
 #### adminKubeconfig
 
 Settings for admin kubeconfig generation.

--- a/pkg/config/cluster/cluster.go
+++ b/pkg/config/cluster/cluster.go
@@ -32,6 +32,7 @@ type Cluster interface {
 	PodCheckpointer() PodCheckpointer
 	CoreDNS() CoreDNS
 	ExtraManifestURLs() []string
+	ExtraManifestHeaderMap() map[string]string
 	AdminKubeconfig() AdminKubeconfig
 }
 

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -429,6 +429,11 @@ func (c *ClusterConfig) ExtraManifestURLs() []string {
 	return c.ExtraManifests
 }
 
+// ExtraManifestHeaderMap implements the Configurator interface.
+func (c *ClusterConfig) ExtraManifestHeaderMap() map[string]string {
+	return c.ExtraManifestHeaders
+}
+
 // PodCheckpointer implements the Configurator interface.
 func (c *ClusterConfig) PodCheckpointer() cluster.PodCheckpointer {
 	if c.PodCheckpointerConfig == nil {

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -343,6 +343,14 @@ type ClusterConfig struct {
 	//         - "https://www.mysweethttpserver.com/manifest2.yaml"
 	ExtraManifests []string `yaml:"extraManifests,omitempty"`
 	//   description: |
+	//     A map of key value pairs that will be added while fetching the ExtraManifests.
+	//   examples:
+	//     - |
+	//       extraManifestHeaders:
+	//         Token: "1234567"
+	//         X-ExtraInfo: info
+	ExtraManifestHeaders map[string]string `yaml:"extraManifestHeaders,omitempty"`
+	//   description: |
 	//     Settings for admin kubeconfig generation.
 	//     Certificate lifetime can be configured.
 	//   examples:


### PR DESCRIPTION
Provides capability to add extra headers in cases where files can only be fetched with token based authenction.


feat: extra manifest headers for fetching manifests

- Changed config to map of key value pairs.


fix: added docs for new extra headers fetch


fix: fix linter issue

(cherry picked from commit dba6de506e4a24b24a105810c39c7c5ab21a44c0)