### PR TITLE
feat: implement circular buffer for system logs

### DIFF
--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -37,7 +37,7 @@ func run() (err error) {
 	}
 
 	// Setup logging to /dev/kmsg.
-	err = kmsg.Setup("[talos] [initramfs]", false)
+	err = kmsg.SetupLogger(nil, "[talos] [initramfs]", nil)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/runtime/logging/cicrular.go
+++ b/internal/app/machined/pkg/runtime/logging/cicrular.go
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package logging
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/pkg/circular"
+	"github.com/talos-systems/talos/internal/pkg/tail"
+)
+
+// These constants should some day move to config.
+const (
+	// Some logs are tiny, no need to reserve too much memory.
+	InitialCapacity = 16384
+	// Cap each log at 1M.
+	MaxCapacity = 1048576
+	// Safety gap to avoid buffer overruns.
+	SafetyGap = 2048
+)
+
+// CircularBufferLoggingManager implements logging to circular fixed size buffer.
+type CircularBufferLoggingManager struct {
+	buffers sync.Map
+}
+
+// NewCircularBufferLoggingManager initializes new CircularBufferLoggingManager.
+func NewCircularBufferLoggingManager() *CircularBufferLoggingManager {
+	return &CircularBufferLoggingManager{}
+}
+
+// ServiceLog implements runtime.LoggingManager interface.
+func (manager *CircularBufferLoggingManager) ServiceLog(id string) runtime.LogHandler {
+	return &circularHandler{
+		manager: manager,
+		id:      id,
+	}
+}
+
+func (manager *CircularBufferLoggingManager) getBuffer(id string, create bool) (*circular.Buffer, error) {
+	buf, ok := manager.buffers.Load(id)
+	if !ok {
+		if !create {
+			return nil, nil
+		}
+
+		b, err := circular.NewBuffer(
+			circular.WithInitialCapacity(InitialCapacity),
+			circular.WithMaxCapacity(MaxCapacity),
+			circular.WithSafetyGap(SafetyGap))
+		if err != nil {
+			return nil, err // only configuration issue might raise error
+		}
+
+		buf, _ = manager.buffers.LoadOrStore(id, b)
+	}
+
+	return buf.(*circular.Buffer), nil
+}
+
+type circularHandler struct {
+	manager *CircularBufferLoggingManager
+	id      string
+
+	buf *circular.Buffer
+}
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (c nopCloser) Close() error {
+	return nil
+}
+
+// Writer implements runtime.LogHandler interface.
+func (handler *circularHandler) Writer() (io.WriteCloser, error) {
+	if handler.buf == nil {
+		var err error
+
+		handler.buf, err = handler.manager.getBuffer(handler.id, true)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return nopCloser{handler.buf}, nil
+}
+
+// Reader implements runtime.LogHandler interface.
+func (handler *circularHandler) Reader(opts ...runtime.LogOption) (io.ReadCloser, error) {
+	if handler.buf == nil {
+		var err error
+
+		handler.buf, err = handler.manager.getBuffer(handler.id, false)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if handler.buf == nil {
+			// only Writer() operation creates new buffers
+			return nil, fmt.Errorf("log %q was not registered", handler.id)
+		}
+	}
+
+	var opt runtime.LogOptions
+
+	for _, o := range opts {
+		if err := o(&opt); err != nil {
+			return nil, err
+		}
+	}
+
+	var r interface {
+		io.ReadCloser
+		io.Seeker
+	}
+
+	if opt.Follow {
+		r = handler.buf.GetStreamingReader()
+	} else {
+		r = handler.buf.GetReader()
+	}
+
+	if opt.TailLines != nil {
+		err := tail.SeekLines(r, *opt.TailLines)
+		if err != nil {
+			r.Close() //nolint: errcheck
+			return nil, fmt.Errorf("error tailing log: %w", err)
+		}
+	}
+
+	return r, nil
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -65,7 +65,12 @@ func SetupLogger(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFu
 			return nil
 		}
 
-		if err = kmsg.Setup("[talos]", true); err != nil {
+		machinedLog, err := r.Logging().ServiceLog("machined").Writer()
+		if err != nil {
+			return err
+		}
+
+		if err = kmsg.SetupLogger(nil, "[talos]", machinedLog); err != nil {
 			return fmt.Errorf("failed to setup logging: %w", err)
 		}
 

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -136,7 +136,7 @@ func (suite *LogsSuite) TestServiceNotFound() {
 	_, err = logsStream.Recv()
 	suite.Require().Error(err)
 
-	suite.Require().Regexp(`.+nosuchservice\.log: no such file or directory$`, err.Error())
+	suite.Require().Regexp(`.+log "nosuchservice" was not registered$`, err.Error())
 }
 
 // TestStreaming verifies that logs are streamed in real-time

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -53,7 +53,7 @@ func (suite *LogsSuite) TestServiceNotFound() {
 		base.ShouldFail(),
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
-		base.StderrShouldMatch(regexp.MustCompile("error getting logs: .*servicenotfound.log: no such file or directory")),
+		base.StderrShouldMatch(regexp.MustCompile(`error getting logs:.+ log "servicenotfound" was not registered`)),
 	)
 }
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -32,15 +32,16 @@ var allSuites []suite.TestingSuite
 
 // Flag values
 var (
-	failFast        bool
-	talosConfig     string
-	endpoint        string
-	k8sEndpoint     string
-	expectedVersion string
-	talosctlPath    string
-	provisionerName string
-	clusterName     string
-	stateDir        string
+	failFast         bool
+	crashdumpEnabled bool
+	talosConfig      string
+	endpoint         string
+	k8sEndpoint      string
+	expectedVersion  string
+	talosctlPath     string
+	provisionerName  string
+	clusterName      string
+	stateDir         string
 )
 
 func TestIntegration(t *testing.T) {
@@ -100,7 +101,7 @@ func TestIntegration(t *testing.T) {
 		}
 	}
 
-	if t.Failed() && cluster != nil && provisioner != nil {
+	if t.Failed() && crashdumpEnabled && cluster != nil && provisioner != nil {
 		// if provisioner & cluster are available,
 		// debugging failed test is easier with crashdump
 		provisioner.CrashDump(context.Background(), cluster, os.Stderr)
@@ -116,6 +117,7 @@ func init() {
 	}
 
 	flag.BoolVar(&failFast, "talos.failfast", false, "fail the test run on the first failed test")
+	flag.BoolVar(&crashdumpEnabled, "talos.crashdump", true, "print crashdump on test failure (only if provisioner is enabled)")
 
 	flag.StringVar(&talosConfig, "talos.config", defaultTalosConfig, "The path to the Talos configuration file")
 	flag.StringVar(&endpoint, "talos.endpoint", "", "endpoint to use (overrides config)")

--- a/internal/pkg/circular/circular.go
+++ b/internal/pkg/circular/circular.go
@@ -1,0 +1,158 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package circular provides a buffer with circular semantics.
+package circular
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Buffer implements circular buffer which supports single writer and multiple
+// readers each with its own offset.
+type Buffer struct {
+	opt Options
+
+	// synchronizing access to data, off
+	mu   sync.Mutex
+	cond *sync.Cond
+
+	// data slice, might grow up to MaxCapacity, then used
+	// as circular buffer
+	data []byte
+
+	// write offset, always goes up, actual offset in data slice
+	// is (off % cap(data))
+	off int64
+}
+
+// NewBuffer creates new Buffer with specified options.
+func NewBuffer(opts ...OptionFunc) (*Buffer, error) {
+	buf := &Buffer{
+		opt: defaultOptions(),
+	}
+
+	for _, o := range opts {
+		if err := o(&buf.opt); err != nil {
+			return nil, err
+		}
+	}
+
+	if buf.opt.InitialCapacity > buf.opt.MaxCapacity {
+		return nil, fmt.Errorf("initial capacity (%d) should be less or equal to max capacity (%d)", buf.opt.InitialCapacity, buf.opt.MaxCapacity)
+	}
+
+	if buf.opt.SafetyGap >= buf.opt.MaxCapacity {
+		return nil, fmt.Errorf("safety gap (%d) should be less than max capacity (%d)", buf.opt.SafetyGap, buf.opt.MaxCapacity)
+	}
+
+	buf.data = make([]byte, buf.opt.InitialCapacity)
+	buf.cond = sync.NewCond(&buf.mu)
+
+	return buf, nil
+}
+
+// Write implements io.Writer interface.
+func (buf *Buffer) Write(p []byte) (n int, err error) {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	l := len(p)
+
+	if buf.off < int64(buf.opt.MaxCapacity) {
+		if buf.off+int64(l) > int64(cap(buf.data)) && cap(buf.data) < buf.opt.MaxCapacity {
+			// grow buffer to ensure write fits, but limit with max capacity
+			size := cap(buf.data) * 2
+			for size < int(buf.off)+l {
+				size *= 2
+			}
+
+			if size > buf.opt.MaxCapacity {
+				size = buf.opt.MaxCapacity
+			}
+
+			data := make([]byte, size)
+			copy(data, buf.data)
+			buf.data = data
+		}
+	}
+
+	for n < l {
+		i := int(buf.off % int64(buf.opt.MaxCapacity))
+
+		nn := buf.opt.MaxCapacity - i
+		if nn > len(p) {
+			nn = len(p)
+		}
+
+		copy(buf.data[i:], p[:nn])
+
+		buf.off += int64(nn)
+		n += nn
+		p = p[nn:]
+	}
+
+	if n > 0 {
+		buf.cond.Broadcast()
+	}
+
+	return n, err
+}
+
+// Capacity returns number of bytes allocated for the buffer.
+func (buf *Buffer) Capacity() int {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	return cap(buf.data)
+}
+
+// Offset returns current write offset (number of bytes written).
+func (buf *Buffer) Offset() int64 {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	return buf.off
+}
+
+// GetStreamingReader returns StreamingReader object which implements io.ReadCloser, io.Seeker.
+//
+// StreamingReader starts at the most distant position in the past available.
+func (buf *Buffer) GetStreamingReader() *StreamingReader {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	off := buf.off - int64(buf.opt.MaxCapacity-buf.opt.SafetyGap)
+	if off < 0 {
+		off = 0
+	}
+
+	return &StreamingReader{
+		buf:        buf,
+		initialOff: off,
+		off:        off,
+	}
+}
+
+// GetReader returns Reader object which implements io.ReadCloser, io.Seeker.
+//
+// Reader starts at the most distant position in the past available and goes
+// to the current write position.
+func (buf *Buffer) GetReader() *Reader {
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+
+	off := buf.off - int64(buf.opt.MaxCapacity-buf.opt.SafetyGap)
+	if off < 0 {
+		off = 0
+	}
+
+	return &Reader{
+		buf:      buf,
+		startOff: off,
+		endOff:   buf.off,
+		off:      off,
+	}
+}

--- a/internal/pkg/circular/circular_test.go
+++ b/internal/pkg/circular/circular_test.go
@@ -1,0 +1,424 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package circular_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/time/rate"
+
+	"github.com/talos-systems/talos/internal/pkg/circular"
+)
+
+type CircularSuite struct {
+	suite.Suite
+}
+
+func (suite *CircularSuite) TestWrites() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(100000))
+	suite.Require().NoError(err)
+
+	n, err := buf.Write(nil)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, n)
+
+	n, err = buf.Write(make([]byte, 100))
+	suite.Require().NoError(err)
+	suite.Require().Equal(100, n)
+
+	n, err = buf.Write(make([]byte, 1000))
+	suite.Require().NoError(err)
+	suite.Require().Equal(1000, n)
+
+	suite.Require().Equal(2048, buf.Capacity())
+	suite.Require().EqualValues(1100, buf.Offset())
+
+	n, err = buf.Write(make([]byte, 5000))
+	suite.Require().NoError(err)
+	suite.Require().Equal(5000, n)
+
+	suite.Require().Equal(8192, buf.Capacity())
+	suite.Require().EqualValues(6100, buf.Offset())
+
+	for i := 0; i < 20; i++ {
+		l := 1 << i
+
+		n, err = buf.Write(make([]byte, l))
+		suite.Require().NoError(err)
+		suite.Require().Equal(l, n)
+	}
+
+	suite.Require().Equal(100000, buf.Capacity())
+	suite.Require().EqualValues(6100+(1<<20)-1, buf.Offset())
+}
+
+func (suite *CircularSuite) TestStreamingReadWriter() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(65536))
+	suite.Require().NoError(err)
+
+	r := buf.GetStreamingReader()
+
+	size := 1048576
+
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(rand.Int31())
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		p := data
+
+		r := rate.NewLimiter(500000, 1000)
+
+		for i := 0; i < len(data); {
+			l := 100 + rand.Intn(100)
+
+			if i+l > len(data) {
+				l = len(data) - i
+			}
+
+			r.WaitN(context.Background(), l) //nolint: errcheck
+
+			n, e := buf.Write(p[:l])
+			suite.Require().NoError(e)
+			suite.Require().Equal(l, n)
+
+			i += l
+			p = p[l:]
+		}
+	}()
+
+	actual := make([]byte, size)
+
+	n, err := io.ReadFull(r, actual)
+	suite.Require().NoError(err)
+	suite.Require().Equal(size, n)
+
+	suite.Require().Equal(data, actual)
+
+	s := make(chan struct{})
+
+	go func() {
+		_, err = r.Read(make([]byte, 1))
+
+		suite.Assert().Equal(err, circular.ErrClosed)
+
+		close(s)
+	}()
+
+	time.Sleep(50 * time.Millisecond) // wait for the goroutine to start
+
+	suite.Require().NoError(r.Close())
+
+	// close should abort reader
+	<-s
+
+	_, err = r.Read(nil)
+	suite.Require().Equal(circular.ErrClosed, err)
+}
+
+func (suite *CircularSuite) TestStreamingMultipleReaders() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(65536))
+	suite.Require().NoError(err)
+
+	n := 5
+
+	readers := make([]*circular.StreamingReader, n)
+
+	for i := 0; i < n; i++ {
+		readers[i] = buf.GetStreamingReader()
+	}
+
+	size := 1048576
+
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(rand.Int31())
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+
+		i := i
+
+		go func() {
+			defer wg.Done()
+
+			actual := make([]byte, size)
+
+			nn, err := io.ReadFull(readers[i], actual)
+			suite.Require().NoError(err)
+			suite.Assert().Equal(size, nn)
+
+			suite.Assert().Equal(data, actual)
+		}()
+	}
+
+	p := data
+
+	r := rate.NewLimiter(500000, 1000)
+
+	for i := 0; i < len(data); {
+		l := 256
+
+		if i+l > len(data) {
+			l = len(data) - i
+		}
+
+		r.WaitN(context.Background(), l) //nolint: errcheck
+
+		n, e := buf.Write(p[:l])
+		suite.Require().NoError(e)
+		suite.Require().Equal(l, n)
+
+		i += l
+		p = p[l:]
+	}
+}
+
+func (suite *CircularSuite) TestStreamingLateAndIdleReaders() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(65536), circular.WithSafetyGap(256))
+	suite.Require().NoError(err)
+
+	idleR := buf.GetStreamingReader()
+
+	size := 100000
+
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(rand.Int31())
+	}
+
+	n, err := buf.Write(data)
+	suite.Require().NoError(err)
+	suite.Require().Equal(size, n)
+
+	lateR := buf.GetStreamingReader()
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		suite.Require().NoError(lateR.Close())
+	}()
+
+	actual, err := ioutil.ReadAll(lateR)
+	suite.Require().Equal(circular.ErrClosed, err)
+	suite.Require().Equal(65536-256, len(actual))
+
+	suite.Require().Equal(data[size-65536+256:], actual)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+
+		suite.Require().NoError(idleR.Close())
+	}()
+
+	actual, err = ioutil.ReadAll(idleR)
+	suite.Require().Equal(circular.ErrClosed, err)
+	suite.Require().Equal(65536, len(actual))
+
+	suite.Require().Equal(data[size-65536:], actual)
+}
+
+func (suite *CircularSuite) TestStreamingSeek() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(65536), circular.WithSafetyGap(256))
+	suite.Require().NoError(err)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xff}, 512))
+	suite.Require().NoError(err)
+
+	r := buf.GetStreamingReader()
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 512))
+	suite.Require().NoError(err)
+
+	off, err := r.Seek(0, io.SeekCurrent)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(0, off)
+
+	data := make([]byte, 256)
+
+	n, err := r.Read(data)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(256, n)
+	suite.Assert().Equal(bytes.Repeat([]byte{0xff}, 256), data)
+
+	off, err = r.Seek(0, io.SeekCurrent)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(256, off)
+
+	off, err = r.Seek(-256, io.SeekEnd)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(768, off)
+
+	n, err = r.Read(data)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(256, n)
+	suite.Assert().Equal(bytes.Repeat([]byte{0xfe}, 256), data)
+
+	off, err = r.Seek(2048, io.SeekStart)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(1024, off)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 65536-256))
+	suite.Require().NoError(err)
+
+	off, err = r.Seek(0, io.SeekStart)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(1024, off)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 1024))
+	suite.Require().NoError(err)
+
+	off, err = r.Seek(0, io.SeekCurrent)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(2048, off)
+
+	_, err = r.Seek(-100, io.SeekStart)
+	suite.Require().Equal(circular.ErrSeekBeforeStart, err)
+}
+
+func (suite *CircularSuite) TestRegularReaderEmpty() {
+	buf, err := circular.NewBuffer()
+	suite.Require().NoError(err)
+
+	n, err := buf.GetReader().Read(nil)
+	suite.Require().Equal(0, n)
+	suite.Require().Equal(io.EOF, err)
+}
+
+func (suite *CircularSuite) TestRegularReader() {
+	buf, err := circular.NewBuffer()
+	suite.Require().NoError(err)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xff}, 512))
+	suite.Require().NoError(err)
+
+	r := buf.GetReader()
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 512))
+	suite.Require().NoError(err)
+
+	actual, err := ioutil.ReadAll(r)
+	suite.Require().NoError(err)
+	suite.Require().Equal(bytes.Repeat([]byte{0xff}, 512), actual)
+}
+
+func (suite *CircularSuite) TestRegularReaderOutOfSync() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(65536), circular.WithSafetyGap(256))
+	suite.Require().NoError(err)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xff}, 512))
+	suite.Require().NoError(err)
+
+	r := buf.GetReader()
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 65536-256))
+	suite.Require().NoError(err)
+
+	_, err = r.Read(nil)
+	suite.Require().Equal(err, circular.ErrOutOfSync)
+}
+
+func (suite *CircularSuite) TestRegularReaderFull() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(4096), circular.WithSafetyGap(256))
+	suite.Require().NoError(err)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xff}, 6146))
+	suite.Require().NoError(err)
+
+	r := buf.GetReader()
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 100))
+	suite.Require().NoError(err)
+
+	actual, err := ioutil.ReadAll(r)
+	suite.Require().NoError(err)
+	suite.Require().Equal(bytes.Repeat([]byte{0xff}, 4096-256), actual)
+
+	suite.Require().NoError(r.Close())
+
+	_, err = r.Read(nil)
+	suite.Require().Equal(err, circular.ErrClosed)
+}
+
+func (suite *CircularSuite) TestRegularSeek() {
+	buf, err := circular.NewBuffer(circular.WithInitialCapacity(2048), circular.WithMaxCapacity(65536), circular.WithSafetyGap(256))
+	suite.Require().NoError(err)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xff}, 512))
+	suite.Require().NoError(err)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 512))
+	suite.Require().NoError(err)
+
+	r := buf.GetReader()
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfc}, 512))
+	suite.Require().NoError(err)
+
+	off, err := r.Seek(0, io.SeekCurrent)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(0, off)
+
+	data := make([]byte, 256)
+
+	n, err := r.Read(data)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(256, n)
+	suite.Assert().Equal(bytes.Repeat([]byte{0xff}, 256), data)
+
+	off, err = r.Seek(0, io.SeekCurrent)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(256, off)
+
+	off, err = r.Seek(-256, io.SeekEnd)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(768, off)
+
+	n, err = r.Read(data)
+	suite.Require().NoError(err)
+	suite.Assert().Equal(256, n)
+	suite.Assert().Equal(bytes.Repeat([]byte{0xfe}, 256), data)
+
+	off, err = r.Seek(2048, io.SeekStart)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(1024, off)
+
+	_, err = buf.Write(bytes.Repeat([]byte{0xfe}, 65536-256))
+	suite.Require().NoError(err)
+
+	off, err = r.Seek(0, io.SeekStart)
+	suite.Require().NoError(err)
+	suite.Assert().EqualValues(0, off)
+
+	_, err = r.Seek(-100, io.SeekStart)
+	suite.Require().Equal(circular.ErrSeekBeforeStart, err)
+
+	_, err = r.Read(nil)
+	suite.Require().Equal(circular.ErrOutOfSync, err)
+}
+
+func TestCircularSuite(t *testing.T) {
+	suite.Run(t, new(CircularSuite))
+}

