### PR TITLE
fix: respect nameservers when using docker cluster

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -336,7 +336,7 @@ func init() {
 	createCmd.Flags().BoolVar(&configDebug, "with-debug", false, "enable debug in Talos config to send service logs to the console")
 	createCmd.Flags().IntVar(&networkMTU, "mtu", 1500, "MTU of the docker bridge network")
 	createCmd.Flags().StringVar(&networkCIDR, "cidr", "10.5.0.0/24", "CIDR of the docker bridge network")
-	createCmd.Flags().StringSliceVar(&nameservers, "nameservers", []string{"8.8.8.8", "1.1.1.1"}, "list of nameservers to use (VM only)")
+	createCmd.Flags().StringSliceVar(&nameservers, "nameservers", []string{"8.8.8.8", "1.1.1.1"}, "list of nameservers to use")
 	createCmd.Flags().IntVar(&workers, "workers", 1, "the number of workers to create")
 	createCmd.Flags().IntVar(&masters, "masters", 1, "the number of masters to create")
 	createCmd.Flags().StringVar(&clusterCpus, "cpus", "1.5", "the share of CPUs as fraction (each container)")

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -32,7 +32,7 @@ talosctl cluster create [flags]
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
       --mtu int                     MTU of the docker bridge network (default 1500)
-      --nameservers strings         list of nameservers to use (VM only) (default [8.8.8.8,1.1.1.1])
+      --nameservers strings         list of nameservers to use (default [8.8.8.8,1.1.1.1])
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
       --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --wait                        wait for the cluster to be ready before returning (default true)

--- a/internal/pkg/provision/providers/docker/docker.go
+++ b/internal/pkg/provision/providers/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
 
@@ -43,9 +44,24 @@ func (p *provisioner) Close() error {
 
 // GenOptions provides a list of additional config generate options.
 func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate.GenOption {
-	return []generate.GenOption{
+	ret := []generate.GenOption{
 		generate.WithPersist(false),
 	}
+
+	if len(networkReq.Nameservers) > 0 {
+		nameservers := make([]string, len(networkReq.Nameservers))
+		for i := range nameservers {
+			nameservers[i] = networkReq.Nameservers[i].String()
+		}
+
+		ret = append(ret, generate.WithNetworkConfig(
+			&v1alpha1.NetworkConfig{
+				NameServers: nameservers,
+			}),
+		)
+	}
+
+	return ret
 }
 
 // GetLoadBalancers returns internal/external loadbalancer endpoints.


### PR DESCRIPTION
This PR will fix some unexpected user behavior where nameservers were
always getting written to 8.8.8.8,1.1.1.1 for the docker-based talos
clusters. This occurred even when updating the docker daemon's config.
This PR will make the docker provisioner respect the --nameserver flag
and allow that to be used to override the defaults.

Should close #2109.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2112)
<!-- Reviewable:end -->
