### PR TITLE
test: provider correct installer kernel args for firecracker

### DIFF
--- a/internal/pkg/provision/providers/firecracker/firecracker.go
+++ b/internal/pkg/provision/providers/firecracker/firecracker.go
@@ -44,6 +44,18 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 
 	return []generate.GenOption{
 		generate.WithInstallDisk("/dev/vda"),
+		generate.WithInstallExtraKernelArgs([]string{
+			"console=ttyS0",
+			// reboot configuration
+			"reboot=k",
+			"panic=1",
+			// disable stuff we don't need
+			"pci=off",
+			"acpi=off",
+			"i8042.noaux=",
+			// Talos-specific
+			"talos.platform=metal",
+		}),
 		generate.WithNetworkConfig(&v1alpha1.NetworkConfig{
 			NameServers: nameservers,
 			NetworkInterfaces: []runtime.Device{

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -82,8 +82,9 @@ type Input struct {
 
 	ExternalEtcd bool
 
-	InstallDisk  string
-	InstallImage string
+	InstallDisk            string
+	InstallImage           string
+	InstallExtraKernelArgs []string
 
 	NetworkConfig *v1alpha1.NetworkConfig
 	CNIConfig     *v1alpha1.CNIConfig
@@ -328,6 +329,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, opts ...GenOption
 		AdditionalMachineCertSANs: additionalMachineCertSANs,
 		InstallDisk:               options.InstallDisk,
 		InstallImage:              options.InstallImage,
+		InstallExtraKernelArgs:    options.InstallExtraKernelArgs,
 		NetworkConfig:             options.NetworkConfig,
 		CNIConfig:                 options.CNIConfig,
 		RegistryMirrors:           options.RegistryMirrors,

--- a/pkg/config/types/v1alpha1/generate/init.go
+++ b/pkg/config/types/v1alpha1/generate/init.go
@@ -29,9 +29,10 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		MachineCertSANs: in.AdditionalMachineCertSANs,
 		MachineToken:    in.TrustdInfo.Token,
 		MachineInstall: &v1alpha1.InstallConfig{
-			InstallDisk:       in.InstallDisk,
-			InstallImage:      in.InstallImage,
-			InstallBootloader: true,
+			InstallDisk:            in.InstallDisk,
+			InstallImage:           in.InstallImage,
+			InstallBootloader:      true,
+			InstallExtraKernelArgs: in.InstallExtraKernelArgs,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,

--- a/pkg/config/types/v1alpha1/generate/join.go
+++ b/pkg/config/types/v1alpha1/generate/join.go
@@ -29,9 +29,10 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 		},
 		MachineNetwork: in.NetworkConfig,
 		MachineInstall: &v1alpha1.InstallConfig{
-			InstallDisk:       in.InstallDisk,
-			InstallImage:      in.InstallImage,
-			InstallBootloader: true,
+			InstallDisk:            in.InstallDisk,
+			InstallImage:           in.InstallImage,
+			InstallBootloader:      true,
+			InstallExtraKernelArgs: in.InstallExtraKernelArgs,
 		},
 		MachineRegistries: v1alpha1.RegistriesConfig{
 			RegistryMirrors: in.RegistryMirrors,

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -48,6 +48,15 @@ func WithInstallImage(imageRef string) GenOption {
 	}
 }
 
+// WithInstallExtraKernelArgs specifies extra kernel arguments to pass to the installer.
+func WithInstallExtraKernelArgs(args []string) GenOption {
+	return func(o *GenOptions) error {
+		o.InstallExtraKernelArgs = args
+
+		return nil
+	}
+}
+
 // WithNetworkConfig allows to pass network config to be used.
 func WithNetworkConfig(network *v1alpha1.NetworkConfig) GenOption {
 	return func(o *GenOptions) error {
@@ -111,6 +120,7 @@ type GenOptions struct {
 	EndpointList              []string
 	InstallDisk               string
 	InstallImage              string
+	InstallExtraKernelArgs    []string
 	AdditionalSubjectAltNames []string
 	NetworkConfig             *v1alpha1.NetworkConfig
 	CNIConfig                 *v1alpha1.CNIConfig


### PR DESCRIPTION
Firecracker never executes the bootloader, so kernel args passed to the
installer aren't used, but if the same disk image is used to boot Talos
e.g. in `qemu`, it fails to set up console properly for example.

This PR simply provides those kernel args to the installer so that
they're persisted in the image.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2321)
<!-- Reviewable:end -->
