### PR TITLE
test: stabilize race unit-tests (circular, events)

### DIFF
--- a/internal/pkg/circular/circular_test.go
+++ b/internal/pkg/circular/circular_test.go
@@ -85,7 +85,7 @@ func (suite *CircularSuite) TestStreamingReadWriter() {
 
 		p := data
 
-		r := rate.NewLimiter(500000, 1000)
+		r := rate.NewLimiter(300_000, 1000)
 
 		for i := 0; i < len(data); {
 			l := 100 + rand.Intn(100)
@@ -176,7 +176,7 @@ func (suite *CircularSuite) TestStreamingMultipleReaders() {
 
 	p := data
 
-	r := rate.NewLimiter(500000, 1000)
+	r := rate.NewLimiter(300_000, 1000)
 
 	for i := 0; i < len(data); {
 		l := 256


### PR DESCRIPTION
Fixes #2243

These tests rely on some kind of sync between readers and writers, as if
circular buffer is overrun, test no longer runs as expected.

We use time-sensitive rate limiter to limit write speed to make sure
readers can always catch up. Lowering the rate should slow down writers
and make tests more likely to succeed.

For #2243, the failure was from buffer overrun: when overrun is
detected, `Watch` function closes the channel (and test "receives" zero
element).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2256)
<!-- Reviewable:end -->
