### PR TITLE
test: fix race in some tests caused by `SetT`

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -91,8 +91,8 @@ func (suite *ContainerdSuite) SetupSuite() {
 
 	go func() {
 		defer suite.containerdWg.Done()
-		defer func() { suite.Require().NoError(suite.containerdRunner.Close()) }()
-		suite.Require().NoError(suite.containerdRunner.Run(MockEventSink))
+		defer suite.containerdRunner.Close()      //nolint: errcheck
+		suite.containerdRunner.Run(MockEventSink) //nolint: errcheck
 	}()
 
 	suite.client, err = containerd.New(suite.containerdAddress)

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -109,8 +109,8 @@ func (suite *ContainerdSuite) SetupSuite() {
 
 	go func() {
 		defer suite.containerdWg.Done()
-		defer func() { suite.Require().NoError(suite.containerdRunner.Close()) }()
-		suite.Require().NoError(suite.containerdRunner.Run(MockEventSink))
+		defer suite.containerdRunner.Close()      //nolint: errcheck
+		suite.containerdRunner.Run(MockEventSink) //nolint: errcheck
 	}()
 
 	suite.client, err = containerd.New(suite.containerdAddress)

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -90,8 +90,8 @@ func (suite *CRISuite) SetupSuite() {
 
 	go func() {
 		defer suite.containerdWg.Done()
-		defer func() { suite.Require().NoError(suite.containerdRunner.Close()) }()
-		suite.Require().NoError(suite.containerdRunner.Run(MockEventSink))
+		defer suite.containerdRunner.Close()      //nolint: errcheck
+		suite.containerdRunner.Run(MockEventSink) //nolint: errcheck
 	}()
 
 	suite.client, err = criclient.NewClient("unix:"+suite.containerdAddress, 30*time.Second)

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -80,8 +80,8 @@ func (suite *CRISuite) SetupSuite() {
 
 	go func() {
 		defer suite.containerdWg.Done()
-		defer func() { suite.Require().NoError(suite.containerdRunner.Close()) }()
-		suite.Require().NoError(suite.containerdRunner.Run(MockEventSink))
+		defer suite.containerdRunner.Close()      //nolint: errcheck
+		suite.containerdRunner.Run(MockEventSink) //nolint: errcheck
 	}()
 
 	suite.client, err = cri.NewClient("unix:"+suite.containerdAddress, 30*time.Second)


### PR DESCRIPTION
Looks like goroutine launched from suite setup might have a race while
trying to access methods which in the end try to load `testing.T` value,
as it changes while each individual test is running.

This leaves us with less diagnostics, but eliminates the race.

Sample:

```
WARNING: DATA RACE
Write at 0x00c00035e418 by goroutine 56:
  github.com/stretchr/testify/suite.(*Suite).SetT()
        /go/pkg/mod/github.com/stretchr/testify@v1.5.1/suite/suite.go:37
        +0x12d
          github.com/talos-systems/talos/internal/pkg/containers/containerd_test.(*ContainerdSuite).SetT()
        <autogenerated>:1 +0x4d
          github.com/stretchr/testify/suite.Run.func2()
        /go/pkg/mod/github.com/stretchr/testify@v1.5.1/suite/suite.go:119
        +0x10f
          testing.tRunner()
        /toolchain/go/src/testing/testing.go:991 +0x1eb

        Previous read at 0x00c00035e418 by goroutine 40:
          github.com/stretchr/testify/suite.(*Suite).Require()
        /go/pkg/mod/github.com/stretchr/testify@v1.5.1/suite/suite.go:42
        +0xdc
          github.com/talos-systems/talos/internal/pkg/containers/containerd_test.(*ContainerdSuite).SetupSuite.func1()
        /src/internal/pkg/containers/containerd/containerd_test.go:119
        +0x101
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2172)
<!-- Reviewable:end -->
