### PR TITLE
chore: upgrade golangci-lint to 1.27

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,6 +112,11 @@ linters:
     - godox
     - gocognit
     - gomnd
+    - nolintlint # TODO: fix & enable me
+    - testpackage # TODO: fix & enable me
+    - goerr113
+    - nestif
+    - godot # TODO: fix & enable me
   disable-all: false
   fast: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.24.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.27.0
 RUN cd $(mktemp -d) \
     && go mod init tmp \
     && go get mvdan.cc/gofumpt/gofumports@aaa7156f4122b1055c466e26e77812fa32bac1d9 \


### PR DESCRIPTION
This version is built with newer Go which fixes
`fatal error: mlock failed` on Ubuntu kernels which are actually
patched, but their minor version doesn't match Go expectations.

New linters were disabled to minimize the changes, and plan is to fix
the linting errors in subsequent PRs.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2236)
<!-- Reviewable:end -->
