### PR TITLE
fix: implement Unload() for services to make sure bootkube runs always

### DIFF
--- a/internal/app/machined/pkg/system/system_test.go
+++ b/internal/app/machined/pkg/system/system_test.go
@@ -22,9 +22,12 @@ func (suite *SystemServicesSuite) TestStartShutdown() {
 	system.Services(nil).LoadAndStart(
 		&MockService{name: "containerd"},
 		&MockService{name: "trustd", dependencies: []string{"containerd"}},
-		&MockService{name: "osd", dependencies: []string{"containerd", "osd"}},
+		&MockService{name: "osd", dependencies: []string{"containerd", "trustd"}},
 	)
 	time.Sleep(10 * time.Millisecond)
+
+	suite.Require().NoError(system.Services(nil).Unload(context.Background(), "trustd", "notrunning"))
+
 	system.Services(nil).Shutdown()
 }
 


### PR DESCRIPTION
The problem was that flow to re-run the service with different
parameters was not consistent: it depends on whether services was loaded
before or not, but that is not reliable, as e.g. with bootstrap API
`bootkube` is loaded for the bootstrap and stays until reboot, and never
loaded for any other boot.

`Unload()` stops and removes the service completely so that new instance
of the service could be loaded and started.

This fixes the edge case with recovery API not running bootkube properly
before reboot after bootstrap.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2284)
<!-- Reviewable:end -->
