### PR TITLE
fix: generate admin kubeconfig with default namespace

### DIFF
--- a/internal/pkg/kubeconfig/admin.go
+++ b/internal/pkg/kubeconfig/admin.go
@@ -31,6 +31,7 @@ users:
 contexts:
 - context:
     cluster: {{ .Cluster }}
+    namespace: default
     user: admin
   name: admin@{{ .Cluster }}
 current-context: admin@{{ .Cluster }}


### PR DESCRIPTION
This ensures that the generated kubeconfig has a namespace. This fixes
an edge case when a user attempts to use the kubeconfig from within a
pod of a different kubernetes cluster. If the kubeconfig does not have a
namespace, kubectl will use the "in cluster namespace" which is
unexpected, especially if the "in cluster namespace" does not exist in
the target cluster.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2361)
<!-- Reviewable:end -->
