### PR TITLE
fix: allow node names

### DIFF
--- a/internal/app/apid/pkg/backend/apid.go
+++ b/internal/app/apid/pkg/backend/apid.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"sync"
 
-	stdlibnet "net"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/talos-systems/grpc-proxy/proxy"
 	"google.golang.org/grpc"
@@ -35,9 +33,9 @@ type APID struct {
 
 // NewAPID creates new instance of APID backend
 func NewAPID(target string, creds credentials.TransportCredentials) (*APID, error) {
-	// perform very basic validation on target
-	if stdlibnet.ParseIP(target) == nil {
-		return nil, fmt.Errorf("invalid target IP %q", target)
+	// perform very basic validation on target, trying to weed out empty addresses or addresses with the port appended
+	if target == "" || net.AddressContainsPort(target) {
+		return nil, fmt.Errorf("invalid target %q", target)
 	}
 
 	return &APID{

--- a/pkg/net/net.go
+++ b/pkg/net/net.go
@@ -50,6 +50,36 @@ func FormatAddress(addr string) string {
 	return addr
 }
 
+// AddressContainsPort checks to see if the supplied address contains both an address and a port.
+// This will not catch every possible permutation, but it is a best-effort routine suitable for prechecking human-interactive parameters.
+func AddressContainsPort(addr string) bool {
+	if !strings.Contains(addr, ":") {
+		return false
+	}
+
+	pieces := strings.Split(addr, ":")
+
+	if ip := net.ParseIP(strings.Trim(addr, "[]")); ip != nil {
+		return false
+	}
+
+	// Check to see if it parses as an IP _without_ the last (presumed) `:port`
+	trimmedAddr := strings.TrimSuffix(addr, ":"+pieces[len(pieces)-1])
+
+	if ip := net.ParseIP(strings.Trim(trimmedAddr, "[]")); ip != nil {
+		// We appear to have a valid IP followed by `:port`
+		return true
+	}
+
+	if len(pieces) > 2 {
+		// No idea what this is, but it doesn't appear to be addr:port
+		return false
+	}
+
+	// Looks like it is host:port
+	return true
+}
+
 // NthIPInNetwork takes an IPNet and returns the nth IP in it.
 func NthIPInNetwork(network *net.IPNet, n int) (net.IP, error) {
 	ip := network.IP

--- a/pkg/net/net_test.go
+++ b/pkg/net/net_test.go
@@ -19,6 +19,21 @@ func TestEmpty(t *testing.T) {
 	// for this package
 }
 
+func TestAddressContainsPort(t *testing.T) {
+	assert.Equal(t, AddressContainsPort("192.168.1.1:9021"), true)
+	assert.Equal(t, AddressContainsPort("node0:10001"), true)
+	assert.Equal(t, AddressContainsPort("node0.testdomain.io:10001"), true)
+	assert.Equal(t, AddressContainsPort("[2001:db8::1]:64321"), true)
+	assert.Equal(t, AddressContainsPort("[2001:db8:3:4:5:6:7:1]:64321"), true)
+
+	assert.Equal(t, AddressContainsPort("[2001:db8:3:4:5:6:7:1:bad]:64321"), false)
+	assert.Equal(t, AddressContainsPort("2001:db8:0::2000"), false)
+	assert.Equal(t, AddressContainsPort("::1"), false)
+	assert.Equal(t, AddressContainsPort("127.0.0.1"), false)
+	assert.Equal(t, AddressContainsPort("node0"), false)
+	assert.Equal(t, AddressContainsPort("node0.testdomain.io"), false)
+}
+
 func TestFormatAddress(t *testing.T) {
 	assert.Equal(t, FormatAddress("2001:db8::1"), "[2001:db8::1]")
 	assert.Equal(t, FormatAddress("[2001:db8::1]"), "[2001:db8::1]")


### PR DESCRIPTION
This allows node names for APID, but checks for empty or port-appended
addresses in a best-effort manner.

Fixes #2163

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2164)
<!-- Reviewable:end -->
