### PR TITLE
docs: clean up docs page scripts in preparation for 0.5 docs

### DIFF
--- a/docs/website/components/Content.vue
+++ b/docs/website/components/Content.vue
@@ -2,13 +2,7 @@
   <article class="max-w-3xl pt-1 pb-4 pl-6 pr-6 mx-auto c-rich-text">
     <div class="flex">
       <h2 class="page-heading flex-grow">{{ doc.title }}</h2>
-      <a
-        :href="
-          'https://github.com/talos-systems/talos/edit/master/docs/website/content/' +
-            $store.getters['sidebar/getActiveDocPath'] +
-            '.md'
-        "
-        class="no-underline font-normal text-sm self-center"
+      <a :href="gitPath" class="no-underline font-normal text-sm self-center"
         ><img
           src="/images/Git-Icon-Black.png"
           height="14px"
@@ -29,17 +23,28 @@ export default {
 
   computed: {
     doc() {
-      const sections = this.$store.getters['sidebar/getSections']
+      const sections = this.$store.state.sidebar.sections
       let activeDocPath = ''
 
-      // if there's an #anchor specified, go there instead of the top-level
+      // if there's an #anchor specified, go there
       if (this.$route.hash) {
         activeDocPath = this.$route.hash.substring(1)
       } else {
-        activeDocPath = this.$store.getters['sidebar/getActiveDocPath']
+        // otherwise go to the first item in the menu
+        activeDocPath = this.$store.state.sidebar.menu[0].path
       }
-
       return sections[activeDocPath]
+    },
+    gitPath() {
+      let path =
+        'https://github.com/talos-systems/talos/edit/master/docs/website/content/'
+
+      if (this.$route.hash) {
+        path += this.$route.hash.substring(1)
+      } else {
+        path += this.$store.state.sidebar.menu[0].path + '/index'
+      }
+      return path + '.md'
     }
   }
 }

--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -33,6 +33,7 @@ export default {
   data() {
     return {
       options: [
+        //        { version: 'v0.5', url: '/docs/v0.5', prerelease: true },
         { version: 'v0.4', url: '/docs/v0.4', prerelease: false },
         { version: 'v0.3', url: '/docs/v0.3', prerelease: false }
       ]

--- a/docs/website/components/Sidebar.vue
+++ b/docs/website/components/Sidebar.vue
@@ -13,15 +13,9 @@
             <div v-if="item.children" class="ml-4 pt-2 sidebar-subcategory">
               {{ item.title }}
             </div>
-
-            <router-link
-              v-else
-              @click="handleClick(item)"
-              :to="'#' + item.path"
-              class="block ml-2"
-            >
+            <nuxt-link v-else :to="'#' + item.path" class="block ml-2">
               <span class="p-2">{{ item.title }}</span>
-            </router-link>
+            </nuxt-link>
 
             <ul v-if="item.children" class="sidebar-children ml-4 mt-2">
               <li
@@ -29,13 +23,9 @@
                 :key="child.path"
                 class="sidebar-item my-2"
               >
-                <router-link
-                  :to="'#' + child.path"
-                  @click="handleClick(child)"
-                  class="block m-1"
-                >
+                <nuxt-link :to="'#' + child.path" class="block m-1">
                   <span class="p-2">{{ child.title }}</span>
-                </router-link>
+                </nuxt-link>
               </li>
             </ul>
           </li>
@@ -47,19 +37,7 @@
 
 <script>
 export default {
-  name: 'Sidebar',
-
-  data() {
-    return {}
-  },
-
-  computed: {},
-
-  methods: {
-    handleClick(item) {
-      this.$store.commit('sidebar/setActiveDocPath', item.path)
-    }
-  }
+  name: 'Sidebar'
 }
 </script>
 

--- a/docs/website/pages/docs/_.vue
+++ b/docs/website/pages/docs/_.vue
@@ -68,10 +68,6 @@ export default {
     store.commit('sidebar/setVersion', version)
     store.commit('sidebar/setSections', sections)
     store.commit('sidebar/setMenu', menu)
-    // The initial state does not have an active doc set, so we set the default
-    // to the first element in the menu.
-    const defaultActiveDoc = menu[0].path
-    store.commit('sidebar/setActiveDocPath', defaultActiveDoc)
   }
 }
 </script>

--- a/docs/website/store/sidebar.js
+++ b/docs/website/store/sidebar.js
@@ -1,32 +1,9 @@
 export const state = () => ({
-  activeDocPath: '',
   lang: '',
   version: '',
   sections: {},
   menu: []
 })
-
-export const getters = {
-  getMenu(state) {
-    return state.menu
-  },
-
-  getSections(state) {
-    return state.sections
-  },
-
-  getLang(state, lang) {
-    return state.lang
-  },
-
-  getVersion(state) {
-    return state.version
-  },
-
-  getActiveDocPath(state) {
-    return state.activeDocPath
-  }
-}
 
 export const mutations = {
   setMenu(state, menu) {
@@ -43,9 +20,5 @@ export const mutations = {
 
   setVersion(state, version) {
     state.version = version
-  },
-
-  setActiveDocPath(state, activeDocPath) {
-    state.activeDocPath = activeDocPath.replace('docs/', '')
   }
 }


### PR DESCRIPTION
- simplify the docs page handling logic and get more nuxt-like
- the handleClick function was vestigial and didn't do anything anymore, remove it
- simplify the Vuex state quite a bit, remove activeDocPath
- clean up github link generation code and fix #2076

Signed-off-by: Timothy Gerla <tim@gerla.net>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2077)
<!-- Reviewable:end -->
