### PR TITLE
chore: extract loadbalancer, network, crashdup and process from firecracker

### DIFF
--- a/internal/pkg/provision/providers/firecracker/create.go
+++ b/internal/pkg/provision/providers/firecracker/create.go
@@ -40,13 +40,13 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	fmt.Fprintln(options.LogWriter, "creating network", request.Network.Name)
 
-	if err = p.createNetwork(ctx, state, request.Network); err != nil {
+	if err = p.CreateNetwork(ctx, state, request.Network); err != nil {
 		return nil, fmt.Errorf("unable to provision CNI network: %w", err)
 	}
 
 	fmt.Fprintln(options.LogWriter, "creating load balancer")
 
-	if err = p.createLoadBalancer(state, request); err != nil {
+	if err = p.CreateLoadBalancer(state, request); err != nil {
 		return nil, fmt.Errorf("error creating loadbalancer: %w", err)
 	}
 

--- a/internal/pkg/provision/providers/firecracker/destroy.go
+++ b/internal/pkg/provision/providers/firecracker/destroy.go
@@ -36,13 +36,13 @@ func (p *provisioner) Destroy(ctx context.Context, cluster provision.Cluster, op
 
 	fmt.Fprintln(options.LogWriter, "removing load balancer")
 
-	if err := p.destroyLoadBalancer(state); err != nil {
+	if err := p.DestroyLoadBalancer(state); err != nil {
 		return fmt.Errorf("error stopping loadbalancer: %w", err)
 	}
 
 	fmt.Fprintln(options.LogWriter, "removing network")
 
-	if err := p.destroyNetwork(state); err != nil {
+	if err := p.DestroyNetwork(state); err != nil {
 		return err
 	}
 

--- a/internal/pkg/provision/providers/firecracker/node.go
+++ b/internal/pkg/provision/providers/firecracker/node.go
@@ -236,5 +236,5 @@ func (p *provisioner) destroyNodes(cluster provision.ClusterInfo, options *provi
 }
 
 func (p *provisioner) destroyNode(node provision.NodeInfo) error {
-	return stopProcessByPidfile(node.ID) // node.ID stores PID path for control process
+	return vm.StopProcessByPidfile(node.ID) // node.ID stores PID path for control process
 }

--- a/internal/pkg/provision/providers/vm/crashdump.go
+++ b/internal/pkg/provision/providers/vm/crashdump.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package firecracker
+package vm
 
 import (
 	"context"
@@ -13,13 +13,12 @@ import (
 	"strings"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
 	"github.com/talos-systems/talos/internal/pkg/tail"
 )
 
 // CrashDump produces debug information to help with debugging failures.
-func (p *provisioner) CrashDump(ctx context.Context, cluster provision.Cluster, out io.Writer) {
-	state, ok := cluster.(*vm.State)
+func (p *Provisioner) CrashDump(ctx context.Context, cluster provision.Cluster, out io.Writer) {
+	state, ok := cluster.(*State)
 	if !ok {
 		fmt.Fprintf(out, "error inspecting firecracker state, %#+v\n", cluster)
 		return

--- a/internal/pkg/provision/providers/vm/loadbalancer.go
+++ b/internal/pkg/provision/providers/vm/loadbalancer.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package firecracker
+package vm
 
 import (
 	"fmt"
@@ -14,7 +14,6 @@ import (
 	"syscall"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
 )
 
 const (
@@ -22,7 +21,8 @@ const (
 	lbLog = "lb.log"
 )
 
-func (p *provisioner) createLoadBalancer(state *vm.State, clusterReq provision.ClusterRequest) error {
+// CreateLoadBalancer creates load balancer.
+func (p *Provisioner) CreateLoadBalancer(state *State, clusterReq provision.ClusterRequest) error {
 	pidPath := state.GetRelativePath(lbPid)
 
 	logFile, err := os.OpenFile(state.GetRelativePath(lbLog), os.O_APPEND|os.O_CREATE|os.O_RDWR, 0o666)
@@ -67,8 +67,9 @@ func (p *provisioner) createLoadBalancer(state *vm.State, clusterReq provision.C
 	return nil
 }
 
-func (p *provisioner) destroyLoadBalancer(state *vm.State) error {
+// DestroyLoadBalancer destoys load balancer.
+func (p *Provisioner) DestroyLoadBalancer(state *State) error {
 	pidPath := state.GetRelativePath(lbPid)
 
-	return stopProcessByPidfile(pidPath)
+	return StopProcessByPidfile(pidPath)
 }

--- a/internal/pkg/provision/providers/vm/network.go
+++ b/internal/pkg/provision/providers/vm/network.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package firecracker
+package vm
 
 import (
 	"bytes"
@@ -20,14 +20,13 @@ import (
 	"github.com/jsimonetti/rtnetlink"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
-	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
 	talosnet "github.com/talos-systems/talos/pkg/net"
 )
 
-func (p *provisioner) createNetwork(ctx context.Context, state *vm.State, network provision.NetworkRequest) error {
-	// build bridge interface name by taking part of checksum of the network name
-	// so that interface name is defined by network name, and different networks have
-	// different bridge interfaces
+// CreateNetwork build bridge interface name by taking part of checksum of the network name
+// so that interface name is defined by network name, and different networks have
+// different bridge interfaces.
+func (p *Provisioner) CreateNetwork(ctx context.Context, state *State, network provision.NetworkRequest) error {
 	networkNameHash := sha256.Sum256([]byte(network.Name))
 	state.BridgeName = fmt.Sprintf("%s%s", "talos", hex.EncodeToString(networkNameHash[:])[:8])
 
@@ -119,8 +118,8 @@ func (p *provisioner) createNetwork(ctx context.Context, state *vm.State, networ
 	return nil
 }
 
-func (p *provisioner) destroyNetwork(state *vm.State) error {
-	// destroy bridge interface by name to clean up
+// DestroyNetwork destroy bridge interface by name to clean up.
+func (p *Provisioner) DestroyNetwork(state *State) error {
 	iface, err := net.InterfaceByName(state.BridgeName)
 	if err != nil {
 		return fmt.Errorf("error looking up bridge interface %q: %w", state.BridgeName, err)

--- a/internal/pkg/provision/providers/vm/process.go
+++ b/internal/pkg/provision/providers/vm/process.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package firecracker
+package vm
 
 import (
 	"errors"
@@ -11,7 +11,8 @@ import (
 	"syscall"
 )
 
-func stopProcessByPidfile(pidPath string) error {
+// StopProcessByPidfile send SIGTERM to pid from pidfile.
+func StopProcessByPidfile(pidPath string) error {
 	pidFile, err := os.Open(pidPath)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
Second part of refactoring to split common logic for VM provisioners
from Firecracker provisioner.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2328)
<!-- Reviewable:end -->