--- a/internal/pkg/circular/errors.go
+++ b/internal/pkg/circular/errors.go
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package circular
+
+import "errors"
+
+// ErrClosed is raised on read from closed Reader.
+var ErrClosed = errors.New("reader is closed")
+
+// ErrSeekBeforeStart is raised when seek goes beyond start of the file.
+var ErrSeekBeforeStart = errors.New("seek before start")
+
+// ErrOutOfSync is raised when reader got too much out of sync with the writer.
+var ErrOutOfSync = errors.New("buffer overrun, read position overwritten")

--- a/internal/pkg/circular/options.go
+++ b/internal/pkg/circular/options.go
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package circular
+
+import "fmt"
+
+// Options defines settings for Buffer.
+type Options struct {
+	InitialCapacity int
+	MaxCapacity     int
+	SafetyGap       int
+}
+
+// defaultOptions returns default initial values.
+func defaultOptions() Options {
+	return Options{
+		InitialCapacity: 16384,
+		MaxCapacity:     1048576,
+		SafetyGap:       1024,
+	}
+}
+
+// OptionFunc allows setting Buffer options.
+type OptionFunc func(*Options) error
+
+// WithInitialCapacity sets initial buffer capacity.
+func WithInitialCapacity(cap int) OptionFunc {
+	return func(opt *Options) error {
+		if cap <= 0 {
+			return fmt.Errorf("initial capacity should be positive: %d", cap)
+		}
+
+		opt.InitialCapacity = cap
+
+		return nil
+	}
+}
+
+// WithMaxCapacity sets maximum buffer capacity.
+func WithMaxCapacity(cap int) OptionFunc {
+	return func(opt *Options) error {
+		if cap <= 0 {
+			return fmt.Errorf("max capacity should be positive: %d", cap)
+		}
+
+		opt.MaxCapacity = cap
+
+		return nil
+	}
+}
+
+// WithSafetyGap sets safety gap between readers and writers to avoid buffer overrun for the reader.
+//
+// Reader initial position is set to be as far as possible in the buffer history, but next concurrent write
+// might overwrite read position, and safety gap helps to prevent it. With safety gap, maximum available
+// bytes to read are: MaxCapacity-SafetyGap.
+func WithSafetyGap(gap int) OptionFunc {
+	return func(opt *Options) error {
+		if gap <= 0 {
+			return fmt.Errorf("safety gap should be positive: %q", gap)
+		}
+
+		opt.SafetyGap = gap
+
+		return nil
+	}
+}

