### PR TITLE
feat: add open-iscsi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -286,33 +286,36 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.2.0-10-g125ce0e /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0-10-g125ce0e /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0-11-gbce91be /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0-11-gbce91be /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-10-g125ce0e /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-10-g125ce0e /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/lvm2:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/libaio:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/musl:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/syslinux:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-10-g125ce0e / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-10-g125ce0e /lib/libblkid.* /rootfs/lib
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-10-g125ce0e /lib/libuuid.* /rootfs/lib
-COPY --from=docker.io/autonomy/kmod:v0.2.0-10-g125ce0e /usr/lib/libkmod.* /rootfs/lib
-COPY --from=docker.io/autonomy/kernel:v0.2.0-10-g125ce0e /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-11-gbce91be /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-11-gbce91be /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/lvm2:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/libaio:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/musl:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/open-isns:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-11-gbce91be / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-11-gbce91be /lib/libblkid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-11-gbce91be /lib/libuuid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-11-gbce91be /lib/libmount.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kmod:v0.2.0-11-gbce91be /usr/lib/libkmod.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kernel:v0.2.0-11-gbce91be /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/


### PR DESCRIPTION
A number of storage providers depend on having open-iscsi installed
on the host. This adds open-iscsi along with any dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2196)
<!-- Reviewable:end -->
