### PR TITLE
fix: update networkd link up check

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -97,11 +97,8 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 			"unmountBoot",
 			UnmountBootPartition,
 		).Append(
-			"resetNetwork",
-			ResetNetwork,
-		).Append(
 			"setupNetwork",
-			SetupDiscoveryNetwork,
+			SetupNetwork,
 		)
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -537,10 +537,10 @@ func ValidateConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 	}, "validateConfig"
 }
 
-// ResetNetwork resets the network.
+// SetupNetwork resets the network and sets it up based on the configuration.
 //
 // nolint: gocyclo
-func ResetNetwork(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
+func SetupNetwork(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		nwd, err := networkd.New(r.Config())
 		if err != nil {
@@ -549,8 +549,8 @@ func ResetNetwork(seq runtime.Sequence, data interface{}) (runtime.TaskExecution
 
 		nwd.Reset()
 
-		return nil
-	}, "resetNetwork"
+		return nwd.Configure()
+	}, "setupNetwork"
 }
 
 // SetUserEnvVars represents the SetUserEnvVars task.

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -247,6 +247,10 @@ func (n *NetworkInterface) waitForLinkToBeUp(linkDev *net.Interface) error {
 			return retry.ExpectedError(fmt.Errorf("link is not ready %s", n.Link.Name))
 		}
 
+		if link.Attributes.OperationalState&rtnetlink.OperStateUp != rtnetlink.OperStateUp && link.Attributes.OperationalState&rtnetlink.OperStateUnknown != rtnetlink.OperStateUnknown {
+			return retry.ExpectedError(fmt.Errorf("link %q operational state is not up or unknown: %d", n.Link.Name, link.Attributes.OperationalState))
+		}
+
 		return nil
 	})
 


### PR DESCRIPTION
Based on ideas from u-root/u-root#1764.

For interface filtering, we bring them up and check for operational
state to be up (check for carrier signal), those without carrier are
skipped.

The reset and setup phases were joined together so that filtering
happens only once followed by interface reset and reconfiguration.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2298)
<!-- Reviewable:end -->
