### PR TITLE
docs: update worker creation flags for azure docs

### DIFF
--- a/docs/website/content/v0.4/en/guides/cloud/azure.md
+++ b/docs/website/content/v0.4/en/guides/cloud/azure.md
@@ -243,6 +243,8 @@ done
   az vm create \
     --name talos-worker-0 \
     --image talos \
+    --vnet-name talos-vnet \
+    --subnet talos-subnet \
     --custom-data ./join.yaml \
     -g $GROUP \
     --admin-username talos \

--- a/docs/website/content/v0.5/en/guides/cloud/azure.md
+++ b/docs/website/content/v0.5/en/guides/cloud/azure.md
@@ -2,6 +2,9 @@
 title: 'Azure'
 ---
 
+**Note: Azure support is broken in v0.5.x of Talos.**
+**Please use v0.6.x instead.**
+
 ## Creating a Cluster via the CLI
 
 In this guide we will create an HA Kubernetes cluster with 1 worker node.
@@ -243,6 +246,8 @@ done
   az vm create \
     --name talos-worker-0 \
     --image talos \
+    --vnet-name talos-vnet \
+    --subnet talos-subnet \
     --custom-data ./join.yaml \
     -g $GROUP \
     --admin-username talos \

--- a/docs/website/content/v0.6/en/guides/cloud/azure.md
+++ b/docs/website/content/v0.6/en/guides/cloud/azure.md
@@ -243,6 +243,8 @@ done
   az vm create \
     --name talos-worker-0 \
     --image talos \
+    --vnet-name talos-vnet \
+    --subnet talos-subnet \
     --custom-data ./join.yaml \
     -g $GROUP \
     --admin-username talos \


### PR DESCRIPTION
This PR updates the worker flags for azure. Fixes an issue where, if you
have multiple subnets and the talos one isn't default, the workers and
control plane nodes came up on different subnets. Requires updating the
firewalls if they don't come up in the same subnet, so this is better
UX.

Also added a note that azure support is broken in v0.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2310)
<!-- Reviewable:end -->
