### PR TITLE
feat: uncordon nodes automatically on boot

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -352,7 +352,7 @@ func create(ctx context.Context) (err error) {
 	checkCtx, checkCtxCancel := context.WithTimeout(ctx, clusterWaitTimeout)
 	defer checkCtxCancel()
 
-	return check.Wait(checkCtx, clusterAccess, check.DefaultClusterChecks(), check.StderrReporter())
+	return check.Wait(checkCtx, clusterAccess, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter())
 }
 
 func saveConfig(cluster provision.Cluster, talosConfigObj *clientconfig.Config) (err error) {

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -75,7 +75,7 @@ var healthCmd = &cobra.Command{
 			checkCtx, checkCtxCancel := context.WithTimeout(ctx, clusterWaitTimeout)
 			defer checkCtxCancel()
 
-			return check.Wait(checkCtx, &state, check.DefaultClusterChecks(), check.StderrReporter())
+			return check.Wait(checkCtx, &state, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter())
 		})
 	},
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -174,6 +174,8 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	).AppendWhen(
 		r.Config().Machine().Type() != runtime.MachineTypeJoin,
 		LabelNodeAsMaster,
+	).Append(
+		UncordonNode,
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
 		UpdateBootloader,

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1080,6 +1080,8 @@ func UnmountSystemDiskBindMounts(seq runtime.Sequence, data interface{}) runtime
 
 // CordonAndDrainNode represents the task for stop all containerd tasks in the
 // k8s.io namespace.
+//
+//nolint: dupl
 func CordonAndDrainNode(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFunc {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		var hostname string
@@ -1095,6 +1097,33 @@ func CordonAndDrainNode(seq runtime.Sequence, data interface{}) runtime.TaskExec
 		}
 
 		if err = kubeHelper.CordonAndDrain(hostname); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+// UncordonNode represents the task for mark node as scheduling enabled.
+//
+// This action undoes the CordonAndDrainNode task.
+//
+//nolint: dupl
+func UncordonNode(seq runtime.Sequence, data interface{}) runtime.TaskExecutionFunc {
+	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
+		var hostname string
+
+		if hostname, err = os.Hostname(); err != nil {
+			return err
+		}
+
+		var kubeHelper *kubernetes.Client
+
+		if kubeHelper, err = kubernetes.NewClientFromKubeletKubeconfig(); err != nil {
+			return err
+		}
+
+		if err = kubeHelper.Uncordon(hostname); err != nil {
 			return err
 		}
 

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -110,7 +110,7 @@ func (apiSuite *APISuite) AssertClusterHealthy(ctx context.Context) {
 	clusterAccess := access.NewAdapter(apiSuite.Cluster, provision.WithTalosClient(apiSuite.Client))
 	defer clusterAccess.Close() //nolint: errcheck
 
-	apiSuite.Require().NoError(check.Wait(ctx, clusterAccess, check.DefaultClusterChecks(), check.StderrReporter()))
+	apiSuite.Require().NoError(check.Wait(ctx, clusterAccess, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter()))
 }
 
 // ReadUptime reads node uptime.

--- a/internal/pkg/cluster/check/default.go
+++ b/internal/pkg/cluster/check/default.go
@@ -75,3 +75,17 @@ func DefaultClusterChecks() []ClusterCheck {
 		},
 	}
 }
+
+// ExtraClusterChecks returns a set of additional Talos cluster readiness checks which work only for newer versions of Talos.
+//
+// ExtraClusterChecks can't be used reliably in upgrade tests, as older versions might not pass the checks.
+func ExtraClusterChecks() []ClusterCheck {
+	return []ClusterCheck{
+		// wait for all the nodes to be schedulable
+		func(cluster ClusterInfo) conditions.Condition {
+			return conditions.PollingCondition("all k8s nodes to report schedulable", func(ctx context.Context) error {
+				return K8sAllNodesSchedulableAssertion(ctx, cluster)
+			}, 2*time.Minute, 5*time.Second)
+		},
+	}
+}


### PR DESCRIPTION
Talos will mark node as schedulable if it was previously cordoned by
Talos (for upgrade, reset, etc.)

If user marked node as not schedulable, Talos won't change it on boot.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2291)
<!-- Reviewable:end -->
