### PR TITLE
fix: update kernel package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -287,31 +287,31 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.2.0 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0-1-g97d99e7 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0-1-g97d99e7 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/musl:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.2.0 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.2.0 /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:v0.2.0 /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:v0.2.0 /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:v0.2.0 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-1-g97d99e7 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-1-g97d99e7 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/musl:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-1-g97d99e7 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-1-g97d99e7 /lib/libblkid.* /rootfs/lib
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-1-g97d99e7 /lib/libuuid.* /rootfs/lib
+COPY --from=docker.io/autonomy/kmod:v0.2.0-1-g97d99e7 /usr/lib/libkmod.* /rootfs/lib
+COPY --from=docker.io/autonomy/kernel:v0.2.0-1-g97d99e7 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/


### PR DESCRIPTION
This updates packages to include a kernel built with
CONFIG_NETFILTER_XT_MATCH_SOCKET=y since it is recommended
by cilium.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2086)
<!-- Reviewable:end -->
