### PR TITLE
chore: use qemu instead of firecracker in CI

### DIFF
--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -26,7 +26,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/cluster/check"
 	"github.com/talos-systems/talos/internal/pkg/provision"
 	"github.com/talos-systems/talos/internal/pkg/provision/access"
-	"github.com/talos-systems/talos/internal/pkg/provision/providers/firecracker"
+	"github.com/talos-systems/talos/internal/pkg/provision/providers/qemu"
 	talosclient "github.com/talos-systems/talos/pkg/client"
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
@@ -163,7 +163,7 @@ func (suite *UpgradeSuite) SetupSuite() {
 
 	var err error
 
-	suite.provisioner, err = firecracker.NewProvisioner(suite.ctx)
+	suite.provisioner, err = qemu.NewProvisioner(suite.ctx)
 	suite.Require().NoError(err)
 }
 


### PR DESCRIPTION
qemu opens up a bunch of possibilities, including the bootloader
testing.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2381)
<!-- Reviewable:end -->
