### PR TITLE
chore: update golangci-lint to 1.28.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.27.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.28.3
+ARG GOFUMPT_VERSION
 RUN cd $(mktemp -d) \
     && go mod init tmp \
-    && go get mvdan.cc/gofumpt/gofumports@aaa7156f4122b1055c466e26e77812fa32bac1d9 \
+    && go get mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
     && mv /go/bin/gofumports /toolchain/go/bin/gofumports
 RUN curl -sfL https://github.com/uber/prototool/releases/download/v1.8.0/prototool-Linux-x86_64.tar.gz | tar -xz --strip-components=2 -C /toolchain/bin prototool/bin/prototool
 COPY ./hack/docgen /go/src/github.com/talos-systems/docgen

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ DOCKER_LOGIN_ENABLED ?= true
 ARTIFACTS := _out
 TOOLS ?= autonomy/tools:v0.2.0-4-g24243c5
 GO_VERSION ?= 1.14
+GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_DEFAULT_TARGET := integration-test-$(OPERATING_SYSTEM)
@@ -32,6 +33,7 @@ COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
 COMMON_ARGS += --push=$(PUSH)
 COMMON_ARGS += --build-arg=TOOLS=$(TOOLS)
+COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
 COMMON_ARGS += --build-arg=SHA=$(SHA)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
@@ -157,7 +159,7 @@ boot: ## Creates a compressed tarball that includes vmlinuz and initramfs.xz. No
 
 .PHONY: fmt
 fmt: ## Formats the source code.
-	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt/gofumports@aaa7156f4122b1055c466e26e77812fa32bac1d9 && cd - && gofumports -w -local github.com/talos-systems/talos ."
+	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && cd - && gofumports -w -local github.com/talos-systems/talos ."
 
 lint-%: ## Runs the specified linter. Valid options are go, protobuf, and markdown (e.g. lint-go).
 	@$(MAKE) target-lint-$*

--- a/cmd/installer/cmd/iso.go
+++ b/cmd/installer/cmd/iso.go
@@ -44,7 +44,7 @@ func runISOCmd() error {
 	for _, dir := range []string{"/mnt/isolinux", "/mnt/usr/install"} {
 		log.Printf("creating %s", dir)
 
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return err
 		}
 	}
