### PR TITLE
chore: add aliases to some `talosctl` commands

### DIFF
--- a/cmd/talosctl/cmd/talos/memory.go
+++ b/cmd/talosctl/cmd/talos/memory.go
@@ -24,7 +24,7 @@ var verbose bool
 // memoryCmd represents the processes command.
 var memoryCmd = &cobra.Command{
 	Use:     "memory",
-	Aliases: []string{"m"},
+	Aliases: []string{"m", "free"},
 	Short:   "Show memory usage",
 	Long:    ``,
 	Args:    cobra.NoArgs,

--- a/cmd/talosctl/cmd/talos/mounts.go
+++ b/cmd/talosctl/cmd/talos/mounts.go
@@ -23,7 +23,7 @@ import (
 // mountsCmd represents the mounts command.
 var mountsCmd = &cobra.Command{
 	Use:     "mounts",
-	Aliases: []string{"m"},
+	Aliases: []string{"mount"},
 	Short:   "List mounts",
 	Long:    ``,
 	Args:    cobra.NoArgs,

--- a/cmd/talosctl/cmd/talos/processes.go
+++ b/cmd/talosctl/cmd/talos/processes.go
@@ -34,7 +34,7 @@ var (
 // processesCmd represents the processes command.
 var processesCmd = &cobra.Command{
 	Use:     "processes",
-	Aliases: []string{"p"},
+	Aliases: []string{"p", "ps"},
 	Short:   "List running processes",
 	Long:    ``,
 	Args:    cobra.NoArgs,

--- a/cmd/talosctl/cmd/talos/routes.go
+++ b/cmd/talosctl/cmd/talos/routes.go
@@ -21,10 +21,11 @@ import (
 
 // routesCmd represents the net routes command.
 var routesCmd = &cobra.Command{
-	Use:   "routes",
-	Short: "List network routes",
-	Long:  ``,
-	Args:  cobra.NoArgs,
+	Use:     "routes",
+	Aliases: []string{"route"},
+	Short:   "List network routes",
+	Long:    ``,
+	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			var remotePeer peer.Peer

--- a/cmd/talosctl/cmd/talos/stats.go
+++ b/cmd/talosctl/cmd/talos/stats.go
@@ -24,10 +24,10 @@ import (
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
-// statsCmd represents the processes command.
+// statsCmd represents the stats command.
 var statsCmd = &cobra.Command{
 	Use:   "stats",
-	Short: "Get processes stats",
+	Short: "Get container stats",
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/talosctl/talosctl.md
+++ b/docs/talosctl/talosctl.md
@@ -47,7 +47,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl routes](talosctl_routes.md)	 - List network routes
 * [talosctl service](talosctl_service.md)	 - Retrieve the state of a service (or all services), control service state
 * [talosctl shutdown](talosctl_shutdown.md)	 - Shutdown a node
-* [talosctl stats](talosctl_stats.md)	 - Get processes stats
+* [talosctl stats](talosctl_stats.md)	 - Get container stats
 * [talosctl time](talosctl_time.md)	 - Gets current server time
 * [talosctl upgrade](talosctl_upgrade.md)	 - Upgrade Talos on the target node
 * [talosctl validate](talosctl_validate.md)	 - Validate config

--- a/docs/talosctl/talosctl_stats.md
+++ b/docs/talosctl/talosctl_stats.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable -->
 ## talosctl stats
 
-Get processes stats
+Get container stats
 
 ### Synopsis
 
-Get processes stats
+Get container stats
 
 ```
 talosctl stats [flags]


### PR DESCRIPTION
Aliases are close to regular UNIX commands.

Fixes #2195

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2383)
<!-- Reviewable:end -->
