### PR TITLE
feat: force nodes to be set in `talosctl` commands using the API

### DIFF
--- a/cmd/talosctl/cmd/talos/crashdump.go
+++ b/cmd/talosctl/cmd/talos/crashdump.go
@@ -25,7 +25,7 @@ var crashdumpCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return WithClientNoNodes(func(ctx context.Context, c *client.Client) error {
 			clientProvider := &cluster.ConfigClientProvider{
 				DefaultClient: c,
 			}

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -60,13 +60,11 @@ var healthCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return WithClient(func(ctx context.Context, c *client.Client) error {
-			if healthCmdFlags.runOnServer {
-				return healthOnServer(ctx, c)
-			}
+		if healthCmdFlags.runOnServer {
+			return WithClient(healthOnServer)
+		}
 
-			return healthOnClient(ctx, c)
-		})
+		return WithClientNoNodes(healthOnClient)
 	},
 }
 

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -28,6 +28,8 @@ function create_cluster {
     --endpoint "${ENDPOINT}" \
     --with-init-node=false \
     --crashdump
+
+  "${TALOSCTL}" config node 10.5.0.2
 }
 
 create_cluster

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -42,6 +42,8 @@ function create_cluster {
     --crashdump \
     ${FIRECRACKER_FLAGS} \
     ${CUSTOM_CNI_FLAG}
+
+  "${TALOSCTL}" config node 172.20.0.2
 }
 
 create_cluster

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -61,7 +61,10 @@ function create_cluster_capi {
     [[ $(date +%s) -gt $timeout ]] && exit 1
     sleep 10
   done
-  ${TALOSCTL} config endpoint "$(${KUBECTL} --kubeconfig /tmp/e2e/docker/kubeconfig get machine -o go-template --template='{{range .status.addresses}}{{if eq .type "ExternalIP"}}{{.address}}{{end}}{{end}}' ${NAME_PREFIX}-controlplane-0)"
+
+  MASTER_IP=$(${KUBECTL} --kubeconfig /tmp/e2e/docker/kubeconfig get machine -o go-template --template='{{range .status.addresses}}{{if eq .type "ExternalIP"}}{{.address}}{{end}}{{end}}' ${NAME_PREFIX}-controlplane-0)
+  "${TALOSCTL}" config endpoint "${MASTER_IP}"
+  "${TALOSCTL}" config node "${MASTER_IP}"
 
   # Wait for the kubeconfig from capi master-0
   timeout=$(($(date +%s) + ${TIMEOUT}))

--- a/internal/integration/api/dmesg.go
+++ b/internal/integration/api/dmesg.go
@@ -119,7 +119,7 @@ DrainLoop:
 
 // TestClusterHasDmesg verifies that all the cluster nodes have dmesg.
 func (suite *DmesgSuite) TestClusterHasDmesg() {
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().Nodes()
 	suite.Require().NotEmpty(nodes)
 
 	ctx := client.WithNodes(suite.ctx, nodes...)

--- a/internal/integration/api/events.go
+++ b/internal/integration/api/events.go
@@ -9,7 +9,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/talos-systems/talos/api/machine"
@@ -37,11 +36,7 @@ func (suite *EventsSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 30*time.Second)
 
-	nodes := suite.DiscoverNodes()
-	suite.Require().NotEmpty(nodes)
-	node := nodes[rand.Intn(len(nodes))]
-
-	suite.nodeCtx = client.WithNodes(suite.ctx, node)
+	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode())
 }
 
 // TearDownTest ...

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"time"
 
 	"github.com/talos-systems/talos/api/common"
@@ -41,11 +40,7 @@ func (suite *LogsSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 2*time.Minute)
 
-	nodes := suite.DiscoverNodes()
-	suite.Require().NotEmpty(nodes)
-	node := nodes[rand.Intn(len(nodes))]
-
-	suite.nodeCtx = client.WithNodes(suite.ctx, node)
+	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode())
 }
 
 // TearDownTest ...

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -53,7 +53,7 @@ func (suite *RebootSuite) TestRebootNodeByNode() {
 		suite.T().Skip("cluster doesn't support reboots")
 	}
 
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().Nodes()
 	suite.Require().NotEmpty(nodes)
 
 	for _, node := range nodes {
@@ -74,7 +74,7 @@ func (suite *RebootSuite) TestRebootAllNodes() {
 	// offset to account for uptime measuremenet inaccuracy
 	const offset = 2 * time.Second
 
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().Nodes()
 	suite.Require().NotEmpty(nodes)
 
 	errCh := make(chan error, len(nodes))

--- a/internal/integration/api/recover.go
+++ b/internal/integration/api/recover.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/talos-systems/talos/api/machine"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/pkg/client"
 )
@@ -81,7 +82,7 @@ func (suite *RecoverSuite) TestRecoverControlPlane() {
 
 	suite.Assert().NoError(eg.Wait())
 
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().NodesByType(runtime.MachineTypeControlPlane)
 	suite.Require().NotEmpty(nodes)
 
 	sort.Strings(nodes)

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -63,7 +63,7 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 		}
 	}
 
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().Nodes()
 	suite.Require().NotEmpty(nodes)
 
 	sort.Strings(nodes)

