### PR TITLE
fix: delete manifests dir on bootkube failure

### DIFF
--- a/internal/app/bootkube/main.go
+++ b/internal/app/bootkube/main.go
@@ -52,6 +52,13 @@ func run() error {
 	}
 
 	defer func() {
+		// We want to cleanup the manifests directory only if bootkube fails.
+		if err != nil {
+			if err = os.RemoveAll(constants.ManifestsDirectory); err != nil {
+				log.Printf("failed to cleanup manifests dir %s", constants.ManifestsDirectory)
+			}
+		}
+
 		if err = os.RemoveAll(constants.AssetsDirectory); err != nil {
 			log.Printf("failed to cleanup bootkube assets dir %s", constants.AssetsDirectory)
 		}


### PR DESCRIPTION
Bootkube expects a clean manifests directory. This ensures that we
clean it up on a failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2223)
<!-- Reviewable:end -->
