### PR TITLE
fix: activate logical volumes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -163,6 +163,9 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	).Append(
 		WriteUserFiles,
 		WriteUserSysctls,
+	).AppendWhen(
+		r.State().Platform().Mode() != runtime.ModeContainer,
+		ActivateLogicalVolumes,
 	).Append(
 		StartAllServices,
 	).AppendWhen(

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -48,6 +48,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/pkg/blockdevice/probe"
 	"github.com/talos-systems/talos/pkg/blockdevice/util"
+	"github.com/talos-systems/talos/pkg/cmd"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/kubernetes"
@@ -1624,6 +1625,17 @@ func SetInitStatus(seq runtime.Sequence, data interface{}) runtime.TaskExecution
 		}
 
 		logger.Println("updated initialization status in etcd")
+
+		return nil
+	}
+}
+
+// ActivateLogicalVolumes represents the task for activating logical volumes.
+func ActivateLogicalVolumes(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFunc {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
+		if _, err = cmd.Run("/sbin/lvm", "vgchange", "-ay"); err != nil {
+			return fmt.Errorf("failed to activate logical volumes: %w", err)
+		}
 
 		return nil
 	}


### PR DESCRIPTION
We need to activate logical volumes on boot so that storage providers,
like Rook, can work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2189)
<!-- Reviewable:end -->
