### PR TITLE
feat: taint master nodes with `NoSchedule` taint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
-	github.com/talos-systems/bootkube-plugin v0.0.0-20200610162424-78d7183391b6
+	github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-smbios v0.0.0-20200219201045-94b8c4e489ee
 	github.com/talos-systems/grpc-proxy v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -680,8 +680,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/bootkube-plugin v0.0.0-20200610162424-78d7183391b6 h1:hNCyhdSCIQyCLGb7dje9kGQqIwaf4+2XyFjZAdzZ9hY=
-github.com/talos-systems/bootkube-plugin v0.0.0-20200610162424-78d7183391b6/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
+github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e h1:Zxo/QrqZANuOBrMBwKq5L2kLrelF4jUKnrWAUfiCgbw=
+github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
 github.com/talos-systems/go-smbios v0.0.0-20200219201045-94b8c4e489ee h1:9i0ZFsjZ0wY8UUn/tk2MQshLBC0PNFJe3+84AUqzzyw=

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -22,6 +22,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/cmd"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/retry"
 )
 
@@ -81,11 +82,11 @@ func (cliSuite *CLISuite) discoverKubectl() cluster.Info {
 	cliSuite.RunCLI([]string{"kubeconfig", tempDir}, StdoutEmpty())
 
 	masterNodes, err := cmd.Run(cliSuite.KubectlPath, "--kubeconfig", filepath.Join(tempDir, "kubeconfig"), "get", "nodes",
-		"-o", "jsonpath={.items[*].status.addresses[?(@.type==\"InternalIP\")].address}", "--selector=node-role.kubernetes.io/master")
+		"-o", "jsonpath={.items[*].status.addresses[?(@.type==\"InternalIP\")].address}", fmt.Sprintf("--selector=%s", constants.LabelNodeRoleMaster))
 	cliSuite.Require().NoError(err)
 
 	workerNodes, err := cmd.Run(cliSuite.KubectlPath, "--kubeconfig", filepath.Join(tempDir, "kubeconfig"), "get", "nodes",
-		"-o", "jsonpath={.items[*].status.addresses[?(@.type==\"InternalIP\")].address}", "--selector=!node-role.kubernetes.io/master")
+		"-o", "jsonpath={.items[*].status.addresses[?(@.type==\"InternalIP\")].address}", fmt.Sprintf("--selector=!%s", constants.LabelNodeRoleMaster))
 	cliSuite.Require().NoError(err)
 
 	return &infoWrapper{

--- a/internal/pkg/cluster/check/kubernetes.go
+++ b/internal/pkg/cluster/check/kubernetes.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/constants"
 )
 
 // K8sAllNodesReportedAssertion checks whether all the nodes show up in node list.
@@ -72,7 +73,7 @@ func K8sFullControlPlaneAssertion(ctx context.Context, cluster ClusterInfo) erro
 
 	for _, node := range nodes.Items {
 		for label := range node.Labels {
-			if label == "node-role.kubernetes.io/master" {
+			if label == constants.LabelNodeRoleMaster {
 				for _, nodeAddress := range node.Status.Addresses {
 					if nodeAddress.Type == v1.NodeInternalIP {
 						actualNodes = append(actualNodes, nodeAddress.Address)


### PR DESCRIPTION
Fixes #2350

This also brings in a fix for `coredns` tolerations from
https://github.com/talos-systems/bootkube-plugin/pull/19.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2375)
<!-- Reviewable:end -->
