### PR TITLE
docs: make v0.5 docs the default

### DIFF
--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -35,7 +35,7 @@ export default {
   data() {
     return {
       options: [
-        { version: 'v0.5', url: '/docs/v0.5', prerelease: true },
+        { version: 'v0.5', url: '/docs/v0.5', prerelease: false },
         { version: 'v0.4', url: '/docs/v0.4', prerelease: false },
         { version: 'v0.3', url: '/docs/v0.3', prerelease: false }
       ],

--- a/docs/website/components/Header.vue
+++ b/docs/website/components/Header.vue
@@ -7,7 +7,7 @@
       <div class="flex py-6 ml-auto">
         <ul class="header-menu">
           <li>
-            <a href="/docs/v0.4">
+            <a href="/docs/v0.5">
               <span class="font-semibold mr-1">Documentation</span>
             </a>
           </li>

--- a/docs/website/pages/index.vue
+++ b/docs/website/pages/index.vue
@@ -27,7 +27,7 @@
             </p>
             <div class="flex-1 text-center pb-4 m-0">
               <a
-                href="https://www.talos.dev/docs/v0.4/#v0.4/en/guides/getting-started/docker"
+                href="https://www.talos.dev/docs/v0.5/en/guides/getting-started/intro"
               >
                 <button class="teal-cta-button">
                   Try it now


### PR DESCRIPTION
This updates links and dropdown menus to point to the v0.5
documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2150)
<!-- Reviewable:end -->
