### PR TITLE
fix: write machined RPC logs to file

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/syslinux"
+	systemlog "github.com/talos-systems/talos/internal/app/machined/pkg/system/log"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/proc/reaper"
@@ -143,7 +144,17 @@ func main() {
 			Controller: c,
 		}
 
-		e := factory.ListenAndServe(server, factory.Network("unix"), factory.SocketPath(constants.MachineSocketPath))
+		l, e := systemlog.New("machined", constants.DefaultLogPath)
+		if e != nil {
+			handle(e)
+		}
+
+		e = factory.ListenAndServe(
+			server,
+			factory.Network("unix"),
+			factory.SocketPath(constants.MachineSocketPath),
+			factory.WithLog("machined ", l),
+		)
 
 		handle(e)
 	}()


### PR DESCRIPTION
This ensures that the machined RPC logs are written to disk so that users
can retrieve them via the log API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2088)
<!-- Reviewable:end -->
