### PR TITLE
fix: fail ntpd service if initial time sync fails

### DIFF
--- a/internal/app/timed/pkg/ntp/ntp.go
+++ b/internal/app/timed/pkg/ntp/ntp.go
@@ -53,6 +53,9 @@ func (n *NTP) Ready() bool {
 func (n *NTP) Daemon() (err error) {
 	if err = n.QueryAndSetTime(); err != nil {
 		log.Println(err)
+
+		// if initial time sync fails, restart the service for more aggressive retry
+		return err
 	}
 
 	for {

--- a/internal/pkg/cluster/check/default.go
+++ b/internal/pkg/cluster/check/default.go
@@ -47,7 +47,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		func(cluster ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("all k8s nodes to report", func(ctx context.Context) error {
 				return K8sAllNodesReportedAssertion(ctx, cluster)
-			}, 5*time.Minute, 5*time.Second)
+			}, 5*time.Minute, 30*time.Second) // give more time per each attempt, as this check is going to build and cache kubeconfig
 		},
 		// wait for all the nodes to report ready at k8s level
 		func(cluster ClusterInfo) conditions.Condition {


### PR DESCRIPTION
Talos depends on accurate time for many actions, so many services depend
on timed successful health check. If timed fails to do initial sync, it
enters pretty long wait loop for the next attempt which might not come
in time for the boot timeout. Instead, fail timed service on initial
sync and rely on service restart for another attempt.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2366)
<!-- Reviewable:end -->