--- a/internal/pkg/circular/reader.go
+++ b/internal/pkg/circular/reader.go
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package circular
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// Reader implements seekable reader with local position in the Buffer which
+// reads from the fixed part of the buffer.
+//
+// Reader is not safe to be used with concurrent Read/Seek operations.
+type Reader struct {
+	buf *Buffer
+
+	startOff, endOff int64
+	off              int64
+
+	closed uint32
+}
+
+// Read implements io.Reader.
+func (r *Reader) Read(p []byte) (n int, err error) {
+	if atomic.LoadUint32(&r.closed) > 0 {
+		err = ErrClosed
+		return
+	}
+
+	r.buf.mu.Lock()
+	defer r.buf.mu.Unlock()
+
+	if r.off < r.buf.off-int64(r.buf.opt.MaxCapacity) {
+		// reader is falling too much behind
+		err = ErrOutOfSync
+
+		return
+	}
+
+	if r.off == r.endOff {
+		err = io.EOF
+
+		return
+	}
+
+	if len(p) == 0 {
+		return
+	}
+
+	n = int(r.endOff - r.off)
+	if n > len(p) {
+		n = len(p)
+	}
+
+	i := int(r.off % int64(r.buf.opt.MaxCapacity))
+	l := r.buf.opt.MaxCapacity - i
+
+	if l < n {
+		copy(p, r.buf.data[i:])
+		copy(p[l:], r.buf.data[:n-l])
+	} else {
+		copy(p, r.buf.data[i:i+n])
+	}
+
+	r.off += int64(n)
+
+	return n, err
+}
+
+// Close implements io.Closer.
+func (r *Reader) Close() error {
+	atomic.StoreUint32(&r.closed, 1)
+
+	return nil
+}
+
+// Seek implements io.Seeker.
+func (r *Reader) Seek(offset int64, whence int) (int64, error) {
+	newOff := r.off
+
+	switch whence {
+	case io.SeekCurrent:
+		newOff += offset
+	case io.SeekEnd:
+		newOff = r.endOff + offset
+	case io.SeekStart:
+		newOff = r.startOff + offset
+	}
+
+	if newOff < r.startOff {
+		return r.off - r.startOff, ErrSeekBeforeStart
+	}
+
+	if newOff > r.endOff {
+		newOff = r.endOff
+	}
+
+	r.off = newOff
+
+	return r.off - r.startOff, nil
+}

