### PR TITLE
fix: wrap etcd address URLs with formatting

### DIFF
--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/kubernetes"
+	"github.com/talos-systems/talos/pkg/net"
 )
 
 // NewClient initializes and returns an etcd client configured to talk to
@@ -62,7 +63,7 @@ func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpo
 
 	// Etcd expects host:port format.
 	for i := 0; i < len(endpoints); i++ {
-		endpoints[i] += ":2379"
+		endpoints[i] = net.FormatAddress(endpoints[i]) + ":2379"
 	}
 
 	return NewClient(endpoints)

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-// IPAddrs finds and returns a list of non-loopback IPv4 addresses of the
+// IPAddrs finds and returns a list of non-loopback IP addresses of the
 // current machine.
 func IPAddrs() (ips []net.IP, err error) {
 	ips = []net.IP{}
@@ -24,8 +24,8 @@ func IPAddrs() (ips []net.IP, err error) {
 	}
 
 	for _, a := range addrs {
-		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.IsGlobalUnicast() {
-			if ipnet.IP.To4() != nil {
+		if ipnet, ok := a.(*net.IPNet); ok {
+			if ipnet.IP.IsGlobalUnicast() && !ipnet.IP.IsLinkLocalUnicast() {
 				ips = append(ips, ipnet.IP)
 			}
 		}
@@ -36,6 +36,8 @@ func IPAddrs() (ips []net.IP, err error) {
 
 // FormatAddress checks that the address has a consistent format.
 func FormatAddress(addr string) string {
+	addr = strings.Trim(addr, "[]")
+
 	if ip := net.ParseIP(addr); ip != nil {
 		// If this is an IPv6 address, encapsulate it in brackets
 		if ip.To4() == nil {


### PR DESCRIPTION
Make certain that all etcd address URLs are properly wrapped to handle
IPv6 addresses.

Fixes #2120

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2122)
<!-- Reviewable:end -->
