### PR TITLE
docs: fix netlify deep linking for 0.5 docs with fallback routes

### DIFF
--- a/docs/website/nuxt.config.js
+++ b/docs/website/nuxt.config.js
@@ -76,6 +76,7 @@ export default {
   },
 
   generate: {
+    fallback: true,
     routes(callback) {
       let generatedRoutes = []
       routes.forEach((route) => {


### PR DESCRIPTION
There are some funny interactions between Netlify and Nuxt/Vue-based SPA apps. Docs urls to individual pages aren't "real" files on disk from Netlify's perspective, so for deep links, we need to set up fallback routes on the Nuxt/Vue side.

More here: https://nuxtjs.org/faq/netlify-deployment#for-site-generated-in-spa-mode

Signed-off-by: Timothy Gerla <tim@gerla.net>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2081)
<!-- Reviewable:end -->