--- a/internal/integration/api/version.go
+++ b/internal/integration/api/version.go
@@ -52,7 +52,7 @@ func (suite *VersionSuite) TestExpectedVersionMaster() {
 
 // TestSameVersionCluster verifies that all the nodes are on the same version.
 func (suite *VersionSuite) TestSameVersionCluster() {
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().Nodes()
 	suite.Require().NotEmpty(nodes)
 
 	ctx := client.WithNodes(suite.ctx, nodes...)

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -8,7 +8,9 @@
 package base
 
 import (
+	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/internal/pkg/provision"
+	"github.com/talos-systems/talos/internal/pkg/provision/access"
 )
 
 // TalosSuite defines most common settings for integration test suites.
@@ -26,18 +28,16 @@ type TalosSuite struct {
 	// TalosctlPath is path to talosctl binary
 	TalosctlPath string
 
-	discoveredNodes []string
+	discoveredNodes cluster.Info
 }
 
 // DiscoverNodes provides basic functionality to discover cluster nodes via test settings.
 //
 // This method is overridden in specific suites to allow for specific discovery.
-func (talosSuite *TalosSuite) DiscoverNodes() []string {
+func (talosSuite *TalosSuite) DiscoverNodes() cluster.Info {
 	if talosSuite.discoveredNodes == nil {
 		if talosSuite.Cluster != nil {
-			for _, node := range talosSuite.Cluster.Info().Nodes {
-				talosSuite.discoveredNodes = append(talosSuite.discoveredNodes, node.PrivateIP.String())
-			}
+			talosSuite.discoveredNodes = access.NewAdapter(talosSuite.Cluster).Info
 		}
 	}
 

--- a/internal/integration/base/discovery_nok8s.go
+++ b/internal/integration/base/discovery_nok8s.go
@@ -6,8 +6,11 @@
 
 package base
 
-import "github.com/talos-systems/talos/pkg/client"
+import (
+	"github.com/talos-systems/talos/internal/pkg/cluster"
+	"github.com/talos-systems/talos/pkg/client"
+)
 
-func discoverNodesK8s(client *client.Client, suite *TalosSuite) ([]string, error) {
+func discoverNodesK8s(client *client.Client, suite *TalosSuite) (cluster.Info, error) {
 	return nil, nil
 }

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -9,6 +9,7 @@ package cli
 import (
 	"regexp"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
 )
 
@@ -24,23 +25,23 @@ func (suite *ContainersSuite) SuiteName() string {
 
 // TestContainerd inspects containers via containerd driver.
 func (suite *ContainersSuite) TestContainerd() {
-	suite.RunCLI([]string{"containers"},
+	suite.RunCLI([]string{"containers", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`IMAGE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`talos/routerd`)),
 	)
-	suite.RunCLI([]string{"containers", "-k"},
+	suite.RunCLI([]string{"containers", "--nodes", suite.RandomDiscoveredNode(), "-k"},
 		base.StdoutShouldMatch(regexp.MustCompile(`kubelet`)),
 	)
 }
 
 // TestCRI inspects containers via CRI driver.
 func (suite *ContainersSuite) TestCRI() {
-	suite.RunCLI([]string{"containers", "-c"},
+	suite.RunCLI([]string{"containers", "--nodes", suite.RandomDiscoveredNode(), "-c"},
 		base.ShouldFail(),
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`CRI inspector is supported only for K8s namespace`)))
-	suite.RunCLI([]string{"containers", "-ck"},
+	suite.RunCLI([]string{"containers", "-ck", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 	)
 }

--- a/internal/integration/cli/copy.go
+++ b/internal/integration/cli/copy.go
@@ -32,7 +32,7 @@ func (suite *CopySuite) TestSuccess() {
 
 	defer os.RemoveAll(tempDir) //nolint: errcheck
 
-	suite.RunCLI([]string{"copy", "/etc/os-release", tempDir},
+	suite.RunCLI([]string{"copy", "--nodes", suite.RandomDiscoveredNode(), "/etc/os-release", tempDir},
 		base.StdoutEmpty())
 
 	_, err = os.Stat(filepath.Join(tempDir, "os-release"))

--- a/internal/integration/cli/dmesg.go
+++ b/internal/integration/cli/dmesg.go
@@ -26,12 +26,12 @@ func (suite *DmesgSuite) SuiteName() string {
 
 // TestHasOutput verifies that dmesg is displayed.
 func (suite *DmesgSuite) TestHasOutput() {
-	suite.RunCLI([]string{"dmesg"}) // default checks for stdout not empty
+	suite.RunCLI([]string{"dmesg", "--nodes", suite.RandomDiscoveredNode()}) // default checks for stdout not empty
 }
 
 // TestClusterHasOutput verifies that each node in the cluster has some output.
 func (suite *DmesgSuite) TestClusterHasOutput() {
-	nodes := suite.DiscoverNodes()
+	nodes := suite.DiscoverNodes().Nodes()
 	suite.Require().NotEmpty(nodes)
 
 	matchers := make([]base.RunOption, 0, len(nodes))

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -88,7 +88,7 @@ func (suite *HealthSuite) TestClientSide() {
 
 // TestServerSide does successful health check run from server-side.
 func (suite *HealthSuite) TestServerSide() {
-	suite.RunCLI([]string{"health"},
+	suite.RunCLI([]string{"health", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
 		base.StderrNotEmpty(),
 		base.StdoutEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`waiting for all k8s nodes to report ready`)),

--- a/internal/integration/cli/interfaces.go
+++ b/internal/integration/cli/interfaces.go
@@ -24,7 +24,7 @@ func (suite *InterfacesSuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *InterfacesSuite) TestSuccess() {
-	suite.RunCLI([]string{"interfaces"},
+	suite.RunCLI([]string{"interfaces", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`lo`)))
 }
 

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -14,6 +14,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
 )
 
@@ -34,7 +35,7 @@ func (suite *KubeconfigSuite) TestDirectory() {
 
 	defer os.RemoveAll(tempDir) //nolint: errcheck
 
-	suite.RunCLI([]string{"kubeconfig", tempDir},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane), tempDir},
 		base.StdoutEmpty())
 
 	path := filepath.Join(tempDir, "kubeconfig")
@@ -58,7 +59,7 @@ func (suite *KubeconfigSuite) TestCwd() {
 
 	suite.Require().NoError(os.Chdir(tempDir))
 
-	suite.RunCLI([]string{"kubeconfig"},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
 		base.StdoutEmpty())
 
 	suite.Require().FileExists(filepath.Join(tempDir, "kubeconfig"))
@@ -82,9 +83,9 @@ func (suite *KubeconfigSuite) TestMerge() {
 
 	path := filepath.Join(tempDir, "config")
 
-	suite.RunCLI([]string{"kubeconfig", path, "-m"},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane), path, "-m"},
 		base.StdoutEmpty())
-	suite.RunCLI([]string{"kubeconfig", path, "-m"})
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane), path, "-m"})
 
 	config, err := clientcmd.LoadFromFile(path)
 	suite.Require().NoError(err)

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -24,7 +24,7 @@ func (suite *ListSuite) SuiteName() string {
 
 // TestSuccess runs comand with success.
 func (suite *ListSuite) TestSuccess() {
-	suite.RunCLI([]string{"list", "/etc"},
+	suite.RunCLI([]string{"list", "--nodes", suite.RandomDiscoveredNode(), "/etc"},
 		base.StdoutShouldMatch(regexp.MustCompile(`os-release`)))
 }
 

--- a/internal/integration/cli/logs.go
+++ b/internal/integration/cli/logs.go
@@ -8,7 +8,6 @@ package cli
 
 import (
 	"fmt"
-	"math/rand"
 	"regexp"
 	"strings"
 
@@ -27,15 +26,12 @@ func (suite *LogsSuite) SuiteName() string {
 
 // TestServiceLogs verifies that logs are displayed.
 func (suite *LogsSuite) TestServiceLogs() {
-	suite.RunCLI([]string{"logs", "kubelet"}) // default checks for stdout not empty
+	suite.RunCLI([]string{"logs", "kubelet", "--nodes", suite.RandomDiscoveredNode()}) // default checks for stdout not empty
 }
 
 // TestTailLogs verifies that logs can be displayed with tail lines.
 func (suite *LogsSuite) TestTailLogs() {
-	nodes := suite.DiscoverNodes()
-	suite.Require().NotEmpty(nodes)
-
-	node := nodes[rand.Intn(len(nodes))]
+	node := suite.RandomDiscoveredNode()
 
 	// run some machined API calls to produce enough log lines
 	for i := 0; i < 10; i++ {
@@ -55,11 +51,10 @@ func (suite *LogsSuite) TestTailLogs() {
 
 // TestServiceNotFound verifies that logs displays an error if service is not found.
 func (suite *LogsSuite) TestServiceNotFound() {
-	suite.RunCLI([]string{"logs", "servicenotfound"},
-		base.ShouldFail(),
+	suite.RunCLI([]string{"logs", "--nodes", suite.RandomDiscoveredNode(), "servicenotfound"},
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
-		base.StderrShouldMatch(regexp.MustCompile(`error getting logs:.+ log "servicenotfound" was not registered`)),
+		base.StderrShouldMatch(regexp.MustCompile(`ERROR:.+ log "servicenotfound" was not registered`)),
 	)
 }
 

--- a/internal/integration/cli/memory.go
+++ b/internal/integration/cli/memory.go
@@ -24,13 +24,13 @@ func (suite *MemorySuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *MemorySuite) TestSuccess() {
-	suite.RunCLI([]string{"memory"},
+	suite.RunCLI([]string{"memory", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`FREE`)))
 }
 
 // TestVerbose verifies verbose mode.
 func (suite *MemorySuite) TestVerbose() {
-	suite.RunCLI([]string{"memory", "-v"},
+	suite.RunCLI([]string{"memory", "-v", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`MemFree: \d+ kB`)))
 }
 

--- a/internal/integration/cli/mounts.go
+++ b/internal/integration/cli/mounts.go
@@ -24,7 +24,7 @@ func (suite *MountsSuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *MountsSuite) TestSuccess() {
-	suite.RunCLI([]string{"mounts"},
+	suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`FILESYSTEM`)))
 }
 

--- a/internal/integration/cli/processes.go
+++ b/internal/integration/cli/processes.go
@@ -24,7 +24,7 @@ func (suite *ProcessesSuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *ProcessesSuite) TestSuccess() {
-	suite.RunCLI([]string{"processes"},
+	suite.RunCLI([]string{"processes", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`PID`)))
 }
 

--- a/internal/integration/cli/read.go
+++ b/internal/integration/cli/read.go
@@ -24,7 +24,7 @@ func (suite *ReadSuite) SuiteName() string {
 
 // TestSuccess runs comand with success.
 func (suite *ReadSuite) TestSuccess() {
-	suite.RunCLI([]string{"read", "/etc/os-release"},
+	suite.RunCLI([]string{"read", "--nodes", suite.RandomDiscoveredNode(), "/etc/os-release"},
 		base.StdoutShouldMatch(regexp.MustCompile(`ID=talos`)))
 }
 

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -7,11 +7,11 @@
 package cli
 
 import (
-	"math/rand"
 	"regexp"
 	"testing"
 	"time"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
 )
 
@@ -31,11 +31,8 @@ func (suite *RestartSuite) TestSystem() {
 		suite.T().Skip("skipping in short mode")
 	}
 
-	nodes := suite.DiscoverNodes()
-	suite.Require().NotEmpty(nodes)
-
 	// trustd only runs on control plane nodes
-	node := nodes[0]
+	node := suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)
 
 	suite.RunCLI([]string{"restart", "-n", node, "trustd"},
 		base.StdoutEmpty())
@@ -51,10 +48,7 @@ func (suite *RestartSuite) TestK8s() {
 		suite.T().Skip("skipping in short mode")
 	}
 
-	nodes := suite.DiscoverNodes()
-	suite.Require().NotEmpty(nodes)
-
-	node := nodes[rand.Intn(len(nodes))]
+	node := suite.RandomDiscoveredNode()
 
 	suite.RunCLI([]string{"restart", "-n", node, "-k", "kubelet"},
 		base.StdoutEmpty())

--- a/internal/integration/cli/routes.go
+++ b/internal/integration/cli/routes.go
@@ -24,7 +24,7 @@ func (suite *RoutesSuite) SuiteName() string {
 
 // TestSuccess verifies successful execution.
 func (suite *RoutesSuite) TestSuccess() {
-	suite.RunCLI([]string{"routes"},
+	suite.RunCLI([]string{"routes", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`GATEWAY`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`127\.0\.0\.0/8`)),
 	)

--- a/internal/integration/cli/services.go
+++ b/internal/integration/cli/services.go
@@ -24,7 +24,7 @@ func (suite *ServicesSuite) SuiteName() string {
 
 // TestList verifies service list.
 func (suite *ServicesSuite) TestList() {
-	suite.RunCLI([]string{"services"},
+	suite.RunCLI([]string{"services", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`routerd`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
@@ -33,13 +33,13 @@ func (suite *ServicesSuite) TestList() {
 
 // TestStatus verifies service status.
 func (suite *ServicesSuite) TestStatus() {
-	suite.RunCLI([]string{"service", "apid"},
+	suite.RunCLI([]string{"service", "apid", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`\[Running\]`)),
 	)
 
-	suite.RunCLI([]string{"service", "routerd", "status"},
+	suite.RunCLI([]string{"service", "routerd", "status", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`STATE`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`routerd`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`\[Running\]`)),

--- a/internal/integration/cli/stats.go
+++ b/internal/integration/cli/stats.go
@@ -9,6 +9,7 @@ package cli
 import (
 	"regexp"
 
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
 )
 
@@ -24,11 +25,11 @@ func (suite *StatsSuite) SuiteName() string {
 
 // TestContainerd inspects stats via containerd driver.
 func (suite *StatsSuite) TestContainerd() {
-	suite.RunCLI([]string{"stats"},
+	suite.RunCLI([]string{"stats", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`routerd`)),
 	)
-	suite.RunCLI([]string{"stats", "-k"},
+	suite.RunCLI([]string{"stats", "-k", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`kubelet`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),
@@ -37,12 +38,12 @@ func (suite *StatsSuite) TestContainerd() {
 
 // TestCRI inspects stats via CRI driver.
 func (suite *StatsSuite) TestCRI() {
-	suite.RunCLI([]string{"stats", "-c"},
+	suite.RunCLI([]string{"stats", "-c", "--nodes", suite.RandomDiscoveredNode()},
 		base.ShouldFail(),
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`CRI inspector is supported only for K8s namespace`)))
-	suite.RunCLI([]string{"stats", "-ck"},
+	suite.RunCLI([]string{"stats", "-ck", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),

--- a/internal/integration/cli/version.go
+++ b/internal/integration/cli/version.go
@@ -24,7 +24,7 @@ func (suite *VersionSuite) SuiteName() string {
 
 // TestExpectedVersionMaster verifies master node version matches expected.
 func (suite *VersionSuite) TestExpectedVersionMaster() {
-	suite.RunCLI([]string{"version"},
+	suite.RunCLI([]string{"version", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`Client:\n\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
 		base.StdoutShouldMatch(regexp.MustCompile(`Server:\n(\s*NODE:[^\n]+\n)?\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),
 	)
@@ -32,7 +32,7 @@ func (suite *VersionSuite) TestExpectedVersionMaster() {
 
 // TestShortVersion verifies short version output.
 func (suite *VersionSuite) TestShortVersion() {
-	suite.RunCLI([]string{"version", "--short"},
+	suite.RunCLI([]string{"version", "--short", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`Client\s*`+regexp.QuoteMeta(suite.Version))),
 	)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -89,6 +89,11 @@ func (c *Client) resolveConfigContext() error {
 	return nil
 }
 
+// GetConfigContext returns resolved config context.
+func (c *Client) GetConfigContext() *config.Context {
+	return c.options.configContext
+}
+
 func (c *Client) getEndpoints() []string {
 	if c.options.unixSocketPath != "" {
 		return []string{c.options.unixSocketPath}


### PR DESCRIPTION
With load-balancing enabled by default running `talosctl` without
`--nodes` is risky, as it might hit any control plane by default without
`--nodes`.

Only two commands do not enforce this check, as they do their own node
contexts: `crashdump` and `health` (client-side).

Integration tests were updated to always supply `--nodes` cli argument,
while doing that I refactored the storage for discovered nodes to use
existing `cluster.Info` interface.

The downside is that with e2e CAPI tests CLI tests will be mostly
skipped as we don't support discovery in CLI tests at the momemnt. This
can be fixed by using `talosctl kubeconfig` + `kubectl get nodes` for
node discovery.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2327)
<!-- Reviewable:end -->
