### PR TITLE
feat: adjust time properly in timed via adjtime()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
-	github.com/beevik/ntp v0.2.0
+	github.com/beevik/ntp v0.3.0
 	github.com/containerd/cgroups v0.0.0-20191125132625-80b32e3c75c9
 	github.com/containerd/containerd v1.3.2
 	github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/aws/aws-sdk-go v1.15.78 h1:LaXy6lWR0YK7LKyuU0QWy2ws/LWTPfYV/UgfiBu4tv
 github.com/aws/aws-sdk-go v1.15.78/go.mod h1:E3/ieXAlvM0XWO57iftYVDLLvQ824smPP3ATZkfNZeM=
 github.com/beevik/ntp v0.2.0 h1:sGsd+kAXzT0bfVfzJfce04g+dSRfrs+tbQW8lweuYgw=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
+github.com/beevik/ntp v0.3.0 h1:xzVrPrE4ziasFXgBVBZJDP0Wg/KpMwk2KHJ4Ba8GrDw=
+github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -124,7 +124,7 @@ func (n *Networkd) Runner(r runtime.Runtime) (runner.Runner, error) {
 }
 
 // HealthFunc implements the HealthcheckedService interface
-func (n *Networkd) HealthFunc(cfg runtime.Configurator) health.Check {
+func (n *Networkd) HealthFunc(r runtime.Runtime) health.Check {
 	return func(ctx context.Context) error {
 		var (
 			conn      *grpc.ClientConn
@@ -133,7 +133,8 @@ func (n *Networkd) HealthFunc(cfg runtime.Configurator) health.Check {
 			readyResp *healthapi.ReadyCheckResponse
 		)
 
-		conn, err = grpc.Dial(
+		conn, err = grpc.DialContext(
+			ctx,
 			fmt.Sprintf("%s://%s", "unix", constants.NetworkSocketPath),
 			grpc.WithInsecure(),
 			grpc.WithContextDialer(dialer.DialUnix()),
@@ -162,7 +163,7 @@ func (n *Networkd) HealthFunc(cfg runtime.Configurator) health.Check {
 
 		msg := fmt.Sprintf("networkd is unhealthy: %s", hcResp.Messages[0].Status.String())
 
-		if cfg.Debug() {
+		if r.Config().Debug() {
 			log.Printf("DEBUG: %s", msg)
 		}
 

--- a/internal/app/machined/pkg/system/services/networkd_test.go
+++ b/internal/app/machined/pkg/system/services/networkd_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
 )
 
-func TestTimedInterfaces(t *testing.T) {
-	assert.Implements(t, (*system.APIStartableService)(nil), new(services.Timed))
-	assert.Implements(t, (*system.APIRestartableService)(nil), new(services.Timed))
-	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Timed))
+func TestNetworkdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Networkd))
 }

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -123,7 +123,8 @@ func (o *OSD) Runner(r runtime.Runtime) (runner.Runner, error) {
 // HealthFunc implements the HealthcheckedService interface
 func (o *OSD) HealthFunc(runtime.Runtime) health.Check {
 	return func(ctx context.Context) error {
-		conn, err := grpc.Dial(
+		conn, err := grpc.DialContext(
+			ctx,
 			fmt.Sprintf("%s://%s", "unix", constants.OSSocketPath),
 			grpc.WithInsecure(),
 			grpc.WithContextDialer(dialer.DialUnix()),

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -120,7 +120,8 @@ func (o *Routerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 // HealthFunc implements the HealthcheckedService interface
 func (o *Routerd) HealthFunc(runtime.Runtime) health.Check {
 	return func(ctx context.Context) error {
-		conn, err := grpc.Dial(
+		conn, err := grpc.DialContext(
+			ctx,
 			fmt.Sprintf("%s://%s", "unix", constants.RouterdSocketPath),
 			grpc.WithInsecure(),
 			grpc.WithContextDialer(dialer.DialUnix()),

--- a/internal/app/timed/main.go
+++ b/internal/app/timed/main.go
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalf("failed to create ntp client: %v", err)
 	}
 
-	log.Println("Starting timed")
+	log.Println("starting timed")
 
 	errch := make(chan error)
 

--- a/internal/app/timed/pkg/ntp/options.go
+++ b/internal/app/timed/pkg/ntp/options.go
@@ -17,6 +17,8 @@ const (
 	MaxAllowablePoll = 1024
 	// MinAllowablePoll is the minimum time allowed for a client to query a time server
 	MinAllowablePoll = 4
+	// AdjustTimeLimit is a maximum time drift to compensate via adjtimex()
+	AdjustTimeLimit = 128 * time.Millisecond
 )
 
 func defaultOptions() *NTP {

--- a/internal/app/timed/pkg/timex/timex.go
+++ b/internal/app/timed/pkg/timex/timex.go
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package timex provides simple wrapper around adjtimex syscall.
+package timex
+
+import "syscall"
+
+// Values for timex.mode.
+//
+//nolint: golint, stylecheck
+const (
+	ADJ_OFFSET    = 0x0001
+	ADJ_FREQUENCY = 0x0002
+	ADJ_MAXERROR  = 0x0004
+	ADJ_ESTERROR  = 0x0008
+	ADJ_STATUS    = 0x0010
+	ADJ_TIMECONST = 0x0020
+	ADJ_TAI       = 0x0080
+	ADJ_SETOFFSET = 0x0100
+	ADJ_MICRO     = 0x1000
+	ADJ_NANO      = 0x2000
+	ADJ_TICK      = 0x4000
+)
+
+// State is clock state.
+type State int
+
+// Clock states.
+//
+//nolint: golint, stylecheck
+const (
+	TIME_OK State = iota
+	TIME_INS
+	TIME_DEL
+	TIME_OOP
+	TIME_WAIT
+	TIME_ERROR
+)
+
+func (state State) String() string {
+	return [...]string{"TIME_OK", "TIME_INS", "TIME_DEL", "TIME_OOP", "TIME_WAIT", "TIME_ERROR"}[int(state)]
+}
+
+// Adjtimex provides a wrapper around syscall.Adjtimex.
+func Adjtimex(buf *syscall.Timex) (state State, err error) {
+	st, err := syscall.Adjtimex(buf)
+
+	return State(st), err
+}


### PR DESCRIPTION
This should be proper way to adjust time incrementally without causing
jumps one in +/- direction. Time-sensitive services might be confused by
huge jumps.

Next steps: insert/delete leap seconds, provide timed health status.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2145)
<!-- Reviewable:end -->
