### PR TITLE
test: update qemu/firecracker provisioners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ provision-tests-track-%:
 # Assets for releases
 
 .PHONY: $(ARTIFACTS)/$(TALOS_RELEASE)
-$(ARTIFACTS)/$(TALOS_RELEASE): $(ARTIFACTS)/$(TALOS_RELEASE)/vmlinux $(ARTIFACTS)/$(TALOS_RELEASE)/initramfs.xz
+$(ARTIFACTS)/$(TALOS_RELEASE): $(ARTIFACTS)/$(TALOS_RELEASE)/vmlinuz $(ARTIFACTS)/$(TALOS_RELEASE)/initramfs.xz
 
 # download release artifacts for specific version
 $(ARTIFACTS)/$(TALOS_RELEASE)/%:

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -14,10 +14,11 @@ talosctl cluster create [flags]
 ### Options
 
 ```
-      --cidr string                 CIDR of the docker bridge network (default "10.5.0.0/24")
-      --cni-bin-path strings        search path for CNI binaries (firecracker only) (default [/opt/cni/bin])
-      --cni-cache-dir string        CNI cache directory path (firecracker only) (default "/var/lib/cni")
-      --cni-conf-dir string         CNI config directory path (firecracker only) (default "/etc/cni/conf.d")
+      --arch string                 cluster architecture (default "amd64")
+      --cidr string                 CIDR of the cluster network (default "10.5.0.0/24")
+      --cni-bin-path strings        search path for CNI binaries (VM only) (default [/opt/cni/bin])
+      --cni-cache-dir string        CNI cache directory path (VM only) (default "/var/lib/cni")
+      --cni-conf-dir string         CNI config directory path (VM only) (default "/etc/cni/conf.d")
       --cpus string                 the share of CPUs as fraction (each container) (default "1.5")
       --crashdump                   print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string       install custom CNI from the URL (Talos cluster)
@@ -35,14 +36,13 @@ talosctl cluster create [flags]
       --kubernetes-version string   desired kubernetes version to run (default "1.19.0-rc.3")
       --masters int                 the number of masters to create (default 1)
       --memory int                  the limit on memory usage in MB (each container) (default 1024)
-      --mtu int                     MTU of the docker bridge network (default 1500)
+      --mtu int                     MTU of the cluster network (default 1500)
       --nameservers strings         list of nameservers to use (default [8.8.8.8,1.1.1.1])
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
-      --vmlinux-path string         the uncompressed kernel image to use (default "_out/vmlinux")
       --vmlinuz-path string         the compressed kernel image to use (default "_out/vmlinuz")
       --wait                        wait for the cluster to be ready before returning (default true)
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
-      --with-bootloader-emulation   enable bootloader emulation to load kernel and initramfs from disk image
+      --with-bootloader             enable bootloader to load kernel and initramfs from disk image after install (default true)
       --with-debug                  enable debug in Talos config to send service logs to the console
       --with-init-node              create the cluster with an init node (default true)
       --workers int                 the number of workers to create (default 1)

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -11,13 +11,13 @@ case "${CI:-false}" in
   true)
     REGISTRY="127.0.0.1:5000"
     REGISTRY_ADDR=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' registry`
-    FIRECRACKER_FLAGS="--registry-mirror ${REGISTRY}=http://${REGISTRY_ADDR}:5000 --with-bootloader-emulation"
+    FIRECRACKER_FLAGS="--registry-mirror ${REGISTRY}=http://${REGISTRY_ADDR}:5000"
     INSTALLER_TAG="${TAG}"
     docker tag ${INSTALLER_IMAGE} 127.0.0.1:5000/autonomy/installer:"${TAG}"
     docker push 127.0.0.1:5000/autonomy/installer:"${TAG}"
     ;;
   *)
-    FIRECRACKER_FLAGS=
+    FIRECRACKER_FLAGS="--with-bootloader=false"
     INSTALLER_TAG="latest"
     ;;
 esac

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -17,7 +17,7 @@ case "${CI:-false}" in
     docker push 127.0.0.1:5000/autonomy/installer:"${TAG}"
     ;;
   *)
-    QEMU_FLAGS=
+    QEMU_FLAGS="--with-bootloader=false"
     INSTALLER_TAG="latest"
     ;;
 esac

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -156,6 +156,7 @@ function run_worker_cis_benchmark {
 }
 
 function get_kubeconfig {
+  rm -f "${TMP}/kubeconfig"
   "${TALOSCTL}" kubeconfig "${TMP}"
 }
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -80,7 +80,7 @@ func upgradeBetweenTwoLastReleases() upgradeSpec {
 	return upgradeSpec{
 		ShortName: fmt.Sprintf("%s-%s", stableVersion, nextVersion),
 
-		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(stableVersion), constants.KernelUncompressedAsset)),
+		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(stableVersion), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(stableVersion), constants.InitramfsAsset)),
 		SourceInstallerImage: fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, stableVersion),
 		SourceVersion:        stableVersion,
