### PR TITLE
fix: prevent formatting the ephemeral partition twice

### DIFF
--- a/cmd/installer/pkg/installer.go
+++ b/cmd/installer/pkg/installer.go
@@ -132,7 +132,7 @@ func (i *Installer) Install(sequence runtime.Sequence) (err error) {
 		defer m.UnmountAll()
 	}
 
-	if sequence == runtime.Upgrade && i.install.Force() {
+	if sequence == runtime.Upgrade && i.bootPartitionFound && i.install.Force() {
 		for dev, targets := range i.manifest.Targets {
 			var bd *blockdevice.BlockDevice
 


### PR DESCRIPTION




# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to accept the PR.
One of our maintainers will comment on your PR with `/accepted`.
-->

## What? (description)

fix: prevent formatting the ephemeral partition twice

## Why? (reasoning)

This adds the requirement of the existence of the boot partition in the
if statement responsible for handling v0.4 style upgrades. Without this,
when upgrading from v0.3 to v0.4, we will attempt to format the
ephemeral partition twice. This will cause upgrades to fail.

## Logs (if applicable)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.