### PR TITLE
feat: allow ability to create dummy nics

### DIFF
--- a/docs/website/content/v0.6/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.6/en/configuration/v1alpha1.md
@@ -737,6 +737,11 @@ The following DHCP options are supported:
 `ignore` is used to exclude a specific interface from configuration.
 This parameter is optional.
 
+##### machine.network.interfaces.dummy
+
+`dummy` is used to specify that this interface should be a virtual-only, dummy interface.
+This parameter is optional.
+
 ##### machine.network.interfaces.routes
 
 `routes` is used to specify static routes that may be necessary.

--- a/internal/app/machined/pkg/runtime/configurator.go
+++ b/internal/app/machined/pkg/runtime/configurator.go
@@ -152,6 +152,7 @@ type Device struct {
 	MTU       int     `yaml:"mtu"`
 	DHCP      bool    `yaml:"dhcp"`
 	Ignore    bool    `yaml:"ignore"`
+	Dummy     bool    `yaml:"dummy"`
 }
 
 // Bond contains the various options for configuring a

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -71,6 +71,11 @@ func buildOptions(device runtime.Device, hostname string) (name string, opts []n
 		}
 	}
 
+	// Handle dummy interface
+	if device.Dummy {
+		opts = append(opts, nic.WithDummy())
+	}
+
 	// Configure Bonding
 	if device.Bond == nil {
 		return device.Interface, opts, err

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -45,6 +45,7 @@ type NetworkInterface struct {
 	Name          string
 	Type          int
 	Ignore        bool
+	Dummy         bool
 	Bonded        bool
 	MTU           uint32
 	Link          *net.Interface
@@ -122,6 +123,10 @@ func (n *NetworkInterface) Create() error {
 
 	if n.Bonded {
 		info = &rtnetlink.LinkInfo{Kind: "bond"}
+	}
+
+	if n.Dummy {
+		info = &rtnetlink.LinkInfo{Kind: "dummy"}
 	}
 
 	if err = n.createLink(n.Name, info); err != nil {

--- a/internal/app/networkd/pkg/nic/options.go
+++ b/internal/app/networkd/pkg/nic/options.go
@@ -23,6 +23,14 @@ func defaultOptions() *NetworkInterface {
 	}
 }
 
+// WithDummy indicates that the interface should be a virtual, dummy interface.
+func WithDummy() Option {
+	return func(n *NetworkInterface) (err error) {
+		n.Dummy = true
+		return
+	}
+}
+
 // WithIgnore indicates that the interface should not be processed by talos.
 func WithIgnore() Option {
 	return func(n *NetworkInterface) (err error) {

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -436,6 +436,11 @@ type NetworkConfig struct {
 	//     `ignore` is used to exclude a specific interface from configuration.
 	//     This parameter is optional.
 	//
+	//     ##### machine.network.interfaces.dummy
+	//
+	//     `dummy` is used to specify that this interface should be a virtual-only, dummy interface.
+	//     This parameter is optional.
+	//
 	//     ##### machine.network.interfaces.routes
 	//
 	//     `routes` is used to specify static routes that may be necessary.


### PR DESCRIPTION
This PR will introduce a new field to v1alpha1 configs that allows users
to set `dummy: true` when specifying interfaces. If present, we will
create a dummy interface with the CIDR information given. This is useful
for users that don't want to use loopback for things like ECMP (or want
more than one dummy interface).

The created dummy interface looked like this with `ip a`:

```
3: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN qlen 1000
    link/ether 66:4a:e3:5f:38:10 brd ff:ff:ff:ff:ff:ff
    inet 10.254.0.5/32 brd 10.254.0.5 scope global dummy0
       valid_lft forever preferred_lft forever
```

Will close #2186 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2220)
<!-- Reviewable:end -->
