### PR TITLE
test: update init node check in reset API tests

### DIFF
--- a/internal/app/machined/pkg/system/system_test.go
+++ b/internal/app/machined/pkg/system/system_test.go
@@ -22,9 +22,12 @@ func (suite *SystemServicesSuite) TestStartShutdown() {
 	system.Services(nil).LoadAndStart(
 		&MockService{name: "containerd"},
 		&MockService{name: "trustd", dependencies: []string{"containerd"}},
-		&MockService{name: "osd", dependencies: []string{"containerd", "osd"}},
+		&MockService{name: "osd", dependencies: []string{"containerd", "trustd"}},
 	)
 	time.Sleep(10 * time.Millisecond)
+
+	suite.Require().NoError(system.Services(nil).Unload(context.Background(), "trustd", "notrunning"))
+
 	system.Services(nil).Shutdown()
 }
 

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -49,7 +49,7 @@ func NewClient(endpoints []string) (client *clientv3.Client, err error) {
 
 // NewClientFromControlPlaneIPs initializes and returns an etcd client
 // configured to talk to all members.
-func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpoint *url.URL) (client *clientv3.Client, err error) {
+func NewClientFromControlPlaneIPs(ctx context.Context, creds *x509.PEMEncodedCertificateAndKey, endpoint *url.URL) (client *clientv3.Client, err error) {
 	h, err := kubernetes.NewTemporaryClientFromPKI(creds, endpoint)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpo
 
 	var endpoints []string
 
-	if endpoints, err = h.MasterIPs(); err != nil {
+	if endpoints, err = h.MasterIPs(ctx); err != nil {
 		return nil, err
 	}
 
@@ -78,7 +78,7 @@ func ValidateForUpgrade(preserve bool) error {
 	}
 
 	if config.Machine().Type() != runtime.MachineTypeJoin {
-		client, err := NewClientFromControlPlaneIPs(config.Cluster().CA(), config.Cluster().Endpoint())
+		client, err := NewClientFromControlPlaneIPs(context.TODO(), config.Cluster().CA(), config.Cluster().Endpoint())
 		if err != nil {
 			return err
 		}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -48,6 +48,10 @@ func NewClientFromKubeletKubeconfig() (client *Client, err error) {
 		return nil, err
 	}
 
+	if config.Timeout == 0 {
+		config.Timeout = 30 * time.Second
+	}
+
 	var clientset *kubernetes.Clientset
 
 	clientset, err = kubernetes.NewForConfig(config)
@@ -83,6 +87,7 @@ func NewClientFromPKI(ca, crt, key []byte, endpoint *url.URL) (client *Client, e
 	config := &restclient.Config{
 		Host:            endpoint.String(),
 		TLSClientConfig: tlsClientConfig,
+		Timeout:         30 * time.Second,
 	}
 
 	var clientset *kubernetes.Clientset
@@ -139,8 +144,8 @@ func NewTemporaryClientFromPKI(ca *x509.PEMEncodedCertificateAndKey, endpoint *u
 }
 
 // MasterIPs cordons and drains a node in one call.
-func (h *Client) MasterIPs() (addrs []string, err error) {
-	endpoints, err := h.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+func (h *Client) MasterIPs(ctx context.Context) (addrs []string, err error) {
+	endpoints, err := h.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously we assumed that node 0 is the init node, and it can't be
reset. With new bootstrap API approach, there's no init node, and all
the nodes can be reset. This corrects the check to skip only the init
node, and with bootstrap API there's no init node (so no nodes are
skipped).

As part of test debugging following updates were done:

* context propagation/timeouts in kubernetes and etcd client

* fixed check for control plane components to check for number of pods
as when controller-manager & schduler are not running, daemonset stats
are not updated

* fixed bootkube start sequence to work always by implementing 'Unload'
method for services

Fixes #2277

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2281)
<!-- Reviewable:end -->
