### PR TITLE
docs: default to v0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Documentation
 
-For instructions on deploying and managing Talos, see the [Documentation](https://www.talos.dev/docs/v0.3/).
+For instructions on deploying and managing Talos, see the [Documentation](https://www.talos.dev/docs/v0.4/).
 
 ## Community
 

--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -33,8 +33,8 @@ export default {
   data() {
     return {
       options: [
-        { version: 'v0.3', url: '/docs/v0.3', prerelease: false },
-        { version: 'v0.4', url: '/docs/v0.4', prerelease: true }
+        { version: 'v0.4', url: '/docs/v0.4', prerelease: false },
+        { version: 'v0.3', url: '/docs/v0.3', prerelease: false }
       ]
     }
   },

--- a/docs/website/components/Header.vue
+++ b/docs/website/components/Header.vue
@@ -7,7 +7,7 @@
       <div class="flex py-6 ml-auto">
         <ul class="header-menu">
           <li>
-            <a href="/docs/v0.3">
+            <a href="/docs/v0.4">
               <span class="font-semibold mr-1">Documentation</span>
             </a>
           </li>

--- a/docs/website/pages/index.vue
+++ b/docs/website/pages/index.vue
@@ -27,7 +27,7 @@
             </p>
             <div class="flex-1 text-center pb-4 m-0">
               <a
-                href="https://www.talos.dev/docs/v0.3/#v0.3/en/guides/getting-started"
+                href="https://www.talos.dev/docs/v0.4/#v0.4/en/guides/getting-started/docker"
               >
                 <button class="teal-cta-button">
                   Try it now


### PR DESCRIPTION
This brings the v0.4 docs out of pre-release status, and updates links
to point to v0.4 docs by default.