### PR TITLE
fix: bump service wait to ten minutes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1578,7 +1578,7 @@ func BootstrapEtcd(seq runtime.Sequence, data interface{}) runtime.TaskExecution
 
 		system.Services(r).ReloadAndStart(svc)
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 		defer cancel()
 
 		return system.WaitForService(system.StateEventUp, svc.ID(r)).Wait(ctx)


### PR DESCRIPTION
This adds a bit more time to the max wait time for services to start.
This fixes a few issues. First it makes the cluster health wait fail
often since there isn't enough time and the boot sequence fails, even
though things are progressing just fine. Second, this gives a bit more
time for users to collect data when debugging and more time for
invoking the bootstrap API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2132)
<!-- Reviewable:end -->
