### PR TITLE
test: stabilize tests by bumping timeouts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -508,6 +508,7 @@ steps:
   commands:
   - make e2e-firecracker
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -558,6 +559,7 @@ steps:
   commands:
   - make provision-tests-track-0
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -580,6 +582,7 @@ steps:
   commands:
   - make provision-tests-track-1
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -1211,6 +1214,7 @@ steps:
   commands:
   - make e2e-firecracker
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -1261,6 +1265,7 @@ steps:
   commands:
   - make provision-tests-track-0
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -1283,6 +1288,7 @@ steps:
   commands:
   - make provision-tests-track-1
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -2006,6 +2012,7 @@ steps:
   commands:
   - make e2e-firecracker
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -2056,6 +2063,7 @@ steps:
   commands:
   - make provision-tests-track-0
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -2078,6 +2086,7 @@ steps:
   commands:
   - make provision-tests-track-1
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -2831,6 +2840,7 @@ steps:
   commands:
   - make e2e-firecracker
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -2881,6 +2891,7 @@ steps:
   commands:
   - make provision-tests-track-0
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -2903,6 +2914,7 @@ steps:
   commands:
   - make provision-tests-track-1
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -3656,6 +3668,7 @@ steps:
   commands:
   - make e2e-firecracker
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -3706,6 +3719,7 @@ steps:
   commands:
   - make provision-tests-track-0
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -3728,6 +3742,7 @@ steps:
   commands:
   - make provision-tests-track-1
   environment:
+    FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS: 2000
     REGISTRY: registry.ci.svc:5000
   privileged: true
   volumes:
@@ -3981,6 +3996,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: c08d82c031f77c8d7a9632194bfcc277540be93583e4ac1d4cf6af24fa12d7c4
+hmac: 0652e53d9c3353bcbc4882c9e020f29d9aac1951480fcea2b2eecb89528a17a7
 
 ...

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -197,10 +197,10 @@ local push_local = Step("push-local", depends_on=[installer_local, talos_local],
 local unit_tests = Step("unit-tests", depends_on=[initramfs]);
 local unit_tests_race = Step("unit-tests-race", depends_on=[golint]);
 local e2e_docker = Step("e2e-docker", depends_on=[talos, osctl_linux]);
-local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});
+local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 local provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});
-local provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry});
-local provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry});
+local provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
+local provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 
 local coverage = {
   name: 'coverage',

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -86,18 +86,14 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 
 			var uptimeAfter float64
 
-			start := time.Now()
-
-			suite.Require().NoError(retry.Constant(3 * time.Minute).Retry(func() error {
-				since := time.Since(start)
-
+			suite.Require().NoError(retry.Constant(10 * time.Minute).Retry(func() error {
 				uptimeAfter, err = suite.ReadUptime(nodeCtx)
 				if err != nil {
 					// API might be unresponsive during reboot
 					return retry.ExpectedError(err)
 				}
 
-				if uptimeAfter >= uptimeBefore+since.Seconds() {
+				if uptimeAfter >= uptimeBefore {
 					// uptime should go down after Reset, as it reboots the node
 					return retry.ExpectedError(fmt.Errorf("uptime didn't go down: before %f, after %f", uptimeBefore, uptimeAfter))
 				}


### PR DESCRIPTION
Bump timeouts for reset API test as K8s control plane teardown might
take 3 minutes on its own.

Bump Go Firecracker SDK timeout when talking to firecracker process.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2083)
<!-- Reviewable:end -->
