### PR TITLE
test: update events test with more flow control

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_events_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_events_test.go
@@ -79,6 +79,8 @@ func TestEvents_Publish(t *testing.T) {
 				if err := e.Watch(func(events <-chan runtime.Event) {
 					defer wg.Done()
 
+					l := rate.NewLimiter(500, tt.cap*8/10)
+
 					for j := 0; j < tt.messages; j++ {
 						event, ok := <-events
 
@@ -97,6 +99,8 @@ func TestEvents_Publish(t *testing.T) {
 						}
 
 						atomic.AddUint32(&got, 1)
+
+						_ = l.Wait(context.Background()) //nolint: errcheck
 					}
 				}); err != nil {
 					t.Errorf("Watch error %s", err)


### PR DESCRIPTION
Some of the event tests rely on publishing more events than buffer
capacity, so consumers should be able to keep up with the producer to
avoid hitting buffer overrun.

Producer was rate-limited already, now adding rate limiting for consumer
with higher burst, it should allow consumers to reach blocked state, but
syncronizes them a bit with each other.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2301)
<!-- Reviewable:end -->
