### PR TITLE
chore: serialize firecracker e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -574,6 +574,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: provision-tests-track-1
@@ -597,6 +598,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: push
@@ -1280,6 +1282,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: provision-tests-track-1
@@ -1303,6 +1306,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: push
@@ -2078,6 +2082,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: provision-tests-track-1
@@ -2101,6 +2106,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: push
@@ -2906,6 +2912,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: provision-tests-track-1
@@ -2929,6 +2936,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: push
@@ -3734,6 +3742,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: provision-tests-track-1
@@ -3757,6 +3766,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
+  - e2e-firecracker
   - provision-tests-prepare
 
 - name: push
@@ -3996,6 +4006,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 0652e53d9c3353bcbc4882c9e020f29d9aac1951480fcea2b2eecb89528a17a7
+hmac: 84e019b528d088bc8729dd2f80210758af8be586990b4405eed53a5f8e6886d9
 
 ...

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -199,8 +199,8 @@ local unit_tests_race = Step("unit-tests-race", depends_on=[golint]);
 local e2e_docker = Step("e2e-docker", depends_on=[talos, osctl_linux]);
 local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 local provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});
-local provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
-local provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[provision_tests_prepare], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
+local provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[e2e_firecracker,provision_tests_prepare], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
+local provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[e2e_firecracker,provision_tests_prepare], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 
 local coverage = {
   name: 'coverage',


### PR DESCRIPTION
This PR will ensure that the firecracker provision tests will only run
after a successful e2e_firecracker run. This is being added in hopes of
freeing up some resources during CI testing and making things more
stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2087)
<!-- Reviewable:end -->
