### PR TITLE
chore: really mount /tmp in CI as tmpfs

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -70,7 +70,9 @@ local volumes = {
   tmp: {
     pipeline: {
       name: 'tmp',
-      temp: {},
+      temp: {
+        'medium': 'memory',
+      },
     },
     step: {
       name: $.tmp.pipeline.name,


### PR DESCRIPTION
This seems to be the way to do it for kube-runner.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2379)
<!-- Reviewable:end -->
