### PR TITLE
fix: detect if partition table is missing

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -184,7 +184,7 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 
 			var pt table.PartitionTable
 
-			pt, err = bd.PartitionTable(true)
+			pt, err = bd.PartitionTable()
 			if err != nil {
 				return err
 			}

--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -147,7 +147,7 @@ func (t *Target) Partition(bd *blockdevice.BlockDevice) (err error) {
 
 	var pt table.PartitionTable
 
-	if pt, err = bd.PartitionTable(true); err != nil {
+	if pt, err = bd.PartitionTable(); err != nil {
 		return err
 	}
 

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -289,7 +289,7 @@ func (p *Point) ResizePartition() (err error) {
 	// nolint: errcheck
 	defer bd.Close()
 
-	pt, err := bd.PartitionTable(true)
+	pt, err := bd.PartitionTable()
 	if err != nil {
 		return err
 	}

--- a/pkg/blockdevice/blockdevice.go
+++ b/pkg/blockdevice/blockdevice.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package blockdevice provides a library for working with block devices.
+package blockdevice
+
+import "errors"
+
+// ErrMissingPartitionTable indicates that the the block device does not have a
+// partition table.
+var ErrMissingPartitionTable = errors.New("missing partition table")

--- a/pkg/blockdevice/blockdevice_darwin.go
+++ b/pkg/blockdevice/blockdevice_darwin.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package blockdevice provides a library for working with block devices.
 package blockdevice
 
 import (
@@ -31,7 +30,7 @@ func (bd *BlockDevice) Close() error {
 }
 
 // PartitionTable returns the block device partition table.
-func (bd *BlockDevice) PartitionTable(read bool) (table.PartitionTable, error) {
+func (bd *BlockDevice) PartitionTable() (table.PartitionTable, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/blockdevice/blockdevice_linux.go
+++ b/pkg/blockdevice/blockdevice_linux.go
@@ -2,12 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package blockdevice provides a library for working with block devices.
 package blockdevice
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -96,13 +94,9 @@ func (bd *BlockDevice) Close() error {
 }
 
 // PartitionTable returns the block device partition table.
-func (bd *BlockDevice) PartitionTable(read bool) (table.PartitionTable, error) {
+func (bd *BlockDevice) PartitionTable() (table.PartitionTable, error) {
 	if bd.table == nil {
-		return nil, errors.New("missing partition table")
-	}
-
-	if !read {
-		return bd.table, nil
+		return nil, ErrMissingPartitionTable
 	}
 
 	return bd.table, bd.table.Read()
@@ -169,7 +163,7 @@ func (bd *BlockDevice) Size() (uint64, error) {
 func (bd *BlockDevice) Reset() (err error) {
 	var pt table.PartitionTable
 
-	if pt, err = bd.PartitionTable(true); err != nil {
+	if pt, err = bd.PartitionTable(); err != nil {
 		return err
 	}
 

--- a/pkg/blockdevice/probe/probe.go
+++ b/pkg/blockdevice/probe/probe.go
@@ -155,7 +155,7 @@ func probe(devpath string) (devpaths []string) {
 	// A partition table was not found, and we have already checked for
 	// a file system on the block device. Let's check if the block device
 	// has partitions.
-	pt, err := bd.PartitionTable(true)
+	pt, err := bd.PartitionTable()
 	if err != nil {
 		return devpaths
 	}


### PR DESCRIPTION
This adds a sentinel error for a missing partition table. This error
is used to detect if a partition table already exists when setting
up user defined disks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2215)
<!-- Reviewable:end -->
