### PR TITLE
chore: upgrade Go to 1.14.3 and use toolchain for race detector

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -443,7 +443,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - lint-go
+  - initramfs
 
 - name: coverage
   image: alpine:3.10
@@ -1151,7 +1151,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - lint-go
+  - initramfs
 
 - name: coverage
   image: alpine:3.10
@@ -1951,7 +1951,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - lint-go
+  - initramfs
 
 - name: coverage
   image: alpine:3.10
@@ -2781,7 +2781,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - lint-go
+  - initramfs
 
 - name: coverage
   image: alpine:3.10
@@ -3611,7 +3611,7 @@ steps:
   - name: tmp
     path: /tmp
   depends_on:
-  - lint-go
+  - initramfs
 
 - name: coverage
   image: alpine:3.10
@@ -4006,6 +4006,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 84e019b528d088bc8729dd2f80210758af8be586990b4405eed53a5f8e6886d9
+hmac: 507e1e1344e87b9c073e3f212b076b15655bea11ba86c9f4f781079547c8aeee
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 # Meta args applied to stage base names.
 
 ARG TOOLS
-ARG GO_VERSION
 
 # The tools target provides base toolchain for the build.
 
@@ -287,31 +286,31 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.2.0-3-g6ac7962 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0-3-g6ac7962 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0-5-ge515e41 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0-5-ge515e41 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-3-g6ac7962 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-3-g6ac7962 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/musl:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-3-g6ac7962 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-3-g6ac7962 /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-3-g6ac7962 /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:v0.2.0-3-g6ac7962 /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:v0.2.0-3-g6ac7962 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-5-ge515e41 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-5-ge515e41 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/musl:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-5-ge515e41 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-5-ge515e41 /lib/libblkid.* /rootfs/lib
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-5-ge515e41 /lib/libuuid.* /rootfs/lib
+COPY --from=docker.io/autonomy/kmod:v0.2.0-5-ge515e41 /usr/lib/libkmod.* /rootfs/lib
+COPY --from=docker.io/autonomy/kernel:v0.2.0-5-ge515e41 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/
@@ -425,13 +424,12 @@ COPY --from=unit-tests-runner /src/coverage.txt /coverage.txt
 
 # The unit-tests-race target performs tests with race detector.
 
-FROM golang:${GO_VERSION} AS unit-tests-race
-COPY --from=base /src /src
-COPY --from=base /go/pkg/mod /go/pkg/mod
-WORKDIR /src
-ENV GO111MODULE on
+FROM base AS unit-tests-race
+RUN unlink /etc/ssl
+COPY --from=rootfs / /
+COPY hack/golang/test.sh /bin
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build go test -v -count 1 -race ${TESTPKGS}
+RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache/go-build /bin/test.sh --race ${TESTPKGS}
 
 # The integration-test target builds integration test binary.
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
-TOOLS ?= autonomy/tools:v0.1.0-4-gac40795
+TOOLS ?= autonomy/tools:v0.2.0-1-g418e800
 GO_VERSION ?= 1.14
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 OSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)
@@ -32,7 +32,6 @@ COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=TOOLS=$(TOOLS)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
-COMMON_ARGS += --build-arg=GO_VERSION=$(GO_VERSION)
 COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
@@ -175,7 +174,7 @@ unit-tests: ## Performs unit tests.
 
 .PHONY: unit-tests-race
 unit-tests-race: ## Performs unit tests with race detection enabled.
-	@$(MAKE) target-$@
+	@$(MAKE) target-$@ TARGET_ARGS="--allow security.insecure"
 
 $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64:
 	@$(MAKE) local-$(INTEGRATION_TEST_DEFAULT_TARGET) DEST=$(ARTIFACTS)

--- a/hack/drone.jsonnet
+++ b/hack/drone.jsonnet
@@ -195,7 +195,7 @@ local image_gcp = Step("image-gcp", depends_on=[image_digital_ocean]);
 local image_vmware = Step("image-vmware", depends_on=[image_gcp]);
 local push_local = Step("push-local", depends_on=[installer_local, talos_local], target="push", environment={"REGISTRY": local_registry, "DOCKER_LOGIN_ENABLED": "false"} );
 local unit_tests = Step("unit-tests", depends_on=[initramfs]);
-local unit_tests_race = Step("unit-tests-race", depends_on=[golint]);
+local unit_tests_race = Step("unit-tests-race", depends_on=[initramfs]);
 local e2e_docker = Step("e2e-docker", depends_on=[talos, osctl_linux]);
 local e2e_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry, "FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 local provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, osctl_linux, kernel, push_local], environment={"REGISTRY": local_registry});

--- a/hack/golang/test.sh
+++ b/hack/golang/test.sh
@@ -2,9 +2,17 @@
 
 set -e
 
+# Set up common test environment variables
+export PLATFORM=container
+
 perform_tests() {
   echo "Performing tests on $1"
   go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 "$1"
+}
+
+perform_race_tests() {
+  echo "Performing race tests on $1"
+  CGO_ENABLED=1 go test -v -race -count 1 "$1"
 }
 
 perform_short_tests() {
@@ -13,6 +21,10 @@ perform_short_tests() {
 }
 
 case $1 in
+  --race)
+  shift
+  perform_race_tests "${1:-./...}"
+  ;;
   --short)
   shift
   perform_short_tests "${1:-./...}"


### PR DESCRIPTION
With Go 1.14.3 we can run race-enabled code on muslc, so this opens path
to run unit-tests-race under Talos environment with rootfs, enabling all
the tests to run under race detector.

Also fixed the tests run by specifying platform in the test environment.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2137)
<!-- Reviewable:end -->
