### PR TITLE
fix: prevent panic on nil pointer in ServiceInfo method

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -592,12 +592,18 @@ func (c *Client) ServiceInfo(ctx context.Context, id string, callOptions ...grpc
 	)
 
 	if err != nil {
-		return
+		return services, err
 	}
 
 	var filtered interface{}
 	filtered, err = FilterMessages(resp, err)
 	resp, _ = filtered.(*machineapi.ServiceListResponse) //nolint: errcheck
+
+	// FilterMessages might remove responses if they actually contain errors,
+	// errors will be merged into `resp`.
+	if resp == nil {
+		return services, err
+	}
 
 	for _, resp := range resp.Messages {
 		for _, svc := range resp.Services {
@@ -610,7 +616,7 @@ func (c *Client) ServiceInfo(ctx context.Context, id string, callOptions ...grpc
 		}
 	}
 
-	return
+	return services, err
 }
 
 // ServiceStart starts a service.


### PR DESCRIPTION
Fixes #2138

`FilterMessages` might return `nil` resp if it extracts errors into
`err` from `resp`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2144)
<!-- Reviewable:end -->
