### PR TITLE
chore: upgrade pkgs and tools for Go 1.14.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -272,36 +272,36 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.2.0-19-g6a2bd10 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0-19-g6a2bd10 /boot/vmlinux /vmlinux
+COPY --from=docker.io/autonomy/kernel:v0.2.0-22-g169146f /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.2.0-22-g169146f /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-19-g6a2bd10 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-19-g6a2bd10 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/lvm2:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/libaio:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/musl:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/open-isns:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/syslinux:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-19-g6a2bd10 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-19-g6a2bd10 /lib/libblkid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-19-g6a2bd10 /lib/libuuid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.2.0-19-g6a2bd10 /lib/libmount.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kmod:v0.2.0-19-g6a2bd10 /usr/lib/libkmod.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kernel:v0.2.0-19-g6a2bd10 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-22-g169146f /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.2.0-22-g169146f /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/lvm2:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/libaio:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/musl:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/open-iscsi:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/open-isns:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.2.0-22-g169146f / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-22-g169146f /lib/libblkid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-22-g169146f /lib/libuuid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.2.0-22-g169146f /lib/libmount.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kmod:v0.2.0-22-g169146f /usr/lib/libkmod.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kernel:v0.2.0-22-g169146f /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
-TOOLS ?= autonomy/tools:v0.2.0-4-g24243c5
+TOOLS ?= autonomy/tools:v0.2.0-7-gc7a0a07
 GO_VERSION ?= 1.14
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")


### PR DESCRIPTION
This also brings in multi-arch pkgs and tools, but we're not consuming
arm64 images yet.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2343)
<!-- Reviewable:end -->
