### PR TITLE
test: remove apid load balancer for firecracker

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -331,8 +331,8 @@ local default_pipeline = Pipeline('default', default_steps) + default_trigger;
 
 // Full integration pipeline.
 
-local integration_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, talosctl_linux, kernel], environment={"FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
-local integration_provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, talosctl_linux, kernel]);
+local integration_firecracker = Step("e2e-firecracker", privileged=true, depends_on=[initramfs, talosctl_linux, kernel, installer, unit_tests, unit_tests_race], environment={"FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
+local integration_provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, talosctl_linux, kernel, installer, unit_tests, unit_tests_race, e2e_firecracker, e2e_docker]);
 local integration_provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[integration_provision_tests_prepare], environment={"FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 local integration_provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[integration_provision_tests_prepare], environment={"FIRECRACKER_GO_SDK_REQUEST_TIMEOUT_MILLISECONDS": "2000"});
 local integration_cilium = Step("e2e-cilium-1.8.0", target="e2e-firecracker", privileged=true, depends_on=[integration_firecracker], environment={

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,8 @@ provision-tests-track-%:
 		TAG=$(TAG) \
 		TALOSCTL=$(PWD)/$(ARTIFACTS)/$(TALOSCTL_DEFAULT_TARGET)-amd64 \
 		INTEGRATION_TEST=$(PWD)/$(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64 \
-		INTEGRATION_TEST_RUN="TestIntegration/.+-TR$*"
+		INTEGRATION_TEST_RUN="TestIntegration/.+-TR$*" \
+		INTEGRATION_TEST_TRACK="$*"
 
 # Assets for releases
 

--- a/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
+++ b/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/talos-systems/talos/internal/pkg/loadbalancer"
-	"github.com/talos-systems/talos/pkg/constants"
 )
 
 var loadbalancerLaunchCmdFlags struct {
@@ -29,17 +28,10 @@ var loadbalancerLaunchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var lb loadbalancer.TCP
 
-		for _, port := range []int{constants.ApidPort, 6443} { // TODO: need to put 6443 as constant or use config?
+		for _, port := range []int{6443} { // TODO: need to put 6443 as constant or use config?
 			upstreams := make([]string, len(loadbalancerLaunchCmdFlags.upstreams))
 			for i := range upstreams {
 				upstreams[i] = fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.upstreams[i], port)
-			}
-
-			if loadbalancerLaunchCmdFlags.apidOnlyInitNode {
-				// for apid, add only init node for now (first item)
-				if port == constants.ApidPort && len(upstreams) > 1 {
-					upstreams = upstreams[:1]
-				}
 			}
 
 			if err := lb.AddRoute(fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.addr, port), upstreams); err != nil {
@@ -54,6 +46,5 @@ var loadbalancerLaunchCmd = &cobra.Command{
 func init() {
 	loadbalancerLaunchCmd.Flags().StringVar(&loadbalancerLaunchCmdFlags.addr, "loadbalancer-addr", "localhost", "load balancer listen address (IP or host)")
 	loadbalancerLaunchCmd.Flags().StringSliceVar(&loadbalancerLaunchCmdFlags.upstreams, "loadbalancer-upstreams", []string{}, "load balancer upstreams (nodes to proxy to)")
-	loadbalancerLaunchCmd.Flags().BoolVar(&loadbalancerLaunchCmdFlags.apidOnlyInitNode, "apid-only-init-node", false, "use only apid init node for load balancing")
 	addCommand(loadbalancerLaunchCmd)
 }

--- a/hack/test/provision-tests.sh
+++ b/hack/test/provision-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eou pipefail
+set -eoux pipefail
 
 case "${CI:-false}" in
   true)
@@ -17,4 +17,8 @@ if [ "${INTEGRATION_TEST_RUN:-undefined}" != "undefined" ]; then
   INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -test.run ${INTEGRATION_TEST_RUN}"
 fi
 
-"${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.provision.mem 2048 -talos.provision.cpu 2 ${INTEGRATION_TEST_FLAGS}
+if [ "${INTEGRATION_TEST_TRACK:-undefined}" != "undefined" ]; then
+  INTEGRATION_TEST_FLAGS="${INTEGRATION_TEST_FLAGS} -talos.provision.cidr 172.$(( ${INTEGRATION_TEST_TRACK} + 21 )).0.0/24"
+fi
+
+"${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.provision.mem 2048 -talos.provision.cpu 2  ${INTEGRATION_TEST_FLAGS}

--- a/internal/pkg/provision/providers/vm/loadbalancer.go
+++ b/internal/pkg/provision/providers/vm/loadbalancer.go
@@ -45,10 +45,6 @@ func (p *Provisioner) CreateLoadBalancer(state *State, clusterReq provision.Clus
 		"--loadbalancer-upstreams", strings.Join(masterIPs, ","),
 	}
 
-	if clusterReq.Network.LoadBalancer.LimitApidOnlyInitNode {
-		args = append(args, "--apid-only-init-node")
-	}
-
 	cmd := exec.Command(clusterReq.SelfExecutable, args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -36,12 +36,6 @@ type CNIConfig struct {
 	CacheDir string
 }
 
-// LoadBalancerConfig describes load balancer provisioned for the cluster.
-type LoadBalancerConfig struct {
-	// Limit apid connection load-balancing to init node
-	LimitApidOnlyInitNode bool
-}
-
 // NetworkRequest describes cluster network.
 type NetworkRequest struct {
 	Name        string
@@ -52,8 +46,6 @@ type NetworkRequest struct {
 
 	// CNI-specific parameters.
 	CNI CNIConfig
-
-	LoadBalancer LoadBalancerConfig
 }
 
 // NodeRequests is a list of NodeRequest.


### PR DESCRIPTION
We're not using load balancer for `apid` (always using client-side load
balancing), so we can remove this safely.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2354)
<!-- Reviewable:end -->
