### PR TITLE
fix: wrap errors in upgrade API handler

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -206,11 +206,11 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 	log.Printf("validating %q", in.GetImage())
 
 	if err = pullAndValidateInstallerImage(ctx, s.Controller.Runtime().Config().Machine().Registries(), in.GetImage()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error validating installer image %q: %w", in.GetImage(), err)
 	}
 
 	if err = etcd.ValidateForUpgrade(in.GetPreserve()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error validating etcd for upgrade: %w", err)
 	}
 
 	go func() {


### PR DESCRIPTION
We often see in the logs errors like:

```
machined Unknown [/machine.MachineService/Upgrade] 6.984959636s unary Unauthorized (:authority=unix:/run/system/machined/machine.sock;content-type=application/grpc;proxyfrom=172.21.0.2,172.21.0.3,172.21.0.4;user-agent=grpc-go/1.26.0)
```

```
* 172.21.0.4: rpc error: code = Unknown desc = Unauthorized
```

These errors are not related to the API handling, but most probably
coming from one of the actions performed by the handler. Wrap the errors
to get better debugging output.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2320)
<!-- Reviewable:end -->
