### PR TITLE
chore: wait for resource deletion in sonobuoy

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -131,7 +131,7 @@ function run_kubernetes_integration_test {
     --mode ${SONOBUOY_MODE}; do
     [[ $(date +%s) -gt $timeout ]] && exit 1
     echo "re-attempting to run sonobuoy"
-    ${SONOBUOY} delete --all
+    ${SONOBUOY} delete --all --wait
     sleep 10
   done
   ${SONOBUOY} status --kubeconfig ${KUBECONFIG} --json | jq . | tee ${TMP}/sonobuoy-status.json


### PR DESCRIPTION
This PR fixes the fix where we try to cleanup sonobuoy. We did that
successfully, but still got errors b/c we were immediately trying to
create service accounts in a namespace that was being deleted. This
should fix that. The sonobuoy default wait period is 1hr, should be
plenty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2279)
<!-- Reviewable:end -->
