### PR TITLE
chore: output where we are pulling configs for each platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -124,6 +124,8 @@ func (a *AWS) Name() string {
 
 // Configuration implements the runtime.Platform interface.
 func (a *AWS) Configuration() ([]byte, error) {
+	log.Printf("fetching machine config from: %q", AWSUserDataEndpoint)
+
 	return download.Download(AWSUserDataEndpoint)
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 
@@ -41,6 +42,8 @@ func (a *Azure) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (a *Azure) Configuration() ([]byte, error) {
+	log.Printf("fetching machine config from: %q", AzureUserDataEndpoint)
+
 	if err := linuxAgent(); err != nil {
 		return nil, err
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -7,6 +7,7 @@ package container
 import (
 	"encoding/base64"
 	"errors"
+	"log"
 	"net"
 	"os"
 
@@ -25,6 +26,8 @@ func (c *Container) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (c *Container) Configuration() ([]byte, error) {
+	log.Printf("fetching machine config from: USERDATA environment variable")
+
 	s, ok := os.LookupEnv("USERDATA")
 	if !ok {
 		return nil, errors.New("missing USERDATA environment variable")

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -7,6 +7,7 @@ package digitalocean
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 
@@ -35,6 +36,8 @@ func (d *DigitalOcean) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (d *DigitalOcean) Configuration() ([]byte, error) {
+	log.Printf("fetching machine config from: %q", DigitalOceanUserDataEndpoint)
+
 	return download.Download(DigitalOceanUserDataEndpoint)
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 
@@ -36,6 +37,8 @@ func (g *GCP) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (g *GCP) Configuration() ([]byte, error) {
+	log.Printf("fetching machine config from: %q", GCUserDataEndpoint)
+
 	return download.Download(GCUserDataEndpoint, download.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -44,6 +44,8 @@ func (m *Metal) Configuration() ([]byte, error) {
 		return nil, fmt.Errorf("no config option was found")
 	}
 
+	log.Printf("fetching machine config from: %q", *option)
+
 	u, err := url.Parse(*option)
 	if err != nil {
 		return nil, err

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
@@ -5,6 +5,7 @@
 package packet
 
 import (
+	"log"
 	"net"
 
 	"github.com/talos-systems/go-procfs/procfs"
@@ -28,6 +29,8 @@ func (p *Packet) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (p *Packet) Configuration() ([]byte, error) {
+	log.Printf("fetching machine config from: %q", PacketUserDataEndpoint)
+
 	return download.Download(PacketUserDataEndpoint)
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 
 	"github.com/vmware/vmw-guestinfo/rpcvmx"
@@ -35,6 +36,8 @@ func (v *VMware) Configuration() ([]byte, error) {
 	}
 
 	if *option == constants.ConfigGuestInfo {
+		log.Printf("fetching machine config from: guestinfo key %q", constants.VMwareGuestInfoConfigKey)
+
 		ok, err := vmcheck.IsVirtualWorld()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR aims to give users some extra info about where the machine
config is getting pulled from. The goal is to allow users to catch
things like typos in the config URL, and to validate that the platform
is set properly.

Will close #2131.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2206)
<!-- Reviewable:end -->