--- a/internal/pkg/circular/streaming.go
+++ b/internal/pkg/circular/streaming.go
@@ -1,0 +1,116 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package circular
+
+import (
+	"io"
+	"sync/atomic"
+)
+
+// StreamingReader implements seekable reader with local position in the Buffer.
+//
+// StreamingReader is not safe to be used with concurrent Read/Seek operations.
+//
+// StreamingReader blocks for new data once it exhausts contents of the buffer.
+type StreamingReader struct {
+	buf *Buffer
+
+	initialOff int64
+	off        int64
+
+	closed uint32
+}
+
+// Read implements io.Reader.
+func (r *StreamingReader) Read(p []byte) (n int, err error) {
+	if atomic.LoadUint32(&r.closed) > 0 {
+		err = ErrClosed
+		return
+	}
+
+	if len(p) == 0 {
+		return
+	}
+
+	r.buf.mu.Lock()
+	defer r.buf.mu.Unlock()
+
+	if r.off < r.buf.off-int64(r.buf.opt.MaxCapacity) {
+		// reader is falling too much behind, so need to rewind to the first available position
+		r.off = r.buf.off - int64(r.buf.opt.MaxCapacity)
+	}
+
+	for r.off == r.buf.off {
+		r.buf.cond.Wait()
+
+		if atomic.LoadUint32(&r.closed) > 0 {
+			err = ErrClosed
+			return
+		}
+	}
+
+	n = int(r.buf.off - r.off)
+	if n > len(p) {
+		n = len(p)
+	}
+
+	i := int(r.off % int64(r.buf.opt.MaxCapacity))
+	l := r.buf.opt.MaxCapacity - i
+
+	if l < n {
+		copy(p, r.buf.data[i:])
+		copy(p[l:], r.buf.data[:n-l])
+	} else {
+		copy(p, r.buf.data[i:i+n])
+	}
+
+	r.off += int64(n)
+
+	return n, err
+}
+
+// Close implements io.Closer.
+func (r *StreamingReader) Close() error {
+	if atomic.CompareAndSwapUint32(&r.closed, 0, 1) {
+		// wake up readers
+		r.buf.cond.Broadcast()
+	}
+
+	return nil
+}
+
+// Seek implements io.Seeker.
+func (r *StreamingReader) Seek(offset int64, whence int) (int64, error) {
+	newOff := r.off
+
+	r.buf.mu.Lock()
+	writeOff := r.buf.off
+	r.buf.mu.Unlock()
+
+	switch whence {
+	case io.SeekCurrent:
+		newOff += offset
+	case io.SeekEnd:
+		newOff = writeOff + offset
+	case io.SeekStart:
+		newOff = r.initialOff + offset
+	}
+
+	if newOff < r.initialOff {
+		return r.off - r.initialOff, ErrSeekBeforeStart
+	}
+
+	if newOff > writeOff {
+		newOff = writeOff
+	}
+
+	if newOff < writeOff-int64(r.buf.opt.MaxCapacity-r.buf.opt.SafetyGap) {
+		newOff = writeOff - int64(r.buf.opt.MaxCapacity-r.buf.opt.SafetyGap)
+	}
+
+	r.off = newOff
+
+	return r.off - r.initialOff, nil
+}

