### PR TITLE
test: fix cli tests after load-balancing got enabled

### DIFF
--- a/internal/app/osd/internal/reg/reg.go
+++ b/internal/app/osd/internal/reg/reg.go
@@ -158,7 +158,11 @@ func (r *Registrator) Restart(ctx context.Context, in *osapi.RestartRequest) (*o
 		return nil, err
 	}
 
-	return &osapi.RestartResponse{}, nil
+	return &osapi.RestartResponse{
+		Messages: []*osapi.Restart{
+			{},
+		},
+	}, nil
 }
 
 // Dmesg implements the osapi.OSDServer interface.

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -8,6 +8,7 @@ package cli
 
 import (
 	"fmt"
+	"math/rand"
 	"regexp"
 	"strings"
 
@@ -31,12 +32,17 @@ func (suite *LogsSuite) TestServiceLogs() {
 
 // TestTailLogs verifies that logs can be displayed with tail lines.
 func (suite *LogsSuite) TestTailLogs() {
+	nodes := suite.DiscoverNodes()
+	suite.Require().NotEmpty(nodes)
+
+	node := nodes[rand.Intn(len(nodes))]
+
 	// run some machined API calls to produce enough log lines
 	for i := 0; i < 10; i++ {
-		suite.RunCLI([]string{"version"})
+		suite.RunCLI([]string{"-n", node, "version"})
 	}
 
-	suite.RunCLI([]string{"logs", "apid", "--tail", "5"},
+	suite.RunCLI([]string{"logs", "apid", "-n", node, "--tail", "5"},
 		base.StdoutMatchFunc(func(stdout string) error {
 			lines := strings.Count(stdout, "\n")
 			if lines != 5 {


### PR DESCRIPTION
There were three problems:

* cli tests did commands in sequence assuming they all hit the same
node, but with load-balancing it's no longer true

* restart test was affected, as it hit different node for check after
restart, and it succeeded immediately, while on original node process
was still starting which resulted in failure in the next tests; replace
the check to make sure service is up and healthy, so that test leaves
cluster in a good state

* restart API response had wrong format (no message returned) which
resulted in failures with apid proxy (when used with `-n`)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2294)
<!-- Reviewable:end -->
