### PR TITLE
fix: skip vmware platform for !amd64

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+// +build amd64
+
 package vmware
 
 import (

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !amd64
+
+package vmware
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/talos-systems/go-procfs/procfs"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+)
+
+// VMware is the concrete type that implements the platform.Platform interface.
+type VMware struct{}
+
+// Name implements the platform.Platform interface.
+func (v *VMware) Name() string {
+	return "vmware"
+}
+
+// Configuration implements the platform.Platform interface.
+func (v *VMware) Configuration() ([]byte, error) {
+	return nil, fmt.Errorf("arch not supported")
+}
+
+// Hostname implements the platform.Platform interface.
+func (v *VMware) Hostname() (hostname []byte, err error) {
+	return nil, fmt.Errorf("arch not supported")
+}
+
+// Mode implements the platform.Platform interface.
+func (v *VMware) Mode() runtime.Mode {
+	return runtime.ModeCloud
+}
+
+// ExternalIPs implements the runtime.Platform interface.
+func (v *VMware) ExternalIPs() (addrs []net.IP, err error) {
+	return addrs, err
+}
+
+// KernelArgs implements the runtime.Platform interface.
+func (v *VMware) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{}
+}


### PR DESCRIPTION
This fixes the build on arm64.

The fix itself is part of PR #2156.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2355)
<!-- Reviewable:end -->
