### PR TITLE
refactor: make `pkg/config` not rely on `machined/../internal/runtime`

### DIFF
--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -16,9 +16,9 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/bundle"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -88,9 +88,9 @@ func genV1Alpha1Config(args []string) error {
 		genOptions = append(genOptions, generate.WithRegistryMirror(components[0], components[1]))
 	}
 
-	configBundle, err := config.NewConfigBundle(
-		config.WithInputOptions(
-			&config.InputOptions{
+	configBundle, err := bundle.NewConfigBundle(
+		bundle.WithInputOptions(
+			&bundle.InputOptions{
 				ClusterName: args[0],
 				Endpoint:    args[1],
 				KubeVersion: kubernetesVersion,
@@ -107,24 +107,24 @@ func genV1Alpha1Config(args []string) error {
 		return fmt.Errorf("failed to generate config bundle: %w", err)
 	}
 
-	for _, t := range []runtime.MachineType{runtime.MachineTypeInit, runtime.MachineTypeControlPlane, runtime.MachineTypeJoin} {
+	for _, t := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin} {
 		name := strings.ToLower(t.String()) + ".yaml"
 		fullFilePath := filepath.Join(outputDir, name)
 
 		var configString string
 
 		switch t {
-		case runtime.MachineTypeInit:
+		case machine.TypeInit:
 			configString, err = configBundle.Init().String()
 			if err != nil {
 				return err
 			}
-		case runtime.MachineTypeControlPlane:
+		case machine.TypeControlPlane:
 			configString, err = configBundle.ControlPlane().String()
 			if err != nil {
 				return err
 			}
-		case runtime.MachineTypeJoin:
+		case machine.TypeJoin:
 			configString, err = configBundle.Join().String()
 			if err != nil {
 				return err

--- a/cmd/talosctl/cmd/mgmt/validate.go
+++ b/cmd/talosctl/cmd/mgmt/validate.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/cli"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 )
 
 var (
@@ -26,7 +26,7 @@ var validateCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		config, err := config.NewFromFile(validateConfigArg)
+		config, err := configloader.NewFromFile(validateConfigArg)
 		if err != nil {
 			return err
 		}

--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -17,10 +17,10 @@ import (
 
 	clusterapi "github.com/talos-systems/talos/api/cluster"
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/internal/pkg/cluster/check"
 	"github.com/talos-systems/talos/pkg/client"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 type clusterNodes struct {
@@ -33,13 +33,13 @@ func (cluster *clusterNodes) Nodes() []string {
 	return append([]string{cluster.InitNode}, append(cluster.ControlPlaneNodes, cluster.WorkerNodes...)...)
 }
 
-func (cluster *clusterNodes) NodesByType(t runtime.MachineType) []string {
+func (cluster *clusterNodes) NodesByType(t machine.Type) []string {
 	switch t {
-	case runtime.MachineTypeInit:
+	case machine.TypeInit:
 		return []string{cluster.InitNode}
-	case runtime.MachineTypeControlPlane:
+	case machine.TypeControlPlane:
 		return cluster.ControlPlaneNodes
-	case runtime.MachineTypeJoin:
+	case machine.TypeJoin:
 		return cluster.WorkerNodes
 	default:
 		panic("unsupported machine type")

--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -18,8 +18,8 @@ import (
 	apidbackend "github.com/talos-systems/talos/internal/app/apid/pkg/backend"
 	"github.com/talos-systems/talos/internal/app/apid/pkg/director"
 	"github.com/talos-systems/talos/internal/app/apid/pkg/provider"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/grpc/proxy/backend"
@@ -131,6 +131,6 @@ func main() {
 	}
 }
 
-func loadConfig() (runtime.Configurator, error) {
-	return config.NewFromFile(*configPath)
+func loadConfig() (config.Provider, error) {
+	return configloader.NewFromFile(*configPath)
 }

--- a/internal/app/apid/pkg/provider/tls.go
+++ b/internal/app/apid/pkg/provider/tls.go
@@ -11,7 +11,7 @@ import (
 	stdlibtls "crypto/tls"
 	stdlibnet "net"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/tls"
 	"github.com/talos-systems/talos/pkg/net"
@@ -23,7 +23,7 @@ type TLSConfig struct {
 }
 
 // NewTLSConfig builds provider from configuration and endpoints.
-func NewTLSConfig(config runtime.Configurator, endpoints []string) (*TLSConfig, error) {
+func NewTLSConfig(config config.Provider, endpoints []string) (*TLSConfig, error) {
 	ips, err := net.IPAddrs()
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover IP addresses: %w", err)

--- a/internal/app/bootkube/assets.go
+++ b/internal/app/bootkube/assets.go
@@ -24,13 +24,13 @@ import (
 	"github.com/kubernetes-sigs/bootkube/pkg/tlsutil"
 	"github.com/talos-systems/bootkube-plugin/pkg/asset"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 	tnet "github.com/talos-systems/talos/pkg/net"
 )
 
 // nolint: gocyclo
-func generateAssets(config runtime.Configurator) (err error) {
+func generateAssets(config config.Provider) (err error) {
 	if err = os.MkdirAll(constants.ManifestsDirectory, 0o644); err != nil {
 		return err
 	}

--- a/internal/app/bootkube/main.go
+++ b/internal/app/bootkube/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubernetes-sigs/bootkube/pkg/bootkube"
 	"github.com/kubernetes-sigs/bootkube/pkg/util"
 
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -95,7 +95,7 @@ func main() {
 
 	defer util.FlushLogs()
 
-	config, err := config.NewFromFile(*configPath)
+	config, err := configloader.NewFromFile(*configPath)
 	if err != nil {
 		log.Fatalf("failed to create config from file: %v", err)
 	}

--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -20,16 +20,16 @@ import (
 
 	"github.com/talos-systems/go-procfs/procfs"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // RunInstallerContainer performs an installation via the installer container.
 //
 //nolint: gocyclo
-func RunInstallerContainer(disk, platform, ref string, reg runtime.Registries, opts ...Option) error {
+func RunInstallerContainer(disk, platform, ref string, reg config.Registries, opts ...Option) error {
 	options := DefaultInstallOptions()
 
 	for _, opt := range opts {

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	clusterapi "github.com/talos-systems/talos/api/cluster"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/internal/pkg/cluster/check"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
@@ -84,13 +84,13 @@ func (cluster *clusterState) Nodes() []string {
 	return append(cluster.controlPlaneNodes, cluster.workerNodes...)
 }
 
-func (cluster *clusterState) NodesByType(t runtime.MachineType) []string {
+func (cluster *clusterState) NodesByType(t machine.Type) []string {
 	switch t {
-	case runtime.MachineTypeInit:
+	case machine.TypeInit:
 		return nil
-	case runtime.MachineTypeControlPlane:
+	case machine.TypeControlPlane:
 		return cluster.controlPlaneNodes
-	case runtime.MachineTypeJoin:
+	case machine.TypeJoin:
 		return cluster.workerNodes
 	default:
 		panic("unsupported machine type")

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -49,6 +49,8 @@ import (
 	"github.com/talos-systems/talos/pkg/archiver"
 	"github.com/talos-systems/talos/pkg/chunker"
 	"github.com/talos-systems/talos/pkg/chunker/stream"
+	"github.com/talos-systems/talos/pkg/config"
+	machinetype "github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/version"
 )
@@ -145,7 +147,7 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (rep
 func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (reply *machine.BootstrapResponse, err error) {
 	log.Printf("bootstrap request received")
 
-	if s.Controller.Runtime().Config().Machine().Type() == runtime.MachineTypeJoin {
+	if s.Controller.Runtime().Config().Machine().Type() == machinetype.TypeJoin {
 		return nil, fmt.Errorf("bootstrap can only be performed on a control plane node")
 	}
 
@@ -269,7 +271,7 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 func (s *Server) Recover(ctx context.Context, in *machine.RecoverRequest) (reply *machine.RecoverResponse, err error) {
 	log.Printf("recover request received")
 
-	if s.Controller.Runtime().Config().Machine().Type() == runtime.MachineTypeJoin {
+	if s.Controller.Runtime().Config().Machine().Type() == machinetype.TypeJoin {
 		return nil, fmt.Errorf("recover can only be performed on a control plane node")
 	}
 
@@ -777,7 +779,7 @@ func (s *Server) Events(req *machine.EventsRequest, l machine.MachineService_Eve
 	return <-errCh
 }
 
-func pullAndValidateInstallerImage(ctx context.Context, reg runtime.Registries, ref string) error {
+func pullAndValidateInstallerImage(ctx context.Context, reg config.Registries, ref string) error {
 	// Pull down specified installer image early so we can bail if it doesn't exist in the upstream registry
 	containerdctx := namespaces.WithNamespace(ctx, constants.SystemContainerdNamespace)
 

--- a/internal/app/machined/pkg/runtime/mode.go
+++ b/internal/app/machined/pkg/runtime/mode.go
@@ -31,6 +31,11 @@ func (m Mode) String() string {
 	return [...]string{cloud, container, metal}[m]
 }
 
+// RequiresInstall implements config.RuntimeMode.
+func (m Mode) RequiresInstall() bool {
+	return m == ModeMetal
+}
+
 // ParseMode returns a `Mode` that matches the specified string.
 func ParseMode(s string) (mod Mode, err error) {
 	switch s {

--- a/internal/app/machined/pkg/runtime/mode_test.go
+++ b/internal/app/machined/pkg/runtime/mode_test.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: scopelint,dupl
+// nolint: scopelint
 package runtime_test
 
 import (

--- a/internal/app/machined/pkg/runtime/runtime.go
+++ b/internal/app/machined/pkg/runtime/runtime.go
@@ -4,9 +4,11 @@
 
 package runtime
 
+import "github.com/talos-systems/talos/pkg/config"
+
 // Runtime defines the runtime parameters.
 type Runtime interface {
-	Config() Configurator
+	Config() config.Provider
 	SetConfig([]byte) error
 	State() State
 	Events() EventStream

--- a/internal/app/machined/pkg/runtime/state.go
+++ b/internal/app/machined/pkg/runtime/state.go
@@ -4,9 +4,30 @@
 
 package runtime
 
+import (
+	"github.com/talos-systems/talos/pkg/blockdevice/probe"
+	"github.com/talos-systems/talos/pkg/config"
+)
+
 // State defines the state.
 type State interface {
 	Platform() Platform
 	Machine() MachineState
 	Cluster() ClusterState
 }
+
+// Machine defines the runtime parameters.
+type Machine interface {
+	State() MachineState
+	Config() config.MachineConfig
+}
+
+// MachineState defines the machined state.
+type MachineState interface {
+	Disk() *probe.ProbedBlockDevice
+	Close() error
+	Installed() bool
+}
+
+// ClusterState defines the cluster state.
+type ClusterState interface{}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/acpi"
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 )
 
 // Controller represents the controller responsible for managing the execution
@@ -53,10 +54,10 @@ func NewController(b []byte) (*Controller, error) {
 		return nil, err
 	}
 
-	var cfg runtime.Configurator
+	var cfg config.Provider
 
 	if b != nil {
-		cfg, err = config.NewFromBytes(b)
+		cfg, err = configloader.NewFromBytes(b)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse config: %w", err)
 		}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -9,18 +9,19 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 )
 
 // Runtime implements the Runtime interface.
 type Runtime struct {
-	c runtime.Configurator
+	c config.Provider
 	s runtime.State
 	e runtime.EventStream
 	l runtime.LoggingManager
 }
 
 // NewRuntime initializes and returns the v1alpha1 runtime.
-func NewRuntime(c runtime.Configurator, s runtime.State, e runtime.EventStream, l runtime.LoggingManager) *Runtime {
+func NewRuntime(c config.Provider, s runtime.State, e runtime.EventStream, l runtime.LoggingManager) *Runtime {
 	return &Runtime{
 		c: c,
 		s: s,
@@ -30,13 +31,13 @@ func NewRuntime(c runtime.Configurator, s runtime.State, e runtime.EventStream, 
 }
 
 // Config implements the Runtime interface.
-func (r *Runtime) Config() runtime.Configurator {
+func (r *Runtime) Config() config.Provider {
 	return r.c
 }
 
 // SetConfig implements the Runtime interface.
 func (r *Runtime) SetConfig(b []byte) error {
-	cfg, err := config.NewFromBytes(b)
+	cfg, err := configloader.NewFromBytes(b)
 	if err != nil {
 		return fmt.Errorf("failed to set config: %w", err)
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -5,8 +5,9 @@
 package v1alpha1
 
 import (
-	"github.com/talos-systems/talos/api/machine"
+	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // Sequencer implements the sequencer interface.
@@ -212,7 +213,7 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 		"startEverything",
 		StartAllServices,
 	).AppendWhen(
-		r.Config().Machine().Type() != runtime.MachineTypeJoin,
+		r.Config().Machine().Type() != machine.TypeJoin,
 		"labelMaster",
 		LabelNodeAsMaster,
 	).AppendWhen(
@@ -286,7 +287,7 @@ func (*Sequencer) Reboot(r runtime.Runtime) []runtime.Phase {
 }
 
 // Recover is the recover sequence.
-func (*Sequencer) Recover(r runtime.Runtime, in *machine.RecoverRequest) []runtime.Phase {
+func (*Sequencer) Recover(r runtime.Runtime, in *machineapi.RecoverRequest) []runtime.Phase {
 	phases := PhaseList{}
 
 	phases = phases.Append("recover", Recover)
@@ -295,7 +296,7 @@ func (*Sequencer) Recover(r runtime.Runtime, in *machine.RecoverRequest) []runti
 }
 
 // Reset is the reset sequence.
-func (*Sequencer) Reset(r runtime.Runtime, in *machine.ResetRequest) []runtime.Phase {
+func (*Sequencer) Reset(r runtime.Runtime, in *machineapi.ResetRequest) []runtime.Phase {
 	phases := PhaseList{}
 
 	switch r.State().Platform().Mode() { //nolint: exhaustive
@@ -313,7 +314,7 @@ func (*Sequencer) Reset(r runtime.Runtime, in *machine.ResetRequest) []runtime.P
 			"drain",
 			CordonAndDrainNode,
 		).AppendWhen(
-			in.GetGraceful() && (r.Config().Machine().Type() != runtime.MachineTypeJoin),
+			in.GetGraceful() && (r.Config().Machine().Type() != machine.TypeJoin),
 			"leave",
 			LeaveEtcd,
 		).AppendWhen(
@@ -384,7 +385,7 @@ func (*Sequencer) Shutdown(r runtime.Runtime) []runtime.Phase {
 }
 
 // Upgrade is the upgrade sequence.
-func (*Sequencer) Upgrade(r runtime.Runtime, in *machine.UpgradeRequest) []runtime.Phase {
+func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []runtime.Phase {
 	phases := PhaseList{}
 
 	switch r.State().Platform().Mode() { //nolint: exhaustive
@@ -395,7 +396,7 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machine.UpgradeRequest) []runti
 			"drain",
 			CordonAndDrainNode,
 		).AppendWhen(
-			!in.GetPreserve() && (r.Config().Machine().Type() != runtime.MachineTypeJoin),
+			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
 			"leave",
 			LeaveEtcd,
 		).AppendWhen(

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/kubernetes-sigs/bootkube/pkg/recovery"
 
-	"github.com/talos-systems/talos/api/machine"
+	machineapi "github.com/talos-systems/talos/api/machine"
 	installer "github.com/talos-systems/talos/cmd/installer/pkg/install"
 	"github.com/talos-systems/talos/internal/app/machined/internal/install"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -50,7 +50,8 @@ import (
 	"github.com/talos-systems/talos/pkg/blockdevice/table"
 	"github.com/talos-systems/talos/pkg/blockdevice/util"
 	"github.com/talos-systems/talos/pkg/cmd"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/kubernetes"
 	"github.com/talos-systems/talos/pkg/retry"
@@ -433,7 +434,7 @@ func LoadConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 			return nil
 		}
 
-		cfg, err := config.NewFromFile(constants.ConfigPath)
+		cfg, err := configloader.NewFromFile(constants.ConfigPath)
 		if err != nil {
 			logger.Printf("downloading config")
 
@@ -629,18 +630,18 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 		}
 
 		switch r.Config().Machine().Type() {
-		case runtime.MachineTypeInit:
+		case machine.TypeInit:
 			svcs.Load(
 				&services.Trustd{},
 				&services.Etcd{Bootstrap: true},
 				&services.Bootkube{},
 			)
-		case runtime.MachineTypeControlPlane:
+		case machine.TypeControlPlane:
 			svcs.Load(
 				&services.Trustd{},
 				&services.Etcd{},
 			)
-		case runtime.MachineTypeJoin:
+		case machine.TypeJoin:
 		}
 
 		system.Services(r).StartAll()
@@ -1313,7 +1314,7 @@ func Upgrade(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		// This should be checked by the gRPC server, but we double check here just
 		// to be safe.
-		in, ok := data.(*machine.UpgradeRequest)
+		in, ok := data.(*machineapi.UpgradeRequest)
 		if !ok {
 			return runtime.ErrInvalidSequenceData
 		}
@@ -1551,11 +1552,11 @@ func Install(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 func Recover(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		var (
-			in *machine.RecoverRequest
+			in *machineapi.RecoverRequest
 			ok bool
 		)
 
-		if in, ok = data.(*machine.RecoverRequest); !ok {
+		if in, ok = data.(*machineapi.RecoverRequest); !ok {
 			return runtime.ErrInvalidSequenceData
 		}
 
@@ -1577,7 +1578,7 @@ func Recover(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 		var backend recovery.Backend
 
 		switch in.Source {
-		case machine.RecoverRequest_ETCD:
+		case machineapi.RecoverRequest_ETCD:
 			var client *clientv3.Client
 
 			client, err = etcd.NewClient([]string{"127.0.0.1:2379"})
@@ -1587,7 +1588,7 @@ func Recover(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 
 			backend = recovery.NewEtcdBackend(client, "/registry")
 
-		case machine.RecoverRequest_APISERVER:
+		case machineapi.RecoverRequest_APISERVER:
 			backend, err = recovery.NewAPIServerBackend(kubeconfigPath)
 			if err != nil {
 				return err

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -25,6 +25,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/kubernetes"
 	"github.com/talos-systems/talos/pkg/retry"
@@ -58,7 +59,7 @@ func (o *APID) PostFunc(r runtime.Runtime, state events.ServiceState) (err error
 
 // Condition implements the Service interface.
 func (o *APID) Condition(r runtime.Runtime) conditions.Condition {
-	if r.Config().Machine().Type() == runtime.MachineTypeJoin {
+	if r.Config().Machine().Type() == machine.TypeJoin {
 		return conditions.WaitForFileToExist(constants.KubeletKubeconfig)
 	}
 
@@ -87,7 +88,7 @@ func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
 		return nil, err
 	}
 
-	if r.Config().Machine().Type() == runtime.MachineTypeJoin {
+	if r.Config().Machine().Type() == machine.TypeJoin {
 		opts := []retry.Option{retry.WithUnits(3 * time.Second), retry.WithJitter(time.Second)}
 
 		err := retry.Constant(4*time.Minute, opts...).Retry(func() error {

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -24,6 +24,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
 	"github.com/talos-systems/talos/internal/pkg/etcd"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/retry"
 )
@@ -103,7 +104,7 @@ func (b *Bootkube) PreFunc(ctx context.Context, r runtime.Runtime) (err error) {
 //
 // This is temorary and should be removed once we remove the init node type.
 func (b *Bootkube) PostFunc(r runtime.Runtime, state events.ServiceState) (err error) {
-	if r.Config().Machine().Type() != runtime.MachineTypeInit {
+	if r.Config().Machine().Type() != machine.TypeInit {
 		return nil
 	}
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -36,6 +36,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/internal/pkg/etcd"
 	"github.com/talos-systems/talos/pkg/argsbuilder"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/net"
@@ -456,12 +457,12 @@ func (e *Etcd) setup(ctx context.Context, r runtime.Runtime, errCh chan error) {
 		}
 
 		switch r.Config().Machine().Type() { //nolint: exhaustive
-		case runtime.MachineTypeInit:
+		case machine.TypeInit:
 			err = e.argsForInit(ctx, r)
 			if err != nil {
 				return err
 			}
-		case runtime.MachineTypeControlPlane:
+		case machine.TypeControlPlane:
 			err = e.argsForControlPlane(ctx, r)
 			if err != nil {
 				return err

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/reg"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 )
@@ -28,7 +28,7 @@ func init() {
 func main() {
 	log.Println("starting initial network configuration")
 
-	config, err := config.NewFromFile(*configPath)
+	config, err := configloader.NewFromFile(*configPath)
 	if err != nil {
 		log.Fatalf("failed to create config from file: %v", err)
 	}

--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -11,7 +11,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 )
 
 // Static implements the Addressing interface.
@@ -19,7 +19,7 @@ type Static struct {
 	CIDR        string
 	Mtu         int
 	FQDN        string
-	RouteList   []runtime.Route
+	RouteList   []config.Route
 	NetIf       *net.Interface
 	NameServers []net.IP
 }

--- a/internal/app/networkd/pkg/networkd/misc.go
+++ b/internal/app/networkd/pkg/networkd/misc.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jsimonetti/rtnetlink"
 	"golang.org/x/sys/unix"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	talosnet "github.com/talos-systems/talos/pkg/net"
 )
 
@@ -114,18 +114,18 @@ ff02::2         ip6-allrouters
 {{ end }}
 `
 
-func writeHosts(hostname string, address net.IP, config runtime.Configurator) (err error) {
-	extraHosts := []runtime.ExtraHost{}
+func writeHosts(hostname string, address net.IP, cfg config.Provider) (err error) {
+	extraHosts := []config.ExtraHost{}
 
-	if config != nil {
-		extraHosts = config.Machine().Network().ExtraHosts()
+	if cfg != nil {
+		extraHosts = cfg.Machine().Network().ExtraHosts()
 	}
 
 	data := struct {
 		IP         string
 		Hostname   string
 		Alias      string
-		ExtraHosts []runtime.ExtraHost
+		ExtraHosts []config.ExtraHost
 	}{
 		IP:         address.String(),
 		Hostname:   hostname,

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -12,16 +12,16 @@ import (
 
 	"github.com/talos-systems/go-procfs/procfs"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // buildOptions translates the supplied config to nic.Option used for
 // configuring the interface.
 // nolint: gocyclo
-func buildOptions(device runtime.Device, hostname string) (name string, opts []nic.Option, err error) {
+func buildOptions(device config.Device, hostname string) (name string, opts []nic.Option, err error) {
 	opts = append(opts, nic.WithName(device.Interface))
 
 	if device.Ignore || procfs.ProcCmdline().Get(constants.KernelParamNetworkInterfaceIgnore).Contains(device.Interface) {
@@ -214,7 +214,7 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 	}
 
 	var (
-		device    = &runtime.Device{}
+		device    = &config.Device{}
 		hostname  string
 		link      *net.Interface
 		resolvers = []net.IP{}
@@ -229,7 +229,7 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 		// case 1:
 		// Gateway
 		case 2:
-			device.Routes = []runtime.Route{
+			device.Routes = []config.Route{
 				{
 					Network: "0.0.0.0/0",
 					Gateway: field,

--- a/internal/app/networkd/pkg/networkd/netconf_test.go
+++ b/internal/app/networkd/pkg/networkd/netconf_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/pkg/config"
 )
 
 type NetconfSuite struct {
@@ -69,8 +69,8 @@ func (suite *NetconfSuite) TestKernelNetconfIncomplete() {
 	suite.Assert().Equal(len(addr.Routes()), 1)
 }
 
-func sampleConfig() []runtime.Device {
-	return []runtime.Device{
+func sampleConfig() []config.Device {
+	return []config.Device{
 		{
 			Interface: "eth0",
 			CIDR:      "192.168.0.10/24",
@@ -78,11 +78,11 @@ func sampleConfig() []runtime.Device {
 		{
 			Interface: "bond0",
 			CIDR:      "192.168.0.10/24",
-			Bond:      &runtime.Bond{Interfaces: []string{"lo"}},
+			Bond:      &config.Bond{Interfaces: []string{"lo"}},
 		},
 		{
 			Interface: "bond0",
-			Bond:      &runtime.Bond{Interfaces: []string{"lo"}, Mode: "balance-rr"},
+			Bond:      &config.Bond{Interfaces: []string{"lo"}, Mode: "balance-rr"},
 		},
 		{
 			Interface: "eth0",
@@ -92,11 +92,11 @@ func sampleConfig() []runtime.Device {
 			Interface: "eth0",
 			MTU:       9100,
 			CIDR:      "192.168.0.10/24",
-			Routes:    []runtime.Route{{Network: "10.0.0.0/8", Gateway: "10.0.0.1"}},
+			Routes:    []config.Route{{Network: "10.0.0.0/8", Gateway: "10.0.0.1"}},
 		},
 		{
 			Interface: "bond0",
-			Bond: &runtime.Bond{
+			Bond: &config.Bond{
 				Interfaces: []string{"lo"},
 				Mode:       "balance-rr",
 				HashPolicy: "layer2",
@@ -108,7 +108,7 @@ func sampleConfig() []runtime.Device {
 		},
 		{
 			Interface: "bondyolo0",
-			Bond: &runtime.Bond{
+			Bond: &config.Bond{
 				Interfaces:      []string{"lo"},
 				Mode:            "balance-rr",
 				HashPolicy:      "layer2",

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -38,7 +39,7 @@ const (
 // and/or a specified configuration file.
 type Networkd struct {
 	Interfaces map[string]*nic.NetworkInterface
-	Config     runtime.Configurator
+	Config     config.Provider
 
 	hostname  string
 	resolvers []string
@@ -50,7 +51,7 @@ type Networkd struct {
 // New takes the supplied configuration and creates an abstract representation
 // of all interfaces (as nic.NetworkInterface).
 // nolint: gocyclo
-func New(config runtime.Configurator) (*Networkd, error) {
+func New(config config.Provider) (*Networkd, error) {
 	var (
 		hostname  string
 		option    *string

--- a/internal/app/networkd/pkg/networkd/networkd_test.go
+++ b/internal/app/networkd/pkg/networkd/networkd_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -46,7 +46,7 @@ func (suite *NetworkdSuite) TestHostname() {
 		err          error
 		hostname     string
 		nwd          *Networkd
-		sampleConfig runtime.Configurator
+		sampleConfig config.Provider
 	)
 
 	nwd, err = New(nil)
@@ -165,13 +165,13 @@ func (suite *NetworkdSuite) TestHostname() {
 	suite.Assert().Equal(addr, net.ParseIP("192.168.0.11"))
 }
 
-func sampleConfigFile() runtime.Configurator {
+func sampleConfigFile() config.Provider {
 	return &v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineNetwork: &v1alpha1.NetworkConfig{
 				NameServers:     []string{"1.2.3.4", "2.3.4.5"},
 				NetworkHostname: "myhostname",
-				NetworkInterfaces: []runtime.Device{
+				NetworkInterfaces: []config.Device{
 					{
 						Interface: "eth0",
 						CIDR:      "192.168.0.10/24",
@@ -180,7 +180,7 @@ func sampleConfigFile() runtime.Configurator {
 					{
 						Interface: "bond0",
 						CIDR:      "192.168.0.10/24",
-						Bond: &runtime.Bond{
+						Bond: &config.Bond{
 							Interfaces: []string{"lo"},
 							Mode:       "balance-rr",
 						},
@@ -191,11 +191,11 @@ func sampleConfigFile() runtime.Configurator {
 	}
 }
 
-func dhcpConfigFile() runtime.Configurator {
+func dhcpConfigFile() config.Provider {
 	return &v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineNetwork: &v1alpha1.NetworkConfig{
-				NetworkInterfaces: []runtime.Device{
+				NetworkInterfaces: []config.Device{
 					{
 						Interface: "eth0",
 					},

--- a/internal/app/networkd/pkg/nic/nic_test.go
+++ b/internal/app/networkd/pkg/nic/nic_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
+	"github.com/talos-systems/talos/pkg/config"
 )
 
 type NicSuite struct {
@@ -117,7 +117,7 @@ func (suite *NicSuite) TestVlan() {
 		{
 			nic.WithName("eth0"),
 			nic.WithVlan(100),
-			nic.WithVlanCIDR(100, "172.21.10.101/28", []runtime.Route{}),
+			nic.WithVlanCIDR(100, "172.21.10.101/28", []config.Route{}),
 		},
 	}
 	for _, test := range testSettings {

--- a/internal/app/networkd/pkg/nic/vlan_options.go
+++ b/internal/app/networkd/pkg/nic/vlan_options.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/mdlayher/netlink"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
+	"github.com/talos-systems/talos/pkg/config"
 )
 
 // Vlan contins interface related parameters to a VLAN device.
@@ -59,7 +59,7 @@ func WithVlanDhcp(id uint16) Option {
 }
 
 // WithVlanCIDR defines if the interface have static CIDRs added.
-func WithVlanCIDR(id uint16, cidr string, routeList []runtime.Route) Option {
+func WithVlanCIDR(id uint16, cidr string, routeList []config.Route) Option {
 	return func(n *NetworkInterface) (err error) {
 		for _, vlan := range n.Vlans {
 			if vlan.ID == id {

--- a/internal/app/timed/main.go
+++ b/internal/app/timed/main.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/timed/pkg/ntp"
 	"github.com/talos-systems/talos/internal/app/timed/pkg/reg"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/startup"
@@ -44,7 +44,7 @@ func main() {
 
 	server := DefaultServer
 
-	config, err := config.NewFromFile(*configPath)
+	config, err := configloader.NewFromFile(*configPath)
 	if err != nil {
 		log.Fatalf("failed to create config from file: %v", err)
 	}

--- a/internal/app/timed/pkg/ntp/ntp_test.go
+++ b/internal/app/timed/pkg/ntp/ntp_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/timed/pkg/ntp"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -36,7 +36,7 @@ func (suite *NtpSuite) TestNtpConfig() {
 	server := "time.cloudflare.com"
 
 	// Test unset config, single server config, multiple server config
-	for _, conf := range []runtime.Configurator{&v1alpha1.Config{MachineConfig: &v1alpha1.MachineConfig{}}, sampleConfigSingleServer(), sampleConfigMultipleServers()} {
+	for _, conf := range []config.Provider{&v1alpha1.Config{MachineConfig: &v1alpha1.MachineConfig{}}, sampleConfigSingleServer(), sampleConfigMultipleServers()} {
 		// Check if ntp servers are defined
 		// Support for only a single time server currently
 		if len(conf.Machine().Time().Servers()) >= 1 {
@@ -51,7 +51,7 @@ func (suite *NtpSuite) TestNtpConfig() {
 	}
 }
 
-func sampleConfigSingleServer() runtime.Configurator {
+func sampleConfigSingleServer() config.Provider {
 	return &v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineTime: &v1alpha1.TimeConfig{
@@ -61,7 +61,7 @@ func sampleConfigSingleServer() runtime.Configurator {
 	}
 }
 
-func sampleConfigMultipleServers() runtime.Configurator {
+func sampleConfigMultipleServers() config.Provider {
 	return &v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineTime: &v1alpha1.TimeConfig{

--- a/internal/app/trustd/internal/reg/reg.go
+++ b/internal/app/trustd/internal/reg/reg.go
@@ -14,14 +14,14 @@ import (
 	"google.golang.org/grpc"
 
 	securityapi "github.com/talos-systems/talos/api/security"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
 // Registrator is the concrete type that implements the factory.Registrator and
 // securityapi.SecurityServer interfaces.
 type Registrator struct {
-	Config runtime.Configurator
+	Config config.Provider
 }
 
 // Register implements the factory.Registrator interface.

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/talos-systems/talos/internal/app/trustd/internal/reg"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
@@ -41,7 +41,7 @@ func main() {
 		log.Fatalf("startup: %s", err)
 	}
 
-	config, err := config.NewFromFile(*configPath)
+	config, err := configloader.NewFromFile(*configPath)
 	if err != nil {
 		log.Fatalf("failed to create config from file: %v", err)
 	}

--- a/internal/integration/api/recover.go
+++ b/internal/integration/api/recover.go
@@ -15,10 +15,10 @@ import (
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/talos-systems/talos/api/machine"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/pkg/client"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 type RecoverSuite struct {
@@ -82,7 +82,7 @@ func (suite *RecoverSuite) TestRecoverControlPlane() {
 
 	suite.Assert().NoError(eg.Wait())
 
-	nodes := suite.DiscoverNodes().NodesByType(runtime.MachineTypeControlPlane)
+	nodes := suite.DiscoverNodes().NodesByType(machine.TypeControlPlane)
 	suite.Require().NotEmpty(nodes)
 
 	sort.Strings(nodes)
@@ -96,8 +96,8 @@ func (suite *RecoverSuite) TestRecoverControlPlane() {
 
 	nodeCtx := client.WithNodes(ctx, node)
 
-	in := &machine.RecoverRequest{
-		Source: machine.RecoverRequest_APISERVER,
+	in := &machineapi.RecoverRequest{
+		Source: machineapi.RecoverRequest_APISERVER,
 	}
 
 	_, err = suite.Client.MachineClient.Recover(nodeCtx, in)

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 type ResetSuite struct {
@@ -57,7 +57,7 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 
 	initNodeAddress := ""
 	for _, node := range suite.Cluster.Info().Nodes {
-		if node.Type == runtime.MachineTypeInit {
+		if node.Type == machine.TypeInit {
 			initNodeAddress = node.PrivateIP.String()
 			break
 		}

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/provision/access"
 	"github.com/talos-systems/talos/pkg/client"
 	"github.com/talos-systems/talos/pkg/client/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/retry"
 )
 
@@ -76,7 +77,7 @@ func (apiSuite *APISuite) DiscoverNodes() cluster.Info {
 }
 
 // RandomNode returns a random node of the specified type (or any type if no types are specified).
-func (apiSuite *APISuite) RandomDiscoveredNode(types ...runtime.MachineType) string {
+func (apiSuite *APISuite) RandomDiscoveredNode(types ...machine.Type) string {
 	nodeInfo := apiSuite.DiscoverNodes()
 
 	var nodes []string

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/cmd"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/retry"
 )
 
@@ -52,7 +52,7 @@ func (cliSuite *CLISuite) DiscoverNodes() cluster.Info {
 }
 
 // RandomNode returns a random node of the specified type (or any type if no types are specified).
-func (cliSuite *CLISuite) RandomDiscoveredNode(types ...runtime.MachineType) string {
+func (cliSuite *CLISuite) RandomDiscoveredNode(types ...machine.Type) string {
 	nodeInfo := cliSuite.DiscoverNodes()
 
 	var nodes []string

--- a/internal/integration/base/cluster.go
+++ b/internal/integration/base/cluster.go
@@ -6,7 +6,7 @@
 
 package base
 
-import "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+import "github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 
 type infoWrapper struct {
 	masterNodes []string
@@ -17,13 +17,13 @@ func (wrapper *infoWrapper) Nodes() []string {
 	return append(wrapper.masterNodes, wrapper.workerNodes...)
 }
 
-func (wrapper *infoWrapper) NodesByType(t runtime.MachineType) []string {
+func (wrapper *infoWrapper) NodesByType(t machine.Type) []string {
 	switch t {
-	case runtime.MachineTypeInit:
+	case machine.TypeInit:
 		return nil
-	case runtime.MachineTypeControlPlane:
+	case machine.TypeControlPlane:
 		return wrapper.masterNodes
-	case runtime.MachineTypeJoin:
+	case machine.TypeJoin:
 		return wrapper.workerNodes
 	default:
 		panic("unreachable")

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -9,8 +9,8 @@ package cli
 import (
 	"regexp"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // ContainersSuite verifies dmesg command.
@@ -41,7 +41,7 @@ func (suite *ContainersSuite) TestCRI() {
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`CRI inspector is supported only for K8s namespace`)))
-	suite.RunCLI([]string{"containers", "-ck", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
+	suite.RunCLI([]string{"containers", "-ck", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 	)
 }

--- a/internal/integration/cli/crashdump.go
+++ b/internal/integration/cli/crashdump.go
@@ -9,8 +9,8 @@ package cli
 import (
 	"regexp"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // CrashdumpSuite verifies crashdump command.
@@ -32,11 +32,11 @@ func (suite *CrashdumpSuite) TestRun() {
 	args := []string{}
 	for _, node := range suite.Cluster.Info().Nodes {
 		switch node.Type {
-		case runtime.MachineTypeInit:
+		case machine.TypeInit:
 			args = append(args, "--init-node", node.PrivateIP.String())
-		case runtime.MachineTypeControlPlane:
+		case machine.TypeControlPlane:
 			args = append(args, "--control-plane-nodes", node.PrivateIP.String())
-		case runtime.MachineTypeJoin:
+		case machine.TypeJoin:
 			args = append(args, "--worker-nodes", node.PrivateIP.String())
 		}
 	}

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // HealthSuite verifies health command.
@@ -36,7 +36,7 @@ func (suite *HealthSuite) TestClientSide() {
 	bootstrapAPIIsUsed := true
 
 	for _, node := range suite.Cluster.Info().Nodes {
-		if node.Type == runtime.MachineTypeInit {
+		if node.Type == machine.TypeInit {
 			bootstrapAPIIsUsed = false
 		}
 	}
@@ -46,9 +46,9 @@ func (suite *HealthSuite) TestClientSide() {
 
 		for _, node := range suite.Cluster.Info().Nodes {
 			switch node.Type {
-			case runtime.MachineTypeControlPlane:
+			case machine.TypeControlPlane:
 				nodes = append(nodes, node.PrivateIP.String())
-			case runtime.MachineTypeJoin:
+			case machine.TypeJoin:
 				args = append(args, "--worker-nodes", node.PrivateIP.String())
 			}
 		}
@@ -65,11 +65,11 @@ func (suite *HealthSuite) TestClientSide() {
 	} else {
 		for _, node := range suite.Cluster.Info().Nodes {
 			switch node.Type {
-			case runtime.MachineTypeInit:
+			case machine.TypeInit:
 				args = append(args, "--init-node", node.PrivateIP.String())
-			case runtime.MachineTypeControlPlane:
+			case machine.TypeControlPlane:
 				args = append(args, "--control-plane-nodes", node.PrivateIP.String())
-			case runtime.MachineTypeJoin:
+			case machine.TypeJoin:
 				args = append(args, "--worker-nodes", node.PrivateIP.String())
 			}
 		}
@@ -88,7 +88,7 @@ func (suite *HealthSuite) TestClientSide() {
 
 // TestServerSide does successful health check run from server-side.
 func (suite *HealthSuite) TestServerSide() {
-	suite.RunCLI([]string{"health", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
+	suite.RunCLI([]string{"health", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
 		base.StderrNotEmpty(),
 		base.StdoutEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`waiting for all k8s nodes to report ready`)),

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -14,8 +14,8 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // KubeconfigSuite verifies dmesg command.
@@ -35,7 +35,7 @@ func (suite *KubeconfigSuite) TestDirectory() {
 
 	defer os.RemoveAll(tempDir) //nolint: errcheck
 
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane), tempDir},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), tempDir},
 		base.StdoutEmpty())
 
 	path := filepath.Join(tempDir, "kubeconfig")
@@ -59,7 +59,7 @@ func (suite *KubeconfigSuite) TestCwd() {
 
 	suite.Require().NoError(os.Chdir(tempDir))
 
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
 		base.StdoutEmpty())
 
 	suite.Require().FileExists(filepath.Join(tempDir, "kubeconfig"))
@@ -83,9 +83,9 @@ func (suite *KubeconfigSuite) TestMerge() {
 
 	path := filepath.Join(tempDir, "config")
 
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane), path, "-m"},
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), path, "-m"},
 		base.StdoutEmpty())
-	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane), path, "-m"})
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), path, "-m"})
 
 	config, err := clientcmd.LoadFromFile(path)
 	suite.Require().NoError(err)

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // RestartSuite verifies dmesg command.
@@ -32,7 +32,7 @@ func (suite *RestartSuite) TestSystem() {
 	}
 
 	// trustd only runs on control plane nodes
-	node := suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)
+	node := suite.RandomDiscoveredNode(machine.TypeControlPlane)
 
 	suite.RunCLI([]string{"restart", "-n", node, "trustd"},
 		base.StdoutEmpty())

--- a/internal/integration/cli/stats.go
+++ b/internal/integration/cli/stats.go
@@ -9,8 +9,8 @@ package cli
 import (
 	"regexp"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // StatsSuite verifies dmesg command.
@@ -43,7 +43,7 @@ func (suite *StatsSuite) TestCRI() {
 		base.StdoutEmpty(),
 		base.StderrNotEmpty(),
 		base.StderrShouldMatch(regexp.MustCompile(`CRI inspector is supported only for K8s namespace`)))
-	suite.RunCLI([]string{"stats", "-ck", "--nodes", suite.RandomDiscoveredNode(runtime.MachineTypeControlPlane)},
+	suite.RunCLI([]string{"stats", "-ck", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
 		base.StdoutShouldMatch(regexp.MustCompile(`CPU`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`kube-system/kube-apiserver`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`k8s.io`)),

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -22,7 +22,6 @@ import (
 
 	machineapi "github.com/talos-systems/talos/api/machine"
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/internal/pkg/cluster/check"
 	"github.com/talos-systems/talos/internal/pkg/provision"
@@ -31,7 +30,9 @@ import (
 	talosclient "github.com/talos-systems/talos/pkg/client"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/bundle"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	talosnet "github.com/talos-systems/talos/pkg/net"
 	"github.com/talos-systems/talos/pkg/retry"
@@ -261,8 +262,8 @@ func (suite *UpgradeSuite) setupCluster() {
 		masterEndpoints[i] = ips[i].String()
 	}
 
-	suite.configBundle, err = config.NewConfigBundle(config.WithInputOptions(
-		&config.InputOptions{
+	suite.configBundle, err = bundle.NewConfigBundle(bundle.WithInputOptions(
+		&bundle.InputOptions{
 			ClusterName: clusterName,
 			Endpoint:    fmt.Sprintf("https://%s:6443", defaultInternalLB),
 			KubeVersion: "", // keep empty so that default version is used per Talos version
@@ -275,7 +276,7 @@ func (suite *UpgradeSuite) setupCluster() {
 	suite.Require().NoError(err)
 
 	for i := 0; i < suite.spec.MasterNodes; i++ {
-		var cfg runtime.Configurator
+		var cfg config.Provider
 
 		if i == 0 {
 			cfg = suite.configBundle.Init()
@@ -407,14 +408,14 @@ func (suite *UpgradeSuite) TestRolling() {
 
 	// upgrade master nodes
 	for _, node := range suite.Cluster.Info().Nodes {
-		if node.Type == runtime.MachineTypeInit || node.Type == runtime.MachineTypeControlPlane {
+		if node.Type == machine.TypeInit || node.Type == machine.TypeControlPlane {
 			suite.upgradeNode(client, node)
 		}
 	}
 
 	// upgrade worker nodes
 	for _, node := range suite.Cluster.Info().Nodes {
-		if node.Type == runtime.MachineTypeJoin {
+		if node.Type == machine.TypeJoin {
 			suite.upgradeNode(client, node)
 		}
 	}

--- a/internal/pkg/cluster/check/default.go
+++ b/internal/pkg/cluster/check/default.go
@@ -9,8 +9,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // DefaultClusterChecks returns a set of default Talos cluster readiness checks.
@@ -19,7 +19,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		// wait for etcd to be healthy on all control plane nodes
 		func(cluster ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
-				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(runtime.MachineTypeInit, runtime.MachineTypeControlPlane))
+				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
 			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for bootkube to finish on init node

--- a/internal/pkg/cluster/check/kubernetes.go
+++ b/internal/pkg/cluster/check/kubernetes.go
@@ -14,8 +14,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cluster"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // K8sAllNodesReportedAssertion checks whether all the nodes show up in node list.
@@ -61,7 +61,7 @@ func K8sFullControlPlaneAssertion(ctx context.Context, cluster ClusterInfo) erro
 		return err
 	}
 
-	expectedNodes := append(cluster.NodesByType(runtime.MachineTypeInit), cluster.NodesByType(runtime.MachineTypeControlPlane)...)
+	expectedNodes := append(cluster.NodesByType(machine.TypeInit), cluster.NodesByType(machine.TypeControlPlane)...)
 
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/internal/pkg/cluster/check/options.go
+++ b/internal/pkg/cluster/check/options.go
@@ -4,13 +4,13 @@
 
 package check
 
-import "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+import "github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 
 // Option represents functional option.
 type Option func(o *Options) error
 
 // WithNodeTypes sets the node types for a check.
-func WithNodeTypes(t ...runtime.MachineType) Option {
+func WithNodeTypes(t ...machine.Type) Option {
 	return func(o *Options) error {
 		o.Types = t
 
@@ -20,7 +20,7 @@ func WithNodeTypes(t ...runtime.MachineType) Option {
 
 // Options describes ClusterCheck parameters.
 type Options struct {
-	Types []runtime.MachineType
+	Types []machine.Type
 }
 
 // DefaultOptions returns the default options.

--- a/internal/pkg/cluster/check/service.go
+++ b/internal/pkg/cluster/check/service.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/client"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // ErrServiceNotFound is an error that indicates that a service was not found.
@@ -30,7 +30,7 @@ func ServiceStateAssertion(ctx context.Context, cluster ClusterInfo, service str
 
 	// by default, we check all control plane nodes. if some nodes don't have that service running,
 	// it won't be returned in the response
-	nodes := append(cluster.NodesByType(runtime.MachineTypeInit), cluster.NodesByType(runtime.MachineTypeControlPlane)...)
+	nodes := append(cluster.NodesByType(machine.TypeInit), cluster.NodesByType(machine.TypeControlPlane)...)
 	nodesCtx := client.WithNodes(ctx, nodes...)
 
 	servicesInfo, err := cli.ServiceInfo(nodesCtx, service)

--- a/internal/pkg/cluster/cluster.go
+++ b/internal/pkg/cluster/cluster.go
@@ -11,8 +11,8 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/client"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // ClientProvider builds Talos client by endpoint.
@@ -41,5 +41,5 @@ type Info interface {
 	// Nodes returns list of all node endpoints (IPs).
 	Nodes() []string
 	// NodesByType return list of node endpoints by type.
-	NodesByType(runtime.MachineType) []string
+	NodesByType(machine.Type) []string
 }

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -10,26 +10,26 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/containers/cri/containerd"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
 type mockConfig struct {
-	mirrors map[string]runtime.RegistryMirrorConfig
-	config  map[string]runtime.RegistryConfig
+	mirrors map[string]config.RegistryMirrorConfig
+	config  map[string]config.RegistryConfig
 }
 
-func (c *mockConfig) Mirrors() map[string]runtime.RegistryMirrorConfig {
+func (c *mockConfig) Mirrors() map[string]config.RegistryMirrorConfig {
 	return c.mirrors
 }
 
-func (c *mockConfig) Config() map[string]runtime.RegistryConfig {
+func (c *mockConfig) Config() map[string]config.RegistryConfig {
 	return c.config
 }
 
-func (c *mockConfig) ExtraFiles() ([]runtime.File, error) {
+func (c *mockConfig) ExtraFiles() ([]config.File, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
@@ -39,20 +39,20 @@ type ConfigSuite struct {
 
 func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 	cfg := &mockConfig{
-		mirrors: map[string]runtime.RegistryMirrorConfig{
+		mirrors: map[string]config.RegistryMirrorConfig{
 			"docker.io": {
 				Endpoints: []string{"https://registry-1.docker.io", "https://registry-2.docker.io"},
 			},
 		},
-		config: map[string]runtime.RegistryConfig{
+		config: map[string]config.RegistryConfig{
 			"some.host:123": {
-				Auth: &runtime.RegistryAuthConfig{
+				Auth: &config.RegistryAuthConfig{
 					Username:      "root",
 					Password:      "secret",
 					Auth:          "auth",
 					IdentityToken: "token",
 				},
-				TLS: &runtime.RegistryTLSConfig{
+				TLS: &config.RegistryTLSConfig{
 					InsecureSkipVerify: true,
 					CA:                 []byte("cacert"),
 					ClientIdentity: &x509.PEMEncodedCertificateAndKey{
@@ -66,7 +66,7 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 
 	files, err := containerd.GenerateRegistriesConfig(cfg)
 	suite.Require().NoError(err)
-	suite.Assert().Equal([]runtime.File{
+	suite.Assert().Equal([]config.File{
 		{
 			Content:     `cacert`,
 			Permissions: 0o600,

--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/retry"
 
 	"github.com/containerd/containerd"
@@ -17,7 +17,7 @@ import (
 
 // Pull is a convenience function that wraps the containerd image pull func with
 // retry functionality.
-func Pull(ctx context.Context, reg runtime.Registries, client *containerd.Client, ref string) (img containerd.Image, err error) {
+func Pull(ctx context.Context, reg config.Registries, client *containerd.Client, ref string) (img containerd.Image, err error) {
 	resolver := NewResolver(reg)
 
 	err = retry.Exponential(1*time.Minute, retry.WithUnits(1*time.Second)).Retry(func() error {

--- a/internal/pkg/containers/image/resolver.go
+++ b/internal/pkg/containers/image/resolver.go
@@ -17,18 +17,18 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"golang.org/x/net/http/httpproxy"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 )
 
 // NewResolver builds registry resolver based on Talos configuration.
-func NewResolver(reg runtime.Registries) remotes.Resolver {
+func NewResolver(reg config.Registries) remotes.Resolver {
 	return docker.NewResolver(docker.ResolverOptions{
 		Hosts: RegistryHosts(reg),
 	})
 }
 
 // RegistryHosts returns host configuration per registry.
-func RegistryHosts(reg runtime.Registries) docker.RegistryHosts {
+func RegistryHosts(reg config.Registries) docker.RegistryHosts {
 	return func(host string) ([]docker.RegistryHost, error) {
 		var registries []docker.RegistryHost
 
@@ -84,7 +84,7 @@ func RegistryHosts(reg runtime.Registries) docker.RegistryHosts {
 }
 
 // RegistryEndpoints returns registry endpoints per host using reg.
-func RegistryEndpoints(reg runtime.Registries, host string) ([]string, error) {
+func RegistryEndpoints(reg config.Registries, host string) ([]string, error) {
 	var endpoints []string
 
 	if hostConfig, ok := reg.Mirrors()[host]; ok {
@@ -111,7 +111,7 @@ func RegistryEndpoints(reg runtime.Registries, host string) ([]string, error) {
 }
 
 // PrepareAuth returns authentication info in the format expected by containerd.
-func PrepareAuth(auth *runtime.RegistryAuthConfig, host, expectedHost string) (string, string, error) {
+func PrepareAuth(auth *config.RegistryAuthConfig, host, expectedHost string) (string, string, error) {
 	if auth == nil {
 		return "", "", nil
 	}

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -13,8 +13,8 @@ import (
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/pkg/transport"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/configloader"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	"github.com/talos-systems/talos/pkg/kubernetes"
@@ -72,12 +72,12 @@ func NewClientFromControlPlaneIPs(ctx context.Context, creds *x509.PEMEncodedCer
 // ValidateForUpgrade validates the etcd cluster state to ensure that performing
 // an upgrade is safe.
 func ValidateForUpgrade(preserve bool) error {
-	config, err := config.NewFromFile(constants.ConfigPath)
+	config, err := configloader.NewFromFile(constants.ConfigPath)
 	if err != nil {
 		return err
 	}
 
-	if config.Machine().Type() != runtime.MachineTypeJoin {
+	if config.Machine().Type() != machine.TypeJoin {
 		client, err := NewClientFromControlPlaneIPs(context.TODO(), config.Cluster().CA(), config.Cluster().Endpoint())
 		if err != nil {
 			return err

--- a/internal/pkg/kubeconfig/admin.go
+++ b/internal/pkg/kubeconfig/admin.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
@@ -38,7 +38,7 @@ current-context: admin@{{ .Cluster }}
 `
 
 // GenerateAdmin generates admin kubeconfig for the cluster.
-func GenerateAdmin(config runtime.ClusterConfig, out io.Writer) error {
+func GenerateAdmin(config config.ClusterConfig, out io.Writer) error {
 	tpl, err := template.New("kubeconfig").Parse(adminKubeConfigTemplate)
 	if err != nil {
 		return fmt.Errorf("error parsing kubeconfig template: %w", err)

--- a/internal/pkg/provision/access/adapter.go
+++ b/internal/pkg/provision/access/adapter.go
@@ -5,9 +5,9 @@
 package access
 
 import (
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/internal/pkg/provision"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // Adapter provides cluster access via provision.Cluster.
@@ -32,7 +32,7 @@ func (wrapper *infoWrapper) Nodes() []string {
 	return nodes
 }
 
-func (wrapper *infoWrapper) NodesByType(t runtime.MachineType) []string {
+func (wrapper *infoWrapper) NodesByType(t machine.Type) []string {
 	var nodes []string
 
 	for _, node := range wrapper.clusterInfo.Nodes {

--- a/internal/pkg/provision/providers/docker/node.go
+++ b/internal/pkg/provision/providers/docker/node.go
@@ -19,8 +19,8 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/provision"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -110,7 +110,7 @@ func (p *provisioner) createNode(ctx context.Context, clusterReq provision.Clust
 
 	// Mutate the container configurations based on the node type.
 
-	if nodeReq.Config.Machine().Type() == runtime.MachineTypeInit || nodeReq.Config.Machine().Type() == runtime.MachineTypeControlPlane {
+	if nodeReq.Config.Machine().Type() == machine.TypeInit || nodeReq.Config.Machine().Type() == machine.TypeControlPlane {
 		portsToOpen := nodeReq.Ports
 
 		if len(options.DockerPorts) > 0 {

--- a/internal/pkg/provision/providers/docker/reflect.go
+++ b/internal/pkg/provision/providers/docker/reflect.go
@@ -9,8 +9,8 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/provision"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory string) (provision.Cluster, error) {
@@ -55,7 +55,7 @@ func (p *provisioner) Reflect(ctx context.Context, clusterName, stateDirectory s
 	}
 
 	for _, node := range nodes {
-		t, err := runtime.ParseMachineType(node.Labels["talos.type"])
+		t, err := machine.ParseType(node.Labels["talos.type"])
 		if err != nil {
 			return nil, err
 		}

--- a/internal/pkg/provision/providers/firecracker/firecracker.go
+++ b/internal/pkg/provision/providers/firecracker/firecracker.go
@@ -8,9 +8,9 @@ package firecracker
 import (
 	"context"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/provision"
 	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
@@ -58,7 +58,7 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 		}),
 		generate.WithNetworkConfig(&v1alpha1.NetworkConfig{
 			NameServers: nameservers,
-			NetworkInterfaces: []runtime.Device{
+			NetworkInterfaces: []config.Device{
 				{
 					Interface: "eth0",
 					CIDR:      "169.254.128.128/32", // link-local IP just to trigger the static networkd config

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // ClusterRequest is the root object describing cluster to be provisioned.
@@ -57,7 +58,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 	found := false
 
 	for i := range reqs {
-		if reqs[i].Config.Machine().Type() == runtime.MachineTypeInit {
+		if reqs[i].Config.Machine().Type() == machine.TypeInit {
 			if found {
 				err = fmt.Errorf("duplicate init node in requests")
 				return
@@ -78,7 +79,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 // MasterNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Config.Machine().Type() == runtime.MachineTypeInit || reqs[i].Config.Machine().Type() == runtime.MachineTypeControlPlane {
+		if reqs[i].Config.Machine().Type() == machine.TypeInit || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -89,7 +90,7 @@ func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 // WorkerNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Config.Machine().Type() == runtime.MachineTypeJoin {
+		if reqs[i].Config.Machine().Type() == machine.TypeJoin {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -101,7 +102,7 @@ func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 type NodeRequest struct {
 	Name   string
 	IP     net.IP
-	Config runtime.Configurator
+	Config config.Provider
 
 	// Share of CPUs, in 1e-9 fractions
 	NanoCPUs int64

--- a/internal/pkg/provision/result.go
+++ b/internal/pkg/provision/result.go
@@ -7,7 +7,7 @@ package provision
 import (
 	"net"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 // Cluster describes the provisioned Cluster.
@@ -40,7 +40,7 @@ type NetworkInfo struct {
 type NodeInfo struct {
 	ID   string
 	Name string
-	Type runtime.MachineType
+	Type machine.Type
 
 	// Share of CPUs, in 1e-9 fractions
 	NanoCPUs int64

--- a/pkg/config/bundle.go
+++ b/pkg/config/bundle.go
@@ -4,3 +4,13 @@
 
 // Package config provides methods to generate and consume Talos configuration.
 package config
+
+import "github.com/talos-systems/talos/pkg/client/config"
+
+// ProviderBundle defines the configuration bundle interface.
+type ProviderBundle interface {
+	Init() Provider
+	ControlPlane() Provider
+	Join() Provider
+	TalosConfig() *config.Config
+}

--- a/pkg/config/configloader/configloader.go
+++ b/pkg/config/configloader/configloader.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package configloader provides methods to load Talos config.
+package configloader
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+)
+
+// content represents the raw config data.
+//
+//docgen: nodoc
+type content struct {
+	Version string `yaml:"version"`
+
+	data []byte
+}
+
+// newConfig initializes and returns a Configurator.
+func newConfig(c content) (config config.Provider, err error) {
+	switch c.Version {
+	case v1alpha1.Version:
+		return v1alpha1.Load(c.data)
+	default:
+		return nil, fmt.Errorf("unknown version: %q", c.Version)
+	}
+}
+
+// NewFromFile will take a filepath and attempt to parse a config file from it.
+func NewFromFile(filepath string) (config.Provider, error) {
+	c, err := fromFile(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	return newConfig(c)
+}
+
+// NewFromBytes will take a byteslice and attempt to parse a config file from it.
+func NewFromBytes(in []byte) (config.Provider, error) {
+	c, err := fromBytes(in)
+	if err != nil {
+		return nil, err
+	}
+
+	return newConfig(c)
+}
+
+// fromFile is a convenience function that reads the config from disk, and
+// unmarshals it.
+func fromFile(p string) (c content, err error) {
+	b, err := ioutil.ReadFile(p)
+	if err != nil {
+		return c, fmt.Errorf("read config: %w", err)
+	}
+
+	return unmarshal(b)
+}
+
+// fromBytes is a convenience function that reads the config from a string, and
+// unmarshals it.
+func fromBytes(b []byte) (c content, err error) {
+	return unmarshal(b)
+}
+
+func unmarshal(b []byte) (c content, err error) {
+	c = content{
+		data: b,
+	}
+
+	if err = yaml.Unmarshal(b, &c); err != nil {
+		return c, fmt.Errorf("failed to parse config: %s", err.Error())
+	}
+
+	return c, nil
+}

--- a/pkg/config/configloader/configloader_test.go
+++ b/pkg/config/configloader/configloader_test.go
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //nolint: testpackage
-package config
+package configloader
 
 import (
 	"testing"
@@ -13,6 +13,7 @@ import (
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
+//docgen: nodoc
 type Suite struct {
 	suite.Suite
 }
@@ -25,11 +26,11 @@ func (suite *Suite) SetupSuite() {}
 
 func (suite *Suite) TestNew() {
 	for _, t := range []struct {
-		content     Content
+		content     content
 		errExpected bool
 	}{
-		{Content{Version: v1alpha1.Version}, false},
-		{Content{Version: ""}, true},
+		{content{Version: v1alpha1.Version}, false},
+		{content{Version: ""}, true},
 	} {
 		_, err := newConfig(t.content)
 

--- a/pkg/config/mode.go
+++ b/pkg/config/mode.go
@@ -2,5 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package config provides methods to generate and consume Talos configuration.
 package config
+
+import "fmt"
+
+// RuntimeMode abstracts current runtime mode.
+type RuntimeMode interface {
+	fmt.Stringer
+	RequiresInstall() bool
+}

--- a/pkg/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/config/types/v1alpha1/bundle/bundle.go
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package bundle
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+
+	clientconfig "github.com/talos-systems/talos/pkg/client/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
+)
+
+// NewConfigBundle returns a new bundle
+// nolint: gocyclo
+func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
+	options := DefaultOptions()
+
+	for _, opt := range opts {
+		if err := opt(&options); err != nil {
+			return nil, err
+		}
+	}
+
+	bundle := &v1alpha1.ConfigBundle{}
+
+	// Configs already exist, we'll pull them in.
+	if options.ExistingConfigs != "" {
+		if options.InputOptions != nil {
+			return bundle, fmt.Errorf("both existing config path and input options specified")
+		}
+
+		// Pull existing machine configs of each type
+		for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin} {
+			data, err := ioutil.ReadFile(filepath.Join(options.ExistingConfigs, strings.ToLower(configType.String())+".yaml"))
+			if err != nil {
+				return bundle, err
+			}
+
+			unmarshalledConfig := &v1alpha1.Config{}
+			if err := yaml.Unmarshal(data, unmarshalledConfig); err != nil {
+				return bundle, err
+			}
+
+			switch configType {
+			case machine.TypeInit:
+				bundle.InitCfg = unmarshalledConfig
+			case machine.TypeControlPlane:
+				bundle.ControlPlaneCfg = unmarshalledConfig
+			case machine.TypeJoin:
+				bundle.JoinCfg = unmarshalledConfig
+			}
+		}
+
+		// Pull existing talosconfig
+		talosConfig, err := ioutil.ReadFile(filepath.Join(options.ExistingConfigs, "talosconfig"))
+		if err != nil {
+			return bundle, err
+		}
+
+		bundle.TalosCfg = &clientconfig.Config{}
+		if err = yaml.Unmarshal(talosConfig, bundle.TalosCfg); err != nil {
+			return bundle, err
+		}
+
+		return bundle, nil
+	}
+
+	// Handle generating net-new configs
+	fmt.Println("generating PKI and tokens")
+
+	var input *generate.Input
+
+	input, err := generate.NewInput(
+		options.InputOptions.ClusterName,
+		options.InputOptions.Endpoint,
+		options.InputOptions.KubeVersion,
+		options.InputOptions.GenOptions...,
+	)
+	if err != nil {
+		return bundle, err
+	}
+
+	for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin} {
+		var generatedConfig *v1alpha1.Config
+
+		generatedConfig, err = generate.Config(configType, input)
+		if err != nil {
+			return bundle, err
+		}
+
+		switch configType {
+		case machine.TypeInit:
+			bundle.InitCfg = generatedConfig
+		case machine.TypeControlPlane:
+			bundle.ControlPlaneCfg = generatedConfig
+		case machine.TypeJoin:
+			bundle.JoinCfg = generatedConfig
+		}
+	}
+
+	bundle.TalosCfg, err = generate.Talosconfig(input, options.InputOptions.GenOptions...)
+	if err != nil {
+		return bundle, err
+	}
+
+	return bundle, nil
+}

--- a/pkg/config/types/v1alpha1/bundle/options.go
+++ b/pkg/config/types/v1alpha1/bundle/options.go
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package config
+package bundle
 
 import "github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 
-// BundleOption controls config options specific to config bundle generation.
-type BundleOption func(o *BundleOptions) error
+// Option controls config options specific to config bundle generation.
+type Option func(o *Options) error
 
 // InputOptions holds necessary params for generating an input.
 type InputOptions struct {
@@ -17,28 +17,28 @@ type InputOptions struct {
 	GenOptions  []generate.GenOption
 }
 
-// BundleOptions describes generate parameters.
-type BundleOptions struct {
+// Options describes generate parameters.
+type Options struct {
 	ExistingConfigs string // path to existing config files
 	InputOptions    *InputOptions
 }
 
-// DefaultBundleOptions returns default options.
-func DefaultBundleOptions() BundleOptions {
-	return BundleOptions{}
+// DefaultOptions returns default options.
+func DefaultOptions() Options {
+	return Options{}
 }
 
 // WithExistingConfigs sets the path to existing config files.
-func WithExistingConfigs(configPath string) BundleOption {
-	return func(o *BundleOptions) error {
+func WithExistingConfigs(configPath string) Option {
+	return func(o *Options) error {
 		o.ExistingConfigs = configPath
 		return nil
 	}
 }
 
 // WithInputOptions allows passing in of various params for net-new input generation.
-func WithInputOptions(inputOpts *InputOptions) BundleOption {
-	return func(o *BundleOptions) error {
+func WithInputOptions(inputOpts *InputOptions) Option {
+	return func(o *Options) error {
 		o.InputOptions = inputOpts
 		return nil
 	}

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -15,9 +15,10 @@ import (
 
 	stdlibx509 "crypto/x509"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/cis"
+	"github.com/talos-systems/talos/pkg/config"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 	tnet "github.com/talos-systems/talos/pkg/net"
@@ -25,17 +26,17 @@ import (
 
 // Config returns the talos config for a given node type.
 // nolint: gocyclo
-func Config(t runtime.MachineType, in *Input) (c *v1alpha1.Config, err error) {
+func Config(t machine.Type, in *Input) (c *v1alpha1.Config, err error) {
 	switch t {
-	case runtime.MachineTypeInit:
+	case machine.TypeInit:
 		if c, err = initUd(in); err != nil {
 			return c, err
 		}
-	case runtime.MachineTypeControlPlane:
+	case machine.TypeControlPlane:
 		if c, err = controlPlaneUd(in); err != nil {
 			return c, err
 		}
-	case runtime.MachineTypeJoin:
+	case machine.TypeJoin:
 		if c, err = workerUd(in); err != nil {
 			return c, err
 		}
@@ -78,7 +79,7 @@ type Input struct {
 	NetworkConfig *v1alpha1.NetworkConfig
 	CNIConfig     *v1alpha1.CNIConfig
 
-	RegistryMirrors map[string]runtime.RegistryMirrorConfig
+	RegistryMirrors map[string]config.RegistryMirrorConfig
 
 	Debug   bool
 	Persist bool

--- a/pkg/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/config/types/v1alpha1/generate/generate_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	genv1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -31,17 +31,17 @@ func (suite *GenerateSuite) SetupSuite() {
 }
 
 func (suite *GenerateSuite) TestGenerateInitSuccess() {
-	_, err := genv1alpha1.Config(runtime.MachineTypeInit, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeInit, suite.input)
 	suite.Require().NoError(err)
 }
 
 func (suite *GenerateSuite) TestGenerateControlPlaneSuccess() {
-	_, err := genv1alpha1.Config(runtime.MachineTypeControlPlane, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeControlPlane, suite.input)
 	suite.Require().NoError(err)
 }
 
 func (suite *GenerateSuite) TestGenerateWorkerSuccess() {
-	_, err := genv1alpha1.Config(runtime.MachineTypeJoin, suite.input)
+	_, err := genv1alpha1.Config(machine.TypeJoin, suite.input)
 	suite.Require().NoError(err)
 }
 

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -5,7 +5,7 @@
 package generate
 
 import (
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -70,10 +70,10 @@ func WithNetworkConfig(network *v1alpha1.NetworkConfig) GenOption {
 func WithRegistryMirror(host string, endpoints ...string) GenOption {
 	return func(o *GenOptions) error {
 		if o.RegistryMirrors == nil {
-			o.RegistryMirrors = make(map[string]runtime.RegistryMirrorConfig)
+			o.RegistryMirrors = make(map[string]config.RegistryMirrorConfig)
 		}
 
-		o.RegistryMirrors[host] = runtime.RegistryMirrorConfig{Endpoints: endpoints}
+		o.RegistryMirrors[host] = config.RegistryMirrorConfig{Endpoints: endpoints}
 
 		return nil
 	}
@@ -124,7 +124,7 @@ type GenOptions struct {
 	AdditionalSubjectAltNames []string
 	NetworkConfig             *v1alpha1.NetworkConfig
 	CNIConfig                 *v1alpha1.CNIConfig
-	RegistryMirrors           map[string]runtime.RegistryMirrorConfig
+	RegistryMirrors           map[string]config.RegistryMirrorConfig
 	DNSDomain                 string
 	Debug                     bool
 	Persist                   bool

--- a/pkg/config/types/v1alpha1/machine/machine.go
+++ b/pkg/config/types/v1alpha1/machine/machine.go
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package machine
+
+import "fmt"
+
+// Type represents a machine type.
+type Type int
+
+const (
+	// TypeInit represents a bootstrap node.
+	TypeInit Type = iota
+	// TypeControlPlane represents a control plane node.
+	TypeControlPlane
+	// TypeJoin represents a worker node.
+	TypeJoin
+)
+
+const (
+	typeInit         = "init"
+	typeControlPlane = "controlplane"
+	typeJoin         = "join"
+)
+
+// String returns the string representation of Type.
+func (t Type) String() string {
+	return [...]string{typeInit, typeControlPlane, typeJoin}[t]
+}
+
+// ParseType parses string constant as Type.
+func ParseType(t string) (Type, error) {
+	switch t {
+	case typeInit:
+		return TypeInit, nil
+	case typeControlPlane:
+		return TypeControlPlane, nil
+	case typeJoin:
+		return TypeJoin, nil
+	default:
+		return 0, fmt.Errorf("unknown machine type: %q", t)
+	}
+}

--- a/pkg/config/types/v1alpha1/machine/machine_test.go
+++ b/pkg/config/types/v1alpha1/machine/machine_test.go
@@ -2,35 +2,35 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// nolint: scopelint,dupl
-package runtime_test
+//nolint: scopelint
+package machine_test
 
 import (
 	"reflect"
 	"testing"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 )
 
 func TestMachineType_String(t *testing.T) {
 	tests := []struct {
 		name string
-		t    runtime.MachineType
+		t    machine.Type
 		want string
 	}{
 		{
 			name: "init",
-			t:    runtime.MachineTypeInit,
+			t:    machine.TypeInit,
 			want: "init",
 		},
 		{
 			name: "controlplane",
-			t:    runtime.MachineTypeControlPlane,
+			t:    machine.TypeControlPlane,
 			want: "controlplane",
 		},
 		{
 			name: "join",
-			t:    runtime.MachineTypeJoin,
+			t:    machine.TypeJoin,
 			want: "join",
 		},
 	}
@@ -52,25 +52,25 @@ func TestParseMachineType(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    runtime.MachineType
+		want    machine.Type
 		wantErr bool
 	}{
 		{
 			name:    "init",
 			args:    args{"init"},
-			want:    runtime.MachineTypeInit,
+			want:    machine.TypeInit,
 			wantErr: false,
 		},
 		{
 			name:    "controlplane",
 			args:    args{"controlplane"},
-			want:    runtime.MachineTypeControlPlane,
+			want:    machine.TypeControlPlane,
 			wantErr: false,
 		},
 		{
 			name:    "join",
 			args:    args{"join"},
-			want:    runtime.MachineTypeJoin,
+			want:    machine.TypeJoin,
 			wantErr: false,
 		},
 		{
@@ -83,7 +83,7 @@ func TestParseMachineType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := runtime.ParseMachineType(tt.args.t)
+			got, err := machine.ParseType(tt.args.t)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseMachineType() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/config/types/v1alpha1/v1alpha1_configurator_bundle.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_configurator_bundle.go
@@ -5,8 +5,8 @@
 package v1alpha1
 
 import (
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/client/config"
+	clientconfig "github.com/talos-systems/talos/pkg/client/config"
+	"github.com/talos-systems/talos/pkg/config"
 )
 
 // ConfigBundle defines the group of v1alpha1 config files.
@@ -15,25 +15,25 @@ type ConfigBundle struct {
 	InitCfg         *Config
 	ControlPlaneCfg *Config
 	JoinCfg         *Config
-	TalosCfg        *config.Config
+	TalosCfg        *clientconfig.Config
 }
 
 // Init implements the ConfiguratorBundle interface.
-func (c *ConfigBundle) Init() runtime.Configurator {
+func (c *ConfigBundle) Init() config.Provider {
 	return c.InitCfg
 }
 
 // ControlPlane implements the ConfiguratorBundle interface.
-func (c *ConfigBundle) ControlPlane() runtime.Configurator {
+func (c *ConfigBundle) ControlPlane() config.Provider {
 	return c.ControlPlaneCfg
 }
 
 // Join implements the ConfiguratorBundle interface.
-func (c *ConfigBundle) Join() runtime.Configurator {
+func (c *ConfigBundle) Join() config.Provider {
 	return c.JoinCfg
 }
 
 // TalosConfig implements the ConfiguratorBundle interface.
-func (c *ConfigBundle) TalosConfig() *config.Config {
+func (c *ConfigBundle) TalosConfig() *clientconfig.Config {
 	return c.TalosCfg
 }

--- a/pkg/config/types/v1alpha1/v1alpha1_loader.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_loader.go
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Load config version v1alpha1.
+func Load(data []byte) (config *Config, err error) {
+	config = &Config{}
+	if err = yaml.Unmarshal(data, config); err != nil {
+		return config, fmt.Errorf("failed to parse v1alpha1 config: %w", err)
+	}
+
+	return config, nil
+}

--- a/pkg/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_provider.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/talos-systems/bootkube-plugin/pkg/asset"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	criplugin "github.com/talos-systems/talos/internal/pkg/containers/cri/containerd"
+	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
@@ -27,32 +28,32 @@ const (
 	Version = "v1alpha1"
 )
 
-// Version implements the Configurator interface.
+// Version implements the config.Provider interface.
 func (c *Config) Version() string {
 	return Version
 }
 
-// Debug implements the Configurator interface.
+// Debug implements the config.Provider interface.
 func (c *Config) Debug() bool {
 	return c.ConfigDebug
 }
 
-// Persist implements the Configurator interface.
+// Persist implements the config.Provider interface.
 func (c *Config) Persist() bool {
 	return c.ConfigPersist
 }
 
-// Machine implements the Configurator interface.
-func (c *Config) Machine() runtime.MachineConfig {
+// Machine implements the config.Provider interface.
+func (c *Config) Machine() config.MachineConfig {
 	return c.MachineConfig
 }
 
-// Cluster implements the Configurator interface.
-func (c *Config) Cluster() runtime.ClusterConfig {
+// Cluster implements the config.Provider interface.
+func (c *Config) Cluster() config.ClusterConfig {
 	return c.ClusterConfig
 }
 
-// String implements the Configurator interface.
+// String implements the config.Provider interface.
 func (c *Config) String() (string, error) {
 	b, err := c.Bytes()
 	if err != nil {
@@ -62,7 +63,7 @@ func (c *Config) String() (string, error) {
 	return string(b), nil
 }
 
-// Bytes implements the Configurator interface.
+// Bytes implements the config.Provider interface.
 func (c *Config) Bytes() ([]byte, error) {
 	b, err := yaml.Marshal(c)
 	if err != nil {
@@ -72,8 +73,8 @@ func (c *Config) Bytes() ([]byte, error) {
 	return b, nil
 }
 
-// Install implements the Configurator interface.
-func (m *MachineConfig) Install() runtime.Install {
+// Install implements the config.Provider interface.
+func (m *MachineConfig) Install() config.Install {
 	if m.MachineInstall == nil {
 		return &InstallConfig{}
 	}
@@ -81,18 +82,18 @@ func (m *MachineConfig) Install() runtime.Install {
 	return m.MachineInstall
 }
 
-// Security implements the Configurator interface.
-func (m *MachineConfig) Security() runtime.Security {
+// Security implements the config.Provider interface.
+func (m *MachineConfig) Security() config.Security {
 	return m
 }
 
-// Disks implements the Configurator interface.
-func (m *MachineConfig) Disks() []runtime.Disk {
+// Disks implements the config.Provider interface.
+func (m *MachineConfig) Disks() []config.Disk {
 	return m.MachineDisks
 }
 
-// Network implements the Configurator interface.
-func (m *MachineConfig) Network() runtime.MachineNetwork {
+// Network implements the config.Provider interface.
+func (m *MachineConfig) Network() config.MachineNetwork {
 	if m.MachineNetwork == nil {
 		return &NetworkConfig{}
 	}
@@ -100,8 +101,8 @@ func (m *MachineConfig) Network() runtime.MachineNetwork {
 	return m.MachineNetwork
 }
 
-// Time implements the Configurator interface.
-func (m *MachineConfig) Time() runtime.Time {
+// Time implements the config.Provider interface.
+func (m *MachineConfig) Time() config.Time {
 	if m.MachineTime == nil {
 		return &TimeConfig{}
 	}
@@ -109,41 +110,41 @@ func (m *MachineConfig) Time() runtime.Time {
 	return m.MachineTime
 }
 
-// Kubelet implements the Configurator interface.
-func (m *MachineConfig) Kubelet() runtime.Kubelet {
+// Kubelet implements the config.Provider interface.
+func (m *MachineConfig) Kubelet() config.Kubelet {
 	return m.MachineKubelet
 }
 
-// Env implements the Configurator interface.
-func (m *MachineConfig) Env() runtime.Env {
+// Env implements the config.Provider interface.
+func (m *MachineConfig) Env() config.Env {
 	return m.MachineEnv
 }
 
-// Files implements the Configurator interface.
-func (m *MachineConfig) Files() ([]runtime.File, error) {
+// Files implements the config.Provider interface.
+func (m *MachineConfig) Files() ([]config.File, error) {
 	files, err := m.Registries().ExtraFiles()
 
 	return append(files, m.MachineFiles...), err
 }
 
-// Type implements the Configurator interface.
-func (m *MachineConfig) Type() runtime.MachineType {
+// Type implements the config.Provider interface.
+func (m *MachineConfig) Type() machine.Type {
 	switch m.MachineType {
 	case "init":
-		return runtime.MachineTypeInit
+		return machine.TypeInit
 	case "controlplane":
-		return runtime.MachineTypeControlPlane
+		return machine.TypeControlPlane
 	default:
-		return runtime.MachineTypeJoin
+		return machine.TypeJoin
 	}
 }
 
-// Server implements the Configurator interface.
+// Server implements the config.Provider interface.
 func (m *MachineConfig) Server() string {
 	return ""
 }
 
-// Sysctls implements the Configurator interface.
+// Sysctls implements the config.Provider interface.
 func (m *MachineConfig) Sysctls() map[string]string {
 	if m.MachineSysctls == nil {
 		m.MachineSysctls = make(map[string]string)
@@ -152,32 +153,32 @@ func (m *MachineConfig) Sysctls() map[string]string {
 	return m.MachineSysctls
 }
 
-// CA implements the Configurator interface.
+// CA implements the config.Provider interface.
 func (m *MachineConfig) CA() *x509.PEMEncodedCertificateAndKey {
 	return m.MachineCA
 }
 
-// Token implements the Configurator interface.
+// Token implements the config.Provider interface.
 func (m *MachineConfig) Token() string {
 	return m.MachineToken
 }
 
-// CertSANs implements the Configurator interface.
+// CertSANs implements the config.Provider interface.
 func (m *MachineConfig) CertSANs() []string {
 	return m.MachineCertSANs
 }
 
-// SetCertSANs implements the Configurator interface.
+// SetCertSANs implements the config.Provider interface.
 func (m *MachineConfig) SetCertSANs(sans []string) {
 	m.MachineCertSANs = append(m.MachineCertSANs, sans...)
 }
 
-// Registries implements the Configurator interface.
-func (m *MachineConfig) Registries() runtime.Registries {
+// Registries implements the config.Provider interface.
+func (m *MachineConfig) Registries() config.Registries {
 	return &m.MachineRegistries
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (k *KubeletConfig) Image() string {
 	image := k.KubeletImage
 
@@ -188,7 +189,7 @@ func (k *KubeletConfig) Image() string {
 	return image
 }
 
-// ExtraArgs implements the Configurator interface.
+// ExtraArgs implements the config.Provider interface.
 func (k *KubeletConfig) ExtraArgs() map[string]string {
 	if k == nil {
 		k = &KubeletConfig{}
@@ -201,22 +202,22 @@ func (k *KubeletConfig) ExtraArgs() map[string]string {
 	return k.KubeletExtraArgs
 }
 
-// ExtraMounts implements the Configurator interface.
+// ExtraMounts implements the config.Provider interface.
 func (k *KubeletConfig) ExtraMounts() []specs.Mount {
 	return k.KubeletExtraMounts
 }
 
-// Name implements the Configurator interface.
+// Name implements the config.Provider interface.
 func (c *ClusterConfig) Name() string {
 	return c.ClusterName
 }
 
-// Endpoint implements the Configurator interface.
+// Endpoint implements the config.Provider interface.
 func (c *ClusterConfig) Endpoint() *url.URL {
 	return c.ControlPlane.Endpoint.URL
 }
 
-// LocalAPIServerPort implements the Configurator interface.
+// LocalAPIServerPort implements the config.Provider interface.
 func (c *ClusterConfig) LocalAPIServerPort() int {
 	if c.ControlPlane.LocalAPIServerPort == 0 {
 		return 6443
@@ -225,12 +226,12 @@ func (c *ClusterConfig) LocalAPIServerPort() int {
 	return c.ControlPlane.LocalAPIServerPort
 }
 
-// CertSANs implements the Configurator interface.
+// CertSANs implements the config.Provider interface.
 func (c *ClusterConfig) CertSANs() []string {
 	return c.APIServerConfig.CertSANs
 }
 
-// SetCertSANs implements the Configurator interface.
+// SetCertSANs implements the config.Provider interface.
 func (c *ClusterConfig) SetCertSANs(sans []string) {
 	if c.APIServerConfig == nil {
 		c.APIServerConfig = &APIServerConfig{}
@@ -239,23 +240,23 @@ func (c *ClusterConfig) SetCertSANs(sans []string) {
 	c.APIServerConfig.CertSANs = append(c.APIServerConfig.CertSANs, sans...)
 }
 
-// CA implements the Configurator interface.
+// CA implements the config.Provider interface.
 func (c *ClusterConfig) CA() *x509.PEMEncodedCertificateAndKey {
 	return c.ClusterCA
 }
 
-// AESCBCEncryptionSecret implements the Configurator interface.
+// AESCBCEncryptionSecret implements the config.Provider interface.
 func (c *ClusterConfig) AESCBCEncryptionSecret() string {
 	return c.ClusterAESCBCEncryptionSecret
 }
 
-// Config implements the Configurator interface.
-func (c *ClusterConfig) Config(t runtime.MachineType) (string, error) {
+// Config implements the config.Provider interface.
+func (c *ClusterConfig) Config(t machine.Type) (string, error) {
 	return "", nil
 }
 
-// APIServer implements the Configurator interface.
-func (c *ClusterConfig) APIServer() runtime.APIServer {
+// APIServer implements the config.Provider interface.
+func (c *ClusterConfig) APIServer() config.APIServer {
 	if c.APIServerConfig == nil {
 		return &APIServerConfig{}
 	}
@@ -263,7 +264,7 @@ func (c *ClusterConfig) APIServer() runtime.APIServer {
 	return c.APIServerConfig
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (a *APIServerConfig) Image() string {
 	image := a.ContainerImage
 
@@ -274,13 +275,13 @@ func (a *APIServerConfig) Image() string {
 	return image
 }
 
-// ExtraArgs implements the Configurator interface.
+// ExtraArgs implements the config.Provider interface.
 func (a *APIServerConfig) ExtraArgs() map[string]string {
 	return a.ExtraArgsConfig
 }
 
-// ControllerManager implements the Configurator interface.
-func (c *ClusterConfig) ControllerManager() runtime.ControllerManager {
+// ControllerManager implements the config.Provider interface.
+func (c *ClusterConfig) ControllerManager() config.ControllerManager {
 	if c.ControllerManagerConfig == nil {
 		return &ControllerManagerConfig{}
 	}
@@ -288,7 +289,7 @@ func (c *ClusterConfig) ControllerManager() runtime.ControllerManager {
 	return c.ControllerManagerConfig
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (c *ControllerManagerConfig) Image() string {
 	image := c.ContainerImage
 
@@ -299,13 +300,13 @@ func (c *ControllerManagerConfig) Image() string {
 	return image
 }
 
-// ExtraArgs implements the Configurator interface.
+// ExtraArgs implements the config.Provider interface.
 func (c *ControllerManagerConfig) ExtraArgs() map[string]string {
 	return c.ExtraArgsConfig
 }
 
-// Proxy implements the Configurator interface.
-func (c *ClusterConfig) Proxy() runtime.Proxy {
+// Proxy implements the config.Provider interface.
+func (c *ClusterConfig) Proxy() config.Proxy {
 	if c.ProxyConfig == nil {
 		return &ProxyConfig{}
 	}
@@ -313,7 +314,7 @@ func (c *ClusterConfig) Proxy() runtime.Proxy {
 	return c.ProxyConfig
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (p *ProxyConfig) Image() string {
 	image := p.ContainerImage
 
@@ -338,8 +339,8 @@ func (p *ProxyConfig) ExtraArgs() map[string]string {
 	return p.ExtraArgsConfig
 }
 
-// Scheduler implements the Configurator interface.
-func (c *ClusterConfig) Scheduler() runtime.Scheduler {
+// Scheduler implements the config.Provider interface.
+func (c *ClusterConfig) Scheduler() config.Scheduler {
 	if c.SchedulerConfig == nil {
 		return &SchedulerConfig{}
 	}
@@ -347,12 +348,12 @@ func (c *ClusterConfig) Scheduler() runtime.Scheduler {
 	return c.SchedulerConfig
 }
 
-// AdminKubeconfig implements the Configurator interface.
-func (c *ClusterConfig) AdminKubeconfig() runtime.AdminKubeconfig {
+// AdminKubeconfig implements the config.Provider interface.
+func (c *ClusterConfig) AdminKubeconfig() config.AdminKubeconfig {
 	return c.AdminKubeconfigConfig
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (s *SchedulerConfig) Image() string {
 	image := s.ContainerImage
 
@@ -363,17 +364,17 @@ func (s *SchedulerConfig) Image() string {
 	return image
 }
 
-// ExtraArgs implements the Configurator interface.
+// ExtraArgs implements the config.Provider interface.
 func (s *SchedulerConfig) ExtraArgs() map[string]string {
 	return s.ExtraArgsConfig
 }
 
-// Etcd implements the Configurator interface.
-func (c *ClusterConfig) Etcd() runtime.Etcd {
+// Etcd implements the config.Provider interface.
+func (c *ClusterConfig) Etcd() config.Etcd {
 	return c.EtcdConfig
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (e *EtcdConfig) Image() string {
 	image := e.ContainerImage
 	suffix := ""
@@ -389,12 +390,12 @@ func (e *EtcdConfig) Image() string {
 	return image
 }
 
-// CA implements the Configurator interface.
+// CA implements the config.Provider interface.
 func (e *EtcdConfig) CA() *x509.PEMEncodedCertificateAndKey {
 	return e.RootCA
 }
 
-// ExtraArgs implements the Configurator interface.
+// ExtraArgs implements the config.Provider interface.
 func (e *EtcdConfig) ExtraArgs() map[string]string {
 	if e.EtcdExtraArgs == nil {
 		e.EtcdExtraArgs = make(map[string]string)
@@ -404,26 +405,26 @@ func (e *EtcdConfig) ExtraArgs() map[string]string {
 }
 
 // Mirrors implements the Registries interface.
-func (r *RegistriesConfig) Mirrors() map[string]runtime.RegistryMirrorConfig {
+func (r *RegistriesConfig) Mirrors() map[string]config.RegistryMirrorConfig {
 	return r.RegistryMirrors
 }
 
 // Config implements the Registries interface.
-func (r *RegistriesConfig) Config() map[string]runtime.RegistryConfig {
+func (r *RegistriesConfig) Config() map[string]config.RegistryConfig {
 	return r.RegistryConfig
 }
 
 // ExtraFiles implements the Registries interface.
-func (r *RegistriesConfig) ExtraFiles() ([]runtime.File, error) {
+func (r *RegistriesConfig) ExtraFiles() ([]config.File, error) {
 	return criplugin.GenerateRegistriesConfig(r)
 }
 
-// Token implements the Configurator interface.
-func (c *ClusterConfig) Token() runtime.Token {
+// Token implements the config.Provider interface.
+func (c *ClusterConfig) Token() config.Token {
 	return c
 }
 
-// ID implements the Configurator interface.
+// ID implements the config.Provider interface.
 func (c *ClusterConfig) ID() string {
 	parts := strings.Split(c.BootstrapToken, ".")
 	if len(parts) != 2 {
@@ -433,7 +434,7 @@ func (c *ClusterConfig) ID() string {
 	return parts[0]
 }
 
-// Secret implements the Configurator interface.
+// Secret implements the config.Provider interface.
 func (c *ClusterConfig) Secret() string {
 	parts := strings.Split(c.BootstrapToken, ".")
 	if len(parts) != 2 {
@@ -443,12 +444,12 @@ func (c *ClusterConfig) Secret() string {
 	return parts[1]
 }
 
-// Network implements the Configurator interface.
-func (c *ClusterConfig) Network() runtime.ClusterNetwork {
+// Network implements the config.Provider interface.
+func (c *ClusterConfig) Network() config.ClusterNetwork {
 	return c
 }
 
-// DNSDomain implements the Configurator interface.
+// DNSDomain implements the config.Provider interface.
 func (c *ClusterConfig) DNSDomain() string {
 	if c.ClusterNetwork == nil {
 		return constants.DefaultDNSDomain
@@ -457,8 +458,8 @@ func (c *ClusterConfig) DNSDomain() string {
 	return c.ClusterNetwork.DNSDomain
 }
 
-// CNI implements the Configurator interface.
-func (c *ClusterConfig) CNI() runtime.CNI {
+// CNI implements the config.Provider interface.
+func (c *ClusterConfig) CNI() config.CNI {
 	switch {
 	case c.ClusterNetwork == nil:
 		fallthrough
@@ -472,7 +473,7 @@ func (c *ClusterConfig) CNI() runtime.CNI {
 	return c.ClusterNetwork.CNI
 }
 
-// PodCIDR implements the Configurator interface.
+// PodCIDR implements the config.Provider interface.
 func (c *ClusterConfig) PodCIDR() string {
 	switch {
 	case c.ClusterNetwork == nil:
@@ -484,7 +485,7 @@ func (c *ClusterConfig) PodCIDR() string {
 	return strings.Join(c.ClusterNetwork.PodSubnet, ",")
 }
 
-// ServiceCIDR implements the Configurator interface.
+// ServiceCIDR implements the config.Provider interface.
 func (c *ClusterConfig) ServiceCIDR() string {
 	switch {
 	case c.ClusterNetwork == nil:
@@ -496,18 +497,18 @@ func (c *ClusterConfig) ServiceCIDR() string {
 	return strings.Join(c.ClusterNetwork.ServiceSubnet, ",")
 }
 
-// ExtraManifestURLs implements the Configurator interface.
+// ExtraManifestURLs implements the config.Provider interface.
 func (c *ClusterConfig) ExtraManifestURLs() []string {
 	return c.ExtraManifests
 }
 
-// ExtraManifestHeaderMap implements the Configurator interface.
+// ExtraManifestHeaderMap implements the config.Provider interface.
 func (c *ClusterConfig) ExtraManifestHeaderMap() map[string]string {
 	return c.ExtraManifestHeaders
 }
 
-// PodCheckpointer implements the Configurator interface.
-func (c *ClusterConfig) PodCheckpointer() runtime.PodCheckpointer {
+// PodCheckpointer implements the config.Provider interface.
+func (c *ClusterConfig) PodCheckpointer() config.PodCheckpointer {
 	if c.PodCheckpointerConfig == nil {
 		return &PodCheckpointer{}
 	}
@@ -515,8 +516,8 @@ func (c *ClusterConfig) PodCheckpointer() runtime.PodCheckpointer {
 	return c.PodCheckpointerConfig
 }
 
-// CoreDNS implements the Configurator interface.
-func (c *ClusterConfig) CoreDNS() runtime.CoreDNS {
+// CoreDNS implements the config.Provider interface.
+func (c *ClusterConfig) CoreDNS() config.CoreDNS {
 	if c.CoreDNSConfig == nil {
 		return &CoreDNS{}
 	}
@@ -524,77 +525,77 @@ func (c *ClusterConfig) CoreDNS() runtime.CoreDNS {
 	return c.CoreDNSConfig
 }
 
-// Name implements the Configurator interface.
+// Name implements the config.Provider interface.
 func (c *CNIConfig) Name() string {
 	return c.CNIName
 }
 
-// URLs implements the Configurator interface.
+// URLs implements the config.Provider interface.
 func (c *CNIConfig) URLs() []string {
 	return c.CNIUrls
 }
 
-// Hostname implements the Configurator interface.
+// Hostname implements the config.Provider interface.
 func (n *NetworkConfig) Hostname() string {
 	return n.NetworkHostname
 }
 
-// SetHostname implements the Configurator interface.
+// SetHostname implements the config.Provider interface.
 func (n *NetworkConfig) SetHostname(hostname string) {
 	n.NetworkHostname = hostname
 }
 
-// Devices implements the Configurator interface.
-func (n *NetworkConfig) Devices() []runtime.Device {
+// Devices implements the config.Provider interface.
+func (n *NetworkConfig) Devices() []config.Device {
 	return n.NetworkInterfaces
 }
 
-// Resolvers implements the Configurator interface.
+// Resolvers implements the config.Provider interface.
 func (n *NetworkConfig) Resolvers() []string {
 	return n.NameServers
 }
 
-// ExtraHosts implements the Configurator interface.
-func (n *NetworkConfig) ExtraHosts() []runtime.ExtraHost {
+// ExtraHosts implements the config.Provider interface.
+func (n *NetworkConfig) ExtraHosts() []config.ExtraHost {
 	return n.ExtraHostEntries
 }
 
-// Servers implements the Configurator interface.
+// Servers implements the config.Provider interface.
 func (t *TimeConfig) Servers() []string {
 	return t.TimeServers
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (i *InstallConfig) Image() string {
 	return i.InstallImage
 }
 
-// Disk implements the Configurator interface.
+// Disk implements the config.Provider interface.
 func (i *InstallConfig) Disk() string {
 	return i.InstallDisk
 }
 
-// ExtraKernelArgs implements the Configurator interface.
+// ExtraKernelArgs implements the config.Provider interface.
 func (i *InstallConfig) ExtraKernelArgs() []string {
 	return i.InstallExtraKernelArgs
 }
 
-// Zero implements the Configurator interface.
+// Zero implements the config.Provider interface.
 func (i *InstallConfig) Zero() bool {
 	return i.InstallWipe
 }
 
-// Force implements the Configurator interface.
+// Force implements the config.Provider interface.
 func (i *InstallConfig) Force() bool {
 	return i.InstallForce
 }
 
-// WithBootloader implements the Configurator interface.
+// WithBootloader implements the config.Provider interface.
 func (i *InstallConfig) WithBootloader() bool {
 	return i.InstallBootloader
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (c *CoreDNS) Image() string {
 	coreDNSImage := asset.DefaultImages.CoreDNS
 
@@ -605,7 +606,7 @@ func (c *CoreDNS) Image() string {
 	return coreDNSImage
 }
 
-// Image implements the Configurator interface.
+// Image implements the config.Provider interface.
 func (p *PodCheckpointer) Image() string {
 	checkpointerImage := constants.PodCheckpointerImage
 
@@ -616,7 +617,7 @@ func (p *PodCheckpointer) Image() string {
 	return checkpointerImage
 }
 
-// CertLifetime implements the Configurator interface.
+// CertLifetime implements the config.Provider interface.
 func (a AdminKubeconfigConfig) CertLifetime() time.Duration {
 	if a.AdminKubeconfigCertLifetime == 0 {
 		return constants.KubernetesAdminCertDefaultLifetime

--- a/pkg/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/config/types/v1alpha1/v1alpha1_types.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
 )
 
@@ -130,7 +130,7 @@ type MachineConfig struct {
 	//             - mountpoint: /var/lib/extra
 	//               size: 10000000000
 	//
-	MachineDisks []runtime.Disk `yaml:"disks,omitempty"` // Note: `size` is in units of bytes.
+	MachineDisks []config.Disk `yaml:"disks,omitempty"` // Note: `size` is in units of bytes.
 	//   description: |
 	//     Used to provide instructions for bare-metal installations.
 	//   examples:
@@ -159,7 +159,7 @@ type MachineConfig struct {
 	//           permissions: 0666
 	//           path: /tmp/file.txt
 	//           op: append
-	MachineFiles []runtime.File `yaml:"files,omitempty"` // Note: The specified `path` is relative to `/var`.
+	MachineFiles []config.File `yaml:"files,omitempty"` // Note: The specified `path` is relative to `/var`.
 	//   description: |
 	//     The `env` field allows for the addition of environment variables to a machine.
 	//     All environment variables are set on the machine in addition to every service.
@@ -182,7 +182,7 @@ type MachineConfig struct {
 	//     - |
 	//       env:
 	//         https_proxy: http://DOMAIN\\USERNAME:PASSWORD@SERVER:PORT/
-	MachineEnv runtime.Env `yaml:"env,omitempty"`
+	MachineEnv config.Env `yaml:"env,omitempty"`
 	//   description: |
 	//     Used to configure the machine's time settings.
 	//   examples:
@@ -449,7 +449,7 @@ type NetworkConfig struct {
 	//     This parameter is optional.
 	//
 	//     Routes can be repeated and includes a `Network` and `Gateway` field.
-	NetworkInterfaces []runtime.Device `yaml:"interfaces,omitempty"`
+	NetworkInterfaces []config.Device `yaml:"interfaces,omitempty"`
 	//   description: |
 	//     Used to statically set the nameservers for the host.
 	//     Defaults to `1.1.1.1` and `8.8.8.8`
@@ -463,7 +463,7 @@ type NetworkConfig struct {
 	//           aliases:
 	//             - test
 	//             - test.domain.tld
-	ExtraHostEntries []runtime.ExtraHost `yaml:"extraHostEntries,omitempty"`
+	ExtraHostEntries []config.ExtraHost `yaml:"extraHostEntries,omitempty"`
 }
 
 // InstallConfig represents the installation options for preparing a node.
@@ -534,14 +534,14 @@ type RegistriesConfig struct {
 	//     Registry name is the first segment of image identifier, with 'docker.io'
 	//     being default one.
 	//     Name '*' catches any registry names not specified explicitly.
-	RegistryMirrors map[string]runtime.RegistryMirrorConfig `yaml:"mirrors,omitempty"`
+	RegistryMirrors map[string]config.RegistryMirrorConfig `yaml:"mirrors,omitempty"`
 	//   description: |
 	//     Specifies TLS & auth configuration for HTTPS image registries.
 	//     Mutual TLS can be enabled with 'clientIdentity' option.
 	//
 	//     TLS configuration can be skipped if registry has trusted
 	//     server certificate.
-	RegistryConfig map[string]runtime.RegistryConfig `yaml:"config,omitempty"`
+	RegistryConfig map[string]config.RegistryConfig `yaml:"config,omitempty"`
 }
 
 // PodCheckpointer represents the pod-checkpointer config values.


### PR DESCRIPTION
This makes `pkg/config` directly importable from other projects.

There should be no functional changes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2368)
<!-- Reviewable:end -->
