### PR TITLE
docs: add 0.5 pre-release docs, add linkable anchors, other fixes

### DIFF
--- a/docs/website/assets/css/main.css
+++ b/docs/website/assets/css/main.css
@@ -29,12 +29,16 @@ body {
 }
 
 .c-rich-text a {
-  @apply text-gray-600;
+  color: #1a76c1;
   font-weight: 400;
 }
 
 .c-rich-text a:hover {
   @apply text-gray-900 no-underline;
+}
+
+.c-rich-text ul {
+  @apply mb-4 list-outside pl-8
 }
 
 pre {
@@ -48,7 +52,6 @@ pre {
 }
 
 code {
-  background: #f4f5f6;
   border-style: none;
   border-width: 0.5px;
   border-radius: 5px;
@@ -86,6 +89,31 @@ p a:hover {
 }
 .section-docs .page-heading {
   @apply mb-1;
+}
+
+.header-anchor {
+  @apply text-sm hidden align-top;
+}
+
+h2:hover > a.header-anchor, h3:hover > a.header-anchor, h4:hover > a.header-anchor {
+  @apply inline;
+}
+
+/*
+  This hack is from https://css-tricks.com/hash-tag-links-padding/.
+  Usually when you click on an anchor link, the page content is scrolled
+  up so that the anchor link is at the top of the screen. But since we
+  have a sticky header, we have to add a "fake" 100px to the header, so that
+  the scroll lands with the header visible. 🤷‍♂️
+*/
+
+h1::before, h2::before, h3::before {
+  display: block;
+  content: " ";
+  margin-top: -100px;
+  height: 100px;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .teal-cta-button {

--- a/docs/website/assets/css/prism-ghcolors.css
+++ b/docs/website/assets/css/prism-ghcolors.css
@@ -45,7 +45,7 @@ pre[class*="language-"] {
 	margin: .5em 0;
 	overflow: auto;
 	border: 1px solid #dddddd;
-	background-color: white;
+  background-color: #f4f5f6;
 }
 
 /* Inline code */

--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -33,7 +33,7 @@ export default {
   data() {
     return {
       options: [
-        //        { version: 'v0.5', url: '/docs/v0.5', prerelease: true },
+        { version: 'v0.5', url: '/docs/v0.5', prerelease: true },
         { version: 'v0.4', url: '/docs/v0.4', prerelease: false },
         { version: 'v0.3', url: '/docs/v0.3', prerelease: false }
       ]

--- a/docs/website/components/Sidebar.vue
+++ b/docs/website/components/Sidebar.vue
@@ -13,7 +13,7 @@
             <div v-if="item.children" class="ml-4 pt-2 sidebar-subcategory">
               {{ item.title }}
             </div>
-            <nuxt-link v-else :to="'#' + item.path" class="block ml-2">
+            <nuxt-link v-else :to="'/docs/' + item.path" class="block ml-2">
               <span class="p-2">{{ item.title }}</span>
             </nuxt-link>
 
@@ -23,7 +23,7 @@
                 :key="child.path"
                 class="sidebar-item my-2"
               >
-                <nuxt-link :to="'#' + child.path" class="block m-1">
+                <nuxt-link :to="'/docs/' + child.path" class="block m-1">
                   <span class="p-2">{{ child.title }}</span>
                 </nuxt-link>
               </li>

--- a/docs/website/content/v0.5.en.json
+++ b/docs/website/content/v0.5.en.json
@@ -1,0 +1,99 @@
+[
+  {
+    "title": "Guides",
+    "path": "v0.5/en/guides/getting-started/intro",
+    "items": [
+      {
+        "title": "Getting Started",
+        "path": "v0.5/en/guides/getting-started",
+
+        "children": [
+          {
+            "title": "Introduction to Talos",
+            "path": "v0.5/en/guides/getting-started/intro"
+          },
+          {
+            "title": "How to Get Help",
+            "path": "v0.5/en/guides/getting-started/help"
+          }
+        ]
+      },
+      {
+        "title": "Local Clusters",
+        "children": [
+          {
+            "title": "Docker",
+            "path": "v0.5/en/guides/local/docker"
+          },
+          {
+            "title": "Firecracker",
+            "path": "v0.5/en/guides/local/firecracker"
+          }
+        ]
+      },
+      {
+        "title": "Cloud",
+        "path": "v0.5/en/guides/cloud",
+        "children": [
+          { "title": "AWS", "path": "v0.5/en/guides/cloud/aws" },
+          { "title": "Azure", "path": "v0.5/en/guides/cloud/azure" },
+          {
+            "title": "Digital Ocean",
+            "path": "v0.5/en/guides/cloud/digitalocean"
+          },
+          { "title": "GCP", "path": "v0.5/en/guides/cloud/gcp" },
+          { "title": "VMware", "path": "v0.5/en/guides/cloud/vmware" }
+        ]
+      },
+      {
+        "title": "Metal",
+        "path": "v0.5/en/guides/metal",
+        "children": [
+          { "title": "Overview", "path": "v0.5/en/guides/metal/overview" },
+          { "title": "Matchbox", "path": "v0.5/en/guides/metal/matchbox" }
+        ]
+      }
+    ]
+  },
+  {
+    "title": "Configuration",
+    "path": "v0.5/en/configuration",
+    "items": [
+      { "title": "Overview", "path": "v0.5/en/configuration/overview" },
+      { "title": "v1alpha1", "path": "v0.5/en/configuration/v1alpha1" }
+    ]
+  },
+  {
+    "title": "Troubleshooting",
+    "path": "v0.5/en/troubleshooting",
+    "items": [
+      { "title": "Overview", "path": "v0.5/en/troubleshooting/overview" },
+      { "title": "PKI", "path": "v0.5/en/troubleshooting/pki" }
+    ]
+  },
+  {
+    "title": "Customization",
+    "path": "v0.5/en/customization",
+    "items": [
+      { "title": "Overview", "path": "v0.5/en/customization/overview" },
+      { "title": "Containerd", "path": "v0.5/en/customization/containerd" },
+      { "title": "Corporate Proxy", "path": "v0.5/en/customization/proxy" },
+      { "title": "Kernel", "path": "v0.5/en/customization/kernel" }
+    ]
+  },
+  {
+    "title": "Components",
+    "path": "v0.5/en/components",
+    "items": [
+      { "title": "Overview", "path": "v0.5/en/components/overview" },
+      { "title": "apid", "path": "v0.5/en/components/apid" },
+      { "title": "kernel", "path": "v0.5/en/components/kernel" },
+      { "title": "machined", "path": "v0.5/en/components/machined" },
+      { "title": "networkd", "path": "v0.5/en/components/networkd" },
+      { "title": "timed", "path": "v0.5/en/components/timed" },
+      { "title": "osd", "path": "v0.5/en/components/osd" },
+      { "title": "trustd", "path": "v0.5/en/components/trustd" },
+      { "title": "udevd", "path": "v0.5/en/components/udevd" }
+    ]
+  }
+]

--- a/docs/website/content/v0.5/en/components/apid.md
+++ b/docs/website/content/v0.5/en/components/apid.md
@@ -1,0 +1,50 @@
+---
+title: 'apid'
+---
+
+When interacting with Talos, the gRPC api endpoint you will interact with directly is `apid`.
+Apid acts as the gateway for all component interactions.
+Apid provides a mechanism to route requests to the appropriate destination when running on a control plane node.
+
+We'll use some examples below to illustrate what `apid` is doing.
+
+When a user wants to interact with a Talos component via `talosctl`, there are two flags that control the interaction with `apid`.
+The `-e | --endpoints` flag is used to denote which Talos node ( via `apid` ) should handle the connection.
+Typically this is a public facing server.
+The `-n | --nodes` flag is used to denote which Talos node(s) should respond to the request.
+If `--nodes` is not specified, the first endpoint will be used.
+
+> Note: Typically there will be an `endpoint` already defined in the Talos config file.
+> Optionally, `nodes` can be included here as well.
+
+For example, if a user wants to interact with `osd`, a command like `talosctl -e cluster.talos.dev memory` may be used.
+
+```bash
+$ talosctl -e cluster.talos.dev memory
+NODE                TOTAL   USED   FREE   SHARED   BUFFERS   CACHE   AVAILABLE
+cluster.talos.dev   7938    1768   2390   145      53        3724    6571
+```
+
+In this case, `talosctl` is interacting with `apid` running on `cluster.talos.dev` and forwarding the request to the `osd` api.
+
+If we wanted to extend our example to retrieve `memory` from another node in our cluster, we could use the command `talosctl -e cluster.talos.dev -n node02 memory`.
+
+```bash
+$ talosctl -e cluster.talos.dev -n node02 memory
+NODE    TOTAL   USED   FREE   SHARED   BUFFERS   CACHE   AVAILABLE
+node02  7938    1768   2390   145      53        3724    6571
+```
+
+The `apid` instance on `cluster.talos.dev` receives the request and forwards it to `apid` running on `node02` which forwards the request to the `osd` api.
+
+We can further extend our example to retrieve `memory` for all nodes in our cluster by appending additional `-n node` flags or using a comma separated list of nodes ( `-n node01,node02,node03` ):
+
+```bash
+$ talosctl -e cluster.talos.dev -n node01 -n node02 -n node03 memory
+NODE     TOTAL    USED    FREE     SHARED   BUFFERS   CACHE   AVAILABLE
+node01   7938     871     4071     137      49        2945    7042
+node02   257844   14408   190796   18138    49        52589   227492
+node03   257844   1830    255186   125      49        777     254556
+```
+
+The `apid` instance on `cluster.talos.dev` receives the request and forwards is to `node01`, `node02`, and `node03` which then forwards the request to their local `osd` api.

--- a/docs/website/content/v0.5/en/components/containerd.md
+++ b/docs/website/content/v0.5/en/components/containerd.md
@@ -1,0 +1,7 @@
+---
+title: containerd
+---
+
+[Containerd](https://github.com/containerd/containerd) provides the container runtime to launch workloads on Talos as well as Kubernetes.
+
+Talos services are namespaced under the `system` namespace in containerd whereas the Kubernetes services are namespaced under the `k8s.io` namespace.

--- a/docs/website/content/v0.5/en/components/kernel.md
+++ b/docs/website/content/v0.5/en/components/kernel.md
@@ -1,0 +1,5 @@
+---
+title: 'kernel'
+---
+
+The Linux kernel included with Talos is configured according to the recommendations outlined in the Kernel Self Protection Project ([KSSP](http://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project)).

--- a/docs/website/content/v0.5/en/components/machined.md
+++ b/docs/website/content/v0.5/en/components/machined.md
@@ -1,0 +1,21 @@
+---
+title: 'machined'
+---
+
+A common theme throughout the design of Talos is minimalism.
+We believe strongly in the UNIX philosophy that each program should do one job well.
+The `init` included in Talos is one example of this, and we are calling it "`machined`".
+
+We wanted to create a focused `init` that had one job - run Kubernetes.
+To that extent, `machined` is relatively static in that it does not allow for arbitrary user defined services.
+Only the services necessary to run Kubernetes and manage the node are available.
+This includes:
+
+- [containerd](/docs/components/containerd)
+- [kubeadm](/docs/components/kubeadm)
+- [kubelet](https://kubernetes.io/docs/concepts/overview/components/)
+- [networkd](/docs/components/networkd)
+- [timed](/docs/components/timed)
+- [osd](/docs/components/osd)
+- [trustd](/docs/components/trustd)
+- [udevd](/docs/components/udevd)

--- a/docs/website/content/v0.5/en/components/networkd.md
+++ b/docs/website/content/v0.5/en/components/networkd.md
@@ -1,0 +1,100 @@
+---
+title: networkd
+---
+
+Networkd handles all of the host level network configuration.
+Configuration is defined under the `networking` key.
+
+By default, we attempt to issue a DHCP request for every interface on the server.
+This can be overridden by supplying one of the following kernel arguments:
+
+- `talos.network.interface.ignore` - specify a list of interfaces to skip discovery on
+- `ip` - `ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>` as documented in the [kernel here](https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt)
+  - ex, `ip=10.0.0.99:::255.0.0.0:control-1:eth0:off:10.0.0.1`
+
+## Examples
+
+Documentation for the network section components can be found under the configuration reference.
+
+### Static Addressing
+
+Static addressing is comprised of specifying `cidr`, `routes` ( remember to add your default gateway ), and `interface`.
+Most likely you'll also want to define the `nameservers` so you have properly functioning DNS.
+
+```yaml
+machine:
+  network:
+    hostname: talos
+    nameservers:
+    - 10.0.0.1
+    time:
+      servers:
+        - time.cloudflare.com
+    interfaces:
+    - interface: eth0
+      cidr: 10.0.0.201/8
+      mtu: 8765
+      routes:
+        - network: 0.0.0.0/0
+          gateway: 10.0.0.1
+    - interface: eth1
+      ignore: true
+```
+
+### Additional Addresses for an Interface
+
+In some environments you may need to set additional addresses on an interface.
+In the following example, we set two additional addresses on the loopback interface.
+
+```yaml
+machine:
+  network:
+    interfaces:
+    - interface: lo0
+      cidr: 192.168.0.21/24
+    - interface: lo0
+      cidr: 10.2.2.2/24
+
+
+```
+
+### Bonding
+
+The following example shows how to create a bonded interface.
+
+```yaml
+machine:
+  network:
+    interfaces:
+    - interface: bond0
+      dhcp: true
+      bond:
+        mode: 802.3ad
+        lacprate: fast
+        hashpolicy: layer3+4
+        miimon: 100
+        updelay: 200
+        downdelay: 200
+        interfaces:
+        - eth0
+        - eth1
+```
+
+### VLANs
+
+To setup vlans on a specific device use an array of VLANs to add.
+The master device may be configured without addressing by setting dhcp to false.
+
+```yaml
+machine:
+  network:
+    interfaces:
+    - interface: eth0
+      dhcp: false
+      vlans:
+      - vlanId: 100
+        cidr: "192.168.2.10/28"
+        routes:
+        - network: 0.0.0.0/0
+          gateway: 192.168.2.1
+```

--- a/docs/website/content/v0.5/en/components/osctl.md
+++ b/docs/website/content/v0.5/en/components/osctl.md
@@ -1,0 +1,15 @@
+---
+title: 'talosctl'
+---
+
+`talosctl` CLI is the client to the [osd](/components/osd) service running on every node.
+`talosctl` should provide enough functionality to be a replacement for typical interactive shell operations.
+With it you can do things like:
+
+- `talosctl logs <service>` - retrieve container logs
+- `talosctl restart <service>` - restart a service
+- `talosctl reboot` - reset a node
+- `talosctl dmesg` - retrieve kernel logs
+- `talosctl ps` - view running services
+- `talosctl top` - view node resources
+- `talosctl services` - view status of Talos services

--- a/docs/website/content/v0.5/en/components/osd.md
+++ b/docs/website/content/v0.5/en/components/osd.md
@@ -1,0 +1,20 @@
+---
+title: 'osd'
+---
+
+Talos is unique in that it has no concept of host-level access.
+There is no ssh daemon.
+There is no interactive console session.
+There are no shells installed.
+Only what is required to run Kubernetes.
+Furthermore, there is no way to run any custom processes on the host level.
+
+To make this work, we needed an out-of-band tool for managing the nodes.
+In an ideal world, the system would be self-healing and we would never have to touch it.
+But, in the real world, this does not happen.
+We still need a way to handle operational scenarios that may arise.
+
+The `osd` daemon provides a way to do just that.
+Based on the Principle of Least Privilege, `osd` provides operational value for cluster administrators by providing an API for node management.
+
+Interactions with `osd` are handled via [talosctl](/docs/components/talosctl) which communicates via gRPC.

--- a/docs/website/content/v0.5/en/components/overview.md
+++ b/docs/website/content/v0.5/en/components/overview.md
@@ -1,0 +1,5 @@
+---
+title: 'Components'
+---
+
+In this section we will discuss the various components of which Talos is comprised.

--- a/docs/website/content/v0.5/en/components/timed.md
+++ b/docs/website/content/v0.5/en/components/timed.md
@@ -1,0 +1,5 @@
+---
+title: timed
+---
+
+Timed handles the host time synchronization.

--- a/docs/website/content/v0.5/en/components/trustd.md
+++ b/docs/website/content/v0.5/en/components/trustd.md
@@ -1,0 +1,14 @@
+---
+title: 'trustd'
+---
+
+Security is one of the highest priorities within Talos.
+To run a Kubernetes cluster a certain level of trust is required to operate a cluster.
+For example, orchestrating the bootstrap of a highly available control plane requires the distribution of sensitive PKI data.
+
+To that end, we created `trustd`.
+Based on the concept of a Root of Trust, `trustd` is a simple daemon responsible for establishing trust within the system.
+Once trust is established, various methods become available to the trustee.
+It can, for example, accept a write request from another node to place a file on disk.
+
+Additional methods and capability will be added to the `trustd` component in support of new functionality in the rest of the Talos environment.

--- a/docs/website/content/v0.5/en/components/udevd.md
+++ b/docs/website/content/v0.5/en/components/udevd.md
@@ -1,0 +1,5 @@
+---
+title: 'udevd'
+---
+
+Udevd handles the kernel device notifications and sets up the necessary links in `/dev`.

--- a/docs/website/content/v0.5/en/configuration/overview.md
+++ b/docs/website/content/v0.5/en/configuration/overview.md
@@ -1,0 +1,16 @@
+---
+title: 'Configuration Overview'
+---
+
+In this section, we will step through the configuration of a Talos based Kubernetes cluster.
+There are three major components we will configure:
+
+- `osd` and `talosctl`
+- the master nodes
+- the worker nodes
+
+Talos enforces a high level of security by using mutual TLS for authentication and authorization.
+
+We recommend that the configuration of Talos be performed by a cluster owner.
+A cluster owner should be a person of authority within an organization, perhaps a director, manager, or senior member of a team.
+They are responsible for storing the root CA, and distributing the PKI for authorized cluster administrators.

--- a/docs/website/content/v0.5/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.5/en/configuration/v1alpha1.md
@@ -1,0 +1,1167 @@
+---
+title: v1alpha1
+---
+
+<!-- markdownlint-disable MD024 -->
+
+Package v1alpha1 configuration file contains all the options available for configuring a machine.
+
+We can generate the files using `talosctl`.
+This configuration is enough to get started in most cases, however it can be customized as needed.
+
+```bash
+talosctl config generate --version v1alpha1 <cluster name> <cluster endpoint>
+````
+
+This will generate a machine config for each node type, and a talosconfig.
+The following is an example of an `init.yaml`:
+
+```yaml
+version: v1alpha1
+machine:
+  type: init
+  token: 5dt69c.npg6duv71zwqhzbg
+  ca:
+    crt: <base64 encoded Ed25519 certificate>
+    key: <base64 encoded Ed25519 key>
+  certSANs: []
+  kubelet: {}
+  network: {}
+  install:
+    disk: /dev/sda
+    image: docker.io/autonomy/installer:latest
+    bootloader: true
+    wipe: false
+    force: false
+cluster:
+  controlPlane:
+    version: 1.18.0
+    endpoint: https://1.2.3.4
+  clusterName: example
+  network:
+    cni: ""
+    dnsDomain: cluster.local
+    podSubnets:
+    - 10.244.0.0/16
+    serviceSubnets:
+    - 10.96.0.0/12
+  token: wlzjyw.bei2zfylhs2by0wd
+  certificateKey: 20d9aafb46d6db4c0958db5b3fc481c8c14fc9b1abd8ac43194f4246b77131be
+  aescbcEncryptionSecret: z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
+  ca:
+    crt: <base64 encoded RSA certificate>
+    key: <base64 encoded RSA key>
+  apiServer: {}
+  controllerManager: {}
+  scheduler: {}
+  etcd:
+    ca:
+      crt: <base64 encoded RSA certificate>
+      key: <base64 encoded RSA key>
+```
+
+### Config
+
+#### version
+
+Indicates the schema used to decode the contents.
+
+Type: `string`
+
+Valid Values:
+
+- ``v1alpha1``
+
+#### debug
+
+Enable verbose logging.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
+#### persist
+
+Indicates whether to pull the machine config upon every boot.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
+#### machine
+
+Provides machine specific configuration options.
+
+Type: `MachineConfig`
+
+#### cluster
+
+Provides cluster specific configuration options.
+
+Type: `ClusterConfig`
+
+---
+
+### MachineConfig
+
+#### type
+
+Defines the role of the machine within the cluster.
+
+##### Init
+
+Init node type designates the first control plane node to come up.
+You can think of it like a bootstrap node.
+This node will perform the initial steps to bootstrap the cluster -- generation of TLS assets, starting of the control plane, etc.
+
+##### Control Plane
+
+Control Plane node type designates the node as a control plane member.
+This means it will host etcd along with the Kubernetes master components such as API Server, Controller Manager, Scheduler.
+
+##### Worker
+
+Worker node type designates the node as a worker node.
+This means it will be an available compute node for scheduling workloads.
+
+Type: `string`
+
+Valid Values:
+
+- ``init``
+- ``controlplane``
+- ``join``
+
+#### token
+
+The `token` is used by a machine to join the PKI of the cluster.
+Using this token, a machine will create a certificate signing request (CSR), and request a certificate that will be used as its' identity.
+
+Type: `string`
+
+Examples:
+
+```yaml
+token: 328hom.uqjzh6jnn2eie9oi
+```
+
+> Warning: It is important to ensure that this token is correct since a machine's certificate has a short TTL by default
+
+#### ca
+
+The root certificate authority of the PKI.
+It is composed of a base64 encoded `crt` and `key`.
+
+Type: `PEMEncodedCertificateAndKey`
+
+Examples:
+
+```yaml
+ca:
+  crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJIekNCMHF...
+  key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM...
+
+```
+
+#### certSANs
+
+Extra certificate subject alternative names for the machine's certificate.
+By default, all non-loopback interface IPs are automatically added to the certificate's SANs.
+
+Type: `array`
+
+Examples:
+
+```yaml
+certSANs:
+  - 10.0.0.10
+  - 172.16.0.10
+  - 192.168.0.10
+
+```
+
+#### kubelet
+
+Used to provide additional options to the kubelet.
+
+Type: `KubeletConfig`
+
+Examples:
+
+```yaml
+kubelet:
+  image:
+  extraArgs:
+    key: value
+
+```
+
+#### network
+
+Used to configure the machine's network.
+
+Type: `NetworkConfig`
+
+Examples:
+
+```yaml
+network:
+  hostname: worker-1
+  interfaces:
+  nameservers:
+    - 9.8.7.6
+    - 8.7.6.5
+
+```
+
+#### disks
+
+Used to partition, format and mount additional disks.
+Since the rootfs is read only with the exception of `/var`, mounts are only valid if they are under `/var`.
+Note that the partitioning and formating is done only once, if and only if no existing  partitions are found.
+
+Type: `array`
+
+Examples:
+
+```yaml
+disks:
+  - device: /dev/sdb
+    partitions:
+      - size: 10000000000
+        mountpoint: /var/lib/extra
+
+```
+
+> Note: `size` is in units of bytes.
+
+#### install
+
+Used to provide instructions for bare-metal installations.
+
+Type: `InstallConfig`
+
+Examples:
+
+```yaml
+install:
+  disk: /dev/sda
+  extraKernelArgs:
+    - option=value
+  image: docker.io/autonomy/installer:latest
+  bootloader: true
+  wipe: false
+  force: false
+
+```
+
+#### files
+
+Allows the addition of user specified files.
+The value of `op` can be `create`, `overwrite`, or `append`.
+In the case of `create`, `path` must not exist.
+In the case of `overwrite`, and `append`, `path` must be a valid file.
+If an `op` value of `append` is used, the existing file will be appended.
+Note that the file contents are not required to be base64 encoded.
+
+Type: `array`
+
+Examples:
+
+```yaml
+files:
+  - content: |
+      ...
+    permissions: 0666
+    path: /tmp/file.txt
+    op: append
+
+```
+
+> Note: The specified `path` is relative to `/var`.
+
+#### env
+
+The `env` field allows for the addition of environment variables to a machine.
+All environment variables are set on the machine in addition to every service.
+
+Type: `Env`
+
+Valid Values:
+
+- ``GRPC_GO_LOG_VERBOSITY_LEVEL``
+- ``GRPC_GO_LOG_SEVERITY_LEVEL``
+- ``http_proxy``
+- ``https_proxy``
+- ``no_proxy``
+
+Examples:
+
+```yaml
+env:
+  GRPC_GO_LOG_VERBOSITY_LEVEL: "99"
+  GRPC_GO_LOG_SEVERITY_LEVEL: info
+  https_proxy: http://SERVER:PORT/
+
+```
+
+```yaml
+env:
+  GRPC_GO_LOG_SEVERITY_LEVEL: error
+  https_proxy: https://USERNAME:PASSWORD@SERVER:PORT/
+
+```
+
+```yaml
+env:
+  https_proxy: http://DOMAIN\\USERNAME:PASSWORD@SERVER:PORT/
+
+```
+
+#### time
+
+Used to configure the machine's time settings.
+
+Type: `TimeConfig`
+
+Examples:
+
+```yaml
+time:
+  servers:
+    - time.cloudflare.com
+
+```
+
+#### sysctls
+
+Used to configure the machine's sysctls.
+
+Type: `map`
+
+Examples:
+
+```yaml
+sysctls:
+  kernel.domainname: talos.dev
+  net.ipv4.ip_forward: "0"
+
+```
+
+#### registries
+
+Used to configure the machine's container image registry mirrors.
+
+Automatically generates matching CRI configuration for registry mirrors.
+
+Section `mirrors` allows to redirect requests for images to non-default registry,
+which might be local registry or caching mirror.
+
+Section `config` provides a way to authenticate to the registry with TLS client
+identity, provide registry CA, or authentication information.
+Authentication information has same meaning with the corresponding field in `.docker/config.json`.
+
+See also matching configuration for [CRI containerd plugin](https://github.com/containerd/cri/blob/master/docs/registry.md).
+
+Type: `RegistriesConfig`
+
+Examples:
+
+```yaml
+registries:
+  mirrors:
+    docker.io:
+      endpoints:
+        - https://registry-1.docker.io
+    '*':
+      endpoints:
+        - http://some.host:123/
+ config:
+  "some.host:123":
+    tls:
+      CA: ... # base64-encoded CA certificate in PEM format
+      clientIdentity:
+        cert: ...  # base64-encoded client certificate in PEM format
+        key: ...  # base64-encoded client key in PEM format
+    auth:
+      username: ...
+      password: ...
+      auth: ...
+      identityToken: ...
+
+```
+
+---
+
+### ClusterConfig
+
+#### controlPlane
+
+Provides control plane specific configuration options.
+
+Type: `ControlPlaneConfig`
+
+Examples:
+
+```yaml
+controlPlane:
+  endpoint: https://1.2.3.4
+  localAPIServerPort: 443
+
+```
+
+#### clusterName
+
+Configures the cluster's name.
+
+Type: `string`
+
+#### network
+
+Provides cluster network configuration.
+
+Type: `ClusterNetworkConfig`
+
+Examples:
+
+```yaml
+network:
+  cni:
+    name: flannel
+  dnsDomain: cluster.local
+  podSubnets:
+  - 10.244.0.0/16
+  serviceSubnets:
+  - 10.96.0.0/12
+
+```
+
+#### token
+
+The [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/).
+
+Type: `string`
+
+Examples:
+
+```yaml
+wlzjyw.bei2zfylhs2by0wd
+```
+
+#### aescbcEncryptionSecret
+
+The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+
+Type: `string`
+
+Examples:
+
+```yaml
+z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
+```
+
+#### ca
+
+The base64 encoded root certificate authority used by Kubernetes.
+
+Type: `PEMEncodedCertificateAndKey`
+
+Examples:
+
+```yaml
+ca:
+  crt: LS0tLS1CRUdJTiBDRV...
+  key: LS0tLS1CRUdJTiBSU0...
+
+```
+
+#### apiServer
+
+API server specific configuration options.
+
+Type: `APIServerConfig`
+
+Examples:
+
+```yaml
+apiServer:
+  image: ...
+  extraArgs:
+    key: value
+  certSANs:
+    - 1.2.3.4
+    - 5.6.7.8
+
+```
+
+#### controllerManager
+
+Controller manager server specific configuration options.
+
+Type: `ControllerManagerConfig`
+
+Examples:
+
+```yaml
+controllerManager:
+  image: ...
+  extraArgs:
+    key: value
+
+```
+
+#### proxy
+
+Kube-proxy server-specific configuration options
+
+Type: `ProxyConfig`
+
+Examples:
+
+```yaml
+proxy:
+  mode: ipvs
+  extraArgs:
+    key: value
+
+```
+
+#### scheduler
+
+Scheduler server specific configuration options.
+
+Type: `SchedulerConfig`
+
+Examples:
+
+```yaml
+scheduler:
+  image: ...
+  extraArgs:
+    key: value
+
+```
+
+#### etcd
+
+Etcd specific configuration options.
+
+Type: `EtcdConfig`
+
+Examples:
+
+```yaml
+etcd:
+  ca:
+    crt: LS0tLS1CRUdJTiBDRV...
+    key: LS0tLS1CRUdJTiBSU0...
+  image: ...
+
+```
+
+#### podCheckpointer
+
+Pod Checkpointer specific configuration options.
+
+Type: `PodCheckpointer`
+
+Examples:
+
+```yaml
+podCheckpointer:
+  image: ...
+
+```
+
+#### coreDNS
+
+Core DNS specific configuration options.
+
+Type: `CoreDNS`
+
+Examples:
+
+```yaml
+coreDNS:
+  image: ...
+
+```
+
+#### extraManifests
+
+A list of urls that point to additional manifests.
+These will get automatically deployed by bootkube.
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraManifests:
+  - "https://www.mysweethttpserver.com/manifest1.yaml"
+  - "https://www.mysweethttpserver.com/manifest2.yaml"
+
+```
+
+#### extraManifestHeaders
+
+A map of key value pairs that will be added while fetching the ExtraManifests.
+
+Type: `map`
+
+Examples:
+
+```yaml
+extraManifestHeaders:
+  Token: "1234567"
+  X-ExtraInfo: info
+
+```
+
+#### adminKubeconfig
+
+Settings for admin kubeconfig generation.
+Certificate lifetime can be configured.
+
+Type: `AdminKubeconfigConfig`
+
+Examples:
+
+```yaml
+adminKubeconfig:
+  certLifetime: 1h
+
+```
+
+---
+
+### KubeletConfig
+
+#### image
+
+The `image` field is an optional reference to an alternative hyperkube image.
+
+Type: `string`
+
+Examples:
+
+```yaml
+image: docker.io/<org>/hyperkube:latest
+```
+
+#### extraArgs
+
+The `extraArgs` field is used to provide additional flags to the kubelet.
+
+Type: `map`
+
+Examples:
+
+```yaml
+extraArgs:
+  key: value
+
+```
+
+#### extraMounts
+
+The `extraMounts` field is used to add additional mounts to the kubelet container.
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraMounts:
+  - source: /var/lib/example
+    destination: /var/lib/example
+    type: bind
+    options:
+      - rshared
+      - ro
+
+```
+
+---
+
+### NetworkConfig
+
+#### hostname
+
+Used to statically set the hostname for the host.
+
+Type: `string`
+
+#### interfaces
+
+`interfaces` is used to define the network interface configuration.
+By default all network interfaces will attempt a DHCP discovery.
+This can be further tuned through this configuration parameter.
+
+##### machine.network.interfaces.interface
+
+This is the interface name that should be configured.
+
+##### machine.network.interfaces.cidr
+
+`cidr` is used to specify a static IP address to the interface.
+This should be in proper CIDR notation ( `192.168.2.5/24` ).
+
+> Note: This option is mutually exclusive with DHCP.
+
+##### machine.network.interfaces.dhcp
+
+`dhcp` is used to specify that this device should be configured via DHCP.
+
+The following DHCP options are supported:
+
+- `OptionClasslessStaticRoute`
+- `OptionDomainNameServer`
+- `OptionDNSDomainSearchList`
+- `OptionHostName`
+
+> Note: This option is mutually exclusive with CIDR.
+
+##### machine.network.interfaces.ignore
+
+`ignore` is used to exclude a specific interface from configuration.
+This parameter is optional.
+
+##### machine.network.interfaces.routes
+
+`routes` is used to specify static routes that may be necessary.
+This parameter is optional.
+
+Routes can be repeated and includes a `Network` and `Gateway` field.
+
+Type: `array`
+
+#### nameservers
+
+Used to statically set the nameservers for the host.
+Defaults to `1.1.1.1` and `8.8.8.8`
+
+Type: `array`
+
+#### extraHostEntries
+
+Allows for extra entries to be added to /etc/hosts file
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraHostEntries:
+  - ip: 192.168.1.100
+    aliases:
+      - test
+      - test.domain.tld
+
+```
+
+---
+
+### InstallConfig
+
+#### disk
+
+The disk used to install the bootloader, and ephemeral partitions.
+
+Type: `string`
+
+Examples:
+
+```yaml
+/dev/sda
+```
+
+```yaml
+/dev/nvme0
+```
+
+#### extraKernelArgs
+
+Allows for supplying extra kernel args to the bootloader config.
+
+Type: `array`
+
+Examples:
+
+```yaml
+extraKernelArgs:
+  - a=b
+
+```
+
+#### image
+
+Allows for supplying the image used to perform the installation.
+
+Type: `string`
+
+Examples:
+
+```yaml
+image: docker.io/<org>/installer:latest
+
+```
+
+#### bootloader
+
+Indicates if a bootloader should be installed.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
+#### wipe
+
+Indicates if zeroes should be written to the `disk` before performing and installation.
+Defaults to `true`.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
+#### force
+
+Indicates if filesystems should be forcefully created.
+
+Type: `bool`
+
+Valid Values:
+
+- `true`
+- `yes`
+- `false`
+- `no`
+
+---
+
+### TimeConfig
+
+#### servers
+
+Specifies time (ntp) servers to use for setting system time.
+Defaults to `pool.ntp.org`
+
+> Note: This parameter only supports a single time server
+
+Type: `array`
+
+---
+
+### RegistriesConfig
+
+#### mirrors
+
+Specifies mirror configuration for each registry.
+This setting allows to use local pull-through caching registires,
+air-gapped installations, etc.
+
+Registry name is the first segment of image identifier, with 'docker.io'
+being default one.
+Name '*' catches any registry names not specified explicitly.
+
+Type: `map`
+
+#### config
+
+Specifies TLS & auth configuration for HTTPS image registries.
+Mutual TLS can be enabled with 'clientIdentity' option.
+
+TLS configuration can be skipped if registry has trusted
+server certificate.
+
+Type: `map`
+
+---
+
+### PodCheckpointer
+
+#### image
+
+The `image` field is an override to the default pod-checkpointer image.
+
+Type: `string`
+
+---
+
+### CoreDNS
+
+#### image
+
+The `image` field is an override to the default coredns image.
+
+Type: `string`
+
+---
+
+### Endpoint
+
+---
+
+### ControlPlaneConfig
+
+#### endpoint
+
+Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
+It is single-valued, and may optionally include a port number.
+
+Type: `Endpoint`
+
+Examples:
+
+```yaml
+https://1.2.3.4:443
+```
+
+#### localAPIServerPort
+
+The port that the API server listens on internally.
+This may be different than the port portion listed in the endpoint field above.
+The default is 6443.
+
+Type: `int`
+
+---
+
+### APIServerConfig
+
+#### image
+
+The container image used in the API server manifest.
+
+Type: `string`
+
+#### extraArgs
+
+Extra arguments to supply to the API server.
+
+Type: `map`
+
+#### certSANs
+
+Extra certificate subject alternative names for the API server's certificate.
+
+Type: `array`
+
+---
+
+### ControllerManagerConfig
+
+#### image
+
+The container image used in the controller manager manifest.
+
+Type: `string`
+
+#### extraArgs
+
+Extra arguments to supply to the controller manager.
+
+Type: `map`
+
+---
+
+### ProxyConfig
+
+#### mode
+
+proxy mode of kube-proxy.
+By default, this is 'iptables'.
+
+Type: `string`
+
+#### extraArgs
+
+Extra arguments to supply to kube-proxy.
+
+Type: `map`
+
+---
+
+### SchedulerConfig
+
+#### image
+
+The container image used in the scheduler manifest.
+
+Type: `string`
+
+#### extraArgs
+
+Extra arguments to supply to the scheduler.
+
+Type: `map`
+
+---
+
+### EtcdConfig
+
+#### image
+
+The container image used to create the etcd service.
+
+Type: `string`
+
+#### ca
+
+The `ca` is the root certificate authority of the PKI.
+It is composed of a base64 encoded `crt` and `key`.
+
+Type: `PEMEncodedCertificateAndKey`
+
+Examples:
+
+```yaml
+ca:
+  crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJIekNCMHF...
+  key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM...
+
+```
+
+#### extraArgs
+
+Extra arguments to supply to etcd.
+Note that the following args are blacklisted:
+
+- `name`
+- `data-dir`
+- `initial-cluster-state`
+- `listen-peer-urls`
+- `listen-client-urls`
+- `cert-file`
+- `key-file`
+- `trusted-ca-file`
+- `peer-client-cert-auth`
+- `peer-cert-file`
+- `peer-trusted-ca-file`
+- `peer-key-file`
+
+Type: `map`
+
+Examples:
+
+```yaml
+extraArgs:
+  initial-cluster: https://1.2.3.4:2380
+  advertise-client-urls: https://1.2.3.4:2379
+
+```
+
+---
+
+### ClusterNetworkConfig
+
+#### cni
+
+The CNI used.
+Composed of "name" and "url".
+The "name" key only supports upstream bootkube options of "flannel" or "custom".
+URLs is only used if name is equal to "custom".
+URLs should point to a single yaml file that will get deployed.
+Empty struct or any other name will default to bootkube's flannel.
+
+Type: `CNIConfig`
+
+Examples:
+
+```yaml
+cni:
+  name: "custom"
+  urls:
+    - "https://www.mysweethttpserver.com/supersecretcni.yaml"
+
+```
+
+#### dnsDomain
+
+The domain used by Kubernetes DNS.
+The default is `cluster.local`
+
+Type: `string`
+
+Examples:
+
+```yaml
+cluser.local
+```
+
+#### podSubnets
+
+The pod subnet CIDR.
+
+Type: `array`
+
+Examples:
+
+```yaml
+podSubnets:
+  - 10.244.0.0/16
+
+```
+
+#### serviceSubnets
+
+The service subnet CIDR.
+
+Type: `array`
+
+Examples:
+
+```yaml
+serviceSubnets:
+  - 10.96.0.0/12
+
+```
+
+---
+
+### CNIConfig
+
+#### name
+
+Name of CNI to use.
+
+Type: `string`
+
+#### urls
+
+URLs containing manifests to apply for CNI.
+
+Type: `array`
+
+---
+
+### AdminKubeconfigConfig
+
+#### certLifetime
+
+Admin kubeconfig certificate lifetime (default is 1 year).
+Field format accepts any Go time.Duration format ('1h' for one hour, '10m' for ten minutes).
+
+Type: `Duration`
+
+---

--- a/docs/website/content/v0.5/en/customization/containerd.md
+++ b/docs/website/content/v0.5/en/customization/containerd.md
@@ -1,0 +1,33 @@
+---
+title: 'Customizing containerd'
+---
+
+We offer the ability to use custom configuration files for containerd.
+The base containerd configuration expects to merge in any additional configs present in `/var/cri/conf.d/*.toml`.
+
+## An example of exposing metrics
+
+Into each machine config, add the following:
+
+```yaml
+machine:
+  ...
+  files:
+    - content: |
+        [metrics]
+          address = "0.0.0.0:11234"
+      path: /var/cri/conf.d/metrics.toml
+      op: create
+```
+
+Create cluster like normal and see that metrics are now present on this port:
+
+```bash
+$ curl 127.0.0.1:11234/v1/metrics
+# HELP container_blkio_io_service_bytes_recursive_bytes The blkio io service bytes recursive
+# TYPE container_blkio_io_service_bytes_recursive_bytes gauge
+container_blkio_io_service_bytes_recursive_bytes{container_id="0677d73196f5f4be1d408aab1c4125cf9e6c458a4bea39e590ac779709ffbe14",device="/dev/dm-0",major="253",minor="0",namespace="k8s.io",op="Async"} 0
+container_blkio_io_service_bytes_recursive_bytes{container_id="0677d73196f5f4be1d408aab1c4125cf9e6c458a4bea39e590ac779709ffbe14",device="/dev/dm-0",major="253",minor="0",namespace="k8s.io",op="Discard"} 0
+...
+...
+```

--- a/docs/website/content/v0.5/en/customization/kernel.md
+++ b/docs/website/content/v0.5/en/customization/kernel.md
@@ -1,0 +1,21 @@
+---
+title: 'Kernel'
+---
+
+## Customizing the Kernel
+
+```docker
+FROM scratch AS customization
+COPY --from=<custom kernel image> /lib/modules /lib/modules
+
+FROM docker.io/andrewrynhard/installer:latest
+COPY --from=<custom kernel image> /boot/vmlinuz /usr/install/vmlinuz
+```
+
+```bash
+docker build --build-arg RM="/lib/modules" -t talos-installer .
+```
+
+> Note: You can use the `--squash` flag to create smaller images.
+
+Now that we have a custom installer we can build Talos for the specific platform we wish to deploy to.

--- a/docs/website/content/v0.5/en/customization/overview.md
+++ b/docs/website/content/v0.5/en/customization/overview.md
@@ -1,0 +1,60 @@
+---
+title: 'Customization'
+---
+
+The installer image contains [`ONBUILD`](https://docs.docker.com/engine/reference/builder/#onbuild) instructions that handle the following:
+
+- the decompression, and unpacking of the `initramfs.xz`
+- the unsquashing of the rootfs
+- the copying of new rootfs files
+- the squashing of the new rootfs
+- and the packing, and compression of the new `initramfs.xz`
+
+When used as a base image, the installer will perform the above steps automatically with the requirement that a `customization` stage be defined in the `Dockerfile`.
+
+For example, say we have an image that contains the contents of a library we wish to add to the Talos rootfs.
+We need to define a stage with the name `customization`:
+
+```docker
+FROM scratch AS customization
+COPY --from=<name|index> <src> <dest>
+```
+
+Using a multi-stage `Dockerfile` we can define the `customization` stage and build `FROM` the installer image:
+
+```docker
+FROM scratch AS customization
+COPY --from=<name|index> <src> <dest>
+
+FROM docker.io/autonomy/installer:latest
+```
+
+When building the image, the `customization` stage will automatically be copied into the rootfs.
+The `customization` stage is not limited to a single `COPY` instruction.
+In fact, you can do whatever you would like in this stage, but keep in mind that everything in `/` will be copied into the rootfs.
+
+> Note: `<dest>` is the path relative to the rootfs that you wish to place the contents of `<src>`.
+
+To build the image, run:
+
+```bash
+docker build --squash -t <organization>/installer:latest .
+```
+
+In the case that you need to perform some cleanup _before_ adding additional files to the rootfs, you can specify the `RM` [build-time variable](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg):
+
+```bash
+docker build --squash --build-arg RM="[<path> ...]" -t <organization>/installer:latest .
+```
+
+This will perform a `rm -rf` on the specified paths relative to the rootfs.
+
+> Note: `RM` must be a whitespace delimited list.
+
+The resulting image can be used to:
+
+- generate an image for any of the supported providers
+- perform bare-metall installs
+- perform upgrades
+
+We will step through common customizations in the remainder of this section.

--- a/docs/website/content/v0.5/en/customization/proxy.md
+++ b/docs/website/content/v0.5/en/customization/proxy.md
@@ -1,0 +1,51 @@
+---
+title: 'Running Behind a Corporate Proxy'
+---
+
+## Appending the Certificate Authority of MITM Proxies
+
+Put into each machine the PEM encoded certificate:
+
+```yaml
+machine:
+  ...
+  files:
+    - content: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      permissions: 0644
+      path: /etc/ssl/certs/ca-certificates
+      op: append
+```
+
+## Configuring a Machine to Use the Proxy
+
+To make use of a proxy:
+
+```yaml
+machine:
+  env:
+    http_proxy: <http proxy>
+    https_proxy: <https proxy>
+    no_proxy: <no proxy>
+```
+
+Additionally, configure the DNS `nameservers`, and NTP `servers`:
+
+```yaml
+machine:
+  env:
+  ...
+  time:
+    servers:
+      - <server 1>
+      - <server ...>
+      - <server n>
+  ...
+  network:
+    nameservers:
+      - <ip 1>
+      - <ip ...>
+      - <ip n>
+```

--- a/docs/website/content/v0.5/en/guides/cloud/aws.md
+++ b/docs/website/content/v0.5/en/guides/cloud/aws.md
@@ -1,0 +1,245 @@
+---
+title: 'AWS'
+---
+
+## Creating a Cluster via the AWS CLI
+
+In this guide we will create an HA Kubernetes cluster with 3 worker nodes.
+We assume an existing VPC, and some familiarity with AWS.
+If you need more information on AWS specifics, please see the [official AWS documentation](https://docs.aws.amazon.com).
+
+### Create the Subnet
+
+```bash
+aws ec2 create-subnet \
+    --region $REGION \
+    --vpc-id $VPC \
+    --cidr-block ${CIDR_BLOCK}
+```
+
+### Create the AMI
+
+#### Prepare the Import Prerequisites
+
+##### Create the S3 Bucket
+
+```bash
+aws s3api create-bucket \
+    --bucket $BUCKET \
+    --create-bucket-configuration LocationConstraint=$REGION \
+    --acl private
+```
+
+##### Create the `vmimport` Role
+
+In order to create an AMI, ensure that the `vmimport` role exists as described in the [official AWS documentation](https://docs.aws.amazon.com/vm-import/latest/userguide/vmie_prereqs.html#vmimport-role).
+
+Note that the role should be associated with the S3 bucket we created above.
+
+##### Create the Image Snapshot
+
+First, download the AWS image from a Talos release:
+
+```bash
+curl -LO https://github.com/talos-systems/talos/releases/download/v0.3.0-alpha.2/aws.tar.gz | tar -xv
+```
+
+Copy the RAW disk to S3 and import it as a snapshot:
+
+```bash
+aws s3 cp disk.raw s3://$BUCKET/talos-aws-tutorial.raw
+aws ec2 import-snapshot \
+    --region $REGION \
+    --description "Talos kubernetes tutorial" \
+    --disk-container "Format=raw,UserBucket={S3Bucket=$BUCKET,S3Key=talos-aws-tutorial.raw}"
+```
+
+Save the `SnapshotId`, as we will need it once the import is done.
+To check on the status of the import, run:
+
+```bash
+aws ec2 describe-import-snapshot-tasks \
+    --region $REGION \
+    --import-task-ids
+```
+
+Once the `SnapshotTaskDetail.Status` indicates `completed`, we can register the image.
+
+##### Register the Image
+
+```bash
+aws ec2 register-image \
+    --region $REGION \
+    --block-device-mappings "DeviceName=/dev/xvda,VirtualName=talos,Ebs={DeleteOnTermination=true,SnapshotId=$SNAPSHOT,VolumeSize=4,VolumeType=gp2}" \
+    --root-device-name /dev/xvda \
+    --virtualization-type hvm \
+    --architecture x86_64 \
+    --ena-support \
+    --name talos-aws-tutorial-ami
+```
+
+We now have an AMI we can use to create our cluster.
+Save the AMI ID, as we will need it when we create EC2 instances.
+
+### Create a Security Group
+
+```bash
+aws ec2 create-security-group \
+    --region $REGION \
+    --group-name talos-aws-tutorial-sg \
+    --description "Security Group for EC2 instances to allow ports required by Talos"
+```
+
+Using the security group ID from above, allow all internal traffic within the same security group:
+
+```bash
+aws ec2 authorize-security-group-ingress \
+    --region $REGION \
+    --group-name talos-aws-tutorial-sg \
+    --protocol all \
+    --port 0 \
+    --group-id $SECURITY_GROUP \
+    --source-group $SECURITY_GROUP
+```
+
+and expose the Talos and Kubernetes APIs:
+
+```bash
+aws ec2 authorize-security-group-ingress \
+    --region $REGION \
+    --group-name talos-aws-tutorial-sg \
+    --protocol tcp \
+    --port 6443 \
+    --cidr 0.0.0.0/0 \
+    --group-id $SECURITY_GROUP
+aws ec2 authorize-security-group-ingress \
+    --region $REGION \
+    --group-name talos-aws-tutorial-sg \
+    --protocol tcp \
+    --port 50000-50001 \
+    --cidr 0.0.0.0/0 \
+    --group-id $SECURITY_GROUP
+```
+
+### Create a Load Balancer
+
+```bash
+aws elbv2 create-load-balancer \
+    --region $REGION \
+    --name talos-aws-tutorial-lb \
+    --type network --subnets $SUBNET
+```
+
+Take note of the DNS name and ARN.
+We will need these soon.
+
+### Create the Machine Configuration Files
+
+#### Generating Base Configurations
+
+Using the DNS name of the loadbalancer created earlier, generate the base configuration files for the Talos machines:
+
+```bash
+$ talosctl gen config talos-k8s-aws-tutorial https://<load balancer IP or DNS>:<port>
+created init.yaml
+created controlplane.yaml
+created join.yaml
+created talosconfig
+```
+
+At this point, you can modify the generated configs to your liking.
+
+#### Validate the Configuration Files
+
+```bash
+$ talosctl validate --config init.yaml --mode cloud
+init.yaml is valid for cloud mode
+$ talosctl validate --config controlplane.yaml --mode cloud
+controlplane.yaml is valid for cloud mode
+$ talosctl validate --config join.yaml --mode cloud
+join.yaml is valid for cloud mode
+```
+
+### Create the EC2 Instances
+
+> Note: There is a known issue that prevents Talos from running on T2 instance types.
+> Please use T3 if you need burstable instance types.
+
+#### Create the Bootstrap Node
+
+```bash
+aws ec2 run-instances \
+    --region $REGION \
+    --image-id $AMI \
+    --count 1 \
+    --instance-type t3.small \
+    --user-data file://init.yaml \
+    --subnet-id $SUBNET \
+    --security-group-ids $SECURITY_GROUP
+```
+
+#### Create the Remaining Control Plane Nodes
+
+```bash
+aws ec2 run-instances \
+    --region $REGION \
+    --image-id $AMI \
+    --count 2 \
+    --instance-type t3.small \
+    --user-data file://controlplane.yaml \
+    --subnet-id $SUBNET \
+    --security-group-ids $SECURITY_GROUP
+```
+
+#### Create the Worker Nodes
+
+```bash
+aws ec2 run-instances \
+    --region $REGION \
+    --image-id $AMI \
+    --count 3 \
+    --instance-type t3.small \
+    --user-data file://join.yaml \
+    --subnet-id $SUBNET \
+    --security-group-ids $SECURITY_GROUP
+```
+
+### Configure the Load Balancer
+
+```bash
+aws elbv2 create-target-group \
+    --region $REGION \
+    --name talos-aws-tutorial-tg \
+    --protocol TCP \
+    --port 6443 \
+    --vpc-id $VPC
+```
+
+Now, using the target group's ARN, register the control plane nodes:
+
+```bash
+aws elbv2 register-targets \
+    --region $REGION \
+    --target-group-arn $TARGET_GROUP_ARN \
+    --targets Id=$CP_NODE_1  Id=$CP_NODE_2  Id=$CP_NODE_3
+```
+
+Using the ARNs of the load balancer and target group from previous steps, create the listener:
+
+```bash
+aws elbv2 create-listener \
+    --region $REGION \
+    --load-balancer-arn $LOAD_BALANCER_ARN \
+    --protocol TCP \
+    --port 443 \
+    --default-actions Type=forward,TargetGroupArn=$TARGET_GROUP_ARN
+```
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig kubeconfig .
+```

--- a/docs/website/content/v0.5/en/guides/cloud/azure.md
+++ b/docs/website/content/v0.5/en/guides/cloud/azure.md
@@ -1,0 +1,278 @@
+---
+title: 'Azure'
+---
+
+## Creating a Cluster via the CLI
+
+In this guide we will create an HA Kubernetes cluster with 1 worker node.
+We assume existing [Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/), and some familiarity with Azure.
+If you need more information on Azure specifics, please see the [official Azure documentation](https://docs.microsoft.com/en-us/azure/).
+
+### Environment Setup
+
+We'll make use of the following environment variables throughout the setup.
+Edit the variables below with your correct information.
+
+```bash
+# Storage account to use
+export STORAGE_ACCOUNT="StorageAccountName"
+
+# Storage container to upload to
+export STORAGE_CONTAINER="StorageContainerName"
+
+# Resource group name
+export GROUP="ResourceGroupName"
+
+# Location
+export LOCATION="centralus"
+
+# Get storage account connection string based on info above
+export CONNECTION=$(az storage account show-connection-string \
+                    -n $STORAGE_ACCOUNT \
+                    -g $GROUP \
+                    -o tsv)
+```
+
+### Create the Image
+
+First, download the Azure image from a [Talos release](https://github.com/talos-systems/talos/releases).
+Once downloaded, untar with `tar -xvf /path/to/azure.tar.gz`
+
+#### Upload the VHD
+
+Once you have pulled down the image, you can upload it to blob storage with:
+
+```bash
+az storage blob upload \
+  --connection-string $CONNECTION \
+  --container-name $STORAGE_CONTAINER \
+  -f /path/to/extracted/talos-azure.vhd \
+  -n talos-azure.vhd
+```
+
+#### Register the Image
+
+Now that the image is present in our blob storage, we'll register it.
+
+```bash
+az image create \
+  --name talos \
+  --source https://$STORAGE_ACCOUNT.blob.core.windows.net/$STORAGE_CONTAINER/talos-azure.vhd \
+  --os-type linux \
+  -g $GROUP
+```
+
+### Network Infrastructure
+
+#### Virtual Networks and Security Groups
+
+Once the image is prepared, we'll want to work through setting up the network.
+Issue the following to create a network security group and add rules to it.
+
+```bash
+# Create vnet
+az network vnet create \
+  --resource-group $GROUP \
+  --location $LOCATION \
+  --name talos-vnet \
+  --subnet-name talos-subnet
+
+# Create network security group
+az network nsg create -g $GROUP -n talos-sg
+
+# Client -> OSD
+az network nsg rule create \
+  -g $GROUP \
+  --nsg-name talos-sg \
+  -n osd \
+  --priority 1001 \
+  --destination-port-ranges 50000 \
+  --direction inbound
+
+# Trustd
+az network nsg rule create \
+  -g $GROUP \
+  --nsg-name talos-sg \
+  -n trustd \
+  --priority 1002 \
+  --destination-port-ranges 50001 \
+  --direction inbound
+
+# etcd
+az network nsg rule create \
+  -g $GROUP \
+  --nsg-name talos-sg \
+  -n etcd \
+  --priority 1003 \
+  --destination-port-ranges 2379-2380 \
+  --direction inbound
+
+# Kubernetes API Server
+az network nsg rule create \
+  -g $GROUP \
+  --nsg-name talos-sg \
+  -n kube \
+  --priority 1004 \
+  --destination-port-ranges 6443 \
+  --direction inbound
+```
+
+#### Load Balancer
+
+We will create a public ip, load balancer, and a health check that we will use for our control plane.
+
+```bash
+# Create public ip
+az network public-ip create \
+  --resource-group $GROUP \
+  --name talos-public-ip \
+  --allocation-method static
+
+# Create lb
+az network lb create \
+  --resource-group $GROUP \
+  --name talos-lb \
+  --public-ip-address talos-public-ip \
+  --frontend-ip-name talos-fe \
+  --backend-pool-name talos-be-pool
+
+# Create health check
+az network lb probe create \
+  --resource-group $GROUP \
+  --lb-name talos-lb \
+  --name talos-lb-health \
+  --protocol tcp \
+  --port 6443
+
+# Create lb rule for 6443
+az network lb rule create \
+  --resource-group $GROUP \
+  --lb-name talos-lb \
+  --name talos-6443 \
+  --protocol tcp \
+  --frontend-ip-name talos-fe \
+  --frontend-port 6443 \
+  --backend-pool-name talos-be-pool \
+  --backend-port 6443 \
+  --probe-name talos-lb-health
+```
+
+#### Network Interfaces
+
+In Azure, we have to pre-create the NICs for our control plane so that they can be associated with our load balancer.
+
+```bash
+for i in $( seq 0 1 2 ); do
+  # Create public IP for each nic
+  az network public-ip create \
+    --resource-group $GROUP \
+    --name talos-controlplane-public-ip-$i \
+    --allocation-method static
+
+
+  # Create nic
+  az network nic create \
+    --resource-group $GROUP \
+    --name talos-controlplane-nic-$i \
+    --vnet-name talos-vnet \
+    --subnet talos-subnet \
+    --network-security-group talos-sg \
+    --public-ip-address talos-controlplane-public-ip-$i\
+    --lb-name talos-lb \
+    --lb-address-pools talos-be-pool
+done
+```
+
+### Cluster Configuration
+
+With our networking bits setup, we'll fetch the IP for our load balancer and create our configuration files.
+
+```bash
+LB_PUBLIC_IP=$(az network public-ip show \
+              --resource-group $GROUP \
+              --name talos-public-ip \
+              --query [ipAddress] \
+              --output tsv)
+
+talosctl gen config talos-k8s-azure-tutorial https://${LB_PUBLIC_IP}:6443
+```
+
+### Compute Creation
+
+We are now ready to create our azure nodes.
+
+```bash
+# Create availability set
+az vm availability-set create \
+  --name talos-controlplane-av-set \
+  -g $GROUP
+
+# Create controlplane 0
+az vm create \
+  --name talos-controlplane-0 \
+  --image talos \
+  --custom-data ./init.yaml \
+  -g $GROUP \
+  --admin-username talos \
+  --generate-ssh-keys \
+  --verbose \
+  --boot-diagnostics-storage $STORAGE_ACCOUNT \
+  --os-disk-size-gb 20 \
+  --nics talos-controlplane-nic-0 \
+  --availability-set talos-controlplane-av-set \
+  --no-wait
+
+# Create 2 more controlplane nodes
+for i in $( seq 1 2 ); do
+  az vm create \
+    --name talos-controlplane-$i \
+    --image talos \
+    --custom-data ./controlplane.yaml \
+    -g $GROUP \
+    --admin-username talos \
+    --generate-ssh-keys \
+    --verbose \
+    --boot-diagnostics-storage $STORAGE_ACCOUNT \
+    --os-disk-size-gb 20 \
+    --nics talos-controlplane-nic-$i \
+    --availability-set talos-controlplane-av-set \
+    --no-wait
+done
+
+# Create worker node
+  az vm create \
+    --name talos-worker-0 \
+    --image talos \
+    --custom-data ./join.yaml \
+    -g $GROUP \
+    --admin-username talos \
+    --generate-ssh-keys \
+    --verbose \
+    --boot-diagnostics-storage $STORAGE_ACCOUNT \
+    --nsg talos-sg \
+    --os-disk-size-gb 20 \
+    --no-wait
+
+# NOTES:
+# `--admin-username` and `--generate-ssh-keys` are required by the az cli,
+# but are not actually used by talos
+# `--os-disk-size-gb` is the backing disk for Kubernetes and any workload containers
+# `--boot-diagnostics-storage` is to enable console output which may be necessary
+# for troubleshooting
+```
+
+### Retrieve the `kubeconfig`
+
+You should now be able to interact with your cluster with `talosctl`.
+We will need to discover the public IP for our first control plane node first.
+
+```bash
+CONTROL_PLANE_0_IP=$(az network public-ip show \
+                    --resource-group $GROUP \
+                    --name talos-controlplane-public-ip-0 \
+                    --query [ipAddress] \
+                    --output tsv)
+talosctl --talosconfig ./talosconfig config endpoint $CONTROL_PLANE_0_IP
+talosctl --talosconfig ./talosconfig kubeconfig .
+kubectl --kubeconfig ./kubeconfig get nodes
+```

--- a/docs/website/content/v0.5/en/guides/cloud/digitalocean.md
+++ b/docs/website/content/v0.5/en/guides/cloud/digitalocean.md
@@ -1,0 +1,148 @@
+---
+title: 'Digital Ocean'
+---
+
+## Creating a Cluster via the CLI
+
+In this guide we will create an HA Kubernetes cluster with 1 worker node.
+We assume an existing [Space](https://www.digitalocean.com/docs/spaces/), and some familiarity with Digital Ocean.
+If you need more information on Digital Ocean specifics, please see the [official Digital Ocean documentation](https://www.digitalocean.com/docs/).
+
+### Create the Image
+
+First, download the Digital Ocean image from a Talos release.
+
+Using an upload method of your choice (`doctl` does not have Spaces support), upload the image to a space.
+Now, create an image using the URL of the uploaded image:
+
+```bash
+doctl compute image create \
+    --region $REGION \
+    --image-name talos-digital-ocean-tutorial \
+    --image-url https://talos-tutorial.$REGION.digitaloceanspaces.com/digital-ocean.raw.gz \
+    Talos
+```
+
+Save the image ID.
+We will need it when creating droplets.
+
+### Create a Load Balancer
+
+```bash
+doctl compute load-balancer create \
+    --region $REGION \
+    --name talos-digital-ocean-tutorial-lb \
+    --tag-name talos-digital-ocean-tutorial-control-plane \
+    --health-check protocol:tcp,port:6443,check_interval_seconds:10,response_timeout_seconds:5,healthy_threshold:5,unhealthy_threshold:3 \
+    --forwarding-rules entry_protocol:tcp,entry_port:443,target_protocol:tcp,target_port:6443
+```
+
+We will need the IP of the load balancer.
+Using the ID of the load balancer, run:
+
+```bash
+doctl compute load-balancer get --format IP <load balancer ID>
+```
+
+Save it, as we will need it in the next step.
+
+### Create the Machine Configuration Files
+
+#### Generating Base Configurations
+
+Using the DNS name of the loadbalancer created earlier, generate the base configuration files for the Talos machines:
+
+```bash
+$ talosctl gen config talos-k8s-digital-ocean-tutorial https://<load balancer IP or DNS>:<port>
+created init.yaml
+created controlplane.yaml
+created join.yaml
+created talosconfig
+```
+
+At this point, you can modify the generated configs to your liking.
+
+#### Validate the Configuration Files
+
+```bash
+$ talosctl validate --config init.yaml --mode cloud
+init.yaml is valid for cloud mode
+$ talosctl validate --config controlplane.yaml --mode cloud
+controlplane.yaml is valid for cloud mode
+$ talosctl validate --config join.yaml --mode cloud
+join.yaml is valid for cloud mode
+```
+
+### Create the Droplets
+
+#### Create the Bootstrap Node
+
+```bash
+doctl compute droplet create \
+    --region $REGION \
+    --image <image ID> \
+    --size s-2vcpu-4gb \
+    --enable-private-networking \
+    --tag-names talos-digital-ocean-tutorial-control-plane \
+    --user-data-file init.yaml \
+    --ssh-keys <ssh key fingerprint> \
+    talos-control-plane-1
+```
+
+> Note: Although SSH is not used by Talos, Digital Ocean still requires that an SSH key be associated with the droplet.
+> Create a dummy key that can be used to satisfy this requirement.
+
+#### Create the Remaining Control Plane Nodes
+
+Run the following twice, to give ourselves three total control plane nodes:
+
+```bash
+doctl compute droplet create \
+    --region $REGION \
+    --image <image ID> \
+    --size s-2vcpu-4gb \
+    --enable-private-networking \
+    --tag-names talos-digital-ocean-tutorial-control-plane \
+    --user-data-file controlplane.yaml \
+    --ssh-keys <ssh key fingerprint> \
+    talos-control-plane-2
+doctl compute droplet create \
+    --region $REGION \
+    --image <image ID> \
+    --size s-2vcpu-4gb \
+    --enable-private-networking \
+    --tag-names talos-digital-ocean-tutorial-control-plane \
+    --user-data-file controlplane.yaml \
+    --ssh-keys <ssh key fingerprint> \
+    talos-control-plane-3
+```
+
+#### Create the Worker Nodes
+
+Run the following to create a worker node:
+
+```bash
+doctl compute droplet create \
+    --region $REGION \
+    --image <image ID> \
+    --size s-2vcpu-4gb \
+    --enable-private-networking \
+    --user-data-file join.yaml \
+    --ssh-keys <ssh key fingerprint> \
+    talos-worker-1
+```
+
+### Retrieve the `kubeconfig`
+
+To configure `talosctl` we will need the first controla plane node's IP:
+
+```bash
+doctl compute droplet get --format PublicIPv4 <droplet ID>
+```
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig kubeconfig .
+```

--- a/docs/website/content/v0.5/en/guides/cloud/gcp.md
+++ b/docs/website/content/v0.5/en/guides/cloud/gcp.md
@@ -1,0 +1,167 @@
+---
+title: 'GCP'
+---
+
+## Creating a Cluster via the CLI
+
+In this guide, we will create an HA Kubernetes cluster in GCP with 1 worker node.
+We will assume an existing [Cloud Storage bucket](https://cloud.google.com/storage/docs/creating-buckets), and some familiarity with Google Cloud.
+If you need more information on Google Cloud specifics, please see the [official Google documentation](https://cloud.google.com/docs/).
+
+### Environment Setup
+
+We'll make use of the following environment variables throughout the setup.
+Edit the variables below with your correct information.
+
+```bash
+# Storage account to use
+export STORAGE_BUCKET="StorageBucketName"
+# Region
+export REGION="us-central1"
+```
+
+### Create the Image
+
+First, download the Google Cloud image from a Talos [release](https://github.com/talos-systems/talos/releases).
+These images are called `gcp.tar.gz`.
+
+#### Upload the Image
+
+Once you have downloaded the image, you can upload it to your storage bucket with:
+
+```bash
+gsutil cp /path/to/gcp.tar.gz gs://$STORAGE_BUCKET
+```
+
+#### Register the image
+
+Now that the image is present in our bucket, we'll register it.
+
+```bash
+gcloud compute images create talos \
+ --source-uri=gs://$STORAGE_BUCKET/gcp.tar.gz \
+ --guest-os-features=VIRTIO_SCSI_MULTIQUEUE
+```
+
+### Network Infrastructure
+
+#### Load Balancers and Firewalls
+
+Once the image is prepared, we'll want to work through setting up the network.
+Issue the following to create a firewall, load balancer, and their required components.
+
+```bash
+# Create Instance Group
+gcloud compute instance-groups unmanaged create talos-ig \
+  --zone $REGION-b
+
+# Create port for IG
+gcloud compute instance-groups set-named-ports talos-ig \
+    --named-ports tcp6443:6443 \
+    --zone $REGION-b
+
+# Create health check
+gcloud compute health-checks create tcp talos-health-check --port 6443
+
+# Create backend
+gcloud compute backend-services create talos-be \
+    --global \
+    --protocol TCP \
+    --health-checks talos-health-check \
+    --timeout 5m \
+    --port-name tcp6443
+
+# Add instance group to backend
+gcloud compute backend-services add-backend talos-be \
+    --global \
+    --instance-group talos-ig \
+    --instance-group-zone $REGION-b
+
+# Create tcp proxy
+gcloud compute target-tcp-proxies create talos-tcp-proxy \
+    --backend-service talos-be \
+    --proxy-header NONE
+
+# Create LB IP
+gcloud compute addresses create talos-lb-ip --global
+
+# Forward 443 from LB IP to tcp proxy
+gcloud compute forwarding-rules create talos-fwd-rule \
+    --global \
+    --ports 443 \
+    --address talos-lb-ip \
+    --target-tcp-proxy talos-tcp-proxy
+
+# Create firewall rule for health checks
+ gcloud compute firewall-rules create talos-controlplane-firewall \
+     --source-ranges 130.211.0.0/22,35.191.0.0/16 \
+     --target-tags talos-controlplane \
+     --allow tcp:6443
+```
+
+### Cluster Configuration
+
+With our networking bits setup, we'll fetch the IP for our load balancer and create our configuration files.
+
+```bash
+LB_PUBLIC_IP=$(gcloud compute forwarding-rules describe talos-fwd-rule \
+               --global \
+               --format json \
+               | jq -r .IPAddress)
+
+talosctl gen config talos-k8s-gcp-tutorial https://${LB_PUBLIC_IP}:443
+```
+
+### Compute Creation
+
+We are now ready to create our azure nodes.
+
+```bash
+# Create control plane 0
+gcloud compute instances create talos-controlplane-0 \
+  --image talos \
+  --zone $REGION-b \
+  --tags talos-controlplane \
+  --boot-disk-size 20GB \
+  --metadata-from-file=user-data=./init.yaml
+
+# Create control plane 1/2
+for i in $( seq 1 2 ); do
+  gcloud compute instances create talos-controlplane-$i \
+    --image talos \
+    --zone $REGION-b \
+    --tags talos-controlplane \
+    --boot-disk-size 20GB \
+    --metadata-from-file=user-data=./controlplane.yaml
+done
+
+# Add control plane nodes to instance group
+for i in $( seq 0 1 2 ); do
+  gcloud compute instance-groups unmanaged add-instances talos-ig \
+      --zone $REGION-b \
+      --instances talos-controlplane-$i
+done
+
+# Create worker
+gcloud compute instances create talos-worker-0 \
+  --image talos \
+  --zone $REGION-b \
+  --boot-disk-size 20GB \
+  --metadata-from-file=user-data=./join.yaml
+```
+
+### Retrieve the `kubeconfig`
+
+You should now be able to interact with your cluster with `talosctl`.
+We will need to discover the public IP for our first control plane node first.
+
+```bash
+CONTROL_PLANE_0_IP=$(gcloud compute instances describe talos-controlplane-0 \
+                     --zone $REGION-b \
+                     --format json \
+                     | jq -r '.networkInterfaces[0].accessConfigs[0].natIP')
+
+talosctl --talosconfig ./talosconfig config endpoint $CONTROL_PLANE_0_IP
+talosctl --talosconfig ./talosconfig kubeconfig .
+kubectl --kubeconfig ./kubeconfig get nodes
+```

--- a/docs/website/content/v0.5/en/guides/cloud/vmware.md
+++ b/docs/website/content/v0.5/en/guides/cloud/vmware.md
@@ -1,0 +1,215 @@
+---
+title: 'VMware'
+---
+
+## Creating a Cluster via the `govc` CLI
+
+In this guide we will create an HA Kubernetes cluster with 3 worker nodes.
+We will use the `govc` cli which can be downloaded [here](https://github.com/vmware/govmomi/tree/master/govc#installation).
+
+### Prerequisites
+
+Prior to starting, it is important to have the following infrastructure in place and available:
+
+- DHCP server
+- Load Balancer or DNS address for cluster endpoint
+  - If using a load balancer, the most common setup is to balance `tcp/443` across the control plane nodes `tcp/6443`
+  - If using a DNS address, the A record should return back the addresses of the control plane nodes
+
+### Create the Machine Configuration Files
+
+#### Generating Base Configurations
+
+Using the DNS name or name of the loadbalancer used in the prereq steps, generate the base configuration files for the Talos machines:
+
+```bash
+$ talosctl gen config talos-k8s-vmware-tutorial https://<load balancer IP or DNS>:<port>
+created init.yaml
+created controlplane.yaml
+created join.yaml
+created talosconfig
+```
+
+```bash
+$ talosctl gen config talos-k8s-vmware-tutorial https://<DNS name>:6443
+created init.yaml
+created controlplane.yaml
+created join.yaml
+created talosconfig
+```
+
+At this point, you can modify the generated configs to your liking.
+
+#### Validate the Configuration Files
+
+```bash
+$ talosctl validate --config init.yaml --mode cloud
+init.yaml is valid for cloud mode
+$ talosctl validate --config controlplane.yaml --mode cloud
+controlplane.yaml is valid for cloud mode
+$ talosctl validate --config join.yaml --mode cloud
+join.yaml is valid for cloud mode
+```
+
+### Set Environment Variables
+
+`govc` makes use of the following environment variables
+
+```bash
+export GOVC_URL=<vCenter url>
+export GOVC_USERNAME=<vCenter username>
+export GOVC_PASSWORD=<vCenter password>
+```
+
+> Note: If your vCenter installation makes use of self signed certificates, you'll want to export `GOVC_INSECURE=true`.
+
+There are some additional variables that you may need to set:
+
+```bash
+export GOVC_DATACENTER=<vCenter datacenter>
+export GOVC_RESOURCE_POOL=<vCenter resource pool>
+export GOVC_DATASTORE=<vCenter datastore>
+export GOVC_NETWORK=<vCenter network>
+```
+
+### Download the OVA
+
+A `talos.ova` asset is published with each [release](https://github.com/talos-systems/talos/releases).
+We will refer to the version of the release as `$TALOS_VERSION` below.
+It can be easily exported with `export TALOS_VERSION="v0.3.0-alpha.10"` or similar.
+
+```bash
+curl -LO https://github.com/talos-systems/talos/releases/download/$TALOS_VERSION/talos.ova
+```
+
+### Import the OVA into vCenter
+
+We'll need to repeat this step for each Talos node we want to create.
+In a typical HA setup, we'll have 3 control plane nodes and N workers.
+In the following example, we'll setup a HA control plane with two worker nodes.
+
+```bash
+govc import.ova -name talos-$TALOS_VERSION /path/to/downloaded/talos.ova
+```
+
+#### Create the Bootstrap Node
+
+We'll clone the OVA to create the bootstrap node (our first control plane node).
+
+```bash
+govc vm.clone -on=false -vm talos-$TALOS_VERSION control-plane-1
+```
+
+Talos makes use of the `guestinfo` facility of VMware to provide the machine/cluster configuration.
+This can be set using the `govc vm.change` command.
+To facilitate persistent storage using the vSphere cloud provider integration with Kubernetes, `disk.enableUUID=1` is used.
+
+```bash
+govc vm.change \
+  -e "guestinfo.talos.config=$(cat init.yaml | base64)" \
+  -e "disk.enableUUID=1" \
+  -vm /ha-datacenter/vm/control-plane-1
+```
+
+#### Update Hardware Resources for the Bootstrap Node
+
+- `-c` is used to configure the number of cpus
+- `-m` is used to configure the amount of memory (in MB)
+
+```bash
+govc vm.change \
+  -c 2 \
+  -m 4096 \
+  -vm /ha-datacenter/vm/control-plane-1
+```
+
+The following can be used to adjust the ephemeral disk size.
+
+```bash
+govc vm.disk.change -vm control-plane-1 -disk.name disk-1000-0 -size 10G
+```
+
+```bash
+govc vm.power -on control-plane-1
+```
+
+#### Create the Remaining Control Plane Nodes
+
+```bash
+govc vm.clone -on=false -vm talos-$TALOS_VERSION control-plane-2
+govc vm.change \
+  -e "guestinfo.talos.config=$(base64 controlplane.yaml)" \
+  -e "disk.enableUUID=1" \
+  -vm /ha-datacenter/vm/control-plane-2
+govc vm.clone -on=false -vm talos-$TALOS_VERSION control-plane-3
+govc vm.change \
+  -e "guestinfo.talos.config=$(base64 controlplane.yaml)" \
+  -e "disk.enableUUID=1" \
+  -vm /ha-datacenter/vm/control-plane-3
+```
+
+```bash
+govc vm.change \
+  -c 2 \
+  -m 4096 \
+  -vm /ha-datacenter/vm/control-plane-2
+govc vm.change \
+  -c 2 \
+  -m 4096 \
+  -vm /ha-datacenter/vm/control-plane-3
+```
+
+```bash
+govc vm.disk.change -vm control-plane-2 -disk.name disk-1000-0 -size 10G
+govc vm.disk.change -vm control-plane-3 -disk.name disk-1000-0 -size 10G
+```
+
+```bash
+govc vm.power -on control-plane-2
+govc vm.power -on control-plane-3
+```
+
+#### Update Settings for the Worker Nodes
+
+```bash
+govc vm.clone -on=false -vm talos-$TALOS_VERSION worker-1
+govc vm.change \
+  -e "guestinfo.talos.config=$(base64 join.yaml)" \
+  -e "disk.enableUUID=1" \
+  -vm /ha-datacenter/vm/worker-1
+govc vm.clone -on=false -vm talos-$TALOS_VERSION worker-2
+govc vm.change \
+  -e "guestinfo.talos.config=$(base64 join.yaml)" \
+  -e "disk.enableUUID=1" \
+  -vm /ha-datacenter/vm/worker-2
+```
+
+```bash
+govc vm.change \
+  -c 4 \
+  -m 8192 \
+  -vm /ha-datacenter/vm/worker-1
+govc vm.change \
+  -c 4 \
+  -m 8192 \
+  -vm /ha-datacenter/vm/worker-2
+```
+
+```bash
+govc vm.disk.change -vm worker-1 -disk.name disk-1000-0 -size 50G
+govc vm.disk.change -vm worker-2 -disk.name disk-1000-0 -size 50G
+```
+
+```bash
+govc vm.power -on worker-1
+govc vm.power -on worker-2
+```
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig kubeconfig .
+```

--- a/docs/website/content/v0.5/en/guides/getting-started/help.md
+++ b/docs/website/content/v0.5/en/guides/getting-started/help.md
@@ -1,0 +1,20 @@
+---
+title: How to Get Help
+---
+
+There are a few ways to get help with your Talos project.
+
+### Open Source Community
+
+We have an active and helpful open source community who would be happy to give you assistance.
+The best way to get a hold of us would be to join our [Slack channel](https://slack.dev.talos-systems.io/).
+If you think you have found a bug, or would like to file a feature request, please use our [GitHub issue tracker](https://github.com/talos-systems/talos/issues).
+We also hold weekly office hours on Zoom.
+[Join the Google Group](https://groups.google.com/a/talos-systems.com/forum/#!forum/community) to receive calendar invitations to the scheduled meetings.
+
+### Commercial Support and Consulting
+
+If you are using Talos in a production setting, and need consulting services to get started or to integrate Talos into your existing environment, we can help.
+Talos Systems, Inc. also offers support contracts with SLA (Service Level Agreement)-bound terms for mission-critical environments.
+
+[Learn More](https://www.talos-systems.com/subscription/)

--- a/docs/website/content/v0.5/en/guides/getting-started/intro.md
+++ b/docs/website/content/v0.5/en/guides/getting-started/intro.md
@@ -1,0 +1,21 @@
+---
+title: Introduction to Talos
+---
+
+Welcome to the Talos documentation!
+Talos is an open source platform to host and maintain Kubernetes clusters.
+It includes a purpose-built operating system and associated management tools.
+It can run on all major cloud providers, virtualization platforms, and bare metal hardware.
+
+All system management is done via an API, and there is no shell or interactive console.
+Some of the capabilities and benefits provided by Talos include:
+
+- **Security**: Talos reduces your attack surface by practicing the Principle of Least Privilege (PoLP) and by securing the API with mutual TLS (mTLS) authentication.
+- **Predictability**: Talos eliminates unneeded variables and reduces unknown factors in your environment by employing immutable infrastructure ideology.
+- **Evolvability**: Talos simplifies your architecture and increases your ability to easily accommodate future changes.
+
+Talos is flexible and can be deployed in a variety of ways, but the easiest way to get started and experiment with the system is to run a local cluster on your laptop or workstation.
+There are two options:
+
+- [Run a Docker-based local cluster](/docs/v0.5/en/guides/local/docker) on your Linux or Mac workstation
+- [Run a Firecracker micro-VM-based](/docs/v0.5/en/guides/local/firecracker) cluster on your Linux workstation

--- a/docs/website/content/v0.5/en/guides/local/docker.md
+++ b/docs/website/content/v0.5/en/guides/local/docker.md
@@ -1,0 +1,48 @@
+---
+title: Docker
+---
+
+In this guide we will create a Kubernetes cluster in Docker, using a containerized version of Talos.
+
+Running Talos in Docker is intended to be used in CI pipelines, and local testing when you need a quick and easy cluster.
+Furthermore, if you are running Talos in production, it provides an excellent way for developers to develop against the same version of Talos.
+
+## Requirements
+
+The follow are requirements for running Talos in Docker:
+
+- Docker 18.03 or greater
+- a recent version of [`talosctl`](https://github.com/talos-systems/talos/releases)
+
+## Create the Cluster
+
+Creating a local cluster is as simple as:
+
+```bash
+talosctl cluster create --wait
+```
+
+Once the above finishes successfully, your talosconfig(`~/.talos/config`) will be configured to point to the new cluster.
+
+> Note: Startup times can take up to a minute before the cluster is available.
+
+## Retrieve and Configure the `kubeconfig`
+
+```bash
+talosctl kubeconfig .
+kubectl --kubeconfig kubeconfig config set-cluster talos_default --server https://127.0.0.1:6443
+```
+
+## Using the Cluster
+
+Once the cluster is available, you can make use of `talosctl` and `kubectl` to interact with the cluster.
+For example, to view current running containers, run `talosctl containers` for a list of containers in the `system` namespace, or `talosctl containers -k` for the `k8s.io` namespace.
+To view the logs of a container, use `talosctl logs <container>` or `talosctl logs -k <container>`.
+
+## Cleaning Up
+
+To cleanup, run:
+
+```bash
+talosctl cluster destroy
+```

--- a/docs/website/content/v0.5/en/guides/local/firecracker.md
+++ b/docs/website/content/v0.5/en/guides/local/firecracker.md
@@ -1,0 +1,290 @@
+---
+title: Firecracker
+---
+
+In this guide we will create a Kubernetes cluster using Firecracker.
+
+## Requirements
+
+- Linux
+- a kernel with KVM enabled (`/dev/kvm` must exist)
+- at least `CAP_SYS_ADMIN` and `CAP_NET_ADMIN` capabilities
+- [firecracker](https://github.com/firecracker-microvm/firecracker/releases) (v0.21.0 or higher)
+- `bridge`, and `firewall` CNI plugins from the [standard CNI plugins](https://github.com/containernetworking/cni), and `tc-redirect-tap` CNI plugin from the [Firecracker Go SDK](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni) installed to `/opt/cni/bin`
+- iptables
+- `/etc/cni/conf.d` directory should exist
+- `/var/run/netns` directory should exist
+
+## Installation
+
+### How to get firecracker (v0.21.0 or higher)
+
+You can download `firecracker` binary via
+[github.com/firecracker-microvm/firecracker/releases](https://github.com/firecracker-microvm/firecracker/releases)
+
+```bash
+curl https://github.com/firecracker-microvm/firecracker/releases/download/<version>/firecracker-<version>-<arch> -L -o firecracker
+```
+
+For example version `v0.21.1` for `linux` platform:
+
+```bash
+curl https://github.com/firecracker-microvm/firecracker/releases/download/v0.21.1/firecracker-v0.21.1-x86_64 -L -o firecracker
+sudo cp firecracker /usr/local/bin
+sudo chmod +x /usr/local/bin/firecracker
+```
+
+### Install talosctl
+
+You can download `talosctl` and all required binaries via
+[github.com/talos-systems/talos/releases](https://github.com/talos-systems/talos/releases)
+
+```bash
+curl https://github.com/talos-systems/talos/releases/download/<version>/talosctl-<platform>-<arch> -L -o talosctl
+```
+
+For example version `v0.4.1` for `linux` platform:
+
+```bash
+curl https://github.com/talos-systems/talos/releases/download/v0.4.1/talosctl-linux-amd64 -L -o talosctl
+sudo cp talosctl /usr/local/bin
+sudo chmod +x /usr/local/bin/talosctl
+```
+
+### Install bridge and firewall required CNI plugins
+
+You can download standard CNI required plugins via
+[github.com/containernetworking/plugins/releases](https://github.com/containernetworking/plugins/releases)
+
+```bash
+curl https://github.com/containernetworking/plugins/releases/download/<version>/cni-plugins-<platform>-<arch>-<version>tgz -L -o cni-plugins-<platform>-<arch>-<version>.tgz
+```
+
+For example version `v0.8.5` for `linux` platform:
+
+```bash
+curl https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz -L -o cni-plugins-linux-amd64-v0.8.5.tgz
+mkdir cni-plugins-linux
+tar -xf cni-plugins-linux-amd64-v0.8.5.tgz -C cni-plugins-linux
+sudo mkdir -p /opt/cni/bin
+sudo cp cni-plugins-linux/{bridge,firewall} /opt/cni/bin
+```
+
+### Install tc-redirect-tap CNI plugin
+
+You should install CNI plugin from the Firecracker Go SDK repository [github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni)
+
+```bash
+go get -d github.com/firecracker-microvm/firecracker-go-sdk
+cd $GOPATH/src/github.com/firecracker-microvm/firecracker-go-sdk/cni
+make all
+sudo cp tc-redirect-tap /opt/cni/bin
+```
+
+## Create the Cluster
+
+```bash
+sudo talosctl cluster create --provisioner firecracker
+```
+
+Once the above finishes successfully, your talosconfig(`~/.talos/config`) will be configured to point to the new cluster.
+
+## Retrieve and Configure the `kubeconfig`
+
+```bash
+talosctl kubeconfig .
+```
+
+## Using the Cluster
+
+Once the cluster is available, you can make use of `talosctl` and `kubectl` to interact with the cluster.
+For example, to view current running containers, run `talosctl containers` for a list of containers in the `system` namespace, or `talosctl containers -k` for the `k8s.io` namespace.
+To view the logs of a container, use `talosctl logs <container>` or `talosctl logs -k <container>`.
+
+A bridge interface will be created, and assigned the default IP 10.5.0.1.
+Each node will be directly accessible on the subnet specified at cluster creation time.
+A loadbalancer runs on 10.5.0.1 by default, which handles loadbalancing for the Talos, and Kubernetes APIs.
+
+You can see a summary of the cluster state by running:
+
+```bash
+$ talosctl cluster show --provisioner firecracker
+PROVISIONER       firecracker
+NAME              talos-default
+NETWORK NAME      talos-default
+NETWORK CIDR      10.5.0.0/24
+NETWORK GATEWAY   10.5.0.1
+NETWORK MTU       1500
+
+NODES:
+
+NAME                     TYPE           IP         CPU    RAM      DISK
+talos-default-master-1   Init           10.5.0.2   1.00   1.6 GB   4.3 GB
+talos-default-master-2   ControlPlane   10.5.0.3   1.00   1.6 GB   4.3 GB
+talos-default-master-3   ControlPlane   10.5.0.4   1.00   1.6 GB   4.3 GB
+talos-default-worker-1   Join           10.5.0.5   1.00   1.6 GB   4.3 GB
+```
+
+## Cleaning Up
+
+To cleanup, run:
+
+```bash
+sudo talosctl cluster destroy --provisioner firecracker
+```
+
+> Note: In that case that the host machine is rebooted before destroying the cluster, you may need to manually remove `~/.talos/clusters/talos-default`.
+
+## Manual Clean Up
+
+The `talosctl cluster destroy` command depends heavily on the clusters state directory.
+It contains all related information of the cluster.
+The PIDs and network associated with the cluster nodes.
+
+If you happened to have deleted the state folder by mistake or you would like to cleanup
+the environment, here are the steps how to do it manually:
+
+### Stopping VMs
+
+Find the process of `firecracker --api-sock` execute:
+
+```bash
+ps -elf | grep '[f]irecracker --api-sock'
+```
+
+To stop the VMs manually, execute:
+
+```bash
+sudo kill -s SIGTERM <PID>
+```
+
+Example output, where VMs are running with PIDs **158065** and **158216**
+
+```bash
+ps -elf | grep '[f]irecracker --api-sock'
+4 S root      158065  157615 44  80   0 - 264152 -     07:54 ?        00:34:25 firecracker --api-sock /root/.talos/clusters/k8s/k8s-master-1.sock
+4 S root      158216  157617 18  80   0 - 264152 -     07:55 ?        00:14:47 firecracker --api-sock /root/.talos/clusters/k8s/k8s-worker-1.sock
+sudo kill -s SIGTERM 158065
+sudo kill -s SIGTERM 158216
+```
+
+### Remove VMs
+
+Find the process of `talosctl firecracker-launch` execute:
+
+```bash
+ps -elf | grep 'talosctl firecracker-launch'
+```
+
+To remove the VMs manually, execute:
+
+```bash
+sudo kill -s SIGTERM <PID>
+```
+
+Example output, where VMs are running with PIDs **157615** and **157617**
+
+```bash
+ps -elf | grep '[t]alosctl firecracker-launch'
+0 S root      157615    2835  0  80   0 - 184934 -     07:53 ?        00:00:00 talosctl firecracker-launch
+0 S root      157617    2835  0  80   0 - 185062 -     07:53 ?        00:00:00 talosctl firecracker-launch
+sudo kill -s SIGTERM 157615
+sudo kill -s SIGTERM 157617
+```
+
+### Remove load balancer
+
+Find the process of `talosctl loadbalancer-launch` execute:
+
+```bash
+ps -elf | grep 'talosctl loadbalancer-launch'
+```
+
+To remove the LB manually, execute:
+
+```bash
+sudo kill -s SIGTERM <PID>
+```
+
+Example output, where loadbalancer is running with PID **157609**
+
+```bash
+ps -elf | grep '[t]alosctl loadbalancer-launch'
+4 S root      157609    2835  0  80   0 - 184998 -     07:53 ?        00:00:07 talosctl loadbalancer-launch --loadbalancer-addr 10.5.0.1 --loadbalancer-upstreams 10.5.0.2
+sudo kill -s SIGTERM 157609
+```
+
+### Remove network
+
+This is more tricky part as if you have already deleted the state folder.
+If you didn't then it is written in the `state.yaml` in the
+`/root/.talos/clusters/<cluster-name>` directory.
+
+```bash
+sudo cat /root/.talos/clusters/<cluster-name>/state.yaml | grep bridgename
+bridgename: talos<uuid>
+```
+
+If you only had one cluster, then it will be the interface with name
+`talos<uuid>`
+
+```bash
+46: talos<uuid>: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
+    link/ether a6:72:f4:0a:d3:9c brd ff:ff:ff:ff:ff:ff
+    inet 10.5.0.1/24 brd 10.5.0.255 scope global talos17c13299
+       valid_lft forever preferred_lft forever
+    inet6 fe80::a472:f4ff:fe0a:d39c/64 scope link
+       valid_lft forever preferred_lft forever
+```
+
+To remove this interface:
+
+```bash
+sudo ip link del talos<uuid>
+```
+
+### Remove state directory
+
+To remove the state directory execute:
+
+```bash
+sudo rm -Rf /root/.talos/clusters/<cluster-name>
+```
+
+## Troubleshooting
+
+### Logs
+
+Inspect logs directory
+
+```bash
+sudo cat /root/.talos/clusters/<cluster-name>/*.log
+```
+
+Logs are saved under `<cluster-name>-<role>-<node-id>.log`
+
+For example in case of **k8s** cluster name:
+
+```bash
+sudo ls -la /root/.talos/clusters/k8s | grep log
+-rw-r--r--. 1 root root      69415 Apr 26 20:58 k8s-master-1.log
+-rw-r--r--. 1 root root      68345 Apr 26 20:58 k8s-worker-1.log
+-rw-r--r--. 1 root root      24621 Apr 26 20:59 lb.log
+```
+
+Inspect logs during the installation
+
+```bash
+sudo su -
+tail -f /root/.talos/clusters/<cluster-name>/*.log
+```
+
+## Post-installation
+
+After executing these steps and you should be able to use `kubectl`
+
+```bash
+sudo talosctl kubeconfig .
+mv kubeconfig $HOME/.kube/config
+sudo chown $USER:$USER $HOME/.kube/config
+```

--- a/docs/website/content/v0.5/en/guides/metal/matchbox.md
+++ b/docs/website/content/v0.5/en/guides/metal/matchbox.md
@@ -1,0 +1,188 @@
+---
+title: Matchbox
+---
+
+## Creating a Cluster
+
+In this guide we will create an HA Kubernetes cluster with 3 worker nodes.
+We assume an existing load balancer, matchbox deployment, and some familiarity with iPXE.
+
+We leave it up to the user to decide if they would like to use static networking, or DHCP.
+The setup and configuration of DHCP will not be covered.
+
+### Create the Machine Configuration Files
+
+#### Generating Base Configurations
+
+Using the DNS name of the load balancer, generate the base configuration files for the Talos machines:
+
+```bash
+$ talosctl gen config talos-k8s-metal-tutorial https://<load balancer IP or DNS>:<port>
+created init.yaml
+created controlplane.yaml
+created join.yaml
+created talosconfig
+```
+
+At this point, you can modify the generated configs to your liking.
+
+#### Validate the Configuration Files
+
+```bash
+$ talosctl validate --config init.yaml --mode metal
+init.yaml is valid for metal mode
+$ talosctl validate --config controlplane.yaml --mode metal
+controlplane.yaml is valid for metal mode
+$ talosctl validate --config join.yaml --mode metal
+join.yaml is valid for metal mode
+```
+
+#### Publishing the Machine Configuration Files
+
+In bare-metal setups it is up to the user to provide the configuration files over HTTP(S).
+A special kernel parameter (`talos.config`) must be used to inform Talos about _where_ it should retreive its' configuration file.
+To keep things simple we will place `init.yaml`, `controlplane.yaml`, and `join.yaml` into Matchbox's `assets` directory.
+This directory is automatically served by Matchbox.
+
+### Create the Matchbox Configuration Files
+
+The profiles we will create will reference `vmlinuz`, and `initramfs.xz`.
+Download these files from the [release](https://github.com/talos-systems/talos/releases) of your choice, and place them in `/var/lib/matchbox/assets`.
+
+#### Profiles
+
+##### The Bootstrap Node
+
+```json
+{
+  "id": "init",
+  "name": "init",
+  "boot": {
+    "kernel": "/assets/vmlinuz",
+    "initrd": ["/assets/initramfs.xz"],
+    "args": [
+      "initrd=initramfs.xz",
+      "page_poison=1",
+      "slab_nomerge",
+      "slub_debug=P",
+      "pti=on",
+      "console=tty0",
+      "console=ttyS0",
+      "printk.devkmsg=on",
+      "talos.platform=metal",
+      "talos.config=http://matchbox.talos.dev/assets/init.yaml"
+    ]
+  }
+}
+```
+
+> Note: Be sure to change `http://matchbox.talos.dev` to the endpoint of your matchbox server.
+
+##### Additional Control Plane Nodes
+
+```json
+{
+  "id": "control-plane",
+  "name": "control-plane",
+  "boot": {
+    "kernel": "/assets/vmlinuz",
+    "initrd": ["/assets/initramfs.xz"],
+    "args": [
+      "initrd=initramfs.xz",
+      "page_poison=1",
+      "slab_nomerge",
+      "slub_debug=P",
+      "pti=on",
+      "console=tty0",
+      "console=ttyS0",
+      "printk.devkmsg=on",
+      "talos.platform=metal",
+      "talos.config=http://matchbox.talos.dev/assets/controlplane.yaml"
+    ]
+  }
+}
+```
+
+##### Worker Nodes
+
+```json
+{
+  "id": "default",
+  "name": "default",
+  "boot": {
+    "kernel": "/assets/vmlinuz",
+    "initrd": ["/assets/initramfs.xz"],
+    "args": [
+      "initrd=initramfs.xz",
+      "page_poison=1",
+      "slab_nomerge",
+      "slub_debug=P",
+      "pti=on",
+      "console=tty0",
+      "console=ttyS0",
+      "printk.devkmsg=on",
+      "talos.platform=metal",
+      "talos.config=http://matchbox.talos.dev/assets/join.yaml"
+    ]
+  }
+}
+```
+
+#### Groups
+
+Now, create the following groups, and ensure that the `selector`s are accurate for your specific setup.
+
+```json
+{
+  "id": "control-plane-1",
+  "name": "control-plane-1",
+  "profile": "init",
+  "selector": {
+    ...
+  }
+}
+```
+
+```json
+{
+  "id": "control-plane-2",
+  "name": "control-plane-2",
+  "profile": "control-plane",
+  "selector": {
+    ...
+  }
+}
+```
+
+```json
+{
+  "id": "control-plane-3",
+  "name": "control-plane-3",
+  "profile": "control-plane",
+  "selector": {
+    ...
+  }
+}
+```
+
+```json
+{
+  "id": "default",
+  "name": "default",
+  "profile": "default"
+}
+```
+
+### Boot the Machines
+
+Now that we have our configuraton files in place, boot all the machines.
+Talos will come up on each machine, grab its' configuration file, and bootstrap itself.
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig kubeconfig .
+```

--- a/docs/website/content/v0.5/en/guides/metal/overview.md
+++ b/docs/website/content/v0.5/en/guides/metal/overview.md
@@ -1,0 +1,20 @@
+---
+title: Deploying Talos on Bare Metal
+---
+
+In this section we will show how you can setup Talos in bare-metal environments.
+
+## Kernel Parameters
+
+The following is a list of kernel parameters you will need to set:
+
+- `talos.config` (required) the HTTP(S) URL at which the machine data can be found
+- `talos.platform` (required) should be 'metal' for bare-metal installs
+
+Talos also enforces some minimum requirements from the KSPP (kernel self-protection project).
+The follow parameters are required:
+
+- `page_poison=1`
+- `slab_nomerge`
+- `slub_debug=P`
+- `pti=on`

--- a/docs/website/content/v0.5/en/troubleshooting/overview.md
+++ b/docs/website/content/v0.5/en/troubleshooting/overview.md
@@ -1,0 +1,5 @@
+---
+title: 'Troubleshooting'
+---
+
+In this section we will provide guidance on troubleshooting various scenarios you may find yourself in.

--- a/docs/website/content/v0.5/en/troubleshooting/pki.md
+++ b/docs/website/content/v0.5/en/troubleshooting/pki.md
@@ -1,0 +1,48 @@
+---
+title: 'PKI'
+---
+
+## Generating an Administrator Key Pair
+
+In order to create a key pair, you will need the root CA.
+
+Save the the CA public key, and CA private key as `ca.crt`, and `ca.key` respectively.
+Now, run the following commands to generate a certificate:
+
+```bash
+talosctl gen key --name admin
+talosctl gen csr --key admin.key --ip 127.0.0.1
+talosctl gen crt --ca ca --csr admin.csr --name admin
+```
+
+Now, base64 encode `admin.crt`, and `admin.key`:
+
+```bash
+cat admin.crt | base64
+cat admin.key | base64
+```
+
+You can now set the `crt` and `key` fields in the `talosconfig` to the base64 encoded strings.
+
+## Renewing an Expired Administrator Certificate
+
+In order to renew the certificate, you will need the root CA, and the admin private key.
+The base64 encoded key can be found in any one of the control plane node's configuration file.
+Where it is exactly will depend on the specific version of the configuration file you are using.
+
+Save the the CA public key, CA private key, and admin private key as `ca.crt`, `ca.key`, and `admin.key` respectively.
+Now, run the following commands to generate a certificate:
+
+```bash
+talosctl gen csr --key admin.key --ip 127.0.0.1
+talosctl gen crt --ca ca --csr admin.csr --name admin
+```
+
+You should see `admin.crt` in your current directory.
+Now, base64 encode `admin.crt`:
+
+```bash
+cat admin.crt | base64
+```
+
+You can now set the certificate in the `talosconfig` to the base64 encoded string.

--- a/docs/website/docgen.js
+++ b/docs/website/docgen.js
@@ -4,17 +4,12 @@ const path = require('path')
 const fs = require('fs-extra')
 const glob = require('glob')
 const config = require('./docgen.config')
-const marked = require('marked')
-const prism = require('prismjs')
-const loadLanguages = require('prismjs/components/')
-
-marked.setOptions({
-  highlight(code, lang) {
-    loadLanguages([lang])
-
-    return prism.highlight(code, prism.languages[lang], lang)
-  }
-})
+const prism = require('markdown-it-prism')
+const md = require('markdown-it')({ html: true, typographer: true })
+  .use(require('markdown-it-anchor'), {
+    permalink: true
+  })
+  .use(prism, {})
 
 const args = process.argv
   .slice(2)
@@ -191,11 +186,12 @@ const Docgen = {
 
     const frontmatterContent = frontmatter(content)
 
-    const title = marked(frontmatterContent.attributes.title || '')
+    const title = md
+      .render(frontmatterContent.attributes.title || '')
       .replace('<p>', '')
       .replace('</p>\n', '')
 
-    const markdownContent = marked(frontmatterContent.body)
+    const markdownContent = md.render(frontmatterContent.body)
 
     // contentFilePath = /my_absolute_file/content/content-delivery/en/topics/introduction.md
 

--- a/docs/website/nuxt.config.js
+++ b/docs/website/nuxt.config.js
@@ -44,9 +44,12 @@ export default {
     '@nuxtjs/eslint-module',
     // Doc: https://github.com/nuxt-community/nuxt-tailwindcss
     '@nuxtjs/tailwindcss',
-    ['@nuxtjs/google-analytics', {
-      id: 'UA-141692582-2'
-    }],
+    [
+      '@nuxtjs/google-analytics',
+      {
+        id: 'UA-141692582-2'
+      }
+    ]
   ],
 
   /*

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -3163,9 +3163,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "clipboard": {
@@ -5217,9 +5217,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "flatten": {
@@ -6087,9 +6087,9 @@
           }
         },
         "yargs-parser": {
-          "version": "18.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-          "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -7048,6 +7048,14 @@
         "type-check": "~0.3.2"
       }
     },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -7325,10 +7333,30 @@
         "object-visit": "^1.0.0"
       }
     },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.2.7.tgz",
+      "integrity": "sha512-REFmIaSS6szaD1bye80DMbp7ePwsPNvLTR5HunsUcZ0SG0rWJQ+Pz24R4UlTKtjKBPhxo0v0tOBDYjZQQknW8Q=="
+    },
+    "markdown-it-prism": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-prism/-/markdown-it-prism-2.0.5.tgz",
+      "integrity": "sha512-u2jErcoLCnENIOUnEbS9w9RWUGiId8fjQovD0Gbo4iT8tZU0/Un4v72E8g8sj/NAzieSCvFVG6KtMwlurSBMnw==",
+      "requires": {
+        "prismjs": "1.19.0"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -7344,6 +7372,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -9979,13 +10012,10 @@
       }
     },
     "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -9996,9 +10026,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -10627,9 +10657,9 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
       "dev": true
     },
     "style-resources-loader": {
@@ -11160,6 +11190,11 @@
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.4.10",

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "axios": "^0.19.2",
     "front-matter": "^3.1.0",
-    "marked": "^0.7.0",
+    "markdown-it": "^10.0.0",
+    "markdown-it-anchor": "^5.2.7",
+    "markdown-it-prism": "^2.0.5",
     "nuxt": "^2.12.0",
     "nuxt-webfontloader": "^1.1.0",
     "prismjs": "^1.19.0"


### PR DESCRIPTION
- add 0.5 docs branched from 0.4
- add intro page and "get help" pages
- moved Docker and Firecracker into a "Local Clusters" category
- switch to markdown-it from markd for consistency between corp site and docs site
- use markdown-it-anchor to create linkable anchors to sections within a page
- improve urls to use / instead of # for docs pages (WARNING: this breaks old links)
- continue to simplify handling in the Content.vue component
- update JS deps

Signed-off-by: Timothy Gerla <tim@gerla.net>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2080)
<!-- Reviewable:end -->
