### PR TITLE
chore: update capi CI manifests to use control planes

### DIFF
--- a/hack/test/capi/cluster-aws.yaml
+++ b/hack/test/capi/cluster-aws.yaml
@@ -4,7 +4,6 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: talos-e2e-{{TAG}}-aws
-  namespace: default
 spec:
   clusterNetwork:
     pods:
@@ -14,13 +13,15 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: AWSCluster
     name: talos-e2e-{{TAG}}-aws
-    namespace: default
+  controlPlaneRef:
+    kind: TalosControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: talos-e2e-{{TAG}}-aws-controlplane
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSCluster
 metadata:
   name: talos-e2e-{{TAG}}-aws
-  namespace: default
 spec:
   region: '{{REGION}}'
   sshKeyName: talos-e2e
@@ -28,164 +29,45 @@ spec:
     vpc:
       id: 'vpc-ff5c5687'
 ---
-## Controlplane 0 configs
+## Control plane configs
 
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: talos-e2e-{{TAG}}-aws-controlplane-0
-  namespace: default
-spec:
-  generateType: init
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    cluster.x-k8s.io/control-plane: 'true'
-  name: talos-e2e-{{TAG}}-aws-controlplane-0
-  namespace: default
-spec:
-  clusterName: talos-e2e-{{TAG}}-aws
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: talos-e2e-{{TAG}}-aws-controlplane-0
-      namespace: default
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSMachine
-    name: talos-e2e-{{TAG}}-aws-controlplane-0
-    namespace: default
-  version: 1.18.3
----
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSMachine
+kind: AWSMachineTemplate
 metadata:
-  name: talos-e2e-{{TAG}}-aws-controlplane-0
-  namespace: default
+  name: talos-e2e-{{TAG}}-aws-controlplane
 spec:
-  cloudInit:
-    insecureSkipSecretsManager: true
-  instanceType: m5.xlarge
-  rootVolume:
-    size: 150
-  sshKeyName: talos-e2e
-  ami:
-    id: '{{AMI}}'
-  subnet:
-    id: 'subnet-c4e9b3a0'
-  additionalSecurityGroups:
-    - id: 'sg-ebe8e59f'
-  publicIP: true
+  template:
+    spec:
+      cloudInit:
+        insecureSkipSecretsManager: true
+      instanceType: m5.xlarge
+      rootVolume:
+        size: 150
+      sshKeyName: talos-e2e
+      ami:
+        id: '{{AMI}}'
+      subnet:
+        id: 'subnet-c4e9b3a0'
+      additionalSecurityGroups:
+        - id: 'sg-ebe8e59f'
+      publicIP: true
 ---
-## Controlplane 1 configs
-
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
 metadata:
-  name: talos-e2e-{{TAG}}-aws-controlplane-1
-  namespace: default
+  name: talos-e2e-{{TAG}}-aws-controlplane
 spec:
-  generateType: controlplane
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    cluster.x-k8s.io/control-plane: 'true'
-  name: talos-e2e-{{TAG}}-aws-controlplane-1
-  namespace: default
-spec:
-  clusterName: talos-e2e-{{TAG}}-aws
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: talos-e2e-{{TAG}}-aws-controlplane-1
-      namespace: default
-  infrastructureRef:
+  version: v1.18.3
+  replicas: 3
+  infrastructureTemplate:
+    kind: AWSMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSMachine
-    name: talos-e2e-{{TAG}}-aws-controlplane-1
-    namespace: default
-  version: 1.18.3
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSMachine
-metadata:
-  name: talos-e2e-{{TAG}}-aws-controlplane-1
-  namespace: default
-spec:
-  cloudInit:
-    insecureSkipSecretsManager: true
-  instanceType: m5.xlarge
-  rootVolume:
-    size: 150
-  sshKeyName: talos-e2e
-  ami:
-    id: '{{AMI}}'
-  subnet:
-    id: 'subnet-c4e9b3a0'
-  additionalSecurityGroups:
-    - id: 'sg-ebe8e59f'
-  publicIP: true
----
-## Controlplane 2 configs
-
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: talos-e2e-{{TAG}}-aws-controlplane-2
-  namespace: default
-spec:
-  generateType: controlplane
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
-    cluster.x-k8s.io/control-plane: 'true'
-  name: talos-e2e-{{TAG}}-aws-controlplane-2
-  namespace: default
-spec:
-  clusterName: talos-e2e-{{TAG}}-aws
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: talos-e2e-{{TAG}}-aws-controlplane-2
-      namespace: default
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: AWSMachine
-    name: talos-e2e-{{TAG}}-aws-controlplane-2
-    namespace: default
-  version: 1.18.3
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: AWSMachine
-metadata:
-  name: talos-e2e-{{TAG}}-aws-controlplane-2
-  namespace: default
-spec:
-  cloudInit:
-    insecureSkipSecretsManager: true
-  instanceType: m5.xlarge
-  rootVolume:
-    size: 150
-  sshKeyName: talos-e2e
-  ami:
-    id: '{{AMI}}'
-  subnet:
-    id: 'subnet-c4e9b3a0'
-  additionalSecurityGroups:
-    - id: 'sg-ebe8e59f'
-  publicIP: true
+    name: talos-e2e-{{TAG}}-aws-controlplane
+  controlPlaneConfig:
+    init:
+      generateType: init
+    controlplane:
+      generateType: controlplane
 ---
 ## Worker deployment configs
 
@@ -206,7 +88,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-aws
     nodepool: nodepool-0
   name: talos-e2e-{{TAG}}-aws-workers
-  namespace: default
 spec:
   clusterName: talos-e2e-{{TAG}}-aws
   replicas: 3
