### PR TITLE
test: bump timeout for upgrade tests

### DIFF
--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -376,7 +376,7 @@ func (suite *UpgradeSuite) upgradeNode(client *talosclient.Client, node provisio
 	suite.Require().Equal("Upgrade request received", resp.Messages[0].Ack)
 
 	// wait for the version to be equal to target version
-	suite.Require().NoError(retry.Constant(5 * time.Minute).Retry(func() error {
+	suite.Require().NoError(retry.Constant(10 * time.Minute).Retry(func() error {
 		var version string
 
 		version, err = suite.readVersion(client, nodeCtx)


### PR DESCRIPTION
'cordonAndDrainNode' task sometimes takes 5 minutes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2384)
<!-- Reviewable:end -->
