### PR TITLE
fix: update container name in docker crashdump

### DIFF
--- a/internal/pkg/provision/providers/docker/crashdump.go
+++ b/internal/pkg/provision/providers/docker/crashdump.go
@@ -24,7 +24,7 @@ func (p *provisioner) CrashDump(ctx context.Context, cluster provision.Cluster, 
 	}
 
 	for _, container := range containers {
-		name := container.Names[0][:1]
+		name := container.Names[0][1:]
 		fmt.Fprintf(out, "%s\n%s\n\n", name, strings.Repeat("=", len(name)))
 
 		logs, err := p.client.ContainerLogs(ctx, container.ID, types.ContainerLogsOptions{


### PR DESCRIPTION
Small bug resulted in container names being cut in the wrong way.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2319)
<!-- Reviewable:end -->
