### PR TITLE
fix: check if machine networking is nil

### DIFF
--- a/pkg/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_validation.go
@@ -98,9 +98,11 @@ func (c *Config) Validate(mode runtime.Mode) error {
 		}
 	}
 
-	for _, device := range c.MachineConfig.MachineNetwork.NetworkInterfaces {
-		if err := ValidateNetworkDevices(device, CheckDeviceInterface, CheckDeviceAddressing); err != nil {
-			result = multierror.Append(result, err)
+	if c.MachineConfig.MachineNetwork != nil {
+		for _, device := range c.MachineConfig.MachineNetwork.NetworkInterfaces {
+			if err := ValidateNetworkDevices(device, CheckDeviceInterface, CheckDeviceAddressing); err != nil {
+				result = multierror.Append(result, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a panic when `machine.network` is defined, but `nil`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2227)
<!-- Reviewable:end -->
