### PR TITLE
fix: ensure disk is not busy

### DIFF
--- a/internal/app/machined/internal/phase/disk/verify_availability.go
+++ b/internal/app/machined/internal/phase/disk/verify_availability.go
@@ -6,6 +6,7 @@ package disk
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -35,36 +36,50 @@ func NewVerifyDiskAvailabilityTask(devname string) phase.Task {
 // TaskFunc returns the runtime function.
 func (task *VerifyDiskAvailability) TaskFunc(mode runtime.Mode) phase.TaskFunc {
 	return func(r runtime.Runtime) error {
-		return task.standard()
+		//  We only need to verify system disk availability if we are going to
+		// reformat the ephemeral partition.
+		if r.Config().Machine().Install().Force() {
+			return task.standard()
+		}
+
+		return nil
 	}
 }
 
 func (task *VerifyDiskAvailability) standard() (err error) {
+	if _, err = os.Stat(task.devname); errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("system disk not found: %w", err)
+	}
+
 	mountsReported := false
 
 	return retry.Constant(3*time.Minute, retry.WithUnits(500*time.Millisecond)).Retry(func() error {
-		if isBusy(task.devname) {
-			if !mountsReported {
-				// if disk is busy, report mounts for debugging purposes but just once
-				// otherwise console might be flooded with messages
-				dumpMounts()
-				mountsReported = true
+		if err = tryLock(task.devname); err != nil {
+			if err == unix.EBUSY {
+				if !mountsReported {
+					// if disk is busy, report mounts for debugging purposes but just once
+					// otherwise console might be flooded with messages
+					dumpMounts()
+					mountsReported = true
+				}
+
+				return retry.ExpectedError(errors.New("system disk in use"))
 			}
 
-			return retry.ExpectedError(errors.New("system disk in use"))
+			return retry.UnexpectedError(fmt.Errorf("failed to verify system disk not in use: %w", err))
 		}
 
 		return nil
 	})
 }
 
-func isBusy(devname string) bool {
+func tryLock(devname string) error {
 	fd, errno := unix.Open(devname, unix.O_RDONLY|unix.O_EXCL|unix.O_CLOEXEC, 0)
 
 	// nolint: errcheck
 	defer unix.Close(fd)
 
-	return errno == unix.EBUSY
+	return errno
 }
 
 func dumpMounts() {

--- a/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/internal/sequencer/v1alpha1/v1alpha1_sequencer.go
@@ -224,7 +224,7 @@ func (d *Sequencer) Upgrade(req *machineapi.UpgradeRequest) error {
 	// TODO(andrewrynhard): This should be more dynamic. If we ever change the
 	// partition scheme there is the chance that 2 is not the correct parition to
 	// check.
-	partname := util.PartName(dev.Device().Name(), 2)
+	partname := util.PartPath(dev.Device().Name(), 2)
 
 	if err := dev.Close(); err != nil {
 		return err

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -76,7 +76,6 @@ func (t *Trustd) Runner(config runtime.Configurator) (runner.Runner, error) {
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: "/tmp", Source: "/tmp", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: constants.ConfigPath, Source: constants.ConfigPath, Options: []string{"rbind", "ro"}},
-		{Type: "bind", Destination: "/etc/kubernetes", Source: "/etc/kubernetes", Options: []string{"rbind", "ro"}},
 	}
 
 	env := []string{}


### PR DESCRIPTION
This fixes a few bugs that collectively caused `EBUSY` error when trying
to format the system disk. It ensures that we use the correct path to
the partition, and requires the path to exist. It also removes the
`/etc/kubernetes` mount from `trustd` as it was discovered that this
mount was causing the `EBUSY`.

(cherry picked from commit d91628ac3d9c98062f760b308d8344c26a6fe1ad)