### PR TITLE
test: use registry mirrors in CI

### DIFF
--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -8,6 +8,8 @@ PROVISIONER=docker
 CLUSTER_NAME=e2e-${PROVISIONER}
 
 function create_cluster {
+  build_registry_mirrors
+
   "${TALOSCTL}" cluster create \
     --provisioner "${PROVISIONER}" \
     --name "${CLUSTER_NAME}" \
@@ -19,6 +21,7 @@ function create_cluster {
     --with-init-node=false \
     --docker-host-ip=127.0.0.1 \
     --endpoint=127.0.0.1 \
+    ${REGISTRY_MIRROR_FLAGS} \
     --crashdump
 
   "${TALOSCTL}" config node 10.5.0.2

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -32,6 +32,8 @@ case "${CUSTOM_CNI_URL:-false}" in
 esac
 
 function create_cluster {
+  build_registry_mirrors
+
   "${TALOSCTL}" cluster create \
     --provisioner "${PROVISIONER}" \
     --name "${CLUSTER_NAME}" \
@@ -43,6 +45,7 @@ function create_cluster {
     --install-image ${REGISTRY:-docker.io}/autonomy/installer:${INSTALLER_TAG} \
     --with-init-node=false \
     --crashdump \
+    ${REGISTRY_MIRROR_FLAGS} \
     ${FIRECRACKER_FLAGS} \
     ${CUSTOM_CNI_FLAG}
 

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -32,6 +32,8 @@ case "${CUSTOM_CNI_URL:-false}" in
 esac
 
 function create_cluster {
+  build_registry_mirrors
+
   "${TALOSCTL}" cluster create \
     --provisioner "${PROVISIONER}" \
     --name "${CLUSTER_NAME}" \
@@ -43,6 +45,7 @@ function create_cluster {
     --install-image ${REGISTRY:-docker.io}/autonomy/installer:${INSTALLER_TAG} \
     --with-init-node=false \
     --crashdump \
+    ${REGISTRY_MIRROR_FLAGS} \
     ${QEMU_FLAGS} \
     ${CUSTOM_CNI_FLAG}
 

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -166,3 +166,18 @@ function dump_cluster_state {
   ${KUBECTL} get nodes -o wide
   ${KUBECTL} get pods --all-namespaces -o wide
 }
+
+function build_registry_mirrors {
+  if [[ "${CI:-false}" == "true" ]]; then
+    REGISTRY_MIRROR_FLAGS=
+
+    for registry in docker.io k8s.gcr.io quay.io gcr.io; do
+      local service="registry-${registry//./-}.ci.svc"
+      local addr=`python -c "import socket; print socket.gethostbyname('${service}')"`
+
+      REGISTRY_MIRROR_FLAGS="${REGISTRY_MIRROR_FLAGS} --registry-mirror ${registry}=http://${addr}:5000"
+    done
+  else
+    REGISTRY_MIRROR_FLAGS=
+  fi
+}


### PR DESCRIPTION
This relies on registry caching mirrors running in the CI.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2349)
<!-- Reviewable:end -->
