### PR TITLE
refactor: remove warning about missing boot partition

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -93,8 +93,6 @@ func NewInstaller(cmdline *procfs.Cmdline, seq runtime.Sequence, opts *Options) 
 
 	if dev, err = probe.GetDevWithFileSystemLabel(constants.BootPartitionLabel); err != nil {
 		i.bootPartitionFound = false
-
-		log.Printf("WARNING: failed to find %s: %v", constants.BootPartitionLabel, err)
 	} else {
 		i.bootPartitionFound = true
 	}


### PR DESCRIPTION
There is no need to really warn about this. We handle this sceanrio just
fine now. The warning just adds confusion.

Fixes #2071.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2072)
<!-- Reviewable:end -->