--- a/internal/pkg/kmsg/kmsg.go
+++ b/internal/pkg/kmsg/kmsg.go
@@ -12,48 +12,17 @@ import (
 	"io"
 	"log"
 	"os"
-	"path/filepath"
 
 	"golang.org/x/sys/unix"
-
-	"github.com/talos-systems/talos/pkg/constants"
 )
-
-// Setup configures the log package to write to the kernel ring buffer via
-// /dev/kmsg.
-func Setup(prefix string, withLogFile bool) error {
-	kmsg, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
-	if err != nil {
-		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
-	}
-
-	var writer io.Writer = &Writer{KmsgWriter: kmsg}
-
-	if withLogFile {
-		if err := os.MkdirAll(constants.DefaultLogPath, 0700); err != nil {
-			return err
-		}
-
-		logPath := filepath.Join(constants.DefaultLogPath, "machined.log")
-
-		f, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-		if err != nil {
-			return fmt.Errorf("failed to open %s: %w", logPath, err)
-		}
-
-		writer = io.MultiWriter(writer, f)
-	}
-
-	log.SetOutput(writer)
-	log.SetPrefix(prefix + " ")
-	log.SetFlags(0)
-
-	return nil
-}
 
 // SetupLogger configures the logger to write to the kernel ring buffer via
 // /dev/kmsg.
