### PR TITLE
feat: print crash dump in `talosctl cluster create` on failure 

### DIFF
--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -19,6 +19,7 @@ talosctl cluster create [flags]
       --cni-cache-dir string        CNI cache directory path (firecracker only) (default "/var/lib/cni")
       --cni-conf-dir string         CNI config directory path (firecracker only) (default "/etc/cni/conf.d")
       --cpus string                 the share of CPUs as fraction (each container) (default "1.5")
+      --crashdump                   print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string       install custom CNI from the URL (Talos cluster)
       --disk int                    the limit on disk size in MB (each VM) (default 4096)
       --dns-domain string           the dns domain to use for cluster (default "cluster.local")

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -26,7 +26,8 @@ function create_cluster {
     --memory 2048 \
     --cpus 4.0 \
     --endpoint "${ENDPOINT}" \
-    --with-init-node=false
+    --with-init-node=false \
+    --crashdump
 }
 
 create_cluster

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -39,6 +39,7 @@ function create_cluster {
     --cidr 172.20.0.0/24 \
     --install-image ${REGISTRY:-docker.io}/autonomy/installer:${INSTALLER_TAG} \
     --with-init-node=false \
+    --crashdump \
     ${FIRECRACKER_FLAGS} \
     ${CUSTOM_CNI_FLAG}
 }


### PR DESCRIPTION
When cluster fails to be bootstrapped or it fails the health check, it's
hard to find the root cause without the logs.

This change adds optional crashdump (it dumps firecracker logs or docker
logs) after provisioning failure. It's not enabled by default.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2300)
<!-- Reviewable:end -->