@@ -98,7 +98,7 @@ func upgradeLastReleaseToCurrent() upgradeSpec {
 	return upgradeSpec{
 		ShortName: fmt.Sprintf("%s-%s", nextVersion, DefaultSettings.CurrentVersion),
 
-		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(nextVersion), constants.KernelUncompressedAsset)),
+		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(nextVersion), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(nextVersion), constants.InitramfsAsset)),
 		SourceInstallerImage: fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, nextVersion),
 		SourceVersion:        nextVersion,
@@ -116,7 +116,7 @@ func upgradeSingeNodePreserve() upgradeSpec {
 	return upgradeSpec{
 		ShortName: fmt.Sprintf("preserve-%s-%s", nextVersion, DefaultSettings.CurrentVersion),
 
-		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(nextVersion), constants.KernelUncompressedAsset)),
+		SourceKernelPath:     helpers.ArtifactPath(filepath.Join(trimVersion(nextVersion), constants.KernelAsset)),
 		SourceInitramfsPath:  helpers.ArtifactPath(filepath.Join(trimVersion(nextVersion), constants.InitramfsAsset)),
 		SourceInstallerImage: fmt.Sprintf("%s:%s", constants.DefaultInstallerImageRepository, nextVersion),
 		SourceVersion:        nextVersion,
@@ -307,7 +307,7 @@ func (suite *UpgradeSuite) setupCluster() {
 			})
 	}
 
-	suite.Cluster, err = suite.provisioner.Create(suite.ctx, request, provision.WithBootladerEmulation(), provision.WithTalosConfig(suite.configBundle.TalosConfig()))
+	suite.Cluster, err = suite.provisioner.Create(suite.ctx, request, provision.WithBootlader(true), provision.WithTalosConfig(suite.configBundle.TalosConfig()))
 	suite.Require().NoError(err)
 
 	suite.clusterAccess = access.NewAdapter(suite.Cluster, provision.WithTalosConfig(suite.configBundle.TalosConfig()))

--- a/internal/pkg/provision/options.go
+++ b/internal/pkg/provision/options.go
@@ -7,6 +7,7 @@ package provision
 import (
 	"io"
 	"os"
+	"runtime"
 
 	"github.com/talos-systems/talos/pkg/client"
 	"github.com/talos-systems/talos/pkg/client/config"
@@ -51,10 +52,19 @@ func WithTalosClient(client *client.Client) Option {
 	}
 }
 
