### PR TITLE
docs: backport intro text to 0.3 and 0.4 docs

### DIFF
--- a/docs/website/content/v0.3/en/guides/index.md
+++ b/docs/website/content/v0.3/en/guides/index.md
@@ -1,6 +1,19 @@
 ---
-title: 'Guides'
+title: Introduction to Talos
 ---
 
-One of the primary goals of Talos is a consistent experience regardless of _where_ you are operating.
-In the following sections we will cover how to deploy Talos to well known platforms.
+Welcome to the Talos documentation!
+Talos is an open source platform to host and maintain Kubernetes clusters.
+It includes a purpose-built operating system and associated management tools.
+It can run on all major cloud providers, virtualization platforms, and bare metal hardware.
+
+All system management is done via an API, and there is no shell or interactive console.
+Some of the capabilities and benefits provided by Talos include:
+
+- **Security**: Talos reduces your attack surface by practicing the Principle of Least Privilege (PoLP) and by securing the API with mutual TLS (mTLS) authentication.
+- **Predictability**: Talos eliminates unneeded variables and reduces unknown factors in your environment by employing immutable infrastructure ideology.
+- **Evolvability**: Talos simplifies your architecture and increases your ability to easily accommodate future changes.
+
+Talos is flexible and can be deployed in a variety of ways, but the easiest way to get started and experiment with the system is to run a local cluster on your laptop or workstation using Docker.
+
+- [Run a Docker-based local cluster](/docs/v0.3/en/guides/getting-started)

--- a/docs/website/content/v0.4/en/guides/index.md
+++ b/docs/website/content/v0.4/en/guides/index.md
@@ -1,6 +1,21 @@
 ---
-title: 'Guides'
+title: Introduction to Talos
 ---
 
-One of the primary goals of Talos is a consistent experience regardless of _where_ you are operating.
-In the following sections we will cover how to deploy Talos to well known platforms.
+Welcome to the Talos documentation!
+Talos is an open source platform to host and maintain Kubernetes clusters.
+It includes a purpose-built operating system and associated management tools.
+It can run on all major cloud providers, virtualization platforms, and bare metal hardware.
+
+All system management is done via an API, and there is no shell or interactive console.
+Some of the capabilities and benefits provided by Talos include:
+
+- **Security**: Talos reduces your attack surface by practicing the Principle of Least Privilege (PoLP) and by securing the API with mutual TLS (mTLS) authentication.
+- **Predictability**: Talos eliminates unneeded variables and reduces unknown factors in your environment by employing immutable infrastructure ideology.
+- **Evolvability**: Talos simplifies your architecture and increases your ability to easily accommodate future changes.
+
+Talos is flexible and can be deployed in a variety of ways, but the easiest way to get started and experiment with the system is to run a local cluster on your laptop or workstation.
+There are two options:
+
+- [Run a Docker-based local cluster](/docs/v0.4/en/guides/getting-started/docker) on your Linux or Mac workstation
+- [Run a Firecracker micro-VM-based](/docs/v0.4/en/guides/getting-started/firecracker) cluster on your Linux workstation


### PR DESCRIPTION
- Replaced the basic intro text for 0.3 and 0.4 on the docs home page with more useful information and links to next steps.

Signed-off-by: Timothy Gerla <tim@gerla.net>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2082)
<!-- Reviewable:end -->
