### PR TITLE
chore: pin markdown linting libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -495,9 +495,9 @@ RUN prototool lint --protoc-bin-path=/toolchain/bin/protoc --protoc-wkt-path=/to
 # The markdownlint target performs linting on Markdown files.
 
 FROM node:8.16.1-alpine AS lint-markdown
-RUN npm i -g markdownlint-cli
-RUN npm i -g textlint
-RUN npm i -g textlint-rule-one-sentence-per-line
+RUN npm i -g markdownlint-cli@0.22.0
+RUN npm i -g textlint@11.6.3
+RUN npm i -g textlint-rule-one-sentence-per-line@1.0.2
 WORKDIR /src
 COPY .markdownlint.json .
 COPY . .


### PR DESCRIPTION
A new version of markdownlint-cli was released that breaks the
lint-markdown target. This pins all the libraries we use for
linting markdown files to specific versions that are known to
work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2084)
<!-- Reviewable:end -->
