### PR TITLE
docs: add install and troubleshooting section in firecracker getting started

### DIFF
--- a/docs/website/content/v0.4/en/guides/getting-started/firecracker.md
+++ b/docs/website/content/v0.4/en/guides/getting-started/firecracker.md
@@ -15,6 +15,72 @@ In this guide we will create a Kubernetes cluster using Firecracker.
 - `/etc/cni/conf.d` directory should exist
 - `/var/run/netns` directory should exist
 
+## Installation
+
+### How to get firecracker (v0.21.0 or higher)
+
+You can download `firecracker` binary via
+[github.com/firecracker-microvm/firecracker/releases](https://github.com/firecracker-microvm/firecracker/releases)
+
+```bash
+curl https://github.com/firecracker-microvm/firecracker/releases/download/<version>/firecracker-<version>-<arch> -L -o firecracker
+```
+
+For example version `v0.21.1` for `linux` platform:
+
+```bash
+curl https://github.com/firecracker-microvm/firecracker/releases/download/v0.21.1/firecracker-v0.21.1-x86_64 -L -o firecracker
+sudo cp firecracker /usr/local/bin
+sudo chmod +x /usr/local/bin/firecracker
+```
+
+### Install talosctl
+
+You can download `talosctl` and all required binaries via
+[github.com/talos-systems/talos/releases](https://github.com/talos-systems/talos/releases)
+
+```bash
+curl https://github.com/talos-systems/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
+```
+
+For example version `v0.4.1` for `linux` platform:
+
+```bash
+curl https://github.com/talos-systems/talos/releases/download/v0.4.1/talosctl-linux-amd64 -L -o talosctl
+sudo cp talosctl /usr/local/bin
+sudo chmod +x /usr/local/bin/talosctl
+```
+
+### Install bridge and firewall required CNI plugins
+
+You can download standard CNI required plugins via
+[github.com/containernetworking/plugins/releases](https://github.com/containernetworking/plugins/releases)
+
+```bash
+curl https://github.com/containernetworking/plugins/releases/download/<version>/cni-plugins-<platform>-<arch>-<version>tgz -L -o cni-plugins-<platform>-<arch>-<version>.tgz
+```
+
+For example version `v0.8.5` for `linux` platform:
+
+```bash
+curl https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz -L -o cni-plugins-linux-amd64-v0.8.5.tgz
+mkdir cni-plugins-linux
+tar -xf cni-plugins-linux-amd64-v0.8.5.tgz -C cni-plugins-linux
+sudo mkdir -p /opt/cni/bin
+sudo cp cni-plugins-linux/{bridge,firewall} /opt/cni/bin
+```
+
+### Install tc-redirect-tap CNI plugin
+
+You should install CNI plugin from the Firecracker Go SDK repository [github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni)
+
+```bash
+go get -d github.com/firecracker-microvm/firecracker-go-sdk
+cd $GOPATH/src/github.com/firecracker-microvm/firecracker-go-sdk/cni
+make all
+sudo cp tc-redirect-tap /opt/cni/bin
+```
+
 ## Create the Cluster
 
 ```bash
@@ -68,3 +134,157 @@ sudo talosctl cluster destroy --provisioner firecracker
 ```
 
 > Note: In that case that the host machine is rebooted before destroying the cluster, you may need to manually remove `~/.talos/clusters/talos-default`.
+
+## Manual Clean Up
+
+The `talosctl cluster destroy` command depends heavily on the clusters state directory.
+It contains all related information of the cluster.
+The PIDs and network associated with the cluster nodes.
+
+If you happened to have deleted the state folder by mistake or you would like to cleanup
+the environment, here are the steps how to do it manually:
+
+### Stopping VMs
+
+Find the process of `firecracker --api-sock` execute:
+
+```bash
+ps -elf | grep '[f]irecracker --api-sock'
+```
+
+To stop the VMs manually, execute:
+
+```bash
+sudo kill -s SIGTERM <PID>
+```
+
+Example output, where VMs are running with PIDs **158065** and **158216**
+
+```bash
+ps -elf | grep '[f]irecracker --api-sock'
+4 S root      158065  157615 44  80   0 - 264152 -     07:54 ?        00:34:25 firecracker --api-sock /root/.talos/clusters/k8s/k8s-master-1.sock
+4 S root      158216  157617 18  80   0 - 264152 -     07:55 ?        00:14:47 firecracker --api-sock /root/.talos/clusters/k8s/k8s-worker-1.sock
+sudo kill -s SIGTERM 158065
+sudo kill -s SIGTERM 158216
+```
+
+### Remove VMs
+
+Find the process of `talosctl firecracker-launch` execute:
+
+```bash
+ps -elf | grep 'talosctl firecracker-launch'
+```
+
+To remove the VMs manually, execute:
+
+```bash
+sudo kill -s SIGTERM <PID>
+```
+
+Example output, where VMs are running with PIDs **157615** and **157617**
+
+```bash
+ps -elf | grep '[t]alosctl firecracker-launch'
+0 S root      157615    2835  0  80   0 - 184934 -     07:53 ?        00:00:00 talosctl firecracker-launch
+0 S root      157617    2835  0  80   0 - 185062 -     07:53 ?        00:00:00 talosctl firecracker-launch
+sudo kill -s SIGTERM 157615
+sudo kill -s SIGTERM 157617
+```
+
+### Remove load balancer
+
+Find the process of `talosctl loadbalancer-launch` execute:
+
+```bash
+ps -elf | grep 'talosctl loadbalancer-launch'
+```
+
+To remove the LB manually, execute:
+
+```bash
+sudo kill -s SIGTERM <PID>
+```
+
+Example output, where loadbalancer is running with PID **157609**
+
+```bash
+ps -elf | grep '[t]alosctl loadbalancer-launch'
+4 S root      157609    2835  0  80   0 - 184998 -     07:53 ?        00:00:07 talosctl loadbalancer-launch --loadbalancer-addr 10.5.0.1 --loadbalancer-upstreams 10.5.0.2
+sudo kill -s SIGTERM 157609
+```
+
+### Remove network
+
+This is more tricky part as if you have already deleted the state folder.
+If you didn't then it is written in the `state.yaml` in the
+`/root/.talos/clusters/<cluster-name>` directory.
+
+```bash
+sudo cat /root/.talos/clusters/<cluster-name>/state.yaml | grep bridgename
+bridgename: talos<uuid>
+```
+
+If you only had one cluster, then it will be the interface with name
+`talos<uuid>`
+
+```bash
+46: talos<uuid>: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
+    link/ether a6:72:f4:0a:d3:9c brd ff:ff:ff:ff:ff:ff
+    inet 10.5.0.1/24 brd 10.5.0.255 scope global talos17c13299
+       valid_lft forever preferred_lft forever
+    inet6 fe80::a472:f4ff:fe0a:d39c/64 scope link
+       valid_lft forever preferred_lft forever
+```
+
+To remove this interface:
+
+```bash
+sudo ip link del talos<uuid>
+```
+
+### Remove state directory
+
+To remove the state directory execute:
+
+```bash
+sudo rm -Rf /root/.talos/clusters/<cluster-name>
+```
+
+## Troubleshooting
+
+### Logs
+
+Inspect logs directory
+
+```bash
+sudo cat /root/.talos/clusters/<cluster-name>/*.log
+```
+
+Logs are saved under `<cluster-name>-<role>-<node-id>.log`
+
+For example in case of **k8s** cluster name:
+
+```bash
+sudo ls -la /root/.talos/clusters/k8s | grep log
+-rw-r--r--. 1 root root      69415 Apr 26 20:58 k8s-master-1.log
+-rw-r--r--. 1 root root      68345 Apr 26 20:58 k8s-worker-1.log
+-rw-r--r--. 1 root root      24621 Apr 26 20:59 lb.log
+```
+
+Inspect logs during the installation
+
+```bash
+sudo su -
+tail -f /root/.talos/clusters/<cluster-name>/*.log
+```
+
+## Post-installation
+
+After executing these steps and you should be able to use `kubectl`
+
+```bash
+sudo talosctl kubeconfig .
+mv kubeconfig $HOME/.kube/config
+sudo chown $USER:$USER $HOME/.kube/config
+```


### PR DESCRIPTION
# Pull Request

    docs: add installation chapter to firecracker getting started
    docs: add troubleshooting chapter to firecracker getting started

## What? (description)

Add installation/troubleshooting chapters to firecracker getting started guide.

## Why? (reasoning)

Missing steps in the getting started guide as discussed in https://github.com/talos-systems/talos/issues/2062

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2064)
<!-- Reviewable:end -->
