### PR TITLE
fix: skip services when in container mode

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -585,9 +585,6 @@ func StartAllServices(seq runtime.Sequence, data interface{}) runtime.TaskExecut
 			&services.Routerd{},
 			&services.Networkd{},
 			&services.OSD{},
-			&services.Timed{},
-			&services.Udevd{},
-			&services.UdevdTrigger{},
 			&services.CRI{},
 			&services.Kubelet{},
 		)

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -66,6 +66,10 @@ func (o *APID) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *APID) DependsOn(r runtime.Runtime) []string {
+	if r.State().Platform().Mode() == runtime.ModeContainer {
+		return []string{"containerd", "networkd"}
+	}
+
 	return []string{"containerd", "networkd", "timed"}
 }
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -81,6 +81,10 @@ func (e *Etcd) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (e *Etcd) DependsOn(r runtime.Runtime) []string {
+	if r.State().Platform().Mode() == runtime.ModeContainer {
+		return []string{"containerd", "networkd"}
+	}
+
 	return []string{"containerd", "networkd", "timed"}
 }
 

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -135,6 +135,10 @@ func (k *Kubelet) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (k *Kubelet) DependsOn(r runtime.Runtime) []string {
+	if r.State().Platform().Mode() == runtime.ModeContainer {
+		return []string{"cri", "networkd"}
+	}
+
 	return []string{"cri", "networkd", "timed"}
 }
 

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -57,6 +57,10 @@ func (t *Trustd) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (t *Trustd) DependsOn(r runtime.Runtime) []string {
+	if r.State().Platform().Mode() == runtime.ModeContainer {
+		return []string{"containerd", "networkd"}
+	}
+
 	return []string{"containerd", "networkd", "timed"}
 }
 


### PR DESCRIPTION
This skips running udevd, udevd-trigger, and timed when running in
container mode. Since the containers run as privileged containers
these services will contend with the host's equivalent services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2194)
<!-- Reviewable:end -->
