### PR TITLE
chore: cleanup sonobuoy after failed attempts

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -130,7 +130,8 @@ function run_kubernetes_integration_test {
     --plugin e2e \
     --mode ${SONOBUOY_MODE}; do
     [[ $(date +%s) -gt $timeout ]] && exit 1
-    echo "attempting to run sonobuoy"
+    echo "re-attempting to run sonobuoy"
+    ${SONOBUOY} delete --all
     sleep 10
   done
   ${SONOBUOY} status --kubeconfig ${KUBECONFIG} --json | jq . | tee ${TMP}/sonobuoy-status.json


### PR DESCRIPTION
This PR will make sure that, if we're going to retry sonobuoy, we run
the delete command first to clean up any dangling resources.

Closes #2266.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2271)
<!-- Reviewable:end -->
