### PR TITLE
fix: run machined API as a service

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -76,7 +76,8 @@ func (s *Server) Reboot(ctx context.Context, in *empty.Empty) (reply *machine.Re
 			log.Println("reboot failed:", err)
 
 			if err != runtime.ErrLocked {
-				// NB: Stopping the gRPC server will trigger machined's reboot mechanism.
+				// NB: We stop the gRPC server since a failed sequence triggers a
+				// reboot.
 				s.server.GracefulStop()
 			}
 		}
@@ -106,7 +107,8 @@ func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (r
 			log.Println("bootstrap failed:", err)
 
 			if err != runtime.ErrLocked {
-				// NB: Stopping the gRPC server will trigger machined's reboot mechanism.
+				// NB: We stop the gRPC server since a failed sequence triggers a
+				// reboot.
 				s.server.GracefulStop()
 			}
 		}
@@ -132,7 +134,8 @@ func (s *Server) Shutdown(ctx context.Context, in *empty.Empty) (reply *machine.
 			log.Println("shutdown failed:", err)
 
 			if err != runtime.ErrLocked {
-				// NB: Stopping the gRPC server will trigger machined's reboot mechanism.
+				// NB: We stop the gRPC server since a failed sequence triggers a
+				// reboot.
 				s.server.GracefulStop()
 			}
 		}
@@ -168,7 +171,8 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 			log.Println("upgrade failed:", err)
 
 			if err != runtime.ErrLocked {
-				// NB: Stopping the gRPC server will trigger machined's reboot mechanism.
+				// NB: We stop the gRPC server since a failed sequence triggers a
+				// reboot.
 				s.server.GracefulStop()
 			}
 		}
@@ -196,7 +200,8 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 			log.Println("reset failed:", err)
 
 			if err != runtime.ErrLocked {
-				// NB: Stopping the gRPC server will trigger machined's reboot mechanism.
+				// NB: We stop the gRPC server since a failed sequence triggers a
+				// reboot.
 				s.server.GracefulStop()
 			}
 		}
@@ -226,7 +231,8 @@ func (s *Server) Recover(ctx context.Context, in *machine.RecoverRequest) (reply
 			log.Println("recover failed:", err)
 
 			if err != runtime.ErrLocked {
-				// NB: Stopping the gRPC server will trigger machined's reboot mechanism.
+				// NB: We stop the gRPC server since a failed sequence triggers a
+				// reboot.
 				s.server.GracefulStop()
 			}
 		}

--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// nolint: dupl,golint
+package services
+
+import (
+	"context"
+	"io"
+
+	v1alpha1server "github.com/talos-systems/talos/internal/app/machined/internal/server/v1alpha1"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/goroutine"
+	"github.com/talos-systems/talos/internal/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/constants"
+	"github.com/talos-systems/talos/pkg/grpc/factory"
+)
+
+type machinedService struct {
+	c runtime.Controller
+}
+
+// Main is an entrypoint the the API service
+func (s *machinedService) Main(ctx context.Context, r runtime.Runtime, logWriter io.Writer) error {
+	// Start the API server.
+	server := factory.NewServer(
+		&v1alpha1server.Server{
+			Controller: s.c,
+		},
+		factory.WithLog("machined ", logWriter),
+	)
+
+	listener, err := factory.NewListener(factory.Network("unix"), factory.SocketPath(constants.MachineSocketPath))
+	if err != nil {
+		return err
+	}
+
+	defer server.Stop()
+
+	go func() {
+		// nolint: errcheck
+		server.Serve(listener)
+	}()
+
+	<-ctx.Done()
+
+	return nil
+}
+
+// Machined implements the Service interface. It serves as the concrete type with
+// the required methods.
+type Machined struct {
+	Controller runtime.Controller
+}
+
+// ID implements the Service interface.
+func (m *Machined) ID(r runtime.Runtime) string {
+	return "machined"
+}
+
+// PreFunc implements the Service interface.
+func (m *Machined) PreFunc(ctx context.Context, r runtime.Runtime) error {
+	return nil
+}
+
+// PostFunc implements the Service interface.
+func (m *Machined) PostFunc(r runtime.Runtime, state events.ServiceState) (err error) {
+	return nil
+}
+
+// Condition implements the Service interface.
+func (m *Machined) Condition(r runtime.Runtime) conditions.Condition {
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (m *Machined) DependsOn(r runtime.Runtime) []string {
+	return nil
+}
+
+// Runner implements the Service interface.
+func (m *Machined) Runner(r runtime.Runtime) (runner.Runner, error) {
+	svc := &machinedService{m.Controller}
+
+	return goroutine.NewRunner(r, "machined", svc.Main), nil
+}


### PR DESCRIPTION
In recent refactoring the machined API service was changed to run outside
of the service framework. This brings it back as a service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2106)
<!-- Reviewable:end -->