-// WithBootladerEmulation enables bootloader emulation.
-func WithBootladerEmulation() Option {
+// WithBootlader enables or disables bootloader (bootloader is enabled by default).
+func WithBootlader(enabled bool) Option {
 	return func(o *Options) error {
-		o.BootloaderEmulation = true
+		o.BootloaderEnabled = enabled
+
+		return nil
+	}
+}
+
+// WithTargetArch specifies target architecture for the cluster.
+func WithTargetArch(arch string) Option {
+	return func(o *Options) error {
+		o.TargetArch = arch
 
 		return nil
 	}
@@ -84,9 +94,10 @@ type Options struct {
 	TalosConfig   *config.Config
 	TalosClient   *client.Client
 	ForceEndpoint string
+	TargetArch    string
 
-	// Enable bootloader by booting from disk image assets.
-	BootloaderEmulation bool
+	// Enable bootloader by booting from disk image after install.
+	BootloaderEnabled bool
 
 	// Expose ports to worker machines in docker provisioner
 	DockerPorts       []string
@@ -96,6 +107,8 @@ type Options struct {
 // DefaultOptions returns default options.
 func DefaultOptions() Options {
 	return Options{
+		BootloaderEnabled: true,
+		TargetArch:        runtime.GOARCH,
 		LogWriter:         os.Stderr,
 		DockerPortsHostIP: "0.0.0.0",
 	}

--- a/internal/pkg/provision/providers/firecracker/kernel.go
+++ b/internal/pkg/provision/providers/firecracker/kernel.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package firecracker
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/talos-systems/talos/internal/pkg/kernel/vmlinuz"
+)
+
+func uncompressKernel(srcKernelPath, dstKernelPath string) error {
+	srcF, err := os.Open(srcKernelPath)
+	if err != nil {
+		return fmt.Errorf("failed to open kernel asset %q: %w", srcKernelPath, err)
+	}
+
+	defer srcF.Close() //nolint: errcheck
+
+	kernelR, err := vmlinuz.Decompress(bufio.NewReader(srcF))
+	if err != nil {
+		return fmt.Errorf("error decompressing kernel: %w", err)
+	}
+
+	defer kernelR.Close() //nolint: errcheck
+
+	dstF, err := os.Create(dstKernelPath)
+	if err != nil {
+		return fmt.Errorf("error creating temporary kernel image file: %w", err)
+	}
+
+	defer dstF.Close() //nolint: errcheck
+
+	if _, err = io.Copy(dstF, kernelR); err != nil {
+		return fmt.Errorf("error extracting kernel: %w", err)
+	}
+
+	return dstF.Close()
+}

--- a/internal/pkg/provision/providers/firecracker/node.go
+++ b/internal/pkg/provision/providers/firecracker/node.go
@@ -96,7 +96,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	cfg := firecracker.Config{
 		SocketPath:      socketPath,
-		KernelImagePath: clusterReq.UncompressedKernelPath,
+		KernelImagePath: clusterReq.KernelPath,
 		KernelArgs:      cmdline.String(),
 		InitrdPath:      clusterReq.InitramfsPath,
 		ForwardSignals:  []os.Signal{}, // don't forward any signals
@@ -147,7 +147,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		FirecrackerConfig:   cfg,
 		Config:              nodeConfig,
 		GatewayAddr:         clusterReq.Network.GatewayAddr,
-		BootloaderEmulation: opts.BootloaderEmulation,
+		BootloaderEmulation: opts.BootloaderEnabled,
 	}
 
 	launchConfigFile, err := os.Create(state.GetRelativePath(fmt.Sprintf("%s.config", nodeReq.Name)))

--- a/internal/pkg/provision/providers/qemu/create.go
+++ b/internal/pkg/provision/providers/qemu/create.go
@@ -60,7 +60,7 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	fmt.Fprintln(options.LogWriter, "creating master nodes")
 
-	if nodeInfo, err = p.createNodes(state, request, request.Nodes.MasterNodes()); err != nil {
+	if nodeInfo, err = p.createNodes(state, request, request.Nodes.MasterNodes(), &options); err != nil {
 		return nil, err
 	}
 
@@ -68,13 +68,11 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 
 	var workerNodeInfo []provision.NodeInfo
 
-	if workerNodeInfo, err = p.createNodes(state, request, request.Nodes.WorkerNodes()); err != nil {
+	if workerNodeInfo, err = p.createNodes(state, request, request.Nodes.WorkerNodes(), &options); err != nil {
 		return nil, err
 	}
 
 	nodeInfo = append(nodeInfo, workerNodeInfo...)
-
-	fmt.Fprintln(options.LogWriter, "creating master nodes")
 
 	state.ClusterInfo = provision.ClusterInfo{
 		ClusterName: request.Name,

--- a/internal/pkg/provision/providers/qemu/qemu.go
+++ b/internal/pkg/provision/providers/qemu/qemu.go
@@ -6,6 +6,7 @@ package qemu
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
 	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
@@ -56,4 +57,15 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
 	// firecracker runs loadbalancer on the bridge, which is good for both internal & external access
 	return networkReq.GatewayAddr.String(), networkReq.GatewayAddr.String()
+}
+
+func qemuArchFromGoArch(arch string) (string, string, error) {
+	switch arch {
+	case "amd64":
+		return "x86_64", "q35", nil
+	case "arm64":
+		return "aarch64", "virt", nil
+	default:
+		return "", "", fmt.Errorf("architecture %q is not supported", arch)
+	}
 }

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -19,10 +19,9 @@ type ClusterRequest struct {
 	Network NetworkRequest
 	Nodes   NodeRequests
 
-	Image                  string
-	UncompressedKernelPath string
-	CompressedKernelPath   string
-	InitramfsPath          string
+	Image         string
+	KernelPath    string
+	InitramfsPath string
 
 	// Path to talosctl executable to re-execute itself as needed.
 	SelfExecutable string


### PR DESCRIPTION
Fixes #2363 #2364 #2370 #2371

Several changes packed together:

* use compressed `vmlinuz` everywhere, firecracker provisioner
uncompresses it before first use, drop `vmlinux`

* handle reboots in qemu launcher to support reset API case, update
empty disk check to handle reset behavior (erasing partition table)

* make bootloader support default in provisioners, and flag to disable
that

* early support for target architecture for qemu provisioner

This should allow us to use `qemu` in CI/CD (not included into this PR):
integration test passes with qemu.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2373)
<!-- Reviewable:end -->
