### PR TITLE
chore: fix nits in the events code

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_events_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_events_test.go
@@ -32,7 +32,6 @@ func TestNewEvents(t *testing.T) {
 			},
 			want: &Events{
 				subscribers: make([]chan machine.Event, 0, 100),
-				Mutex:       &sync.Mutex{},
 			},
 		},
 	}
@@ -62,7 +61,6 @@ func BenchmarkWatch(b *testing.B) {
 func TestEvents_Watch(t *testing.T) {
 	type fields struct {
 		subscribers []chan machine.Event
-		Mutex       *sync.Mutex
 	}
 
 	tests := []struct {
@@ -75,7 +73,6 @@ func TestEvents_Watch(t *testing.T) {
 			count: 10,
 			fields: fields{
 				subscribers: make([]chan machine.Event, 0, 100),
-				Mutex:       &sync.Mutex{},
 			},
 		},
 	}
@@ -84,7 +81,6 @@ func TestEvents_Watch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Events{
 				subscribers: tt.fields.subscribers,
-				Mutex:       tt.fields.Mutex,
 			}
 
 			var wg sync.WaitGroup
@@ -145,7 +141,6 @@ func TestEvents_Publish(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Events{
 				subscribers: tt.fields.subscribers,
-				Mutex:       tt.fields.Mutex,
 			}
 
 			var wg sync.WaitGroup


### PR DESCRIPTION
1. `sync.Mutex` zero value is fine as initial value, and it's part of
the `Events` structured which is passed by pointer, it's fine to embed
it. (simplify)

2. Add safety net around potentially blocked event subscribers so that
it doesn't block event propagation. This is not a perfect solution, but
my feeling that it's better than blocking.

3. Fix delete sequence - first remove the channel, then close it, as
otherwise send might panic to closed channel.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2107)
<!-- Reviewable:end -->
