### PR TITLE
feat: add round-robin LB policy to Talos client by default

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -202,7 +202,7 @@ func create(ctx context.Context) (err error) {
 			}))
 		}
 
-		defaultInternalLB, defaultExternalLB := provisioner.GetLoadBalancers(request.Network)
+		defaultInternalLB, _ := provisioner.GetLoadBalancers(request.Network)
 
 		if defaultInternalLB == "" {
 			// provisioner doesn't provide internal LB, so use first master node
@@ -218,7 +218,10 @@ func create(ctx context.Context) (err error) {
 		case forceInitNodeAsEndpoint:
 			endpointList = []string{ips[0].String()}
 		default:
-			endpointList = []string{defaultExternalLB}
+			// use control plane nodes as endpoints, client-side load-balancing
+			for i := 0; i < masters; i++ {
+				endpointList = append(endpointList, ips[i].String())
+			}
 		}
 
 		genOptions = append(genOptions, generate.WithEndpointList(endpointList))

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -245,7 +245,7 @@ func (suite *UpgradeSuite) setupCluster() {
 		StateDirectory: suite.stateDir,
 	}
 
-	defaultInternalLB, defaultExternalLB := suite.provisioner.GetLoadBalancers(request.Network)
+	defaultInternalLB, _ := suite.provisioner.GetLoadBalancers(request.Network)
 
 	genOptions := suite.provisioner.GenOptions(request.Network)
 
@@ -256,6 +256,11 @@ func (suite *UpgradeSuite) setupCluster() {
 		genOptions = append(genOptions, generate.WithRegistryMirror(parts[0], parts[1]))
 	}
 
+	masterEndpoints := make([]string, suite.spec.MasterNodes)
+	for i := range masterEndpoints {
+		masterEndpoints[i] = ips[i].String()
+	}
+
 	suite.configBundle, err = config.NewConfigBundle(config.WithInputOptions(
 		&config.InputOptions{
 			ClusterName: clusterName,
@@ -263,7 +268,7 @@ func (suite *UpgradeSuite) setupCluster() {
 			KubeVersion: "", // keep empty so that default version is used per Talos version
 			GenOptions: append(
 				genOptions,
-				generate.WithEndpointList([]string{defaultExternalLB}),
+				generate.WithEndpointList(masterEndpoints),
 				generate.WithInstallImage(suite.spec.SourceInstallerImage),
 			),
 		}))

--- a/internal/pkg/cluster/check/default.go
+++ b/internal/pkg/cluster/check/default.go
@@ -59,7 +59,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		func(cluster ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("all control plane components to be ready", func(ctx context.Context) error {
 				return K8sFullControlPlaneAssertion(ctx, cluster)
-			}, 2*time.Minute, 5*time.Second)
+			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for kube-proxy to report ready
 		func(cluster ClusterInfo) conditions.Condition {

--- a/internal/pkg/cluster/check/reporter.go
+++ b/internal/pkg/cluster/check/reporter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/talos-systems/talos/internal/pkg/conditions"
 )
@@ -21,7 +22,7 @@ func (wr *writerReporter) Update(condition conditions.Condition) {
 	line := fmt.Sprintf("waiting for %s", condition)
 
 	if line != wr.lastLine {
-		fmt.Fprintln(wr.w, line)
+		fmt.Fprintln(wr.w, strings.TrimSpace(line))
 		wr.lastLine = line
 	}
 }

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -73,6 +73,10 @@ func (c *Client) EventsWatch(ctx context.Context, watchFunc func(<-chan Event), 
 		return fmt.Errorf("error fetching events: %s", err)
 	}
 
+	if err = stream.CloseSend(); err != nil {
+		return err
+	}
+
 	defaultNode := RemotePeer(stream.Context())
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Handling of multiple endpoints has already been implemented in #2094.

This PR enables round-robin policy so that grpc picks up new endpoint
for each call (and not send each request to the first control plane
node).

Endpoint list is randomized to handle cases when only one request is
going to be sent, so that it doesn't go always to the first node in the
list.

gprc handles dead/unresponsive nodes automatically for us.

`talosctl cluster create` and provision tests switched to use
client-side load balancer for Talos API.

On the additional improvements we got:

* `talosctl` now reports correct node IP when using commands without
`-n`, not the loadbalancer IP (if using multiple endpoints of course)

* loadbalancer can't provide reliable handling of errors when upstream
server is unresponsive or there're no upstreams available, grpc returns
much more helpful errors

Fixes #1641

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2288)
<!-- Reviewable:end -->
