### PR TITLE
test: provide node discovery for cli tests via kubectl

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -110,7 +110,7 @@ function run_talos_integration_test {
       ;;
     esac
 
-  "${INTEGRATION_TEST}" -test.v -talos.failfast -talos.talosctlpath "${TALOSCTL}" -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" "${TEST_SHORT}"
+  "${INTEGRATION_TEST}" -test.v -talos.failfast -talos.talosctlpath "${TALOSCTL}" -talos.kubectlpath "${KUBECTL}" -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" "${TEST_SHORT}"
 }
 
 function run_talos_integration_test_docker {
@@ -123,7 +123,7 @@ function run_talos_integration_test_docker {
       ;;
     esac
 
-  "${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.k8sendpoint 127.0.0.1:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" "${TEST_SHORT}"
+  "${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.kubectlpath "${KUBECTL}" -talos.k8sendpoint 127.0.0.1:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" "${TEST_SHORT}"
 }
 
 function run_kubernetes_integration_test {

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -25,8 +25,10 @@ type TalosSuite struct {
 	TalosConfig string
 	// Version is the (expected) version of Talos tests are running against
 	Version string
-	// TalosctlPath is path to talosctl binary
+	// TalosctlPath is a path to talosctl binary
 	TalosctlPath string
+	// KubectlPath is a path to kubectl binary
+	KubectlPath string
 
 	discoveredNodes cluster.Info
 }

--- a/internal/integration/base/cluster.go
+++ b/internal/integration/base/cluster.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration
+
+package base
+
+import "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+
+type infoWrapper struct {
+	masterNodes []string
+	workerNodes []string
+}
+
+func (wrapper *infoWrapper) Nodes() []string {
+	return append(wrapper.masterNodes, wrapper.workerNodes...)
+}
+
+func (wrapper *infoWrapper) NodesByType(t runtime.MachineType) []string {
+	switch t {
+	case runtime.MachineTypeInit:
+		return nil
+	case runtime.MachineTypeControlPlane:
+		return wrapper.masterNodes
+	case runtime.MachineTypeJoin:
+		return wrapper.workerNodes
+	default:
+		panic("unreachable")
+	}
+}

--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -16,33 +16,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/client"
 	"github.com/talos-systems/talos/pkg/constants"
 )
-
-type infoWrapper struct {
-	masterNodes []string
-	workerNodes []string
-}
-
-func (wrapper *infoWrapper) Nodes() []string {
-	return append(wrapper.masterNodes, wrapper.workerNodes...)
-}
-
-func (wrapper *infoWrapper) NodesByType(t runtime.MachineType) []string {
-	switch t {
-	case runtime.MachineTypeInit:
-		return nil
-	case runtime.MachineTypeControlPlane:
-		return wrapper.masterNodes
-	case runtime.MachineTypeJoin:
-		return wrapper.workerNodes
-	default:
-		panic("unreachable")
-	}
-}
 
 func discoverNodesK8s(client *client.Client, suite *TalosSuite) (cluster.Info, error) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -39,6 +39,7 @@ var (
 	k8sEndpoint      string
 	expectedVersion  string
 	talosctlPath     string
+	kubectlPath      string
 	provisionerName  string
 	clusterName      string
 	stateDir         string
@@ -83,6 +84,7 @@ func TestIntegration(t *testing.T) {
 				TalosConfig:  talosConfig,
 				Version:      expectedVersion,
 				TalosctlPath: talosctlPath,
+				KubectlPath:  kubectlPath,
 			})
 		}
 
@@ -127,6 +129,7 @@ func init() {
 	flag.StringVar(&clusterName, "talos.name", "talos-default", "the name of the cluster")
 	flag.StringVar(&expectedVersion, "talos.version", version.Tag, "expected Talos version")
 	flag.StringVar(&talosctlPath, "talos.talosctlpath", "talosctl", "The path to 'talosctl' binary")
+	flag.StringVar(&kubectlPath, "talos.kubectlpath", "kubectl", "The path to 'kubectl' binary")
 
 	flag.StringVar(&provision_test.DefaultSettings.CIDR, "talos.provision.cidr", provision_test.DefaultSettings.CIDR, "CIDR to use to provision clusters (provision tests only)")
 	flag.Var(&provision_test.DefaultSettings.RegistryMirrors, "talos.provision.registry-mirror", "registry mirrors to use (provision tests only)")


### PR DESCRIPTION
Fixes #2330

CLI tests require node discovery as `--nodes` flag is enforced for most
of the `talosctl commands`.

For clusters created via `talosctl cluster create`, cluster provisioner
state provides all the necessary information, but clusters created via
CAPI don't have the state attached.

API tests rely on Talos and Kubernetes APIs to fetch kubeconfig and
access Nodes K8s API.

CLI tests should rely only on CLI tools, so we use `kubectl get nodes` +
`talosctl kubeconfig` to fetch list of master and worker nodes.

This discovery method relies on "bootstrap" node being set in
`talosconfig` (to fetch `kubeconfig`).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2337)
<!-- Reviewable:end -->
