### PR TITLE
feat: allow dual-stack support with bootkube wrapper

### DIFF
--- a/docs/website/content/v0.4/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.4/en/configuration/v1alpha1.md
@@ -520,6 +520,22 @@ controllerManager:
 
 ```
 
+#### proxy
+
+Kube-proxy server-specific configuration options
+
+Type: `ProxyConfig`
+
+Examples:
+
+```yaml
+proxy:
+  mode: ipvs
+  extraArgs:
+    key: value
+
+```
+
 #### scheduler
 
 Scheduler server specific configuration options.
@@ -964,6 +980,23 @@ Type: `string`
 #### extraArgs
 
 Extra arguments to supply to the controller manager.
+
+Type: `map`
+
+---
+
+### ProxyConfig
+
+#### mode
+
+proxy mode of kube-proxy.
+By default, this is 'iptables'.
+
+Type: `string`
+
+#### extraArgs
+
+Extra arguments to supply to kube-proxy.
 
 Type: `map`
 

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
-	github.com/talos-systems/bootkube-plugin v0.0.0-20200418011639-b642f0b2921d
+	github.com/talos-systems/bootkube-plugin v0.0.0-20200428220847-2d8b58bf3941
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-smbios v0.0.0-20200219201045-94b8c4e489ee
 	github.com/talos-systems/grpc-proxy v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/bootkube-plugin v0.0.0-20200418011639-b642f0b2921d h1:UMQx8f7FqcQhwrKpBVGxxF7Kakjr+r7OQ941HmO1cgA=
-github.com/talos-systems/bootkube-plugin v0.0.0-20200418011639-b642f0b2921d/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
+github.com/talos-systems/bootkube-plugin v0.0.0-20200428220847-2d8b58bf3941 h1:+YwUn+yPyjFl2x0J9fLaDdV1mmg/H1Lcia+1D8t3Grc=
+github.com/talos-systems/bootkube-plugin v0.0.0-20200428220847-2d8b58bf3941/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
 github.com/talos-systems/go-smbios v0.0.0-20200219201045-94b8c4e489ee h1:9i0ZFsjZ0wY8UUn/tk2MQshLBC0PNFJe3+84AUqzzyw=

--- a/internal/app/machined/pkg/runtime/configurator.go
+++ b/internal/app/machined/pkg/runtime/configurator.go
@@ -337,6 +337,7 @@ type ClusterConfig interface {
 	Name() string
 	APIServer() APIServer
 	ControllerManager() ControllerManager
+	Proxy() Proxy
 	Scheduler() Scheduler
 	Endpoint() *url.URL
 	Token() Token
@@ -380,6 +381,17 @@ type APIServer interface {
 // ControllerManager defines the requirements for a config that pertains to controller manager related
 // options.
 type ControllerManager interface {
+	ExtraArgs() map[string]string
+}
+
+// Proxy defines the requirements for a config that pertains to the kube-proxy
+// options.
+type Proxy interface {
+
+	// Mode indicates the proxy mode for kube-proxy.  By default, this is `iptables`.  Other options include `ipvs`.
+	Mode() string
+
+	// ExtraArgs describe an additional set of arguments to be supplied to the execution of `kube-proxy`
 	ExtraArgs() map[string]string
 }
 

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -50,6 +50,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			CertSANs: certSANs,
 		},
 		ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{},
+		ProxyConfig:             &v1alpha1.ProxyConfig{},
 		SchedulerConfig:         &v1alpha1.SchedulerConfig{},
 		EtcdConfig: &v1alpha1.EtcdConfig{
 			RootCA: in.Certs.Etcd,

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator.go
@@ -281,6 +281,29 @@ func (c *ControllerManagerConfig) ExtraArgs() map[string]string {
 	return c.ExtraArgsConfig
 }
 
+// Proxy implements the Configurator interface
+func (c *ClusterConfig) Proxy() runtime.Proxy {
+	if c.ProxyConfig == nil {
+		return &ProxyConfig{}
+	}
+
+	return c.ProxyConfig
+}
+
+// Mode implements the Proxy interface
+func (p *ProxyConfig) Mode() string {
+	if p.ModeConfig == "" {
+		return "iptables"
+	}
+
+	return p.ModeConfig
+}
+
+// ExtraArgs implements the Proxy interface.
+func (p *ProxyConfig) ExtraArgs() map[string]string {
+	return p.ExtraArgsConfig
+}
+
 // Scheduler implements the Configurator interface.
 func (c *ClusterConfig) Scheduler() runtime.Scheduler {
 	if c.SchedulerConfig == nil {

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -301,6 +301,15 @@ type ClusterConfig struct {
 	//           key: value
 	ControllerManagerConfig *ControllerManagerConfig `yaml:"controllerManager,omitempty"`
 	//   description: |
+	//     Kube-proxy server-specific configuration options
+	//   examples:
+	//     - |
+	//       proxy:
+	//         mode: ipvs
+	//         extraArgs:
+	//           key: value
+	ProxyConfig *ProxyConfig `yaml:"proxy,omitempty"`
+	//   description: |
 	//     Scheduler server specific configuration options.
 	//   examples:
 	//     - |
@@ -605,6 +614,17 @@ type ControllerManagerConfig struct {
 	Image string `yaml:"image,omitempty"`
 	//   description: |
 	//     Extra arguments to supply to the controller manager.
+	ExtraArgsConfig map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+// ProxyConfig represents the kube proxy configuration values
+type ProxyConfig struct {
+	//   description: |
+	//     proxy mode of kube-proxy.
+	//     By default, this is 'iptables'.
+	ModeConfig string `yaml:"mode,omitempty"`
+	//   description: |
+	//     Extra arguments to supply to kube-proxy.
 	ExtraArgsConfig map[string]string `yaml:"extraArgs,omitempty"`
 }
 


### PR DESCRIPTION
Handle dual-stack configurations with the bootkube wrapper.  This uses
the new PodCIDRs and ServiceCIDRs `asset.Config` parameters in bootkube.

Fixes #2055

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2056)
<!-- Reviewable:end -->
