### PR TITLE
test: workaround famous flaky Containerd.RunTwice test

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -179,6 +179,11 @@ func (suite *ContainerdSuite) TestRunTwice() {
 		suite.Assert().NoError(r.Run(MockEventSink))
 		// calling stop when Run has finished is no-op
 		suite.Assert().NoError(r.Stop())
+
+		if i == 0 {
+			// wait a bit to let containerd clean up the state
+			time.Sleep(100 * time.Millisecond)
+		}
 	}
 }
 


### PR DESCRIPTION
I'm not sure if this is going to stop it, but feels like we're hitting
some race condition in containerd itself, so attempt to sleep a bit in
between the container launches to avoid the errors.

```
=== RUN   TestContainerdSuite/TestRunTwice
2020/07/10 18:57:24 state Running: Started task 036de7a9-f667-48e8-905f-216233980f94 (PID 4964) for container 036de7a9-f667-48e8-905f-216233980f94
    TestContainerdSuite/TestRunTwice: containerd_test.go:179:
        	Error Trace:	containerd_test.go:179
        	Error:      	Received unexpected error:
        	            	failed to create task: "036de7a9-f667-48e8-905f-216233980f94": dial unix \00/containerd-shim/f88fff9fe9795db4229846b09b2da816f6bd981b8112345486ff3b5653892920.sock: connect: connection refused: unknown
        	Test:       	TestContainerdSuite/TestRunTwice
--- FAIL: TestContainerdSuite (6.62s)
    --- PASS: TestContainerdSuite/TestContainerCleanup (0.92s)
    --- PASS: TestContainerdSuite/TestImportFail (0.54s)
    --- PASS: TestContainerdSuite/TestImportSuccess (0.45s)
    --- PASS: TestContainerdSuite/TestRunLogs (0.26s)
    --- PASS: TestContainerdSuite/TestRunSuccess (0.31s)
    --- FAIL: TestContainerdSuite/TestRunTwice (0.39s)
    --- PASS: TestContainerdSuite/TestStopFailingAndRestarting (1.61s)
    --- PASS: TestContainerdSuite/TestStopSigKill (0.95s)
FAIL
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2302)
<!-- Reviewable:end -->
