### PR TITLE
fix: pass dev path to mkfs

### DIFF
--- a/cmd/installer/pkg/manifest/manifest.go
+++ b/cmd/installer/pkg/manifest/manifest.go
@@ -184,11 +184,11 @@ func (t *Target) Partition(bd *blockdevice.BlockDevice) (err error) {
 // Format creates a filesystem on the device/partition.
 func (t *Target) Format() error {
 	if t.Label == constants.BootPartitionLabel {
-		log.Printf("formatting partition %s - %s as %s\n", t.PartitionName, t.Label, "fat")
+		log.Printf("formatting partition %q - %q as %q\n", t.PartitionName, t.Label, "fat")
 		return vfat.MakeFS(t.PartitionName, vfat.WithLabel(t.Label))
 	}
 
-	log.Printf("formatting partition %s - %s as %s\n", t.PartitionName, t.Label, "xfs")
+	log.Printf("formatting partition %q - %q as %q\n", t.PartitionName, t.Label, "xfs")
 	opts := []xfs.Option{xfs.WithForce(t.Force)}
 
 	if t.Label != "" {

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,7 @@ github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8
 github.com/elazarl/goproxy/ext v0.0.0-20191011121108-aa519ddbe484/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.11.1+incompatible h1:CjKsv3uWcCMvySPQYKxO8XX3f9zD4FeZRsW4G0B4ffE=
 github.com/emicklei/go-restful v2.11.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/blockdevice/filesystem/xfs/xfs.go
+++ b/pkg/blockdevice/filesystem/xfs/xfs.go
@@ -6,6 +6,8 @@
 package xfs
 
 import (
+	"fmt"
+
 	"github.com/talos-systems/talos/pkg/cmd"
 )
 
@@ -19,6 +21,10 @@ func GrowFS(partname string) error {
 
 // MakeFS creates a XFS filesystem on the specified partition.
 func MakeFS(partname string, setters ...Option) error {
+	if partname == "" {
+		return fmt.Errorf("missing path to disk")
+	}
+
 	opts := NewDefaultOptions(setters...)
 
 	// The ftype=1 naming option is required by overlayfs.


### PR DESCRIPTION
This fixes a bug caused by a missing device argument to `mkfs.xfs`.
Without a device, `mkfs.xfs` will error out. Additionally, this ensures
that the installer container is started with the `kmsg` writer that
ensures logs are formatted correctly for `/dev/kmsg`. Without this we
lose a lot of the logs output by the container, one of them being any
error from `mkfs.xfs`