### PR TITLE
fix: update timeouts on service startup to match boot timeout

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1111,7 +1111,7 @@ func LeaveEtcd(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFunc
 			return err
 		}
 
-		client, err := etcd.NewClientFromControlPlaneIPs(r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
+		client, err := etcd.NewClientFromControlPlaneIPs(ctx, r.Config().Cluster().CA(), r.Config().Cluster().Endpoint())
 		if err != nil {
 			return err
 		}
@@ -1119,7 +1119,7 @@ func LeaveEtcd(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFunc
 		// nolint: errcheck
 		defer client.Close()
 
-		resp, err := client.MemberList(context.Background())
+		resp, err := client.MemberList(ctx)
 		if err != nil {
 			return err
 		}
@@ -1138,12 +1138,12 @@ func LeaveEtcd(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFunc
 
 		logger.Println("leaving etcd cluster")
 
-		_, err = client.MemberRemove(context.Background(), *id)
+		_, err = client.MemberRemove(ctx, *id)
 		if err != nil {
 			return err
 		}
 
-		if err = system.Services(nil).Stop(context.Background(), "etcd"); err != nil {
+		if err = system.Services(nil).Stop(ctx, "etcd"); err != nil {
 			return err
 		}
 

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -49,7 +49,7 @@ func NewClient(endpoints []string) (client *clientv3.Client, err error) {
 
 // NewClientFromControlPlaneIPs initializes and returns an etcd client
 // configured to talk to all members.
-func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpoint *url.URL) (client *clientv3.Client, err error) {
+func NewClientFromControlPlaneIPs(ctx context.Context, creds *x509.PEMEncodedCertificateAndKey, endpoint *url.URL) (client *clientv3.Client, err error) {
 	h, err := kubernetes.NewTemporaryClientFromPKI(creds, endpoint)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func NewClientFromControlPlaneIPs(creds *x509.PEMEncodedCertificateAndKey, endpo
 
 	var endpoints []string
 
-	if endpoints, err = h.MasterIPs(); err != nil {
+	if endpoints, err = h.MasterIPs(ctx); err != nil {
 		return nil, err
 	}
 
@@ -78,7 +78,7 @@ func ValidateForUpgrade(preserve bool) error {
 	}
 
 	if config.Machine().Type() != runtime.MachineTypeJoin {
-		client, err := NewClientFromControlPlaneIPs(config.Cluster().CA(), config.Cluster().Endpoint())
+		client, err := NewClientFromControlPlaneIPs(context.TODO(), config.Cluster().CA(), config.Cluster().Endpoint())
 		if err != nil {
 			return err
 		}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -48,6 +48,10 @@ func NewClientFromKubeletKubeconfig() (client *Client, err error) {
 		return nil, err
 	}
 
+	if config.Timeout == 0 {
+		config.Timeout = 30 * time.Second
+	}
+
 	var clientset *kubernetes.Clientset
 
 	clientset, err = kubernetes.NewForConfig(config)
@@ -83,6 +87,7 @@ func NewClientFromPKI(ca, crt, key []byte, endpoint *url.URL) (client *Client, e
 	config := &restclient.Config{
 		Host:            endpoint.String(),
 		TLSClientConfig: tlsClientConfig,
+		Timeout:         30 * time.Second,
 	}
 
 	var clientset *kubernetes.Clientset
@@ -139,8 +144,8 @@ func NewTemporaryClientFromPKI(ca *x509.PEMEncodedCertificateAndKey, endpoint *u
 }
 
 // MasterIPs cordons and drains a node in one call.
-func (h *Client) MasterIPs() (addrs []string, err error) {
-	endpoints, err := h.CoreV1().Endpoints("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+func (h *Client) MasterIPs(ctx context.Context) (addrs []string, err error) {
+	endpoints, err := h.CoreV1().Endpoints("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There's a global timeout for all services to be up: it's 5 minutes. We
need to make sure each service startup takes less than that, otherwise
boot sequence is aborted and there's no way to see the error message for
each particular service.

Also propagate contexts correctly and set some default timeouts to make
sure API operations are not hanging forever.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

