### PR TITLE
chore: enable nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,7 +112,6 @@ linters:
     - godox
     - gocognit
     - gomnd
-    - nolintlint # TODO: fix & enable me
     - testpackage # TODO: fix & enable me
     - goerr113
     - nestif

--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -62,7 +62,6 @@ func runImageCmd() (err error) {
 		return err
 	}
 
-	// nolint: errcheck
 	defer func() {
 		log.Println("detaching loopback device")
 
@@ -92,7 +91,7 @@ func runImageCmd() (err error) {
 	return nil
 }
 
-//nolint: gocyclo,interfacer
+//nolint: gocyclo
 func finalize(platform runtime.Platform, img string) (err error) {
 	dir := filepath.Dir(img)
 

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -160,7 +160,7 @@ func genV1Alpha1Config(args []string) error {
 func init() {
 	genCmd.AddCommand(genConfigCmd)
 	genConfigCmd.Flags().StringVar(&installDisk, "install-disk", "/dev/sda", "the disk to install to")
-	genConfigCmd.Flags().StringVar(&installImage, "install-image", helpers.DefaultImage(constants.DefaultInstallerImageRepository), "the image used to perform an installation") // nolint: lll
+	genConfigCmd.Flags().StringVar(&installImage, "install-image", helpers.DefaultImage(constants.DefaultInstallerImageRepository), "the image used to perform an installation")
 	genConfigCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
 	genConfigCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	genConfigCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")

--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -72,7 +72,6 @@ func init() {
 	addCommand(processesCmd)
 }
 
-// nolint: gocyclo
 func processesUI(ctx context.Context, c *client.Client) {
 	l := widgets.NewParagraph()
 	l.Border = false

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/talos-systems/talos/pkg/version"
 )
 
-// nolint: gocyclo
 func run() (err error) {
 	// Mount the pseudo devices.
 	pseudo, err := mount.PseudoMountPoints()

--- a/internal/app/machined/pkg/runtime/controller_test.go
+++ b/internal/app/machined/pkg/runtime/controller_test.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: scopelint,dupl
 package runtime
 
 // import (

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
@@ -49,7 +49,6 @@ func NewPlatform(platform string) (p runtime.Platform, err error) {
 	return newPlatform(platform)
 }
 
-// nolint: gocyclo
 func newPlatform(platform string) (p runtime.Platform, err error) {
 	switch platform {
 	case "aws":

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint dupl,scopelint
+//nolint: scopelint,dupl
 package v1alpha1
 
 import (

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_events_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_events_test.go
@@ -80,7 +80,7 @@ func TestEvents_Publish(t *testing.T) {
 					for j := 0; j < tt.messages; j++ {
 						event := <-events
 
-						seq, err := strconv.Atoi(event.Payload.(*machine.SequenceEvent).Sequence) //nolint: errcheck
+						seq, err := strconv.Atoi(event.Payload.(*machine.SequenceEvent).Sequence)
 						if err != nil {
 							t.Fatalf("failed to convert sequence to number: %s", err)
 						}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -361,7 +361,6 @@ func createBindMount(src, dst string) (err error) {
 		return err
 	}
 
-	// nolint: errcheck
 	if err = f.Close(); err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -60,7 +60,6 @@ type ContainerdSuite struct {
 	image  containerd.Image
 }
 
-// nolint: dupl
 func (suite *ContainerdSuite) SetupSuite() {
 	var err error
 

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -273,7 +273,6 @@ func newKubeletConfiguration(clusterDNS []string, dnsDomain string) *kubeletconf
 	}
 }
 
-// nolint: gocyclo
 func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 	denyListArgs := argsbuilder.Args{
 		"bootstrap-kubeconfig":       constants.KubeletBootstrapKubeconfig,

--- a/internal/app/machined/pkg/system/services/machined.go
+++ b/internal/app/machined/pkg/system/services/machined.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/app/machined/pkg/system/services/osd.go
+++ b/internal/app/machined/pkg/system/services/osd.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/app/machined/pkg/system/services/timed.go
+++ b/internal/app/machined/pkg/system/services/timed.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl,golint
+// nolint: golint
 package services
 
 import (

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -78,7 +78,6 @@ func WithAnnotations(annotations map[string]string) oci.SpecOpts {
 	}
 }
 
-// nolint: dupl
 func (suite *ContainerdSuite) SetupSuite() {
 	var err error
 

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -37,7 +37,6 @@ const (
 func MockEventSink(state events.ServiceState, message string, args ...interface{}) {
 }
 
-// nolint: maligned
 type CRISuite struct {
 	suite.Suite
 
@@ -56,7 +55,6 @@ type CRISuite struct {
 	pods []string
 }
 
-// nolint: dupl
 func (suite *CRISuite) SetupSuite() {
 	var err error
 

--- a/internal/pkg/containers/image/resolver_test.go
+++ b/internal/pkg/containers/image/resolver_test.go
@@ -132,7 +132,7 @@ func (suite *ResolverSuite) TestRegistryHosts() {
 	suite.Assert().Equal("https", registryHosts[0].Scheme)
 	suite.Assert().Equal("registry-1.docker.io", registryHosts[0].Host)
 	suite.Assert().Equal("/v2", registryHosts[0].Path)
-	suite.Assert().Nil(registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig) //nolint: errcheck
+	suite.Assert().Nil(registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig)
 
 	cfg := &mockConfig{
 		mirrors: map[string]runtime.RegistryMirrorConfig{
@@ -148,11 +148,11 @@ func (suite *ResolverSuite) TestRegistryHosts() {
 	suite.Assert().Equal("http", registryHosts[0].Scheme)
 	suite.Assert().Equal("127.0.0.1:5000", registryHosts[0].Host)
 	suite.Assert().Equal("/docker.io", registryHosts[0].Path)
-	suite.Assert().Nil(registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig) //nolint: errcheck
+	suite.Assert().Nil(registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig)
 	suite.Assert().Equal("https", registryHosts[1].Scheme)
 	suite.Assert().Equal("some.host", registryHosts[1].Host)
 	suite.Assert().Equal("/v2", registryHosts[1].Path)
-	suite.Assert().Nil(registryHosts[1].Client.Transport.(*http.Transport).TLSClientConfig) //nolint: errcheck
+	suite.Assert().Nil(registryHosts[1].Client.Transport.(*http.Transport).TLSClientConfig)
 
 	cfg = &mockConfig{
 		mirrors: map[string]runtime.RegistryMirrorConfig{
@@ -181,7 +181,7 @@ func (suite *ResolverSuite) TestRegistryHosts() {
 	suite.Assert().Equal("some.host:123", registryHosts[0].Host)
 	suite.Assert().Equal("/v2", registryHosts[0].Path)
 
-	tlsClientConfig := registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig //nolint: errcheck
+	tlsClientConfig := registryHosts[0].Client.Transport.(*http.Transport).TLSClientConfig
 	suite.Require().NotNil(tlsClientConfig)
 	suite.Require().NotNil(tlsClientConfig.RootCAs)
 	suite.Require().Empty(tlsClientConfig.Certificates)

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -31,7 +31,6 @@ const (
 func MockEventSink(state events.ServiceState, message string, args ...interface{}) {
 }
 
-// nolint: maligned
 type CRISuite struct {
 	suite.Suite
 
@@ -46,7 +45,6 @@ type CRISuite struct {
 	ctxCancel context.CancelFunc
 }
 
-// nolint: dupl
 func (suite *CRISuite) SetupSuite() {
 	var err error
 

--- a/internal/pkg/provision/providers/firecracker/node.go
+++ b/internal/pkg/provision/providers/firecracker/node.go
@@ -74,7 +74,6 @@ func (p *provisioner) createNodes(state *state, clusterReq provision.ClusterRequ
 	return nodesInfo, multiErr.ErrorOrNil()
 }
 
-//nolint: gocyclo
 func (p *provisioner) createNode(state *state, clusterReq provision.ClusterRequest, nodeReq provision.NodeRequest, opts *provision.Options) (provision.NodeInfo, error) {
 	socketPath := filepath.Join(state.statePath, fmt.Sprintf("%s.sock", nodeReq.Name))
 	pidPath := filepath.Join(state.statePath, fmt.Sprintf("%s.pid", nodeReq.Name))

--- a/pkg/retry/constant_test.go
+++ b/pkg/retry/constant_test.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl
 package retry
 
 import (

--- a/pkg/retry/exponential_test.go
+++ b/pkg/retry/exponential_test.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl
 package retry
 
 import (

--- a/pkg/retry/linear_test.go
+++ b/pkg/retry/linear_test.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: dupl
 package retry
 
 import (


### PR DESCRIPTION
It makes sure our `//nolint:` directives are not redundant.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2247)
<!-- Reviewable:end -->