@@ -67,7 +67,7 @@ func runISOCmd() error {
 			// nolint: errcheck
 			defer from.Close()
 
-			to, err := os.OpenFile(f, os.O_RDWR|os.O_CREATE, 0666)
+			to, err := os.OpenFile(f, os.O_RDWR|os.O_CREATE, 0o666)
 			if err != nil {
 				return err
 			}
@@ -83,7 +83,7 @@ func runISOCmd() error {
 
 	log.Println("creating isolinux.cfg")
 
-	if err := ioutil.WriteFile("/mnt/isolinux/isolinux.cfg", isolinuxCfg, 0666); err != nil {
+	if err := ioutil.WriteFile("/mnt/isolinux/isolinux.cfg", isolinuxCfg, 0o666); err != nil {
 		return err
 	}
 
@@ -106,7 +106,7 @@ func runISOCmd() error {
 	// nolint: errcheck
 	defer from.Close()
 
-	to, err := os.OpenFile(filepath.Join(outputArg, "talos.iso"), os.O_RDWR|os.O_CREATE, 0666)
+	to, err := os.OpenFile(filepath.Join(outputArg, "talos.iso"), os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -100,7 +100,7 @@ func NewInstaller(cmdline *procfs.Cmdline, seq runtime.Sequence, opts *Options) 
 	}
 
 	if seq == runtime.SequenceUpgrade && i.bootPartitionFound {
-		if err = os.MkdirAll("/boot", 0777); err != nil {
+		if err = os.MkdirAll("/boot", 0o777); err != nil {
 			return nil, err
 		}
 
@@ -299,7 +299,7 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 		// nolint: errcheck
 		defer src.Close()
 
-		dst, err := os.OpenFile(constants.ConfigPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+		dst, err := os.OpenFile(constants.ConfigPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 		if err != nil {
 			return err
 		}

--- a/cmd/installer/pkg/ova/ova.go
+++ b/cmd/installer/pkg/ova/ova.go
@@ -176,11 +176,11 @@ func CreateOVAFromRAW(name, src, out string) (err error) {
 	// nolint: errcheck
 	defer os.RemoveAll(dir)
 
-	if err = ioutil.WriteFile(filepath.Join(dir, name+".mf"), []byte(mf), 0666); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(dir, name+".mf"), []byte(mf), 0o666); err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, name+".ovf"), []byte(ovf), 0666); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(dir, name+".ovf"), []byte(ovf), 0o666); err != nil {
 		return err
 	}
 

--- a/cmd/talosctl/cmd/docs.go
+++ b/cmd/talosctl/cmd/docs.go
@@ -28,7 +28,7 @@ var docsCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := args[0]
 
-		if err := os.MkdirAll(out, 0777); err != nil {
+		if err := os.MkdirAll(out, 0o777); err != nil {
 			return fmt.Errorf("failed to create output directory %q", out)
 		}
 

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -131,7 +131,7 @@ func genV1Alpha1Config(args []string) error {
 			}
 		}
 
-		if err = ioutil.WriteFile(fullFilePath, []byte(configString), 0644); err != nil {
+		if err = ioutil.WriteFile(fullFilePath, []byte(configString), 0o644); err != nil {
 			return err
 		}
 
@@ -148,7 +148,7 @@ func genV1Alpha1Config(args []string) error {
 
 	fullFilePath := filepath.Join(outputDir, "talosconfig")
 
-	if err = ioutil.WriteFile(fullFilePath, data, 0644); err != nil {
+	if err = ioutil.WriteFile(fullFilePath, data, 0o644); err != nil {
 		return fmt.Errorf("%w", err)
 	}
 

--- a/cmd/talosctl/cmd/mgmt/gen.go
+++ b/cmd/talosctl/cmd/mgmt/gen.go
@@ -59,15 +59,15 @@ var caCmd = &cobra.Command{
 			return fmt.Errorf("error generating CA: %w", err)
 		}
 
-		if err := ioutil.WriteFile(organization+".crt", ca.CrtPEM, 0600); err != nil {
+		if err := ioutil.WriteFile(organization+".crt", ca.CrtPEM, 0o600); err != nil {
 			return fmt.Errorf("error writing CA certificate: %w", err)
 		}
 
-		if err := ioutil.WriteFile(organization+".sha256", []byte(x509.Hash(ca.Crt)), 0600); err != nil {
+		if err := ioutil.WriteFile(organization+".sha256", []byte(x509.Hash(ca.Crt)), 0o600); err != nil {
 			return fmt.Errorf("error writing certificate hash: %w", err)
 		}
 
-		if err := ioutil.WriteFile(organization+".key", ca.KeyPEM, 0600); err != nil {
+		if err := ioutil.WriteFile(organization+".key", ca.KeyPEM, 0o600); err != nil {
 			return fmt.Errorf("error writing key: %w", err)
 		}
 
@@ -87,7 +87,7 @@ var keyCmd = &cobra.Command{
 			return fmt.Errorf("error generating key: %w", err)
 		}
 
-		if err := ioutil.WriteFile(name+".key", key.PrivateKeyPEM, 0600); err != nil {
+		if err := ioutil.WriteFile(name+".key", key.PrivateKeyPEM, 0o600); err != nil {
 			return fmt.Errorf("error writing key: %w", err)
 		}
 
@@ -133,7 +133,7 @@ var csrCmd = &cobra.Command{
 			return fmt.Errorf("error generating CSR: %s", err)
 		}
 
-		if err := ioutil.WriteFile(strings.TrimSuffix(key, path.Ext(key))+".csr", csr.X509CertificateRequestPEM, 0600); err != nil {
+		if err := ioutil.WriteFile(strings.TrimSuffix(key, path.Ext(key))+".csr", csr.X509CertificateRequestPEM, 0o600); err != nil {
 			return fmt.Errorf("error writing CSR: %s", err)
 		}
 
@@ -198,7 +198,7 @@ var crtCmd = &cobra.Command{
 			return fmt.Errorf("error signing certificate: %s", err)
 		}
 
-		if err = ioutil.WriteFile(name+".crt", signedCrt.X509CertificatePEM, 0600); err != nil {
+		if err = ioutil.WriteFile(name+".crt", signedCrt.X509CertificatePEM, 0o600); err != nil {
 			return fmt.Errorf("error writing certificate: %s", err)
 		}
 
@@ -229,10 +229,10 @@ var keypairCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error generating CA: %s", err)
 		}
-		if err := ioutil.WriteFile(organization+".crt", ca.CrtPEM, 0600); err != nil {
+		if err := ioutil.WriteFile(organization+".crt", ca.CrtPEM, 0o600); err != nil {
 			return fmt.Errorf("error writing certificate: %s", err)
 		}
-		if err := ioutil.WriteFile(organization+".key", ca.KeyPEM, 0600); err != nil {
+		if err := ioutil.WriteFile(organization+".key", ca.KeyPEM, 0o600); err != nil {
 			return fmt.Errorf("error writing key: %s", err)
 		}
 

--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -72,7 +72,7 @@ captures ownership and permission bits.`,
 				if !os.IsNotExist(err) {
 					return fmt.Errorf("failed to stat local path: %w", err)
 				}
-				if err = os.MkdirAll(localPath, 0777); err != nil {
+				if err = os.MkdirAll(localPath, 0o777); err != nil {
 					return fmt.Errorf("error creating local path %q: %w", localPath, err)
 				}
 			}

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -112,7 +112,7 @@ func extractAndMerge(args []string, r io.ReadCloser) error {
 
 	// base file does not exist, dump config as is
 	if _, err = os.Stat(localPath); os.IsNotExist(err) {
-		err = os.MkdirAll(filepath.Dir(localPath), 0755)
+		err = os.MkdirAll(filepath.Dir(localPath), 0o755)
 		if err != nil {
 			return err
 		}

--- a/cmd/talosctl/pkg/talos/helpers/archive.go
+++ b/cmd/talosctl/pkg/talos/helpers/archive.go
@@ -88,7 +88,7 @@ func ExtractTarGz(localPath string, r io.ReadCloser) error {
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			mode := hdr.FileInfo().Mode()
-			mode |= 0700 // make rwx for the owner
+			mode |= 0o700 // make rwx for the owner
 
 			if err = os.Mkdir(path, mode); err != nil {
 				return fmt.Errorf("error creating directory %q mode %s: %w", path, mode, err)

--- a/internal/app/bootkube/assets.go
+++ b/internal/app/bootkube/assets.go
@@ -31,7 +31,7 @@ import (
 
 // nolint: gocyclo
 func generateAssets(config runtime.Configurator) (err error) {
-	if err = os.MkdirAll(constants.ManifestsDirectory, 0644); err != nil {
+	if err = os.MkdirAll(constants.ManifestsDirectory, 0o644); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -114,7 +114,7 @@ func RunInstallerContainer(disk, platform, ref string, reg runtime.Registries, o
 		return err
 	}
 
-	f, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
+	f, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0o666)
 	if err != nil {
 		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
 	}

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -580,7 +580,7 @@ func (s *Server) Kubeconfig(empty *empty.Empty, obj machine.MachineService_Kubec
 		Name:     "kubeconfig",
 		Size:     int64(b.Len()),
 		ModTime:  time.Now(),
-		Mode:     0600,
+		Mode:     0o600,
 	})
 	if err != nil {
 		return err

--- a/internal/app/machined/pkg/runtime/logging/file.go
+++ b/internal/app/machined/pkg/runtime/logging/file.go
@@ -60,7 +60,7 @@ func (handler *fileLogHandler) Writer() (io.WriteCloser, error) {
 		return nil, err
 	}
 
-	return os.OpenFile(handler.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+	return os.OpenFile(handler.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o666)
 }
 
 // Reader implements runtime.LogHandler interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/syslinux/syslinux.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/syslinux/syslinux.go
@@ -120,7 +120,7 @@ func Install(fallback string, config interface{}, sequence runtime.Sequence, boo
 
 // Labels parses the syslinux config and returns the current active label, and
 // what should be the next label.
-func Labels() (current string, next string, err error) {
+func Labels() (current, next string, err error) {
 	var b []byte
 
 	if b, err = ioutil.ReadFile(SyslinuxConfig); err != nil {
@@ -174,7 +174,7 @@ func RevertTo(label string) (err error) {
 
 	b = re.ReplaceAll(b, []byte(fmt.Sprintf("DEFAULT %s", label)))
 
-	if err = ioutil.WriteFile(SyslinuxConfig, b, 0600); err != nil {
+	if err = ioutil.WriteFile(SyslinuxConfig, b, 0o600); err != nil {
 		return err
 	}
 
@@ -185,7 +185,7 @@ func RevertTo(label string) (err error) {
 //
 // nolint: gocyclo
 func Revert() (err error) {
-	f, err := os.OpenFile(SyslinuxLdlinux, os.O_RDWR, 0700)
+	f, err := os.OpenFile(SyslinuxLdlinux, os.O_RDWR, 0o700)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
@@ -246,7 +246,7 @@ func writeCfg(base, path string, syslinuxcfg *Cfg) (err error) {
 
 	log.Printf("writing %s to disk", path)
 
-	if err = ioutil.WriteFile(path, wr.Bytes(), 0600); err != nil {
+	if err = ioutil.WriteFile(path, wr.Bytes(), 0o600); err != nil {
 		return err
 	}
 
@@ -267,7 +267,7 @@ func writeCfg(base, path string, syslinuxcfg *Cfg) (err error) {
 
 		log.Printf("writing syslinux label %q to disk", label.Root)
 
-		if err = ioutil.WriteFile(filepath.Join(dir, "include.cfg"), wr.Bytes(), 0600); err != nil {
+		if err = ioutil.WriteFile(filepath.Join(dir, "include.cfg"), wr.Bytes(), 0o600); err != nil {
 			return err
 		}
 	}
@@ -309,7 +309,7 @@ func copyFile(src, dst string) error {
 func writeUEFIFiles() (err error) {
 	dir := filepath.Join(constants.BootMountPoint, "EFI", "BOOT")
 
-	if err = os.MkdirAll(dir, 0700); err != nil {
+	if err = os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 
@@ -342,7 +342,7 @@ func update() (err error) {
 func setADV(ldlinux, fallback string) (err error) {
 	var f *os.File
 
-	if f, err = os.OpenFile(ldlinux, os.O_RDWR, 0700); err != nil {
+	if f, err = os.OpenFile(ldlinux, os.O_RDWR, 0o700); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -5,6 +5,7 @@
 package azure
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
@@ -16,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/talos-systems/go-procfs/procfs"
 	"golang.org/x/sys/unix"
@@ -89,7 +91,10 @@ func (a *Azure) Hostname() (hostname []byte, err error) {
 		resp *http.Response
 	)
 
-	req, err = http.NewRequest("GET", AzureHostnameEndpoint, nil)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	req, err = http.NewRequestWithContext(ctx, "GET", AzureHostnameEndpoint, nil)
 	if err != nil {
 		return
 	}
@@ -126,7 +131,10 @@ func (a *Azure) ExternalIPs() (addrs []net.IP, err error) {
 		resp *http.Response
 	)
 
-	if req, err = http.NewRequest("GET", AzureInterfacesEndpoint, nil); err != nil {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	if req, err = http.NewRequestWithContext(ctx, "GET", AzureInterfacesEndpoint, nil); err != nil {
 		return
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/register.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/register.go
@@ -6,10 +6,12 @@ package azure
 
 import (
 	"bytes"
+	"context"
 	"encoding/xml"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // This should provide the bare minimum to trigger a node in ready condition to allow
@@ -31,7 +33,10 @@ func goalState() (gs *GoalState, err error) {
 		return gs, nil
 	}
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return gs, err
 	}
@@ -101,7 +106,10 @@ func reportHealth(gsIncarnation, gsContainerID, gsInstanceID string) (err error)
 		resp *http.Response
 	)
 
-	req, err = http.NewRequest("POST", u.String(), b)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	req, err = http.NewRequestWithContext(ctx, "POST", u.String(), b)
 	if err != nil {
 		return err
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -5,12 +5,14 @@
 package gcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/talos-systems/go-procfs/procfs"
 
@@ -60,7 +62,10 @@ func (g *GCP) ExternalIPs() (addrs []net.IP, err error) {
 		resp *http.Response
 	)
 
-	if req, err = http.NewRequest("GET", GCExternalIPEndpoint, nil); err != nil {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
+	if req, err = http.NewRequestWithContext(ctx, "GET", GCExternalIPEndpoint, nil); err != nil {
 		return
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -93,7 +93,7 @@ func (c *Controller) Run(seq runtime.Sequence, data interface{}, setters ...runt
 
 	// Allow only one sequence to run at a time with the exception of bootstrap
 	// and reset sequences.
-	switch seq {
+	switch seq { //nolint: exhaustive
 	case runtime.SequenceBootstrap, runtime.SequenceReset, runtime.SequenceRecover:
 		// Do not attempt to lock.
 	default:
@@ -380,6 +380,7 @@ func (c *Controller) phases(seq runtime.Sequence, data interface{}) ([]runtime.P
 		}
 
 		phases = c.s.Reset(c.r, in)
+	case runtime.SequenceNoop:
 	default:
 		return nil, fmt.Errorf("sequence not implemented: %q", seq)
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -44,7 +44,7 @@ func (p PhaseList) AppendWhen(when bool, name string, tasks ...runtime.TaskSetup
 func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 	phases := PhaseList{}
 
-	switch r.State().Platform().Mode() {
+	switch r.State().Platform().Mode() { //nolint: exhaustive
 	case runtime.ModeContainer:
 		phases = phases.Append(
 			"systemRequirements",
@@ -112,7 +112,7 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 func (*Sequencer) Install(r runtime.Runtime) []runtime.Phase {
 	phases := PhaseList{}
 
-	switch r.State().Platform().Mode() {
+	switch r.State().Platform().Mode() { //nolint: exhaustive
 	case runtime.ModeContainer:
 		return nil
 	default:
@@ -252,7 +252,7 @@ func (*Sequencer) Bootstrap(r runtime.Runtime) []runtime.Phase {
 func (*Sequencer) Reboot(r runtime.Runtime) []runtime.Phase {
 	phases := PhaseList{}
 
-	switch r.State().Platform().Mode() {
+	switch r.State().Platform().Mode() { //nolint: exhaustive
 	case runtime.ModeContainer:
 		phases = phases.Append(
 			"stopEverything",
@@ -298,7 +298,7 @@ func (*Sequencer) Recover(r runtime.Runtime, in *machine.RecoverRequest) []runti
 func (*Sequencer) Reset(r runtime.Runtime, in *machine.ResetRequest) []runtime.Phase {
 	phases := PhaseList{}
 
-	switch r.State().Platform().Mode() {
+	switch r.State().Platform().Mode() { //nolint: exhaustive
 	case runtime.ModeContainer:
 		phases = phases.Append(
 			"stopEverything",
@@ -350,7 +350,7 @@ func (*Sequencer) Reset(r runtime.Runtime, in *machine.ResetRequest) []runtime.P
 func (*Sequencer) Shutdown(r runtime.Runtime) []runtime.Phase {
 	phases := PhaseList{}
 
-	switch r.State().Platform().Mode() {
+	switch r.State().Platform().Mode() { //nolint: exhaustive
 	case runtime.ModeContainer:
 		phases = phases.Append(
 			"stopEverything",
@@ -387,7 +387,7 @@ func (*Sequencer) Shutdown(r runtime.Runtime) []runtime.Phase {
 func (*Sequencer) Upgrade(r runtime.Runtime, in *machine.UpgradeRequest) []runtime.Phase {
 	phases := PhaseList{}
 
-	switch r.State().Platform().Mode() {
+	switch r.State().Platform().Mode() { //nolint: exhaustive
 	case runtime.ModeContainer:
 		return nil
 	default:

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -97,7 +97,7 @@ func EnforceKSPPRequirements(seq runtime.Sequence, data interface{}) (runtime.Ta
 func SetupSystemDirectory(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		for _, p := range []string{constants.SystemEtcPath, constants.SystemRunPath, constants.SystemVarPath} {
-			if err = os.MkdirAll(p, 0700); err != nil {
+			if err = os.MkdirAll(p, 0o700); err != nil {
 				return err
 			}
 		}
@@ -269,7 +269,7 @@ func WriteIMAPolicy(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 			return fmt.Errorf("policy file does not exist: %w", err)
 		}
 
-		f, err := os.OpenFile("/sys/kernel/security/ima/policy", os.O_APPEND|os.O_WRONLY, 0644)
+		f, err := os.OpenFile("/sys/kernel/security/ima/policy", os.O_APPEND|os.O_WRONLY, 0o644)
 		if err != nil {
 			return err
 		}
@@ -348,7 +348,7 @@ func OSRelease() (err error) {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(constants.SystemEtcPath, "os-release"), writer.Bytes(), 0644)
+	return ioutil.WriteFile(filepath.Join(constants.SystemEtcPath, "os-release"), writer.Bytes(), 0o644)
 }
 
 // createBindMount creates a common way to create a writable source file with a
@@ -357,7 +357,7 @@ func OSRelease() (err error) {
 func createBindMount(src, dst string) (err error) {
 	var f *os.File
 
-	if f, err = os.OpenFile(src, os.O_WRONLY|os.O_CREATE, 0644); err != nil {
+	if f, err = os.OpenFile(src, os.O_WRONLY|os.O_CREATE, 0o644); err != nil {
 		return err
 	}
 
@@ -493,7 +493,7 @@ func SaveConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 			return err
 		}
 
-		return ioutil.WriteFile(constants.ConfigPath, b, 0600)
+		return ioutil.WriteFile(constants.ConfigPath, b, 0o600)
 	}, "saveConfig"
 }
 
@@ -640,6 +640,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 				&services.Trustd{},
 				&services.Etcd{},
 			)
+		case runtime.MachineTypeJoin:
 		}
 
 		system.Services(r).StartAll()
@@ -740,7 +741,7 @@ func SetupSharedFilesystems(seq runtime.Sequence, data interface{}) (runtime.Tas
 func SetupVarDirectory(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		for _, p := range []string{"/var/log/pods", "/var/lib/kubelet", "/var/run/lock"} {
-			if err = os.MkdirAll(p, 0700); err != nil {
+			if err = os.MkdirAll(p, 0o700); err != nil {
 				return err
 			}
 		}
@@ -835,7 +836,7 @@ func mountDisks(r runtime.Runtime) (err error) {
 			}
 
 			if _, err = os.Stat(part.MountPoint); errors.Is(err, os.ErrNotExist) {
-				if err = os.MkdirAll(part.MountPoint, 0700); err != nil {
+				if err = os.MkdirAll(part.MountPoint, 0o700); err != nil {
 					return err
 				}
 			}
@@ -1160,7 +1161,10 @@ func LeaveEtcd(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFun
 
 		for _, member := range resp.Members {
 			if member.Name == hostname {
+				member := member
 				id = &member.ID
+
+				break
 			}
 		}
 
@@ -1371,7 +1375,7 @@ func LabelNodeAsMaster(seq runtime.Sequence, data interface{}) (runtime.TaskExec
 // UpdateBootloader represents the UpdateBootloader task.
 func UpdateBootloader(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		f, err := os.OpenFile(syslinux.SyslinuxLdlinux, os.O_RDWR, 0700)
+		f, err := os.OpenFile(syslinux.SyslinuxLdlinux, os.O_RDWR, 0o700)
 		if err != nil {
 			return err
 		}
@@ -1563,7 +1567,7 @@ func Recover(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 			return err
 		}
 
-		if err = ioutil.WriteFile(kubeconfigPath, b.Bytes(), 0600); err != nil {
+		if err = ioutil.WriteFile(kubeconfigPath, b.Bytes(), 0o600); err != nil {
 			return fmt.Errorf("failed to create recovery kubeconfig: %w", err)
 		}
 
@@ -1595,7 +1599,7 @@ func Recover(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 			return err
 		}
 
-		if err = os.MkdirAll(constants.AssetsDirectory, 0600); err != nil {
+		if err = os.MkdirAll(constants.AssetsDirectory, 0o600); err != nil {
 			return err
 		}
 

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -69,8 +69,8 @@ func (suite *ContainerdSuite) SetupSuite() {
 	suite.loggingManager = logging.NewFileLoggingManager(suite.tmpDir)
 
 	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
-	suite.Require().NoError(os.Mkdir(stateDir, 0777))
-	suite.Require().NoError(os.Mkdir(rootDir, 0777))
+	suite.Require().NoError(os.Mkdir(stateDir, 0o777))
+	suite.Require().NoError(os.Mkdir(rootDir, 0o777))
 
 	suite.containerdAddress = filepath.Join(suite.tmpDir, "run.sock")
 
@@ -254,7 +254,7 @@ func (suite *ContainerdSuite) TestRunLogs() {
 
 func (suite *ContainerdSuite) TestStopFailingAndRestarting() {
 	testDir := filepath.Join(suite.tmpDir, "test")
-	suite.Assert().NoError(os.Mkdir(testDir, 0770))
+	suite.Assert().NoError(os.Mkdir(testDir, 0o770))
 
 	testFile := filepath.Join(testDir, "talos-test")
 	// nolint: errcheck

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -410,7 +410,7 @@ func (svcrunner *ServiceRunner) inStateLocked(event StateEvent) bool {
 		// up when:
 		//   a) either skipped or already finished
 		//   b) or running and healthy (if supports health checks)
-		switch svcrunner.state {
+		switch svcrunner.state { //nolint: exhaustive
 		case events.StateSkipped, events.StateFinished:
 			return true
 		case events.StateRunning:
@@ -424,7 +424,7 @@ func (svcrunner *ServiceRunner) inStateLocked(event StateEvent) bool {
 		}
 	case StateEventDown:
 		// down when in any of the terminal states
-		switch svcrunner.state {
+		switch svcrunner.state { //nolint: exhaustive
 		case events.StateFailed, events.StateFinished, events.StateSkipped:
 			return true
 		default:

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -83,7 +83,7 @@ func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
 	endpoints := []string{"127.0.0.1"}
 
 	// Ensure socket dir exists
-	if err := os.MkdirAll(filepath.Dir(constants.APISocketPath), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.APISocketPath), 0o750); err != nil {
 		return nil, err
 	}
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -141,15 +141,15 @@ func (e *Etcd) HealthSettings(runtime.Runtime) *health.Settings {
 
 // nolint: gocyclo
 func generatePKI(r runtime.Runtime) (err error) {
-	if err = os.MkdirAll(constants.EtcdPKIPath, 0644); err != nil {
+	if err = os.MkdirAll(constants.EtcdPKIPath, 0o644); err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(constants.KubernetesEtcdCACert, r.Config().Cluster().Etcd().CA().Crt, 0500); err != nil {
+	if err = ioutil.WriteFile(constants.KubernetesEtcdCACert, r.Config().Cluster().Etcd().CA().Crt, 0o500); err != nil {
 		return fmt.Errorf("failed to write CA certificate: %w", err)
 	}
 
-	if err = ioutil.WriteFile(constants.KubernetesEtcdCAKey, r.Config().Cluster().Etcd().CA().Key, 0500); err != nil {
+	if err = ioutil.WriteFile(constants.KubernetesEtcdCAKey, r.Config().Cluster().Etcd().CA().Key, 0o500); err != nil {
 		return fmt.Errorf("failed to write CA key: %w", err)
 	}
 
@@ -238,11 +238,11 @@ func generatePKI(r runtime.Runtime) (err error) {
 		return fmt.Errorf("failled to create peer certificate: %w", err)
 	}
 
-	if err := ioutil.WriteFile(constants.KubernetesEtcdPeerKey, peerKey.KeyPEM, 0500); err != nil {
+	if err := ioutil.WriteFile(constants.KubernetesEtcdPeerKey, peerKey.KeyPEM, 0o500); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(constants.KubernetesEtcdPeerCert, peer.X509CertificatePEM, 0500); err != nil {
+	if err := ioutil.WriteFile(constants.KubernetesEtcdPeerCert, peer.X509CertificatePEM, 0o500); err != nil {
 		return err
 	}
 
@@ -433,7 +433,7 @@ func (e *Etcd) setup(ctx context.Context, r runtime.Runtime, errCh chan error) {
 	errCh <- func() error {
 		var err error
 
-		if err = os.MkdirAll(constants.EtcdDataPath, 0755); err != nil {
+		if err = os.MkdirAll(constants.EtcdDataPath, 0o755); err != nil {
 			return err
 		}
 
@@ -454,7 +454,7 @@ func (e *Etcd) setup(ctx context.Context, r runtime.Runtime, errCh chan error) {
 			return fmt.Errorf("failed to pull image %q: %w", r.Config().Cluster().Etcd().Image(), err)
 		}
 
-		switch r.Config().Machine().Type() {
+		switch r.Config().Machine().Type() { //nolint: exhaustive
 		case runtime.MachineTypeInit:
 			err = e.argsForInit(ctx, r)
 			if err != nil {
@@ -465,6 +465,8 @@ func (e *Etcd) setup(ctx context.Context, r runtime.Runtime, errCh chan error) {
 			if err != nil {
 				return err
 			}
+		default:
+			return fmt.Errorf("unexpected machine type: %s", r.Config().Machine().Type())
 		}
 
 		return nil
@@ -573,7 +575,7 @@ func IsDirEmpty(name string) (bool, error) {
 }
 
 // primaryAndListenAddresses calculates the primary (advertised) and listen (bind) addresses for etcd.
-func primaryAndListenAddresses() (primary string, listen string, err error) {
+func primaryAndListenAddresses() (primary, listen string, err error) {
 	ips, err := net.IPAddrs()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to discover interface IP addresses: %w", err)

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -89,15 +89,15 @@ func (k *Kubelet) PreFunc(ctx context.Context, r runtime.Runtime) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(constants.KubeletBootstrapKubeconfig, buf.Bytes(), 0600); err != nil {
+	if err := ioutil.WriteFile(constants.KubeletBootstrapKubeconfig, buf.Bytes(), 0o600); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(constants.KubernetesCACert), 0700); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.KubernetesCACert), 0o700); err != nil {
 		return err
 	}
 
-	if err := ioutil.WriteFile(constants.KubernetesCACert, r.Config().Cluster().CA().Crt, 0500); err != nil {
+	if err := ioutil.WriteFile(constants.KubernetesCACert, r.Config().Cluster().CA().Crt, 0o500); err != nil {
 		return err
 	}
 
@@ -328,7 +328,7 @@ func writeKubeletConfig(r runtime.Runtime) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile("/etc/kubernetes/kubelet.yaml", buf.Bytes(), 0600); err != nil {
+	if err := ioutil.WriteFile("/etc/kubernetes/kubelet.yaml", buf.Bytes(), 0o600); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -81,7 +81,7 @@ func (n *Networkd) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	// Ensure socket dir exists
-	if err := os.MkdirAll(filepath.Dir(constants.NetworkSocketPath), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.NetworkSocketPath), 0o750); err != nil {
 		return nil, err
 	}
 

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -76,7 +76,7 @@ func (o *Routerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	// Ensure socket dir exists
-	if err := os.MkdirAll(filepath.Dir(constants.RouterdSocketPath), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.RouterdSocketPath), 0o750); err != nil {
 		return nil, err
 	}
 

--- a/internal/app/machined/pkg/system/services/timed.go
+++ b/internal/app/machined/pkg/system/services/timed.go
@@ -77,7 +77,7 @@ func (n *Timed) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	// Ensure socket dir exists
-	if err := os.MkdirAll(filepath.Dir(constants.TimeSocketPath), 0750); err != nil {
+	if err := os.MkdirAll(filepath.Dir(constants.TimeSocketPath), 0o750); err != nil {
 		return nil, err
 	}
 

--- a/internal/app/networkd/pkg/networkd/misc.go
+++ b/internal/app/networkd/pkg/networkd/misc.go
@@ -97,7 +97,7 @@ func writeResolvConf(resolvers []string) (err error) {
 
 	log.Println("writing resolvconf")
 
-	return ioutil.WriteFile("/etc/resolv.conf", []byte(resolvconf.String()), 0644)
+	return ioutil.WriteFile("/etc/resolv.conf", []byte(resolvconf.String()), 0o644)
 }
 
 const hostsTemplate = `
@@ -149,5 +149,5 @@ func writeHosts(hostname string, address net.IP, config runtime.Configurator) (e
 		return err
 	}
 
-	return ioutil.WriteFile("/etc/hosts", writer.Bytes(), 0644)
+	return ioutil.WriteFile("/etc/hosts", writer.Bytes(), 0o644)
 }

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -276,7 +276,7 @@ func (n *Networkd) Hostname() (err error) {
 }
 
 // nolint: gocyclo
-func (n *Networkd) decideHostname() (hostname string, domainname string, address net.IP, err error) {
+func (n *Networkd) decideHostname() (hostname, domainname string, address net.IP, err error) {
 	// Set hostname to default
 	address = net.ParseIP("127.0.1.1")
 	hostname = fmt.Sprintf("%s-%s", "talos", strings.ReplaceAll(address.String(), ".", "-"))

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -68,8 +68,8 @@ func (suite *ContainerdSuite) SetupSuite() {
 	suite.loggingManager = logging.NewFileLoggingManager(suite.tmpDir)
 
 	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
-	suite.Require().NoError(os.Mkdir(stateDir, 0777))
-	suite.Require().NoError(os.Mkdir(rootDir, 0777))
+	suite.Require().NoError(os.Mkdir(stateDir, 0o777))
+	suite.Require().NoError(os.Mkdir(rootDir, 0o777))
 
 	suite.containerdAddress = filepath.Join(suite.tmpDir, "run.sock")
 

--- a/internal/pkg/containers/cri/containerd/config.go
+++ b/internal/pkg/containers/cri/containerd/config.go
@@ -95,7 +95,7 @@ func GenerateRegistriesConfig(input runtime.Registries) ([]runtime.File, error) 
 
 				extraFiles = append(extraFiles, runtime.File{
 					Content:     string(hostConfig.TLS.CA),
-					Permissions: 0600,
+					Permissions: 0o600,
 					Path:        path,
 					Op:          "create",
 				})
@@ -108,7 +108,7 @@ func GenerateRegistriesConfig(input runtime.Registries) ([]runtime.File, error) 
 
 				extraFiles = append(extraFiles, runtime.File{
 					Content:     string(hostConfig.TLS.ClientIdentity.Crt),
-					Permissions: 0600,
+					Permissions: 0o600,
 					Path:        path,
 					Op:          "create",
 				})
@@ -121,7 +121,7 @@ func GenerateRegistriesConfig(input runtime.Registries) ([]runtime.File, error) 
 
 				extraFiles = append(extraFiles, runtime.File{
 					Content:     string(hostConfig.TLS.ClientIdentity.Key),
-					Permissions: 0600,
+					Permissions: 0o600,
 					Path:        path,
 					Op:          "create",
 				})
@@ -146,7 +146,7 @@ func GenerateRegistriesConfig(input runtime.Registries) ([]runtime.File, error) 
 	// configuration pieces for CRI plugin
 	return append(extraFiles, runtime.File{
 		Content:     buf.String(),
-		Permissions: 0644,
+		Permissions: 0o644,
 		Path:        constants.CRIContainerdConfig,
 		Op:          "append",
 	}), nil

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -69,19 +69,19 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 	suite.Assert().Equal([]runtime.File{
 		{
 			Content:     `cacert`,
-			Permissions: 0600,
+			Permissions: 0o600,
 			Path:        "/etc/cri/ca/some.host:123.crt",
 			Op:          "create",
 		},
 		{
 			Content:     `clientcert`,
-			Permissions: 0600,
+			Permissions: 0o600,
 			Path:        "/etc/cri/client/some.host:123.crt",
 			Op:          "create",
 		},
 		{
 			Content:     `clientkey`,
-			Permissions: 0600,
+			Permissions: 0o600,
 			Path:        "/etc/cri/client/some.host:123.key",
 			Op:          "create",
 		},
@@ -105,7 +105,7 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
             cert_file = "/etc/cri/client/some.host:123.crt"
             key_file = "/etc/cri/client/some.host:123.key"
 `,
-			Permissions: 0644,
+			Permissions: 0o644,
 			Path:        constants.CRIContainerdConfig,
 			Op:          "append",
 		},

--- a/internal/pkg/containers/cri/cri.go
+++ b/internal/pkg/containers/cri/cri.go
@@ -85,7 +85,7 @@ func (i *inspector) Images() (map[string]string, error) {
 	return result, nil
 }
 
-func parseContainerDisplay(id string) (namespace string, pod string, name string) {
+func parseContainerDisplay(id string) (namespace, pod, name string) {
 	slashIdx := strings.Index(id, "/")
 	if slashIdx > 0 {
 		namespace, pod = id[:slashIdx], id[slashIdx+1:]

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -62,8 +62,8 @@ func (suite *CRISuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
-	suite.Require().NoError(os.Mkdir(stateDir, 0777))
-	suite.Require().NoError(os.Mkdir(rootDir, 0777))
+	suite.Require().NoError(os.Mkdir(stateDir, 0o777))
+	suite.Require().NoError(os.Mkdir(rootDir, 0o777))
 
 	suite.containerdAddress = filepath.Join(suite.tmpDir, "run.sock")
 

--- a/internal/pkg/containers/image/resolver_test.go
+++ b/internal/pkg/containers/image/resolver_test.go
@@ -188,7 +188,7 @@ func (suite *ResolverSuite) TestRegistryHosts() {
 
 	suite.Require().NotNil(registryHosts[0].Authorizer)
 
-	req, err := http.NewRequest("GET", "htts://some.host:123/v2", nil)
+	req, err := http.NewRequest("GET", "htts://some.host:123/v2", nil) //nolint: noctx
 	suite.Require().NoError(err)
 
 	resp := &http.Response{}

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -52,8 +52,8 @@ func (suite *CRISuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	stateDir, rootDir := filepath.Join(suite.tmpDir, "state"), filepath.Join(suite.tmpDir, "root")
-	suite.Require().NoError(os.Mkdir(stateDir, 0777))
-	suite.Require().NoError(os.Mkdir(rootDir, 0777))
+	suite.Require().NoError(os.Mkdir(stateDir, 0o777))
+	suite.Require().NoError(os.Mkdir(rootDir, 0o777))
 
 	suite.containerdAddress = filepath.Join(suite.tmpDir, "run.sock")
 

--- a/internal/pkg/kmsg/kmsg.go
+++ b/internal/pkg/kmsg/kmsg.go
@@ -23,7 +23,7 @@ import (
 //
 // If extraWriter is not nil, logs will be copied to it as well.
 func SetupLogger(logger *log.Logger, prefix string, extraWriter io.Writer) error {
-	kmsg, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0666)
+	kmsg, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0o666)
 	if err != nil {
 		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
 	}

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -145,7 +145,7 @@ type Points struct {
 }
 
 // NewMountPoint initializes and returns a Point struct.
-func NewMountPoint(source string, target string, fstype string, flags uintptr, data string, setters ...Option) *Point {
+func NewMountPoint(source, target, fstype string, flags uintptr, data string, setters ...Option) *Point {
 	opts := NewDefaultOptions(setters...)
 
 	return &Point{

--- a/internal/pkg/provision/providers/firecracker/inmemhttp/inmemhttp_test.go
+++ b/internal/pkg/provision/providers/firecracker/inmemhttp/inmemhttp_test.go
@@ -27,7 +27,7 @@ func TestServer(t *testing.T) {
 	srv.Serve()
 	defer srv.Shutdown(context.Background()) //nolint: errcheck
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/test.txt", srv.GetAddr()))
+	resp, err := http.Get(fmt.Sprintf("http://%s/test.txt", srv.GetAddr())) //nolint: noctx
 	assert.NoError(t, err)
 
 	defer resp.Body.Close() //nolint: errcheck
@@ -41,7 +41,7 @@ func TestServer(t *testing.T) {
 
 	assert.NoError(t, resp.Body.Close())
 
-	resp, err = http.Head(fmt.Sprintf("http://%s/test.txt", srv.GetAddr()))
+	resp, err = http.Head(fmt.Sprintf("http://%s/test.txt", srv.GetAddr())) //nolint: noctx
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -50,7 +50,7 @@ func TestServer(t *testing.T) {
 
 	assert.NoError(t, resp.Body.Close())
 
-	resp, err = http.Get(fmt.Sprintf("http://%s/test.txt2", srv.GetAddr()))
+	resp, err = http.Get(fmt.Sprintf("http://%s/test.txt2", srv.GetAddr())) //nolint: noctx
 	assert.NoError(t, err)
 
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/internal/pkg/provision/providers/firecracker/loadbalancer.go
+++ b/internal/pkg/provision/providers/firecracker/loadbalancer.go
@@ -25,7 +25,7 @@ const (
 func (p *provisioner) createLoadBalancer(state *state, clusterReq provision.ClusterRequest) error {
 	pidPath := filepath.Join(state.statePath, lbPid)
 
-	logFile, err := os.OpenFile(filepath.Join(state.statePath, lbLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+	logFile, err := os.OpenFile(filepath.Join(state.statePath, lbLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/provision/providers/firecracker/node.go
+++ b/internal/pkg/provision/providers/firecracker/node.go
@@ -148,7 +148,7 @@ func (p *provisioner) createNode(state *state, clusterReq provision.ClusterReque
 		},
 	}
 
-	logFile, err := os.OpenFile(filepath.Join(state.statePath, fmt.Sprintf("%s.log", nodeReq.Name)), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
+	logFile, err := os.OpenFile(filepath.Join(state.statePath, fmt.Sprintf("%s.log", nodeReq.Name)), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
 	if err != nil {
 		return provision.NodeInfo{}, err
 	}

--- a/pkg/archiver/archiver_test.go
+++ b/pkg/archiver/archiver_test.go
@@ -28,31 +28,31 @@ var filesFixture = []struct {
 }{
 	{
 		Path:     "/etc/hostname",
-		Mode:     0644,
+		Mode:     0o644,
 		Contents: []byte("localhost"),
 	},
 	{
 		Path:     "/etc/certs/ca.crt",
-		Mode:     0600,
+		Mode:     0o600,
 		Contents: []byte("-- CA PEM CERT -- VERY SECRET"),
 	},
 	{
 		Path: "/dev/random",
-		Mode: 0600 | os.ModeCharDevice,
+		Mode: 0o600 | os.ModeCharDevice,
 	},
 	{
 		Path:     "/usr/bin/cp",
-		Mode:     0755,
+		Mode:     0o755,
 		Contents: []byte("ELF EXECUTABLE IIRC"),
 	},
 	{
 		Path:     "/usr/bin/mv",
-		Mode:     0644 | os.ModeSymlink,
+		Mode:     0o644 | os.ModeSymlink,
 		Contents: []byte("/usr/bin/cp"),
 	},
 	{
 		Path:     "/lib/dynalib.so",
-		Mode:     0644,
+		Mode:     0o644,
 		Contents: []byte("SOME LIBRARY OUT THERE"),
 		Size:     20 * 1024,
 	},
@@ -65,7 +65,7 @@ func (suite *CommonSuite) SetupSuite() {
 	suite.Require().NoError(err)
 
 	for _, file := range filesFixture {
-		suite.Require().NoError(os.MkdirAll(filepath.Join(suite.tmpDir, filepath.Dir(file.Path)), 0777))
+		suite.Require().NoError(os.MkdirAll(filepath.Join(suite.tmpDir, filepath.Dir(file.Path)), 0o777))
 
 		if file.Mode&os.ModeSymlink != 0 {
 			suite.Require().NoError(os.Symlink(string(file.Contents), filepath.Join(suite.tmpDir, file.Path)))

--- a/pkg/archiver/walker_test.go
+++ b/pkg/archiver/walker_test.go
@@ -79,7 +79,7 @@ func (suite *WalkerSuite) TestIterationFile() {
 
 func (suite *WalkerSuite) TestIterationSymlink() {
 	original := filepath.Join(suite.tmpDir, "original")
-	err := os.Mkdir(original, 0755)
+	err := os.Mkdir(original, 0o755)
 	suite.Require().NoError(err)
 
 	newname := filepath.Join(suite.tmpDir, "new")
@@ -88,7 +88,7 @@ func (suite *WalkerSuite) TestIterationSymlink() {
 	err = os.Symlink("original", newname)
 	suite.Require().NoError(err)
 
-	err = ioutil.WriteFile(filepath.Join(original, "original.txt"), []byte{}, 0666)
+	err = ioutil.WriteFile(filepath.Join(original, "original.txt"), []byte{}, 0o666)
 	suite.Require().NoError(err)
 
 	ch, err := archiver.Walker(context.Background(), newname)

--- a/pkg/blockdevice/blkpg/blkpg_linux.go
+++ b/pkg/blockdevice/blkpg/blkpg_linux.go
@@ -77,7 +77,7 @@ func inform(f *os.File, partition table.Partition, op int32) (err error) {
 		)
 
 		if errno != 0 {
-			switch errno {
+			switch errno { //nolint: exhaustive
 			case unix.EBUSY:
 				return retry.ExpectedError(err)
 			default:

--- a/pkg/blockdevice/blockdevice_linux.go
+++ b/pkg/blockdevice/blockdevice_linux.go
@@ -129,7 +129,7 @@ func (bd *BlockDevice) RereadPartitionTable() error {
 		if _, _, ret = unix.Syscall(unix.SYS_IOCTL, bd.f.Fd(), unix.BLKRRPART, 0); ret == 0 {
 			return nil
 		}
-		switch ret {
+		switch ret { //nolint: exhaustive
 		case syscall.EBUSY:
 			return retry.ExpectedError(err)
 		default:

--- a/pkg/blockdevice/lba/lba_darwin.go
+++ b/pkg/blockdevice/lba/lba_darwin.go
@@ -33,7 +33,7 @@ func (lba *LogicalBlockAddresser) Make(size uint64) []byte {
 }
 
 // Copy copies from src to dst in the specified range.
-func (lba *LogicalBlockAddresser) Copy(dst []byte, src []byte, rng Range) (int, error) {
+func (lba *LogicalBlockAddresser) Copy(dst, src []byte, rng Range) (int, error) {
 	return 0, fmt.Errorf("not implemented")
 }
 

--- a/pkg/blockdevice/lba/lba_linux.go
+++ b/pkg/blockdevice/lba/lba_linux.go
@@ -67,7 +67,7 @@ func (lba *LogicalBlockAddresser) Make(size uint64) []byte {
 }
 
 // Copy copies from src to dst in the specified range.
-func (lba *LogicalBlockAddresser) Copy(dst []byte, src []byte, rng Range) (int, error) {
+func (lba *LogicalBlockAddresser) Copy(dst, src []byte, rng Range) (int, error) {
 	size := lba.LogicalBlockSize
 	n := copy(dst[size*rng.Start:size*rng.End], src)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -221,7 +221,7 @@ func CredentialsFromConfigContext(context *config.Context) (*Credentials, error)
 // NewClientContextAndCredentialsFromConfig initializes Credentials from config file.
 //
 // Deprecated: use Option-based methods for client creation.
-func NewClientContextAndCredentialsFromConfig(p string, ctx string) (context *config.Context, creds *Credentials, err error) {
+func NewClientContextAndCredentialsFromConfig(p, ctx string) (context *config.Context, creds *Credentials, err error) {
 	c, err := config.Open(p)
 	if err != nil {
 		return

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -81,11 +81,11 @@ func (c *Config) Save(p string) (err error) {
 		return
 	}
 
-	if err = os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+	if err = os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(p, configBytes, 0600); err != nil {
+	if err = ioutil.WriteFile(p, configBytes, 0o600); err != nil {
 		return
 	}
 

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -216,7 +216,7 @@ func NewAdminCertificateAndKey(crt, key []byte, loopback string) (p *x509.PEMEnc
 // NewInput generates the sensitive data required to generate all config
 // types.
 // nolint: dupl,gocyclo
-func NewInput(clustername string, endpoint string, kubernetesVersion string, opts ...GenOption) (input *Input, err error) {
+func NewInput(clustername, endpoint, kubernetesVersion string, opts ...GenOption) (input *Input, err error) {
 	options := DefaultGenOptions()
 
 	for _, opt := range opts {
@@ -376,7 +376,7 @@ func randBytes(length int) (string, error) {
 
 // genToken will generate a token of the format abc.123 (like kubeadm/trustd), where the length of the first string (before the dot)
 // and length of the second string (after dot) are specified as inputs.
-func genToken(lenFirst int, lenSecond int) (string, error) {
+func genToken(lenFirst, lenSecond int) (string, error) {
 	var err error
 
 	tokenTemp := make([]string, 2)
@@ -395,7 +395,7 @@ func genToken(lenFirst int, lenSecond int) (string, error) {
 }
 
 // emptyIf returns empty string if the 2nd argument is empty string, otherwise returns the first argumewnt.
-func emptyIf(str string, check string) string {
+func emptyIf(str, check string) string {
 	if check == "" {
 		return ""
 	}

--- a/pkg/follow/follow.go
+++ b/pkg/follow/follow.go
@@ -148,7 +148,7 @@ func (r *Reader) notify() {
 				continue
 			}
 
-			switch event.Op {
+			switch event.Op { //nolint: exhaustive
 			case fsnotify.Write:
 				// non-blocking send, we need to keep processing fsnotify events
 				// at least signal message is in r.notifyCh which will allow Read to wake up

--- a/pkg/grpc/factory/factory.go
+++ b/pkg/grpc/factory/factory.go
@@ -179,7 +179,7 @@ func NewListener(setters ...Option) (net.Listener, error) {
 		}
 
 		// Make any dirs on the path to the listening socket.
-		if err := os.MkdirAll(filepath.Dir(address), 0700); err != nil {
+		if err := os.MkdirAll(filepath.Dir(address), 0o700); err != nil {
 			return nil, fmt.Errorf("error creating containing directory for the file socket; %w", err)
 		}
 	case "tcp":

--- a/pkg/grpc/gen/remote.go
+++ b/pkg/grpc/gen/remote.go
@@ -96,7 +96,7 @@ func (g *RemoteGenerator) Close() error {
 	return g.conn.Close()
 }
 
-func (g *RemoteGenerator) poll(in *securityapi.CertificateRequest) (ca []byte, crt []byte, err error) {
+func (g *RemoteGenerator) poll(in *securityapi.CertificateRequest) (ca, crt []byte, err error) {
 	timeout := time.NewTimer(time.Minute * 5)
 	defer timeout.Stop()
 

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -18,7 +18,7 @@ type SystemProperty struct {
 
 // WriteSystemProperty writes a value to a key under /proc/sys.
 func WriteSystemProperty(prop *SystemProperty) error {
-	return ioutil.WriteFile(prop.Path(), []byte(prop.Value), 0644)
+	return ioutil.WriteFile(prop.Path(), []byte(prop.Value), 0o644)
 }
 
 // ReadSystemProperty reads a value from a key under /proc/sys.


### PR DESCRIPTION
Fixes #2272

`gofumpt` is now included into `golangci-lint`, but not the
`gofumports`, so we keep it using it as separate binary, but we keep
versions in sync with `golangci-lint`.

This contains fixes from:

* `gofumpt` (automated, mostly around octal constants)
* `exhaustive` in `switch` statements
* `noctx` (adding context with default timeout to http requests)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2315)
<!-- Reviewable:end -->
