### PR TITLE
fix: prevent formatting the ephemeral partition twice

### DIFF
--- a/cmd/installer/pkg/installer.go
+++ b/cmd/installer/pkg/installer.go
@@ -132,7 +132,7 @@ func (i *Installer) Install(sequence runtime.Sequence) (err error) {
 		defer m.UnmountAll()
 	}
 
-	if sequence == runtime.Upgrade && i.install.Force() {
+	if sequence == runtime.Upgrade && i.bootPartitionFound && i.install.Force() {
 		for dev, targets := range i.manifest.Targets {
 			var bd *blockdevice.BlockDevice
 


### PR DESCRIPTION
This adds the requirement of the existence of the boot partition in the
if statement responsible for handling v0.4 style upgrades. Without this,
when upgrading from v0.3 to v0.4, we will attempt to format the
ephemeral partition twice. This will cause upgrades to fail.