### PR TITLE
fix: bump timeouts

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -654,7 +654,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 			all = append(all, cond)
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 
 		defer cancel()
 
@@ -1690,7 +1690,7 @@ func BootstrapKubernetes(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 
 		system.Services(r).LoadAndStart(svc)
 
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 		defer cancel()
 
 		return system.WaitForService(system.StateEventFinished, svc.ID(r)).Wait(ctx)


### PR DESCRIPTION
This bumps some timeouts that can cause nodes to reboot too quickly when
things go wrong, making it difficult to debug. Give users a little bit
more time before we reboot automatically.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2362)
<!-- Reviewable:end -->
