### PR TITLE
test: destroy clusters in e2e tests (qemu/firecracker)

### DIFF
--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -50,10 +50,11 @@ function create_cluster {
 }
 
 function destroy_cluster() {
-  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}"
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
 }
 
 create_cluster
 get_kubeconfig
 run_talos_integration_test
 run_kubernetes_integration_test
+destroy_cluster

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -50,10 +50,11 @@ function create_cluster {
 }
 
 function destroy_cluster() {
-  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}"
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
 }
 
 create_cluster
 get_kubeconfig
 run_talos_integration_test
 run_kubernetes_integration_test
+destroy_cluster


### PR DESCRIPTION
As the build runs inside containers which are part of a single pod, we
need to clean up networking bits (bridge interface, etc.), so that it
doesn't cause problems for other steps.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2386)
<!-- Reviewable:end -->
