### PR TITLE
docs: add kernel options to firecracker reqs

### DIFF
--- a/docs/website/content/v0.4/en/guides/getting-started/firecracker.md
+++ b/docs/website/content/v0.4/en/guides/getting-started/firecracker.md
@@ -7,7 +7,10 @@ In this guide we will create a Kubernetes cluster using Firecracker.
 ## Requirements
 
 - Linux
-- a kernel with KVM enabled (`/dev/kvm` must exist)
+- a kernel with
+  - KVM enabled (`/dev/kvm` must exist)
+  - `CONFIG_NET_SCH_NETEM` enabled
+  - `CONFIG_NET_SCH_INGRESS` enabled
 - at least `CAP_SYS_ADMIN` and `CAP_NET_ADMIN` capabilities
 - [firecracker](https://github.com/firecracker-microvm/firecracker/releases) (v0.21.0 or higher)
 - `bridge`, and `firewall` CNI plugins from the [standard CNI plugins](https://github.com/containernetworking/cni), and `tc-redirect-tap` CNI plugin from the [Firecracker Go SDK](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni) installed to `/opt/cni/bin`

--- a/docs/website/content/v0.5/en/guides/local/firecracker.md
+++ b/docs/website/content/v0.5/en/guides/local/firecracker.md
@@ -7,7 +7,10 @@ In this guide we will create a Kubernetes cluster using Firecracker.
 ## Requirements
 
 - Linux
-- a kernel with KVM enabled (`/dev/kvm` must exist)
+- a kernel with
+  - KVM enabled (`/dev/kvm` must exist)
+  - `CONFIG_NET_SCH_NETEM` enabled
+  - `CONFIG_NET_SCH_INGRESS` enabled
 - at least `CAP_SYS_ADMIN` and `CAP_NET_ADMIN` capabilities
 - [firecracker](https://github.com/firecracker-microvm/firecracker/releases) (v0.21.0 or higher)
 - `bridge`, and `firewall` CNI plugins from the [standard CNI plugins](https://github.com/containernetworking/cni), and `tc-redirect-tap` CNI plugin from the [Firecracker Go SDK](https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni) installed to `/opt/cni/bin`


### PR DESCRIPTION
This adds a note on a few more requirements on the host kernel for
running Talos with firecracker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2168)
<!-- Reviewable:end -->
