### PR TITLE
test: run `e2e-firecracker-short` for default pipeline only

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: false
+
 coverage:
   status:
     project:
@@ -5,6 +8,7 @@ coverage:
         target: 26%
         threshold: 0.5%
         base: auto
+        if_ci_failed: success
     patch: off
 
 comment: false

--- a/.drone.yml
+++ b/.drone.yml
@@ -399,7 +399,7 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - initramfs
+  - unit-tests
 
 - name: coverage
   image: alpine:3.10
@@ -477,6 +477,9 @@ steps:
     path: /root/.kube
   - name: dev
     path: /dev
+  when:
+    event:
+    - pull_request
   depends_on:
   - initramfs
   - talosctl-linux
@@ -983,7 +986,7 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - initramfs
+  - unit-tests
 
 - name: coverage
   image: alpine:3.10
@@ -1061,6 +1064,9 @@ steps:
     path: /root/.kube
   - name: dev
     path: /dev
+  when:
+    event:
+    - pull_request
   depends_on:
   - initramfs
   - talosctl-linux
@@ -1143,7 +1149,10 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - e2e-firecracker-short
+  - initramfs
+  - talosctl-linux
+  - kernel
+  - push-local
 
 - name: provision-tests-prepare
   pull: always
@@ -1163,7 +1172,9 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - e2e-firecracker-short
+  - initramfs
+  - talosctl-linux
+  - kernel
   - push-local
 
 - name: provision-tests-track-0
@@ -1669,7 +1680,7 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - initramfs
+  - unit-tests
 
 - name: coverage
   image: alpine:3.10
@@ -1747,6 +1758,9 @@ steps:
     path: /root/.kube
   - name: dev
     path: /dev
+  when:
+    event:
+    - pull_request
   depends_on:
   - initramfs
   - talosctl-linux
@@ -1841,7 +1855,6 @@ steps:
     path: /tmp
   depends_on:
   - e2e-docker-short
-  - e2e-firecracker-short
 
 - name: e2e-aws
   pull: always
@@ -2345,7 +2358,7 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - initramfs
+  - unit-tests
 
 - name: coverage
   image: alpine:3.10
@@ -2423,6 +2436,9 @@ steps:
     path: /root/.kube
   - name: dev
     path: /dev
+  when:
+    event:
+    - pull_request
   depends_on:
   - initramfs
   - talosctl-linux
@@ -2517,7 +2533,6 @@ steps:
     path: /tmp
   depends_on:
   - e2e-docker-short
-  - e2e-firecracker-short
 
 - name: e2e-aws
   pull: always
@@ -3049,7 +3064,7 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - initramfs
+  - unit-tests
 
 - name: coverage
   image: alpine:3.10
@@ -3127,6 +3142,9 @@ steps:
     path: /root/.kube
   - name: dev
     path: /dev
+  when:
+    event:
+    - pull_request
   depends_on:
   - initramfs
   - talosctl-linux
@@ -3221,7 +3239,6 @@ steps:
     path: /tmp
   depends_on:
   - e2e-docker-short
-  - e2e-firecracker-short
 
 - name: e2e-aws
   pull: always
@@ -3753,7 +3770,7 @@ steps:
   - name: dev
     path: /dev
   depends_on:
-  - initramfs
+  - unit-tests
 
 - name: coverage
   image: alpine:3.10
@@ -3831,6 +3848,9 @@ steps:
     path: /root/.kube
   - name: dev
     path: /dev
+  when:
+    event:
+    - pull_request
   depends_on:
   - initramfs
   - talosctl-linux
@@ -4058,12 +4078,13 @@ trigger:
 depends_on:
 - default
 - e2e
+- integration
 - conformance
 - nightly
 - release
 
 ---
 kind: signature
-hmac: 6be7dc693eaca8b4e5278a5004ddb9e83d1f9fc6a3c84e92dbf5ce039848bc7c
+hmac: ecee32cc330a94218c52faa57c47bb0efb70de2cfdf541d4adbf2e57b74b44b1
 
 ...


### PR DESCRIPTION
As many pipelines inherit steps from `default_steps`, take out
`e2e-firecracker-short` from `default_steps`.

`e2e` pipeline only relies on `e2e-docker`.

`integration` pipeline does full firecracker run with `e2e-firecracker`.

`release` pipeline manually pulls in `e2e-firecracker-short` to be on
the safe side.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2255)
<!-- Reviewable:end -->
