### PR TITLE
chore: fix prototool lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -484,11 +484,13 @@ RUN --mount=type=cache,target=/.cache/go-build golangci-lint run --config .golan
 RUN find . -name '*.pb.go' | xargs rm
 RUN FILES="$(gofumports -l -local github.com/talos-systems/talos .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumports -w -local github.com/talos-systems/talos .':\n${FILES}"; exit 1)
 
-# The protolint target performs linting on Markdown files.
+# The protolint target performs linting on protobuf files.
 
 FROM base AS lint-protobuf
-COPY prototool.yaml /src
-RUN prototool lint --protoc-bin-path=/toolchain/bin/protoc --protoc-wkt-path=/toolchain/include .
+WORKDIR /src/api
+COPY api .
+COPY prototool.yaml .
+RUN prototool lint --protoc-bin-path=/toolchain/bin/protoc --protoc-wkt-path=/toolchain/include
 
 # The markdownlint target performs linting on Markdown files.
 


### PR DESCRIPTION
We were never copying the protobuf files in, so prototool was never
really linting anything. This ensures that the `api` directory is copied
in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2069)
<!-- Reviewable:end -->
