### PR TITLE
test: fix racy test ReaderNoFollow

### DIFF
--- a/internal/pkg/kmsg/reader_test.go
+++ b/internal/pkg/kmsg/reader_test.go
@@ -6,6 +6,7 @@ package kmsg_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -80,6 +81,13 @@ LOOP:
 				}
 
 				break LOOP
+			}
+
+			if closed && errors.Is(packet.Err, os.ErrClosed) {
+				// ignore 'file already closed' error as it might happen
+				// from the branch below depending on whether context cancel or
+				// read() finishes first
+				continue
 			}
 
 			assert.NoError(t, packet.Err)


### PR DESCRIPTION
Due to the race between `Read()` and context cancellation, error might
be returned which we can safely ignore.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2352)
<!-- Reviewable:end -->
