### PR TITLE
fix: update status when adjusting the time

### DIFF
--- a/internal/app/timed/pkg/ntp/ntp.go
+++ b/internal/app/timed/pkg/ntp/ntp.go
@@ -135,12 +135,15 @@ func adjustTime(offset time.Duration) error {
 
 	fmt.Fprintf(&buf, "adjusting time by %s", offset)
 
-	state, err := timex.Adjtimex(&syscall.Timex{
-		Modes:  timex.ADJ_OFFSET | timex.ADJ_NANO,
+	req := syscall.Timex{
+		Modes:  timex.ADJ_OFFSET | timex.ADJ_NANO | timex.ADJ_STATUS,
 		Offset: int64(offset / time.Nanosecond),
-	})
+		Status: timex.STA_PLL,
+	}
 
-	fmt.Fprintf(&buf, ", state %s", state)
+	state, err := timex.Adjtimex(&req)
+
+	fmt.Fprintf(&buf, ", state %s, status %s", state, timex.Status(req.Status))
 
 	if err != nil {
 		fmt.Println(&buf, ", error was %s", err)

--- a/internal/app/timed/pkg/timex/timex.go
+++ b/internal/app/timed/pkg/timex/timex.go
@@ -5,7 +5,10 @@
 // Package timex provides simple wrapper around adjtimex syscall.
 package timex
 
-import "syscall"
+import (
+	"strings"
+	"syscall"
+)
 
 // Values for timex.mode.
 //
@@ -23,6 +26,60 @@ const (
 	ADJ_NANO      = 0x2000
 	ADJ_TICK      = 0x4000
 )
+
+// Status is bitmask field of statuses.
+type Status int32
+
+// Clock statuses.
+//
+//nolint: golint, stylecheck
+const (
+	STA_PLL       = 0x0001 /* enable PLL updates (rw) */
+	STA_PPSFREQ   = 0x0002 /* enable PPS freq discipline (rw) */
+	STA_PPSTIME   = 0x0004 /* enable PPS time discipline (rw) */
+	STA_FLL       = 0x0008 /* select frequency-lock mode (rw) */
+	STA_INS       = 0x0010 /* insert leap (rw) */
+	STA_DEL       = 0x0020 /* delete leap (rw) */
+	STA_UNSYNC    = 0x0040 /* clock unsynchronized (rw) */
+	STA_FREQHOLD  = 0x0080 /* hold frequency (rw) */
+	STA_PPSSIGNAL = 0x0100 /* PPS signal present (ro) */
+	STA_PPSJITTER = 0x0200 /* PPS signal jitter exceeded (ro) */
+	STA_PPSWANDER = 0x0400 /* PPS signal wander exceeded (ro) */
+	STA_PPSERROR  = 0x0800 /* PPS signal calibration error (ro) */
+	STA_CLOCKERR  = 0x1000 /* clock hardware fault (ro) */
+	STA_NANO      = 0x2000 /* resolution (0 = us, 1 = ns) (ro) */
+	STA_MODE      = 0x4000 /* mode (0 = PLL, 1 = FLL) (ro) */
+	STA_CLK       = 0x8000 /* clock source (0 = A, 1 = B) (ro) */
+)
+
+func (status Status) String() string {
+	var labels []string
+
+	for bit, label := range map[Status]string{
+		STA_PLL:       "STA_PLL",
+		STA_PPSFREQ:   "STA_PPSFREQ",
+		STA_PPSTIME:   "STA_PPSTIME",
+		STA_FLL:       "STA_FLL",
+		STA_INS:       "STA_INS",
+		STA_DEL:       "STA_DEL",
+		STA_UNSYNC:    "STA_UNSYNC",
+		STA_FREQHOLD:  "STA_FREQHOLD",
+		STA_PPSSIGNAL: "STA_PPSSIGNAL",
+		STA_PPSJITTER: "STA_PPSJITTER",
+		STA_PPSWANDER: "STA_PPSWANDER",
+		STA_PPSERROR:  "STA_PPSERROR",
+		STA_CLOCKERR:  "STA_CLOCKERR",
+		STA_NANO:      "STA_NANO",
+		STA_MODE:      "STA_MODE",
+		STA_CLK:       "STA_CLK",
+	} {
+		if (status & bit) == bit {
+			labels = append(labels, label)
+		}
+	}
+
+	return strings.Join(labels, " | ")
+}
 
 // State is clock state.
 type State int


### PR DESCRIPTION
Status big `STA_UNSYNC` should be cleared otherwise kernel assumes that
time is not sync. `STA_PLL` is set to notify kernel that we apply offset
adjustments periodically.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2374)
<!-- Reviewable:end -->
