### PR TITLE
fix: refactor client creation API

### DIFF
--- a/internal/pkg/cluster/config.go
+++ b/internal/pkg/cluster/config.go
@@ -5,12 +5,11 @@
 package cluster
 
 import (
+	"context"
 	"strings"
 
 	"github.com/talos-systems/talos/pkg/client"
 	"github.com/talos-systems/talos/pkg/client/config"
-	"github.com/talos-systems/talos/pkg/constants"
-	"github.com/talos-systems/talos/pkg/grpc/tls"
 )
 
 // ConfigClientProvider builds Talos client from client config.
@@ -45,30 +44,15 @@ func (c *ConfigClientProvider) Client(endpoints ...string) (*client.Client, erro
 		return c.DefaultClient, nil
 	}
 
-	configContext, creds, err := client.NewClientContextAndCredentialsFromParsedConfig(c.TalosConfig, "")
-	if err != nil {
-		return nil, err
+	opts := []client.OptionFunc{
+		client.WithConfig(c.TalosConfig),
 	}
 
-	if len(endpoints) == 0 {
-		endpoints = configContext.Endpoints
+	if len(endpoints) > 0 {
+		opts = append(opts, client.WithEndpoints(endpoints...))
 	}
 
-	tlsconfig, err := tls.New(
-		tls.WithKeypair(creds.Crt),
-		tls.WithClientAuthType(tls.Mutual),
-		tls.WithCACertPEM(creds.CA),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := client.NewClient(tlsconfig, endpoints, constants.ApidPort)
-	if err == nil {
-		c.clients[key] = client
-	}
-
-	return client, err
+	return client.New(context.TODO(), opts...)
 }
 
 // Close all the client connections.

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	"github.com/talos-systems/talos/pkg/client/config"
+)
+
+// Options contains the set of client configuration options
+type Options struct {
+	endpointsOverride []string
+	config            *config.Config
+	configContext     *config.Context
+	tlsConfig         *tls.Config
+	grpcDialOptions   []grpc.DialOption
+
+	contextOverride    string
+	contextOverrideSet bool
+}
+
+// OptionFunc sets an option for the creation of the Client
+type OptionFunc func(*Options) error
+
+// WithConfig configures the Client with the configuration provided.
+// Additionally use WithContextName to override the default context in the Config.
+func WithConfig(cfg *config.Config) OptionFunc {
+	return func(o *Options) error {
+		o.config = cfg
+		return nil
+	}
+}
+
+// WithContextName overrides the default context inside a provided client Config.
+func WithContextName(name string) OptionFunc {
+	return func(o *Options) error {
+		o.contextOverride = name
+
+		o.contextOverrideSet = true
+
+		return nil
+	}
+}
+
+// WithConfigContext configures the Client with the configuration context provided.
+func WithConfigContext(cfg *config.Context) OptionFunc {
+	return func(o *Options) error {
+		o.configContext = cfg
+		return nil
+	}
+}
+
+// WithGRPCDialOptions adds the given grpc.DialOptions to a Client.
+func WithGRPCDialOptions(opts ...grpc.DialOption) OptionFunc {
+	return func(o *Options) error {
+		o.grpcDialOptions = append(o.grpcDialOptions, opts...)
+		return nil
+	}
+}
+
+// WithTLSConfig overrides the default TLS configuration with the one provided.
+func WithTLSConfig(tlsConfig *tls.Config) OptionFunc {
+	return func(o *Options) error {
+		o.tlsConfig = tlsConfig
+		return nil
+	}
+}
+
+// WithEndpoints overrides the default endpoints with the provided list.
+func WithEndpoints(endpoints ...string) OptionFunc {
+	return func(o *Options) error {
+		o.endpointsOverride = endpoints
+		return nil
+	}
+}
+
+// WithDefaultConfig creates a Client with its configuration sourced from the
+// default config file location.
+// Additionally use WithContextName to select a context other than the default.
+func WithDefaultConfig() OptionFunc {
+	return func(o *Options) (err error) {
+		defaultConfigPath, err := config.GetDefaultPath()
+		if err != nil {
+			return fmt.Errorf("no client configuration provided and no default path found: %w", err)
+		}
+
+		return WithConfigFromFile(defaultConfigPath)(o)
+	}
+}
+
+// WithConfigFromFile creates a Client with its configuration extracted from the given file.
+// Additionally use WithContextName to select a context other than the default.
+func WithConfigFromFile(fn string) OptionFunc {
+	return func(o *Options) (err error) {
+		cfg, err := config.Open(fn)
+		if err != nil {
+			return fmt.Errorf("failed to read config from %q: %w", fn, err)
+		}
+
+		o.config = cfg
+
+		return nil
+	}
+}

--- a/pkg/client/resolver.go
+++ b/pkg/client/resolver.go
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc/resolver"
+
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/net"
+)
+
+func init() {
+	resolver.Register(&talosListResolverBuilder{})
+}
+
+const talosListResolverScheme = "taloslist"
+
+type talosListResolverBuilder struct{}
+
+// Build implements resolver.Builder.
+func (b *talosListResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	r := &talosListResolver{
+		target: target,
+		cc:     cc,
+	}
+	r.start()
+
+	return r, nil
+}
+
+// Build implements resolver.Builder.
+func (b *talosListResolverBuilder) Scheme() string {
+	return talosListResolverScheme
+}
+
+type talosListResolver struct {
+	target resolver.Target
+	cc     resolver.ClientConn
+}
+
+func (r *talosListResolver) start() {
+	var addrs []resolver.Address // nolint: prealloc
+
+	for _, a := range strings.Split(r.target.Endpoint, ",") {
+		addrs = append(addrs, resolver.Address{
+			ServerName: a,
+			Addr:       fmt.Sprintf("%s:%d", net.FormatAddress(a), constants.ApidPort),
+		})
+	}
+
+	r.cc.UpdateState(resolver.State{
+		Addresses: addrs,
+	})
+}
+
+// ResolveNow implements resolver.Resolver.
+func (r *talosListResolver) ResolveNow(o resolver.ResolveNowOptions) {}
+
+// ResolveNow implements resolver.Resolver.
+func (r *talosListResolver) Close() {}


### PR DESCRIPTION
Create a new `client.NewFromConfigContext` to make external API systems
easier to construct.

This also makes a first pass at supporting multiple endpoints properly
by creating a custom grpc resolver.  (Proper load balancing support is
still a TODO.)

Fixes #2093

# Pull Request

## What? (description)

Refactor client construction API for easier use with external tooling.

## Why? (reasoning)

Several steps in constructing a client were embedded within the talosctl command, resulting in repeated and non-obvious code when constructing custom clients.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2094)
<!-- Reviewable:end -->