-func SetupLogger(logger *log.Logger, prefix string, withLogFile bool) error {
+//
+// If logger is nil, default `log` logger is redirectred.
+//
+// If extraWriter is not nil, logs will be copied to it as well.
+func SetupLogger(logger *log.Logger, prefix string, extraWriter io.Writer) error {
 	kmsg, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
 	if err != nil {
 		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
@@ -61,24 +30,19 @@ func SetupLogger(logger *log.Logger, prefix string, withLogFile bool) error {
 
 	var writer io.Writer = &Writer{KmsgWriter: kmsg}
 
-	if withLogFile {
-		if err := os.MkdirAll(constants.DefaultLogPath, 0700); err != nil {
-			return err
-		}
-
-		logPath := filepath.Join(constants.DefaultLogPath, "machined.log")
-
-		f, err := os.OpenFile(logPath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-		if err != nil {
-			return fmt.Errorf("failed to open %s: %w", logPath, err)
-		}
-
-		writer = io.MultiWriter(writer, f)
+	if extraWriter != nil {
+		writer = io.MultiWriter(writer, extraWriter)
 	}
 
-	logger.SetOutput(writer)
-	logger.SetPrefix(prefix + " ")
-	logger.SetFlags(0)
+	if logger != nil {
+		logger.SetOutput(writer)
+		logger.SetPrefix(prefix + " ")
+		logger.SetFlags(0)
+	} else {
+		log.SetOutput(writer)
+		log.SetPrefix(prefix + " ")
+		log.SetFlags(0)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This replaces logging to files with inotify following to pure in-memory
circular buffer which grows on demand capped at specified maximum
capacity.

The concern with previous approach was that logs on tmpfs were growing
without any bound potentially consuming all the node memory.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2230)
<!-- Reviewable:end -->
