### PR TITLE
fix: skip removing CRI state when doing upgrade with preserve

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -398,7 +398,8 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machine.UpgradeRequest) []runti
 			!in.GetPreserve() && (r.Config().Machine().Type() != runtime.MachineTypeJoin),
 			"leave",
 			LeaveEtcd,
-		).Append(
+		).AppendWhen(
+			!in.GetPreserve(),
 			"cleanup",
 			RemoveAllPods,
 		).Append(

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -665,8 +665,8 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 // StopServicesForUpgrade represents the StopServicesForUpgrade task.
 func StopServicesForUpgrade(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		for _, service := range []string{"cri", "udevd"} {
-			if err = system.Services(nil).Stop(context.Background(), service); err != nil {
+		for _, service := range []string{"kubelet", "cri", "udevd"} {
+			if err = system.Services(nil).Stop(ctx, service); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
For single-node upgrades if we drop the CRI state, API server won't
start after reboot and this breaks the control plane.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2340)
<!-- Reviewable:end -->
