### PR TITLE
fix: use kubernetes version in config generator

### DIFF
--- a/docs/website/content/v0.5/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.5/en/configuration/v1alpha1.md
@@ -35,7 +35,6 @@ machine:
     force: false
 cluster:
   controlPlane:
-    version: 1.18.0
     endpoint: https://1.2.3.4
   clusterName: example
   network:

--- a/docs/website/content/v0.6/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.6/en/configuration/v1alpha1.md
@@ -35,7 +35,6 @@ machine:
     force: false
 cluster:
   controlPlane:
-    version: 1.18.3
     endpoint: https://1.2.3.4
   clusterName: example
   network:

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -260,7 +260,7 @@ func (suite *UpgradeSuite) setupCluster() {
 		&config.InputOptions{
 			ClusterName: clusterName,
 			Endpoint:    fmt.Sprintf("https://%s:6443", defaultInternalLB),
-			KubeVersion: constants.DefaultKubernetesVersion, // TODO: should be upgradeable
+			KubeVersion: "", // keep empty so that default version is used per Talos version
 			GenOptions: append(
 				genOptions,
 				generate.WithEndpointList([]string{defaultExternalLB}),

--- a/pkg/config/types/v1alpha1/doc.go
+++ b/pkg/config/types/v1alpha1/doc.go
@@ -34,7 +34,6 @@ machine:
     force: false
 cluster:
   controlPlane:
-    version: 1.18.3
     endpoint: https://1.2.3.4
   clusterName: example
   network:

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -391,3 +391,12 @@ func genToken(lenFirst int, lenSecond int) (string, error) {
 
 	return tokenTemp[0] + "." + tokenTemp[1], nil
 }
+
+// emptyIf returns empty string if the 2nd argument is empty string, otherwise returns the first argumewnt.
+func emptyIf(str string, check string) string {
+	if check == "" {
+		return ""
+	}
+
+	return str
+}

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -5,9 +5,11 @@
 package generate
 
 import (
+	"fmt"
 	"net/url"
 
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 func initUd(in *Input) (*v1alpha1.Config, error) {
@@ -18,8 +20,10 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 	}
 
 	machine := &v1alpha1.MachineConfig{
-		MachineType:     "init",
-		MachineKubelet:  &v1alpha1.KubeletConfig{},
+		MachineType: "init",
+		MachineKubelet: &v1alpha1.KubeletConfig{
+			KubeletImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubeletImage, in.KubernetesVersion), in.KubernetesVersion),
+		},
 		MachineNetwork:  in.NetworkConfig,
 		MachineCA:       in.Certs.OS,
 		MachineCertSANs: in.AdditionalMachineCertSANs,
@@ -47,11 +51,18 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		APIServerConfig: &v1alpha1.APIServerConfig{
-			CertSANs: certSANs,
+			CertSANs:       certSANs,
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, in.KubernetesVersion), in.KubernetesVersion),
 		},
-		ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{},
-		ProxyConfig:             &v1alpha1.ProxyConfig{},
-		SchedulerConfig:         &v1alpha1.SchedulerConfig{},
+		ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, in.KubernetesVersion), in.KubernetesVersion),
+		},
+		ProxyConfig: &v1alpha1.ProxyConfig{
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubeProxyImage, in.KubernetesVersion), in.KubernetesVersion),
+		},
+		SchedulerConfig: &v1alpha1.SchedulerConfig{
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, in.KubernetesVersion), in.KubernetesVersion),
+		},
 		EtcdConfig: &v1alpha1.EtcdConfig{
 			RootCA: in.Certs.Etcd,
 		},

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -5,9 +5,11 @@
 package generate
 
 import (
+	"fmt"
 	"net/url"
 
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
@@ -22,8 +24,10 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 		MachineType:     "worker",
 		MachineToken:    in.TrustdInfo.Token,
 		MachineCertSANs: in.AdditionalMachineCertSANs,
-		MachineKubelet:  &v1alpha1.KubeletConfig{},
-		MachineNetwork:  in.NetworkConfig,
+		MachineKubelet: &v1alpha1.KubeletConfig{
+			KubeletImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubeletImage, in.KubernetesVersion), in.KubernetesVersion),
+		},
+		MachineNetwork: in.NetworkConfig,
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:       in.InstallDisk,
 			InstallImage:      in.InstallImage,


### PR DESCRIPTION
Update all k8s image references to point to the version specified by the user.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2241)
<!-- Reviewable:end -->
