### PR TITLE
fix: improve node uncordon tasks

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -174,7 +174,8 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	).AppendWhen(
 		r.Config().Machine().Type() != runtime.MachineTypeJoin,
 		LabelNodeAsMaster,
-	).Append(
+	).AppendWhen(
+		r.State().Platform().Mode() != runtime.ModeContainer,
 		UncordonNode,
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1123,6 +1123,10 @@ func UncordonNode(seq runtime.Sequence, data interface{}) runtime.TaskExecutionF
 			return err
 		}
 
+		if err = kubeHelper.WaitUntilReady(hostname); err != nil {
+			return err
+		}
+
 		if err = kubeHelper.Uncordon(hostname); err != nil {
 			return err
 		}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -202,6 +202,33 @@ func (h *Client) LabelNodeAsMaster(name string) (err error) {
 	return nil
 }
 
+// WaitUntilReady waits for a node to be ready.
+func (h *Client) WaitUntilReady(name string) error {
+	return retry.Exponential(3*time.Minute, retry.WithUnits(250*time.Millisecond), retry.WithJitter(50*time.Millisecond)).Retry(func() error {
+		attemptCtx, attemptCtxCancel := context.WithTimeout(context.TODO(), 30*time.Second)
+		defer attemptCtxCancel()
+
+		node, err := h.CoreV1().Nodes().Get(attemptCtx, name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return retry.ExpectedError(err)
+			}
+
+			return retry.UnexpectedError(err)
+		}
+
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady {
+				if cond.Status != corev1.ConditionTrue {
+					return retry.ExpectedError(fmt.Errorf("node not ready"))
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
 // CordonAndDrain cordons and drains a node in one call.
 func (h *Client) CordonAndDrain(node string) (err error) {
 	if err = h.Cordon(node); err != nil {
@@ -247,7 +274,10 @@ func (h *Client) Cordon(name string) error {
 // Uncordon marks a node as schedulable.
 func (h *Client) Uncordon(name string) error {
 	err := retry.Exponential(30*time.Second, retry.WithUnits(250*time.Millisecond), retry.WithJitter(50*time.Millisecond)).Retry(func() error {
-		node, err := h.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
+		attemptCtx, attemptCtxCancel := context.WithTimeout(context.TODO(), 10*time.Second)
+		defer attemptCtxCancel()
+
+		node, err := h.CoreV1().Nodes().Get(attemptCtx, name, metav1.GetOptions{})
 		if err != nil {
 			return retry.UnexpectedError(err)
 		}
@@ -261,7 +291,7 @@ func (h *Client) Uncordon(name string) error {
 			node.Spec.Unschedulable = false
 			delete(node.ObjectMeta.Annotations, talosCordonedAnnotationName)
 
-			if _, err := h.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{}); err != nil {
+			if _, err := h.CoreV1().Nodes().Update(attemptCtx, node, metav1.UpdateOptions{}); err != nil {
 				return retry.ExpectedError(err)
 			}
 		}


### PR DESCRIPTION
1. Increase retry timeout.

2. Use timeout per attempt.

3. Check for node readiness as a gate to succeed.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2296)
<!-- Reviewable:end -->
