### PR TITLE
feat: allow reset API at all times

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -80,9 +80,12 @@ func (c *Controller) Run(seq runtime.Sequence, data interface{}) error {
 		return runtime.ErrUndefinedRuntime
 	}
 
-	// Allow only one sequence to run at a time with the exception of the
-	// bootstrap sequence.
-	if seq != runtime.SequenceBootstrap {
+	// Allow only one sequence to run at a time with the exception of bootstrap
+	// and reset sequences.
+	switch seq {
+	case runtime.SequenceBootstrap, runtime.SequenceReset:
+		// Do not attempt to lock.
+	default:
 		if c.TryLock() {
 			c.Runtime().Events().Publish(&machine.SequenceEvent{
 				Sequence: seq.String(),


### PR DESCRIPTION
It is common to want to reset a node when it is stuck in the boot
sequence due to misconfiguration. This allows the reset sequence
at all times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2167)
<!-- Reviewable:end -->
