### PR TITLE
chore: upgrade Go to 1.14.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -271,36 +271,36 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.2.0-18-gd6048b1 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0-18-gd6048b1 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0-19-g6a2bd10 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0-19-g6a2bd10 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-18-gd6048b1 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-18-gd6048b1 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/lvm2:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/libaio:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/musl:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/open-isns:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-18-gd6048b1 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-18-gd6048b1 /lib/libblkid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-18-gd6048b1 /lib/libuuid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-18-gd6048b1 /lib/libmount.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kmod:v0.2.0-18-gd6048b1 /usr/lib/libkmod.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kernel:v0.2.0-18-gd6048b1 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-19-g6a2bd10 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-19-g6a2bd10 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/lvm2:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/libaio:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/musl:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/open-isns:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-19-g6a2bd10 / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-19-g6a2bd10 /lib/libblkid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-19-g6a2bd10 /lib/libuuid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-19-g6a2bd10 /lib/libmount.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kmod:v0.2.0-19-g6a2bd10 /usr/lib/libkmod.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kernel:v0.2.0-19-g6a2bd10 /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
-TOOLS ?= autonomy/tools:v0.2.0-3-g9a08c57
+TOOLS ?= autonomy/tools:v0.2.0-4-g24243c5
 GO_VERSION ?= 1.14
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)


### PR DESCRIPTION
go1.14.5 (released 2020/07/14) includes security fixes to the
crypto/x509 and net/http packages.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2314)
<!-- Reviewable:end -->
