### PR TITLE
fix: workaround edge case for etcd re-injection on bootstrap

### DIFF
--- a/internal/app/machined/pkg/system/system.go
+++ b/internal/app/machined/pkg/system/system.go
@@ -109,8 +109,12 @@ func (s *singleton) Unload(ctx context.Context, serviceIDs ...string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	s.runningMu.Lock()
+	defer s.runningMu.Unlock()
+
 	for _, id := range servicesToRemove {
 		delete(s.state, id)
+		delete(s.running, id) // this fixes an edge case when defer() in Start() doesn't have time to remove stopped service from running
 	}
 
 	return nil


### PR DESCRIPTION
Logs:

```
[   27.739699] [talos] bootstrap request received
[   27.740500] [talos] bootstrap sequence: 3 phase(s)
[   27.741297] [talos] phase etcd (1/3): 1 tasks(s)
[   27.741991] [talos] task bootstrapEtcd (1/1): starting
[   27.742855] [talos] service[etcd](Failed): Failed to run pre stage: context canceled
[   27.744355] [talos] service[etcd](Finished): Bootstrap requested
```

`etcd` was stopped, `Finished` state was injected, but new service never
started. This is most likely a race in `Start`: it removes service from
`running` after it stops, but event that service got stopped is sent
before that, so task might see service as stopped, unload it, load it
back, but `Start()` will be no-op as service is considered to be
running.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2380)
<!-- Reviewable:end -->
