### PR TITLE
test: add an option to bind docker to specific host IP

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -62,6 +62,7 @@ var (
 	cniConfDir              string
 	cniCacheDir             string
 	ports                   string
+	dockerHostIP            string
 	withInitNode            bool
 	customCNIUrl            string
 	crashdumpOnFailure      bool
@@ -171,6 +172,8 @@ func create(ctx context.Context) (err error) {
 		portList := strings.Split(ports, ",")
 		provisionOptions = append(provisionOptions, provision.WithDockerPorts(portList))
 	}
+
+	provisionOptions = append(provisionOptions, provision.WithDockerPortsHostIP(dockerHostIP))
 
 	if bootloaderEmulation {
 		provisionOptions = append(provisionOptions, provision.WithBootladerEmulation())
@@ -436,6 +439,7 @@ func init() {
 		"",
 		"Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)",
 	)
+	createCmd.Flags().StringVar(&dockerHostIP, "docker-host-ip", "0.0.0.0", "Host IP to forward exposed ports to (Docker provisioner only)")
 	createCmd.Flags().BoolVar(&withInitNode, "with-init-node", true, "create the cluster with an init node")
 	createCmd.Flags().StringVar(&customCNIUrl, "custom-cni-url", "", "install custom CNI from the URL (Talos cluster)")
 	createCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -23,6 +23,7 @@ talosctl cluster create [flags]
       --custom-cni-url string       install custom CNI from the URL (Talos cluster)
       --disk int                    the limit on disk size in MB (each VM) (default 4096)
       --dns-domain string           the dns domain to use for cluster (default "cluster.local")
+      --docker-host-ip string       Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
       --endpoint string             use endpoint instead of provider defaults
   -p, --exposed-ports string        Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
   -h, --help                        help for create

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -69,6 +69,15 @@ func WithDockerPorts(ports []string) Option {
 	}
 }
 
+// WithDockerPortsHostIP sets host IP for docker provisioner to expose ports on workers.
+func WithDockerPortsHostIP(hostIP string) Option {
+	return func(o *Options) error {
+		o.DockerPortsHostIP = hostIP
+
+		return nil
+	}
+}
+
 // Options describes Provisioner parameters.
 type Options struct {
 	LogWriter     io.Writer
@@ -80,12 +89,14 @@ type Options struct {
 	BootloaderEmulation bool
 
 	// Expose ports to worker machines in docker provisioner
-	DockerPorts []string
+	DockerPorts       []string
+	DockerPortsHostIP string
 }
 
 // DefaultOptions returns default options.
 func DefaultOptions() Options {
 	return Options{
-		LogWriter: os.Stderr,
+		LogWriter:         os.Stderr,
+		DockerPortsHostIP: "0.0.0.0",
 	}
 }

--- a/internal/pkg/provision/providers/docker/node.go
+++ b/internal/pkg/provision/providers/docker/node.go
@@ -119,7 +119,7 @@ func (p *provisioner) createNode(ctx context.Context, clusterReq provision.Clust
 
 		var generatedPortMap portMap
 
-		generatedPortMap, err = genPortMap(portsToOpen)
+		generatedPortMap, err = genPortMap(portsToOpen, options.DockerPortsHostIP)
 		if err != nil {
 			return provision.NodeInfo{}, err
 		}
@@ -204,7 +204,7 @@ func (p *provisioner) destroyNodes(ctx context.Context, clusterName string, opti
 	return multiErr.ErrorOrNil()
 }
 
-func genPortMap(portList []string) (portMap, error) {
+func genPortMap(portList []string, hostIP string) (portMap, error) {
 	portSetRet := nat.PortSet{}
 	portMapRet := nat.PortMap{}
 
@@ -229,7 +229,7 @@ func genPortMap(portList []string) (portMap, error) {
 		portSetRet[natPort] = struct{}{}
 		portMapRet[natPort] = []nat.PortBinding{
 			{
-				HostIP:   "0.0.0.0",
+				HostIP:   hostIP,
 				HostPort: explodedPort[0],
 			},
 		}


### PR DESCRIPTION
This allows to override default `0.0.0.0` (`*`) to a specific IP to
avoid conflicts.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2353)
<!-- Reviewable:end -->