@@ -226,19 +107,16 @@ spec:
           apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
           kind: TalosConfigTemplate
           name: talos-e2e-{{TAG}}-aws-workers
-          namespace: default
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: talos-e2e-{{TAG}}-aws-workers
-        namespace: default
       version: 1.18.3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate
 metadata:
   name: talos-e2e-{{TAG}}-aws-workers
-  namespace: default
 spec:
   template:
     spec:

--- a/hack/test/capi/cluster-gcp.yaml
+++ b/hack/test/capi/cluster-gcp.yaml
@@ -4,7 +4,6 @@ apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
   name: talos-e2e-{{TAG}}-gcp
-  namespace: default
 spec:
   clusterNetwork:
     pods:
@@ -14,157 +13,48 @@ spec:
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
     kind: GCPCluster
     name: talos-e2e-{{TAG}}-gcp
-    namespace: default
+  controlPlaneRef:
+    kind: TalosControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+    name: talos-e2e-{{TAG}}-gcp-controlplane
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: GCPCluster
 metadata:
   name: talos-e2e-{{TAG}}-gcp
-  namespace: default
 spec:
   project: talos-testbed
   region: us-central1
 ---
-## Controlplane 0 configs
-
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: talos-e2e-{{TAG}}-gcp-controlplane-0
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-spec:
-  generateType: init
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    cluster.x-k8s.io/control-plane: 'true'
-  name: talos-e2e-{{TAG}}-gcp-controlplane-0
-  namespace: default
-spec:
-  failureDomain: "us-central1-a"
-  clusterName: talos-e2e-{{TAG}}-gcp
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: talos-e2e-{{TAG}}-gcp-controlplane-0
-      namespace: default
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: GCPMachine
-    name: talos-e2e-{{TAG}}-gcp-controlplane-0
-    namespace: default
-  version: 1.18.3
----
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: GCPMachine
+kind: GCPMachineTemplate
 metadata:
-  name: talos-e2e-{{TAG}}-gcp-controlplane-0
-  namespace: default
+  name: talos-e2e-{{TAG}}-gcp-controlplane
 spec:
-  instanceType: n1-standard-4
-  image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
-  serviceAccounts: {}
-  publicIP: true
-  rootDeviceSize: 150
+  template:
+    spec:
+      instanceType: n1-standard-4
+      image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
+      serviceAccounts: {}
+      publicIP: true
+      rootDeviceSize: 150
 ---
-## Controlplane 1 configs
-
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
+apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
+kind: TalosControlPlane
 metadata:
-  name: talos-e2e-{{TAG}}-gcp-controlplane-1
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
+  name: talos-e2e-{{TAG}}-gcp-controlplane
 spec:
-  generateType: controlplane
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    cluster.x-k8s.io/control-plane: 'true'
-  name: talos-e2e-{{TAG}}-gcp-controlplane-1
-  namespace: default
-spec:
-  failureDomain: "us-central1-a"
-  clusterName: talos-e2e-{{TAG}}-gcp
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: talos-e2e-{{TAG}}-gcp-controlplane-1
-      namespace: default
-  infrastructureRef:
+  version: v1.18.3
+  replicas: 3
+  infrastructureTemplate:
+    kind: GCPMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: GCPMachine
-    name: talos-e2e-{{TAG}}-gcp-controlplane-1
-    namespace: default
-  version: 1.18.3
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: GCPMachine
-metadata:
-  name: talos-e2e-{{TAG}}-gcp-controlplane-1
-  namespace: default
-spec:
-  instanceType: n1-standard-4
-  image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
-  serviceAccounts: {}
-  publicIP: true
-  rootDeviceSize: 150
----
-## Controlplane 2 configs
-
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-kind: TalosConfig
-metadata:
-  name: talos-e2e-{{TAG}}-gcp-controlplane-2
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-spec:
-  generateType: controlplane
----
-apiVersion: cluster.x-k8s.io/v1alpha3
-kind: Machine
-metadata:
-  labels:
-    cluster.x-k8s.io/cluster-name: talos-e2e-{{TAG}}-gcp
-    cluster.x-k8s.io/control-plane: 'true'
-  name: talos-e2e-{{TAG}}-gcp-controlplane-2
-  namespace: default
-spec:
-  failureDomain: "us-central1-a"
-  clusterName: talos-e2e-{{TAG}}-gcp
-  bootstrap:
-    configRef:
-      apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-      kind: TalosConfig
-      name: talos-e2e-{{TAG}}-gcp-controlplane-2
-      namespace: default
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: GCPMachine
-    name: talos-e2e-{{TAG}}-gcp-controlplane-2
-    namespace: default
-  version: 1.18.3
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: GCPMachine
-metadata:
-  name: talos-e2e-{{TAG}}-gcp-controlplane-2
-  namespace: default
-spec:
-  instanceType: n1-standard-4
-  image: projects/talos-testbed/global/images/talos-e2e-{{TAG}}
-  serviceAccounts: {}
-  publicIP: true
-  rootDeviceSize: 150
+    name: talos-e2e-{{TAG}}-gcp-controlplane
+  controlPlaneConfig:
+    init:
+      generateType: init
+    controlplane:
+      generateType: controlplane
 ---
 ## Worker deployment configs
 

--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 source ./hack/test/e2e.sh
 
 export CABPT_VERSION="0.2.0-alpha.0"
-export CACPPT_VERSION="0.1.0-alpha.0"
+export CACPPT_VERSION="0.1.0-alpha.2"
 export CAPA_VERSION="0.5.4"
 
 # We need to override this here since e2e.sh will set it to ${TMP}/capi/kubeconfig.


### PR DESCRIPTION
This PR will update the CI testing to make use of our control plane
provider, as well as the other CAPI components.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2313)
<!-- Reviewable:end -->
