### PR TITLE
fix: wait for bootkube to finish before trying to uncordon the node

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -215,6 +215,9 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 		r.Config().Machine().Type() != runtime.MachineTypeJoin,
 		"labelMaster",
 		LabelNodeAsMaster,
+	).Append(
+		"waitForBootstrap",
+		WaitForBootkube,
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
 		"uncordon",

--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -301,6 +301,16 @@ func (s *singleton) Stop(ctx context.Context, serviceIDs ...string) (err error) 
 	return conditions.WaitForAll(conds...).Wait(ctx)
 }
 
+// IsLoaded checks whether service is registered.
+func (s *singleton) IsLoaded(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, exists := s.state[id]
+
+	return exists
+}
+
 // IsRunning checks service status (started/stopped).
 //
 // It doesn't check if service runner was started or not, just pure


### PR DESCRIPTION
This fixes potential race issue when temporary control plane is torn
down by bootkube and `uncordonNode` task is running.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2342)
<!-- Reviewable:end -->
