### PR TITLE
chore: fix markdown lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,6 @@ See [Contributing](CONTRIBUTING.md) for our guidelines.
 
 ## License
 
-[![license](https://img.shields.io/github/license/talos-systems/talos.svg?style=flat-square)](https://github.com/talos-systems/talos/blob/master/LICENSE)
+<a href="https://github.com/talos-systems/talos/blob/master/LICENSE">
+  <img alt="GitHub" src="https://img.shields.io/github/license/talos-systems/talos?style=flat-square">
+</a>


### PR DESCRIPTION
The one sentence per line linter thinks that the ! is part of a sentence. This
uses HTML to get around this limitation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2143)
<!-- Reviewable:end -->
