### PR TITLE
feat: add iscsid service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -286,36 +286,36 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.2.0-11-gbce91be /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0-11-gbce91be /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0-12-g24fcf28 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0-12-g24fcf28 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-11-gbce91be /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-11-gbce91be /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/lvm2:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/libaio:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/musl:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/open-isns:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/syslinux:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-11-gbce91be / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-11-gbce91be /lib/libblkid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-11-gbce91be /lib/libuuid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-11-gbce91be /lib/libmount.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kmod:v0.2.0-11-gbce91be /usr/lib/libkmod.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kernel:v0.2.0-11-gbce91be /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-12-g24fcf28 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-12-g24fcf28 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/lvm2:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/libaio:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/musl:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/open-isns:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-12-g24fcf28 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-12-g24fcf28 /lib/libblkid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-12-g24fcf28 /lib/libuuid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-12-g24fcf28 /lib/libmount.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kmod:v0.2.0-12-g24fcf28 /usr/lib/libkmod.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kernel:v0.2.0-12-g24fcf28 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -594,6 +594,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) runtime.TaskExecut
 				&services.Timed{},
 				&services.Udevd{},
 				&services.UdevdTrigger{},
+				&services.Iscsid{},
 			)
 		}
 

--- a/internal/app/machined/pkg/system/services/iscsid.go
+++ b/internal/app/machined/pkg/system/services/iscsid.go
@@ -1,0 +1,72 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/conditions"
+)
+
+// Iscsid implements the Service interface. It serves as the concrete type with
+// the required methods.
+type Iscsid struct{}
+
+// ID implements the Service interface.
+func (c *Iscsid) ID(r runtime.Runtime) string {
+	return "iscsid"
+}
+
+// PreFunc implements the Service interface.
+func (c *Iscsid) PreFunc(ctx context.Context, r runtime.Runtime) error {
+	return nil
+}
+
+// PostFunc implements the Service interface.
+func (c *Iscsid) PostFunc(r runtime.Runtime, state events.ServiceState) (err error) {
+	return nil
+}
+
+// Condition implements the Service interface.
+func (c *Iscsid) Condition(r runtime.Runtime) conditions.Condition {
+	return nil
+}
+
+// DependsOn implements the Service interface.
+func (c *Iscsid) DependsOn(r runtime.Runtime) []string {
+	return nil
+}
+
+// Runner implements the Service interface.
+func (c *Iscsid) Runner(r runtime.Runtime) (runner.Runner, error) {
+	// Set the process arguments.
+	args := &runner.Args{
+		ID: c.ID(r),
+		ProcessArgs: []string{
+			"/sbin/iscsid",
+			"-f",
+		},
+	}
+
+	env := []string{}
+	for key, val := range r.Config().Machine().Env() {
+		env = append(env, fmt.Sprintf("%s=%s", key, val))
+	}
+
+	return restart.New(process.NewRunner(
+		r.Config().Debug(),
+		args,
+		runner.WithLoggingManager(r.Logging()),
+		runner.WithEnv(env),
+	),
+		restart.WithType(restart.Forever),
+	), nil
+}


### PR DESCRIPTION
It is common for storage providers to require iscsid running on
the host. This adds an `iscsid` service and an updated kernel
that has the required isci kernel modules enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2199)
<!-- Reviewable:end -->
