### PR TITLE
refactor: remove structs from config provider

### DIFF
--- a/docs/website/content/v0.6/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.6/en/configuration/v1alpha1.md
@@ -1176,3 +1176,444 @@ Field format accepts any Go time.Duration format ('1h' for one hour, '10m' for t
 Type: `Duration`
 
 ---
+
+### MachineDisk
+
+#### device
+
+The name of the disk to use.
+Type: `string`
+
+#### partitions
+
+A list of partitions to create on the disk.
+Type: `array`
+
+---
+
+### DiskPartition
+
+#### size
+
+This size of the partition in bytes.
+
+Type: `uint`
+
+#### mountpoint
+
+Where to mount the partition.
+Type: `string`
+
+---
+
+### MachineFile
+
+#### content
+
+The contents of file.
+Type: `string`
+
+#### permissions
+
+The file's permissions in octal.
+Type: `FileMode`
+
+#### path
+
+The path of the file.
+Type: `string`
+
+#### op
+
+The operation to use
+Type: `string`
+
+Valid Values:
+
+- `create`
+- `append`
+
+---
+
+### ExtraHost
+
+#### ip
+
+The IP of the host.
+Type: `string`
+
+#### aliases
+
+The host alias.
+Type: `array`
+
+---
+
+### Device
+
+#### interface
+
+The interface name.
+Type: `string`
+
+#### cidr
+
+The CIDR to use.
+Type: `string`
+
+#### routes
+
+A list of routes associated with the interface.
+Type: `array`
+
+#### bond
+
+Bond specific options.
+Type: `Bond`
+
+#### vlans
+
+VLAN specific options.
+Type: `array`
+
+#### mtu
+
+The interface's MTU.
+Type: `int`
+
+#### dhcp
+
+Indicates if DHCP should be used.
+Type: `bool`
+
+#### ignore
+
+Indicates if the interface should be ignored.
+Type: `bool`
+
+#### dummy
+
+Indicates if the interface is a dummy interface.
+Type: `bool`
+
+---
+
+### Bond
+
+#### interfaces
+
+The interfaces that make up the bond.
+Type: `array`
+
+#### arpIPTarget
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `array`
+
+#### mode
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### xmitHashPolicy
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### lacpRate
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### adActorSystem
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### arpValidate
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### arpAllTargets
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### primary
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### primaryReselect
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### failOverMac
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### adSelect
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `string`
+
+#### miimon
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### updelay
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### downdelay
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### arpInterval
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### resendIgmp
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### minLinks
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### lpInterval
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### packetsPerSlave
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+#### numPeerNotif
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint8`
+
+#### tlbDynamicLb
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint8`
+
+#### allSlavesActive
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint8`
+
+#### useCarrier
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `bool`
+
+#### adActorSysPrio
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint16`
+
+#### adUserPortKey
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint16`
+
+#### peerNotifyDelay
+
+A bond option.
+Please see the official kernel documentation.
+
+Type: `uint32`
+
+---
+
+### Vlan
+
+#### cidr
+
+The CIDR to use.
+Type: `string`
+
+#### routes
+
+A list of routes associated with the VLAN.
+Type: `array`
+
+#### dhcp
+
+Indicates if DHCP should be used.
+Type: `bool`
+
+#### vlanId
+
+The VLAN's ID.
+Type: `uint16`
+
+---
+
+### Route
+
+#### network
+
+The route's network.
+Type: `string`
+
+#### gateway
+
+The route's gateway.
+Type: `string`
+
+---
+
+### RegistryMirrorConfig
+
+#### endpoints
+
+List of endpoints (URLs) for registry mirrors to use.
+Endpoint configures HTTP/HTTPS access mode, host name,
+port and path (if path is not set, it defaults to `/v2`).
+
+Type: `array`
+
+---
+
+### RegistryConfig
+
+#### tls
+
+The TLS configuration for this registry.
+Type: `RegistryTLSConfig`
+
+#### auth
+
+The auth configuration for this registry.
+Type: `RegistryAuthConfig`
+
+---
+
+### RegistryAuthConfig
+
+#### username
+
+Optional registry authentication.
+The meaning of each field is the same with the corresponding field in .docker/config.json.
+
+Type: `string`
+
+#### password
+
+Optional registry authentication.
+The meaning of each field is the same with the corresponding field in .docker/config.json.
+
+Type: `string`
+
+#### auth
+
+Optional registry authentication.
+The meaning of each field is the same with the corresponding field in .docker/config.json.
+
+Type: `string`
+
+#### identityToken
+
+Optional registry authentication.
+The meaning of each field is the same with the corresponding field in .docker/config.json.
+
+Type: `string`
+
+---
+
+### RegistryTLSConfig
+
+#### clientIdentity
+
+Enable mutual TLS authentication with the registry.
+Client certificate and key should be base64-encoded.
+
+Type: `PEMEncodedCertificateAndKey`
+
+Examples:
+
+```yaml
+clientIdentity:
+  crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJIekNCMHF...
+  key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM...
+
+```
+
+#### ca
+
+CA registry certificate to add the list of trusted certificates.
+Certificate should be base64-encoded.
+
+Type: `array`
+
+#### insecureSkipVerify
+
+Skip TLS server certificate verification (not recommended).
+
+Type: `bool`
+
+---

--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -87,9 +87,9 @@ func (s *Static) Scope() uint8 {
 func (s *Static) Routes() (routes []*Route) {
 	for _, route := range s.RouteList {
 		// nolint: errcheck
-		_, ipnet, _ := net.ParseCIDR(route.Network)
+		_, ipnet, _ := net.ParseCIDR(route.Network())
 
-		routes = append(routes, &Route{Dest: ipnet, Router: net.ParseIP(route.Gateway)})
+		routes = append(routes, &Route{Dest: ipnet, Router: net.ParseIP(route.Gateway())})
 	}
 
 	return routes

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -15,6 +15,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
 	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
@@ -22,17 +23,17 @@ import (
 // configuring the interface.
 // nolint: gocyclo
 func buildOptions(device config.Device, hostname string) (name string, opts []nic.Option, err error) {
-	opts = append(opts, nic.WithName(device.Interface))
+	opts = append(opts, nic.WithName(device.Interface()))
 
-	if device.Ignore || procfs.ProcCmdline().Get(constants.KernelParamNetworkInterfaceIgnore).Contains(device.Interface) {
+	if device.Ignore() || procfs.ProcCmdline().Get(constants.KernelParamNetworkInterfaceIgnore).Contains(device.Interface()) {
 		opts = append(opts, nic.WithIgnore())
-		return device.Interface, opts, err
+		return device.Interface(), opts, err
 	}
 
 	// Configure Addressing
 	switch {
-	case device.CIDR != "":
-		s := &address.Static{CIDR: device.CIDR, RouteList: device.Routes, Mtu: device.MTU}
+	case device.CIDR() != "":
+		s := &address.Static{CIDR: device.CIDR(), RouteList: device.Routes(), Mtu: device.MTU()}
 
 		// Set a default for the hostname to ensure we always have a valid
 		// ip + hostname pair
@@ -44,13 +45,13 @@ func buildOptions(device config.Device, hostname string) (name string, opts []ni
 		}
 
 		opts = append(opts, nic.WithAddressing(s))
-	case device.DHCP:
+	case device.DHCP():
 		d := &address.DHCP{}
 		opts = append(opts, nic.WithAddressing(d))
 	default:
 		// Allow master interface without any addressing if VLANs exist
-		if len(device.Vlans) > 0 {
-			log.Printf("no addressing for master device %s", device.Interface)
+		if len(device.Vlans()) > 0 {
+			log.Printf("no addressing for master device %s", device.Interface())
 
 			opts = append(opts, nic.WithNoAddressing())
 		} else {
@@ -60,140 +61,140 @@ func buildOptions(device config.Device, hostname string) (name string, opts []ni
 	}
 
 	// Configure Vlan interfaces
-	for _, vlan := range device.Vlans {
-		opts = append(opts, nic.WithVlan(vlan.ID))
-		if vlan.CIDR != "" {
-			opts = append(opts, nic.WithVlanCIDR(vlan.ID, vlan.CIDR, vlan.Routes))
+	for _, vlan := range device.Vlans() {
+		opts = append(opts, nic.WithVlan(vlan.ID()))
+		if vlan.CIDR() != "" {
+			opts = append(opts, nic.WithVlanCIDR(vlan.ID(), vlan.CIDR(), vlan.Routes()))
 		}
 
-		if vlan.DHCP {
-			opts = append(opts, nic.WithVlanDhcp(vlan.ID))
+		if vlan.DHCP() {
+			opts = append(opts, nic.WithVlanDhcp(vlan.ID()))
 		}
 	}
 
 	// Handle dummy interface
-	if device.Dummy {
+	if device.Dummy() {
 		opts = append(opts, nic.WithDummy())
 	}
 
 	// Configure Bonding
-	if device.Bond == nil {
-		return device.Interface, opts, err
+	if device.Bond() == nil {
+		return device.Interface(), opts, err
 	}
 
 	opts = append(opts, nic.WithBond(true))
 
-	if len(device.Bond.Interfaces) == 0 {
-		return device.Interface, opts, fmt.Errorf("invalid bond configuration for %s: must supply sub interfaces for bonded interface", device.Interface)
+	if len(device.Bond().Interfaces()) == 0 {
+		return device.Interface(), opts, fmt.Errorf("invalid bond configuration for %s: must supply sub interfaces for bonded interface", device.Interface())
 	}
 
-	opts = append(opts, nic.WithSubInterface(device.Bond.Interfaces...))
+	opts = append(opts, nic.WithSubInterface(device.Bond().Interfaces()...))
 
-	if device.Bond.Mode != "" {
-		opts = append(opts, nic.WithBondMode(device.Bond.Mode))
+	if device.Bond().Mode() != "" {
+		opts = append(opts, nic.WithBondMode(device.Bond().Mode()))
 	}
 
-	if device.Bond.HashPolicy != "" {
-		opts = append(opts, nic.WithHashPolicy(device.Bond.HashPolicy))
+	if device.Bond().HashPolicy() != "" {
+		opts = append(opts, nic.WithHashPolicy(device.Bond().HashPolicy()))
 	}
 
-	if device.Bond.LACPRate != "" {
-		opts = append(opts, nic.WithLACPRate(device.Bond.LACPRate))
+	if device.Bond().LACPRate() != "" {
+		opts = append(opts, nic.WithLACPRate(device.Bond().LACPRate()))
 	}
 
-	if device.Bond.MIIMon > 0 {
-		opts = append(opts, nic.WithMIIMon(device.Bond.MIIMon))
+	if device.Bond().MIIMon() > 0 {
+		opts = append(opts, nic.WithMIIMon(device.Bond().MIIMon()))
 	}
 
-	if device.Bond.UpDelay > 0 {
-		opts = append(opts, nic.WithUpDelay(device.Bond.UpDelay))
+	if device.Bond().UpDelay() > 0 {
+		opts = append(opts, nic.WithUpDelay(device.Bond().UpDelay()))
 	}
 
-	if device.Bond.DownDelay > 0 {
-		opts = append(opts, nic.WithDownDelay(device.Bond.DownDelay))
+	if device.Bond().DownDelay() > 0 {
+		opts = append(opts, nic.WithDownDelay(device.Bond().DownDelay()))
 	}
 
-	if !device.Bond.UseCarrier {
-		opts = append(opts, nic.WithUseCarrier(device.Bond.UseCarrier))
+	if !device.Bond().UseCarrier() {
+		opts = append(opts, nic.WithUseCarrier(device.Bond().UseCarrier()))
 	}
 
-	if device.Bond.ARPInterval > 0 {
-		opts = append(opts, nic.WithARPInterval(device.Bond.ARPInterval))
+	if device.Bond().ARPInterval() > 0 {
+		opts = append(opts, nic.WithARPInterval(device.Bond().ARPInterval()))
 	}
 
 	// if device.Bond.ARPIPTarget {
 	//	opts = append(opts, nic.WithARPIPTarget(device.Bond.ARPIPTarget))
 	//}
 
-	if device.Bond.ARPValidate != "" {
-		opts = append(opts, nic.WithARPValidate(device.Bond.ARPValidate))
+	if device.Bond().ARPValidate() != "" {
+		opts = append(opts, nic.WithARPValidate(device.Bond().ARPValidate()))
 	}
 
-	if device.Bond.ARPAllTargets != "" {
-		opts = append(opts, nic.WithARPAllTargets(device.Bond.ARPAllTargets))
+	if device.Bond().ARPAllTargets() != "" {
+		opts = append(opts, nic.WithARPAllTargets(device.Bond().ARPAllTargets()))
 	}
 
-	if device.Bond.Primary != "" {
-		opts = append(opts, nic.WithPrimary(device.Bond.Primary))
+	if device.Bond().Primary() != "" {
+		opts = append(opts, nic.WithPrimary(device.Bond().Primary()))
 	}
 
-	if device.Bond.PrimaryReselect != "" {
-		opts = append(opts, nic.WithPrimaryReselect(device.Bond.PrimaryReselect))
+	if device.Bond().PrimaryReselect() != "" {
+		opts = append(opts, nic.WithPrimaryReselect(device.Bond().PrimaryReselect()))
 	}
 
-	if device.Bond.FailOverMac != "" {
-		opts = append(opts, nic.WithFailOverMAC(device.Bond.FailOverMac))
+	if device.Bond().FailOverMac() != "" {
+		opts = append(opts, nic.WithFailOverMAC(device.Bond().FailOverMac()))
 	}
 
-	if device.Bond.ResendIGMP > 0 {
-		opts = append(opts, nic.WithResendIGMP(device.Bond.ResendIGMP))
+	if device.Bond().ResendIGMP() > 0 {
+		opts = append(opts, nic.WithResendIGMP(device.Bond().ResendIGMP()))
 	}
 
-	if device.Bond.NumPeerNotif > 0 {
-		opts = append(opts, nic.WithNumPeerNotif(device.Bond.NumPeerNotif))
+	if device.Bond().NumPeerNotif() > 0 {
+		opts = append(opts, nic.WithNumPeerNotif(device.Bond().NumPeerNotif()))
 	}
 
-	if device.Bond.AllSlavesActive > 0 {
-		opts = append(opts, nic.WithAllSlavesActive(device.Bond.AllSlavesActive))
+	if device.Bond().AllSlavesActive() > 0 {
+		opts = append(opts, nic.WithAllSlavesActive(device.Bond().AllSlavesActive()))
 	}
 
-	if device.Bond.MinLinks > 0 {
-		opts = append(opts, nic.WithMinLinks(device.Bond.MinLinks))
+	if device.Bond().MinLinks() > 0 {
+		opts = append(opts, nic.WithMinLinks(device.Bond().MinLinks()))
 	}
 
-	if device.Bond.LPInterval > 0 {
-		opts = append(opts, nic.WithLPInterval(device.Bond.LPInterval))
+	if device.Bond().LPInterval() > 0 {
+		opts = append(opts, nic.WithLPInterval(device.Bond().LPInterval()))
 	}
 
-	if device.Bond.PacketsPerSlave > 0 {
-		opts = append(opts, nic.WithPacketsPerSlave(device.Bond.PacketsPerSlave))
+	if device.Bond().PacketsPerSlave() > 0 {
+		opts = append(opts, nic.WithPacketsPerSlave(device.Bond().PacketsPerSlave()))
 	}
 
-	if device.Bond.ADSelect != "" {
-		opts = append(opts, nic.WithADSelect(device.Bond.ADSelect))
+	if device.Bond().ADSelect() != "" {
+		opts = append(opts, nic.WithADSelect(device.Bond().ADSelect()))
 	}
 
-	if device.Bond.ADActorSysPrio > 0 {
-		opts = append(opts, nic.WithADActorSysPrio(device.Bond.ADActorSysPrio))
+	if device.Bond().ADActorSysPrio() > 0 {
+		opts = append(opts, nic.WithADActorSysPrio(device.Bond().ADActorSysPrio()))
 	}
 
-	if device.Bond.ADUserPortKey > 0 {
-		opts = append(opts, nic.WithADUserPortKey(device.Bond.ADUserPortKey))
+	if device.Bond().ADUserPortKey() > 0 {
+		opts = append(opts, nic.WithADUserPortKey(device.Bond().ADUserPortKey()))
 	}
 
 	// if device.Bond.ADActorSystem != "" {
 	//	opts = append(opts, nic.WithADActorSystem(device.Bond.ADActorSystem))
 	//}
 
-	if device.Bond.TLBDynamicLB > 0 {
-		opts = append(opts, nic.WithTLBDynamicLB(device.Bond.TLBDynamicLB))
+	if device.Bond().TLBDynamicLB() > 0 {
+		opts = append(opts, nic.WithTLBDynamicLB(device.Bond().TLBDynamicLB()))
 	}
 
-	if device.Bond.PeerNotifyDelay > 0 {
-		opts = append(opts, nic.WithPeerNotifyDelay(device.Bond.PeerNotifyDelay))
+	if device.Bond().PeerNotifyDelay() > 0 {
+		opts = append(opts, nic.WithPeerNotifyDelay(device.Bond().PeerNotifyDelay()))
 	}
 
-	return device.Interface, opts, err
+	return device.Interface(), opts, err
 }
 
 // nolint: gocyclo
@@ -214,7 +215,7 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 	}
 
 	var (
-		device    = &config.Device{}
+		device    = &v1alpha1.Device{}
 		hostname  string
 		link      *net.Interface
 		resolvers = []net.IP{}
@@ -224,15 +225,15 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 		switch idx {
 		// Address
 		case 0:
-			device.CIDR = field
+			device.DeviceCIDR = field
 		// NFS Server
 		// case 1:
 		// Gateway
 		case 2:
-			device.Routes = []config.Route{
+			device.DeviceRoutes = []*v1alpha1.Route{
 				{
-					Network: "0.0.0.0/0",
-					Gateway: field,
+					RouteNetwork: "0.0.0.0/0",
+					RouteGateway: field,
 				},
 			}
 		// Netmask
@@ -240,7 +241,7 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 			mask := net.ParseIP(field).To4()
 			ipmask := net.IPv4Mask(mask[0], mask[1], mask[2], mask[3])
 			ones, _ := ipmask.Size()
-			device.CIDR = fmt.Sprintf("%s/%d", device.CIDR, ones)
+			device.DeviceCIDR = fmt.Sprintf("%s/%d", device.CIDR(), ones)
 		// Hostname
 		case 4:
 			hostname = field
@@ -287,11 +288,17 @@ func buildKernelOptions(cmdline string) (name string, opts []nic.Option) {
 		}
 	}
 
-	if device.Interface == "" {
+	if device.DeviceInterface == "" {
 		opts = append(opts, nic.WithName(link.Name))
 	}
 
-	s := &address.Static{Mtu: device.MTU, NameServers: resolvers, FQDN: hostname, NetIf: link, CIDR: device.CIDR, RouteList: device.Routes}
+	routes := make([]config.Route, len(device.DeviceRoutes))
+
+	for i := 0; i < len(device.DeviceRoutes); i++ {
+		routes[i] = device.DeviceRoutes[i]
+	}
+
+	s := &address.Static{Mtu: device.DeviceMTU, NameServers: resolvers, FQDN: hostname, NetIf: link, CIDR: device.DeviceCIDR, RouteList: routes}
 	opts = append(opts, nic.WithAddressing(s))
 
 	return link.Name, opts

--- a/internal/app/networkd/pkg/networkd/netconf_test.go
+++ b/internal/app/networkd/pkg/networkd/netconf_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
 	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
 type NetconfSuite struct {
@@ -71,69 +72,69 @@ func (suite *NetconfSuite) TestKernelNetconfIncomplete() {
 
 func sampleConfig() []config.Device {
 	return []config.Device{
-		{
-			Interface: "eth0",
-			CIDR:      "192.168.0.10/24",
+		&v1alpha1.Device{
+			DeviceInterface: "eth0",
+			DeviceCIDR:      "192.168.0.10/24",
 		},
-		{
-			Interface: "bond0",
-			CIDR:      "192.168.0.10/24",
-			Bond:      &config.Bond{Interfaces: []string{"lo"}},
+		&v1alpha1.Device{
+			DeviceInterface: "bond0",
+			DeviceCIDR:      "192.168.0.10/24",
+			DeviceBond:      &v1alpha1.Bond{BondInterfaces: []string{"lo"}},
 		},
-		{
-			Interface: "bond0",
-			Bond:      &config.Bond{Interfaces: []string{"lo"}, Mode: "balance-rr"},
+		&v1alpha1.Device{
+			DeviceInterface: "bond0",
+			DeviceBond:      &v1alpha1.Bond{BondInterfaces: []string{"lo"}, BondMode: "balance-rr"},
 		},
-		{
-			Interface: "eth0",
-			Ignore:    true,
+		&v1alpha1.Device{
+			DeviceInterface: "eth0",
+			DeviceIgnore:    true,
 		},
-		{
-			Interface: "eth0",
-			MTU:       9100,
-			CIDR:      "192.168.0.10/24",
-			Routes:    []config.Route{{Network: "10.0.0.0/8", Gateway: "10.0.0.1"}},
+		&v1alpha1.Device{
+			DeviceInterface: "eth0",
+			DeviceMTU:       9100,
+			DeviceCIDR:      "192.168.0.10/24",
+			DeviceRoutes:    []*v1alpha1.Route{{RouteNetwork: "10.0.0.0/8", RouteGateway: "10.0.0.1"}},
 		},
-		{
-			Interface: "bond0",
-			Bond: &config.Bond{
-				Interfaces: []string{"lo"},
-				Mode:       "balance-rr",
-				HashPolicy: "layer2",
-				LACPRate:   "fast",
-				MIIMon:     200,
-				UpDelay:    100,
-				DownDelay:  100,
+		&v1alpha1.Device{
+			DeviceInterface: "bond0",
+			DeviceBond: &v1alpha1.Bond{
+				BondInterfaces: []string{"lo"},
+				BondMode:       "balance-rr",
+				BondHashPolicy: "layer2",
+				BondLACPRate:   "fast",
+				BondMIIMon:     200,
+				BondUpDelay:    100,
+				BondDownDelay:  100,
 			},
 		},
-		{
-			Interface: "bondyolo0",
-			Bond: &config.Bond{
-				Interfaces:      []string{"lo"},
-				Mode:            "balance-rr",
-				HashPolicy:      "layer2",
-				LACPRate:        "fast",
-				MIIMon:          200,
-				UpDelay:         100,
-				DownDelay:       100,
-				UseCarrier:      false,
-				ARPInterval:     230,
-				ARPValidate:     "all",
-				ARPAllTargets:   "all",
-				Primary:         "lo",
-				PrimaryReselect: "better",
-				FailOverMac:     "none",
-				ResendIGMP:      10,
-				NumPeerNotif:    5,
-				AllSlavesActive: 1,
-				MinLinks:        1,
-				LPInterval:      100,
-				PacketsPerSlave: 50,
-				ADSelect:        "bandwidth",
-				ADActorSysPrio:  23,
-				ADUserPortKey:   323,
-				TLBDynamicLB:    1,
-				PeerNotifyDelay: 200,
+		&v1alpha1.Device{
+			DeviceInterface: "bondyolo0",
+			DeviceBond: &v1alpha1.Bond{
+				BondInterfaces:      []string{"lo"},
+				BondMode:            "balance-rr",
+				BondHashPolicy:      "layer2",
+				BondLACPRate:        "fast",
+				BondMIIMon:          200,
+				BondUpDelay:         100,
+				BondDownDelay:       100,
+				BondUseCarrier:      false,
+				BondARPInterval:     230,
+				BondARPValidate:     "all",
+				BondARPAllTargets:   "all",
+				BondPrimary:         "lo",
+				BondPrimaryReselect: "better",
+				BondFailOverMac:     "none",
+				BondResendIGMP:      10,
+				BondNumPeerNotif:    5,
+				BondAllSlavesActive: 1,
+				BondMinLinks:        1,
+				BondLPInterval:      100,
+				BondPacketsPerSlave: 50,
+				BondADSelect:        "bandwidth",
+				BondADActorSysPrio:  23,
+				BondADUserPortKey:   323,
+				BondTLBDynamicLB:    1,
+				BondPeerNotifyDelay: 200,
 			},
 		},
 	}

--- a/internal/app/networkd/pkg/networkd/networkd_test.go
+++ b/internal/app/networkd/pkg/networkd/networkd_test.go
@@ -171,18 +171,18 @@ func sampleConfigFile() config.Provider {
 			MachineNetwork: &v1alpha1.NetworkConfig{
 				NameServers:     []string{"1.2.3.4", "2.3.4.5"},
 				NetworkHostname: "myhostname",
-				NetworkInterfaces: []config.Device{
+				NetworkInterfaces: []*v1alpha1.Device{
 					{
-						Interface: "eth0",
-						CIDR:      "192.168.0.10/24",
-						MTU:       9100,
+						DeviceInterface: "eth0",
+						DeviceCIDR:      "192.168.0.10/24",
+						DeviceMTU:       9100,
 					},
 					{
-						Interface: "bond0",
-						CIDR:      "192.168.0.10/24",
-						Bond: &config.Bond{
-							Interfaces: []string{"lo"},
-							Mode:       "balance-rr",
+						DeviceInterface: "bond0",
+						DeviceCIDR:      "192.168.0.10/24",
+						DeviceBond: &v1alpha1.Bond{
+							BondInterfaces: []string{"lo"},
+							BondMode:       "balance-rr",
 						},
 					},
 				},
@@ -195,9 +195,9 @@ func dhcpConfigFile() config.Provider {
 	return &v1alpha1.Config{
 		MachineConfig: &v1alpha1.MachineConfig{
 			MachineNetwork: &v1alpha1.NetworkConfig{
-				NetworkInterfaces: []config.Device{
+				NetworkInterfaces: []*v1alpha1.Device{
 					{
-						Interface: "eth0",
+						DeviceInterface: "eth0",
 					},
 				},
 			},

--- a/internal/pkg/containers/cri/containerd/config.go
+++ b/internal/pkg/containers/cri/containerd/config.go
@@ -4,150 +4,50 @@
 
 package containerd
 
-import (
-	"bytes"
-	"fmt"
-	"path/filepath"
-
-	"github.com/BurntSushi/toml"
-
-	"github.com/talos-systems/talos/pkg/config"
-	"github.com/talos-systems/talos/pkg/constants"
-)
-
-// config structures to generate TOML containerd CRI plugin config.
-type mirror struct {
+// Mirror represents a registry mirror.
+type Mirror struct {
 	Endpoints []string `toml:"endpoint"`
 }
 
-type authConfig struct {
+// AuthConfig represents the registry auth options.
+type AuthConfig struct {
 	Username      string `toml:"username"`
 	Password      string `toml:"password"`
 	Auth          string `toml:"auth"`
 	IdentityToken string `toml:"identitytoken"`
 }
 
-type tlsConfig struct {
+// TLSConfig represents the registry TLS options.
+type TLSConfig struct {
 	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
 	CAFile             string `toml:"ca_file"`
 	CertFile           string `toml:"cert_file"`
 	KeyFile            string `toml:"key_file"`
 }
 
-type registryConfig struct {
-	Auth *authConfig `toml:"auth"`
-	TLS  *tlsConfig  `toml:"tls"`
+// RegistryConfig represents a registry.
+type RegistryConfig struct {
+	Auth *AuthConfig `toml:"auth"`
+	TLS  *TLSConfig  `toml:"tls"`
 }
 
-type registry struct {
-	Mirrors map[string]mirror         `toml:"mirrors"`
-	Configs map[string]registryConfig `toml:"configs"`
+// Registry represents the registry configuration.
+type Registry struct {
+	Mirrors map[string]Mirror         `toml:"mirrors"`
+	Configs map[string]RegistryConfig `toml:"configs"`
 }
 
-type criConfig struct {
-	Registry registry `toml:"registry"`
+// CRIConfig represents the CRI config.
+type CRIConfig struct {
+	Registry Registry `toml:"registry"`
 }
 
-type pluginsConfig struct {
-	CRI criConfig `toml:"cri"`
+// PluginsConfig represents the CRI plugins config.
+type PluginsConfig struct {
+	CRI CRIConfig `toml:"cri"`
 }
 
-type containerdConfig struct {
-	Plugins pluginsConfig `toml:"plugins"`
-}
-
-// GenerateRegistriesConfig for containerd CRI plugin (TOML format).
-//
-//nolint: gocyclo
-func GenerateRegistriesConfig(input config.Registries) ([]config.File, error) {
-	caPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "ca")
-	clientPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "client")
-
-	var ctrdCfg containerdConfig
-	ctrdCfg.Plugins.CRI.Registry.Mirrors = make(map[string]mirror)
-	ctrdCfg.Plugins.CRI.Registry.Configs = make(map[string]registryConfig)
-
-	for mirrorName, mirrorConfig := range input.Mirrors() {
-		ctrdCfg.Plugins.CRI.Registry.Mirrors[mirrorName] = mirror{Endpoints: mirrorConfig.Endpoints}
-	}
-
-	var extraFiles []config.File
-
-	for registryHost, hostConfig := range input.Config() {
-		cfg := registryConfig{}
-
-		if hostConfig.Auth != nil {
-			cfg.Auth = &authConfig{
-				Username:      hostConfig.Auth.Username,
-				Password:      hostConfig.Auth.Password,
-				Auth:          hostConfig.Auth.Auth,
-				IdentityToken: hostConfig.Auth.IdentityToken,
-			}
-		}
-
-		if hostConfig.TLS != nil {
-			cfg.TLS = &tlsConfig{
-				InsecureSkipVerify: hostConfig.TLS.InsecureSkipVerify,
-			}
-
-			if hostConfig.TLS.CA != nil {
-				path := filepath.Join(caPath, fmt.Sprintf("%s.crt", registryHost))
-
-				extraFiles = append(extraFiles, config.File{
-					Content:     string(hostConfig.TLS.CA),
-					Permissions: 0o600,
-					Path:        path,
-					Op:          "create",
-				})
-
-				cfg.TLS.CAFile = path
-			}
-
-			if hostConfig.TLS.ClientIdentity.Crt != nil {
-				path := filepath.Join(clientPath, fmt.Sprintf("%s.crt", registryHost))
-
-				extraFiles = append(extraFiles, config.File{
-					Content:     string(hostConfig.TLS.ClientIdentity.Crt),
-					Permissions: 0o600,
-					Path:        path,
-					Op:          "create",
-				})
-
-				cfg.TLS.CertFile = path
-			}
-
-			if hostConfig.TLS.ClientIdentity.Key != nil {
-				path := filepath.Join(clientPath, fmt.Sprintf("%s.key", registryHost))
-
-				extraFiles = append(extraFiles, config.File{
-					Content:     string(hostConfig.TLS.ClientIdentity.Key),
-					Permissions: 0o600,
-					Path:        path,
-					Op:          "create",
-				})
-
-				cfg.TLS.KeyFile = path
-			}
-		}
-
-		if cfg.Auth != nil || cfg.TLS != nil {
-			ctrdCfg.Plugins.CRI.Registry.Configs[registryHost] = cfg
-		}
-	}
-
-	var buf bytes.Buffer
-
-	if err := toml.NewEncoder(&buf).Encode(&ctrdCfg); err != nil {
-		return nil, err
-	}
-
-	// CRI plugin doesn't support merging configs for plugins across files,
-	// so we have to append CRI plugin to the main config, as it already contains
-	// configuration pieces for CRI plugin
-	return append(extraFiles, config.File{
-		Content:     buf.String(),
-		Permissions: 0o644,
-		Path:        constants.CRIContainerdConfig,
-		Op:          "append",
-	}), nil
+// Config represnts the containerd config.
+type Config struct {
+	Plugins PluginsConfig `toml:"plugins"`
 }

--- a/internal/pkg/containers/cri/containerd/containerd.go
+++ b/internal/pkg/containers/cri/containerd/containerd.go
@@ -4,3 +4,111 @@
 
 // Package containerd provides support for containerd CRI plugin
 package containerd
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/talos-systems/talos/pkg/config"
+	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/constants"
+)
+
+// GenerateRegistriesConfig returns a list of extra files.
+//
+//nolint: gocyclo
+func GenerateRegistriesConfig(r config.Registries) ([]config.File, error) {
+	caPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "ca")
+	clientPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "client")
+
+	var ctrdCfg Config
+	ctrdCfg.Plugins.CRI.Registry.Mirrors = make(map[string]Mirror)
+	ctrdCfg.Plugins.CRI.Registry.Configs = make(map[string]RegistryConfig)
+
+	for mirrorName, mirrorConfig := range r.Mirrors() {
+		ctrdCfg.Plugins.CRI.Registry.Mirrors[mirrorName] = Mirror{Endpoints: mirrorConfig.Endpoints()}
+	}
+
+	var extraFiles []config.File
+
+	for registryHost, hostConfig := range r.Config() {
+		cfg := RegistryConfig{}
+
+		if hostConfig.Auth() != nil {
+			cfg.Auth = &AuthConfig{
+				Username:      hostConfig.Auth().Username(),
+				Password:      hostConfig.Auth().Password(),
+				Auth:          hostConfig.Auth().Auth(),
+				IdentityToken: hostConfig.Auth().IdentityToken(),
+			}
+		}
+
+		if hostConfig.TLS() != nil {
+			cfg.TLS = &TLSConfig{
+				InsecureSkipVerify: hostConfig.TLS().InsecureSkipVerify(),
+			}
+
+			if hostConfig.TLS().CA() != nil {
+				path := filepath.Join(caPath, fmt.Sprintf("%s.crt", registryHost))
+
+				extraFiles = append(extraFiles, &v1alpha1.MachineFile{
+					FileContent:     string(hostConfig.TLS().CA()),
+					FilePermissions: 0o600,
+					FilePath:        path,
+					FileOp:          "create",
+				})
+
+				cfg.TLS.CAFile = path
+			}
+
+			if hostConfig.TLS().ClientIdentity() != nil && hostConfig.TLS().ClientIdentity().Crt != nil {
+				path := filepath.Join(clientPath, fmt.Sprintf("%s.crt", registryHost))
+
+				extraFiles = append(extraFiles, &v1alpha1.MachineFile{
+					FileContent:     string(hostConfig.TLS().ClientIdentity().Crt),
+					FilePermissions: 0o600,
+					FilePath:        path,
+					FileOp:          "create",
+				})
+
+				cfg.TLS.CertFile = path
+			}
+
+			if hostConfig.TLS().ClientIdentity() != nil && hostConfig.TLS().ClientIdentity().Key != nil {
+				path := filepath.Join(clientPath, fmt.Sprintf("%s.key", registryHost))
+
+				extraFiles = append(extraFiles, &v1alpha1.MachineFile{
+					FileContent:     string(hostConfig.TLS().ClientIdentity().Key),
+					FilePermissions: 0o600,
+					FilePath:        path,
+					FileOp:          "create",
+				})
+
+				cfg.TLS.KeyFile = path
+			}
+		}
+
+		if cfg.Auth != nil || cfg.TLS != nil {
+			ctrdCfg.Plugins.CRI.Registry.Configs[registryHost] = cfg
+		}
+	}
+
+	var buf bytes.Buffer
+
+	if err := toml.NewEncoder(&buf).Encode(&ctrdCfg); err != nil {
+		return nil, err
+	}
+
+	// CRI plugin doesn't support merging configs for plugins across files,
+	// so we have to append CRI plugin to the main config, as it already contains
+	// configuration pieces for CRI plugin
+	return append(extraFiles, &v1alpha1.MachineFile{
+		FileContent:     buf.String(),
+		FilePermissions: 0o644,
+		FilePath:        constants.CRIContainerdConfig,
+		FileOp:          "append",
+	}), nil
+}

--- a/internal/pkg/containers/image/resolver.go
+++ b/internal/pkg/containers/image/resolver.go
@@ -28,6 +28,8 @@ func NewResolver(reg config.Registries) remotes.Resolver {
 }
 
 // RegistryHosts returns host configuration per registry.
+//
+//nolint: gocyclo
 func RegistryHosts(reg config.Registries) docker.RegistryHosts {
 	return func(host string) ([]docker.RegistryHost, error) {
 		var registries []docker.RegistryHost
@@ -48,12 +50,12 @@ func RegistryHosts(reg config.Registries) docker.RegistryHosts {
 
 			registryConfig := reg.Config()[u.Host]
 
-			if u.Scheme != "https" && registryConfig.TLS != nil {
+			if u.Scheme != "https" && registryConfig != nil && registryConfig.TLS() != nil {
 				return nil, fmt.Errorf("TLS config specified for non-HTTPS registry: %q", u.Host)
 			}
 
-			if registryConfig.TLS != nil {
-				transport.TLSClientConfig, err = registryConfig.TLS.GetTLSConfig()
+			if registryConfig != nil && registryConfig.TLS() != nil {
+				transport.TLSClientConfig, err = registryConfig.TLS().GetTLSConfig()
 				if err != nil {
 					return nil, fmt.Errorf("error preparing TLS config for %q: %w", u.Host, err)
 				}
@@ -70,7 +72,11 @@ func RegistryHosts(reg config.Registries) docker.RegistryHosts {
 				Authorizer: docker.NewDockerAuthorizer(
 					docker.WithAuthClient(client),
 					docker.WithAuthCreds(func(host string) (string, string, error) {
-						return PrepareAuth(registryConfig.Auth, uu.Host, host)
+						if registryConfig == nil {
+							return "", "", nil
+						}
+
+						return PrepareAuth(registryConfig.Auth(), uu.Host, host)
 					})),
 				Host:         uu.Host,
 				Scheme:       uu.Scheme,
@@ -88,12 +94,12 @@ func RegistryEndpoints(reg config.Registries, host string) ([]string, error) {
 	var endpoints []string
 
 	if hostConfig, ok := reg.Mirrors()[host]; ok {
-		endpoints = hostConfig.Endpoints
+		endpoints = hostConfig.Endpoints()
 	}
 
 	if endpoints == nil {
 		if catchAllConfig, ok := reg.Mirrors()["*"]; ok {
-			endpoints = catchAllConfig.Endpoints
+			endpoints = catchAllConfig.Endpoints()
 		}
 	}
 
@@ -111,7 +117,7 @@ func RegistryEndpoints(reg config.Registries, host string) ([]string, error) {
 }
 
 // PrepareAuth returns authentication info in the format expected by containerd.
-func PrepareAuth(auth *config.RegistryAuthConfig, host, expectedHost string) (string, string, error) {
+func PrepareAuth(auth config.RegistryAuthConfig, host, expectedHost string) (string, string, error) {
 	if auth == nil {
 		return "", "", nil
 	}
@@ -121,19 +127,19 @@ func PrepareAuth(auth *config.RegistryAuthConfig, host, expectedHost string) (st
 		return "", "", nil
 	}
 
-	if auth.Username != "" {
-		return auth.Username, auth.Password, nil
+	if auth.Username() != "" {
+		return auth.Username(), auth.Password(), nil
 	}
 
-	if auth.IdentityToken != "" {
-		return "", auth.IdentityToken, nil
+	if auth.IdentityToken() != "" {
+		return "", auth.IdentityToken(), nil
 	}
 
-	if auth.Auth != "" {
-		decLen := base64.StdEncoding.DecodedLen(len(auth.Auth))
+	if auth.Auth() != "" {
+		decLen := base64.StdEncoding.DecodedLen(len(auth.Auth()))
 		decoded := make([]byte, decLen)
 
-		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.Auth))
+		_, err := base64.StdEncoding.Decode(decoded, []byte(auth.Auth()))
 		if err != nil {
 			return "", "", fmt.Errorf("error parsing auth for %q: %w", host, err)
 		}

--- a/internal/pkg/provision/providers/firecracker/firecracker.go
+++ b/internal/pkg/provision/providers/firecracker/firecracker.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
 	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
-	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/generate"
 )
@@ -58,11 +57,11 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 		}),
 		generate.WithNetworkConfig(&v1alpha1.NetworkConfig{
 			NameServers: nameservers,
-			NetworkInterfaces: []config.Device{
+			NetworkInterfaces: []*v1alpha1.Device{
 				{
-					Interface: "eth0",
-					CIDR:      "169.254.128.128/32", // link-local IP just to trigger the static networkd config
-					MTU:       networkReq.MTU,
+					DeviceInterface: "eth0",
+					DeviceCIDR:      "169.254.128.128/32", // link-local IP just to trigger the static networkd config
+					DeviceMTU:       networkReq.MTU,
 				},
 			},
 		}),

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -6,8 +6,6 @@ package config
 
 import (
 	"crypto/tls"
-	stdx509 "crypto/x509"
-	"fmt"
 	"net/url"
 	"os"
 	"time"
@@ -48,26 +46,26 @@ type MachineConfig interface {
 
 // Disk represents the options available for partitioning, formatting, and
 // mounting extra disks.
-type Disk struct {
-	Device     string      `yaml:"device,omitempty"`
-	Partitions []Partition `yaml:"partitions,omitempty"`
+type Disk interface {
+	Device() string
+	Partitions() []Partition
 }
 
 // Partition represents the options for a device partition.
-type Partition struct {
-	Size       uint   `yaml:"size,omitempty"`
-	MountPoint string `yaml:"mountpoint,omitempty"`
+type Partition interface {
+	Size() uint
+	MountPoint() string
 }
 
 // Env represents a set of environment variables.
 type Env = map[string]string
 
 // File represents a file to write to disk.
-type File struct {
-	Content     string      `yaml:"content"`
-	Permissions os.FileMode `yaml:"permissions"`
-	Path        string      `yaml:"path"`
-	Op          string      `yaml:"op"`
+type File interface {
+	Content() string
+	Permissions() os.FileMode
+	Path() string
+	Op() string
 }
 
 // Install defines the requirements for a config that pertains to install
@@ -101,68 +99,68 @@ type MachineNetwork interface {
 }
 
 // ExtraHost represents a host entry in /etc/hosts.
-type ExtraHost struct {
-	IP      string   `yaml:"ip"`
-	Aliases []string `yaml:"aliases"`
+type ExtraHost interface {
+	IP() string
+	Aliases() []string
 }
 
 // Device represents a network interface.
-type Device struct {
-	Interface string  `yaml:"interface"`
-	CIDR      string  `yaml:"cidr"`
-	Routes    []Route `yaml:"routes"`
-	Bond      *Bond   `yaml:"bond"`
-	Vlans     []*Vlan `yaml:"vlans"`
-	MTU       int     `yaml:"mtu"`
-	DHCP      bool    `yaml:"dhcp"`
-	Ignore    bool    `yaml:"ignore"`
-	Dummy     bool    `yaml:"dummy"`
+type Device interface {
+	Interface() string
+	CIDR() string
+	Routes() []Route
+	Bond() Bond
+	Vlans() []Vlan
+	MTU() int
+	DHCP() bool
+	Ignore() bool
+	Dummy() bool
 }
 
 // Bond contains the various options for configuring a
 // bonded interface.
-type Bond struct {
-	Interfaces      []string `yaml:"interfaces"`
-	ARPIPTarget     []string `yaml:"arpIPTarget"`
-	Mode            string   `yaml:"mode"`
-	HashPolicy      string   `yaml:"xmitHashPolicy"`
-	LACPRate        string   `yaml:"lacpRate"`
-	ADActorSystem   string   `yaml:"adActorSystem"`
-	ARPValidate     string   `yaml:"arpValidate"`
-	ARPAllTargets   string   `yaml:"arpAllTargets"`
-	Primary         string   `yaml:"primary"`
-	PrimaryReselect string   `yaml:"primaryReselect"`
-	FailOverMac     string   `yaml:"failOverMac"`
-	ADSelect        string   `yaml:"adSelect"`
-	MIIMon          uint32   `yaml:"miimon"`
-	UpDelay         uint32   `yaml:"updelay"`
-	DownDelay       uint32   `yaml:"downdelay"`
-	ARPInterval     uint32   `yaml:"arpInterval"`
-	ResendIGMP      uint32   `yaml:"resendIgmp"`
-	MinLinks        uint32   `yaml:"minLinks"`
-	LPInterval      uint32   `yaml:"lpInterval"`
-	PacketsPerSlave uint32   `yaml:"packetsPerSlave"`
-	NumPeerNotif    uint8    `yaml:"numPeerNotif"`
-	TLBDynamicLB    uint8    `yaml:"tlbDynamicLb"`
-	AllSlavesActive uint8    `yaml:"allSlavesActive"`
-	UseCarrier      bool     `yaml:"useCarrier"`
-	ADActorSysPrio  uint16   `yaml:"adActorSysPrio"`
-	ADUserPortKey   uint16   `yaml:"adUserPortKey"`
-	PeerNotifyDelay uint32   `yaml:"peerNotifyDelay"`
+type Bond interface {
+	Interfaces() []string
+	ARPIPTarget() []string
+	Mode() string
+	HashPolicy() string
+	LACPRate() string
+	ADActorSystem() string
+	ARPValidate() string
+	ARPAllTargets() string
+	Primary() string
+	PrimaryReselect() string
+	FailOverMac() string
+	ADSelect() string
+	MIIMon() uint32
+	UpDelay() uint32
+	DownDelay() uint32
+	ARPInterval() uint32
+	ResendIGMP() uint32
+	MinLinks() uint32
+	LPInterval() uint32
+	PacketsPerSlave() uint32
+	NumPeerNotif() uint8
+	TLBDynamicLB() uint8
+	AllSlavesActive() uint8
+	UseCarrier() bool
+	ADActorSysPrio() uint16
+	ADUserPortKey() uint16
+	PeerNotifyDelay() uint32
 }
 
 // Vlan represents vlan settings for a device.
-type Vlan struct {
-	CIDR   string  `ỳaml:"cidr"`
-	Routes []Route `yaml:"routes"`
-	DHCP   bool    `yaml:"dhcp"`
-	ID     uint16  `yaml:"vlanId"`
+type Vlan interface {
+	CIDR() string
+	Routes() []Route
+	DHCP() bool
+	ID() uint16
 }
 
 // Route represents a network route.
-type Route struct {
-	Network string `yaml:"network"`
-	Gateway string `yaml:"gateway"`
+type Route interface {
+	Network() string
+	Gateway() string
 }
 
 // Time defines the requirements for a config that pertains to time related
@@ -185,88 +183,33 @@ type Registries interface {
 	Mirrors() map[string]RegistryMirrorConfig
 	// Registry config (auth, TLS) by hostname.
 	Config() map[string]RegistryConfig
-	// ExtraFiles generates TOML config for containerd CRI plugin.
-	ExtraFiles() ([]File, error)
 }
 
 // RegistryMirrorConfig represents mirror configuration for a registry.
-type RegistryMirrorConfig struct {
-	//   description: |
-	//     List of endpoints (URLs) for registry mirrors to use.
-	//     Endpoint configures HTTP/HTTPS access mode, host name,
-	//     port and path (if path is not set, it defaults to `/v2`).
-	Endpoints []string `yaml:"endpoints"`
+type RegistryMirrorConfig interface {
+	Endpoints() []string
 }
 
 // RegistryConfig specifies auth & TLS config per registry.
-type RegistryConfig struct {
-	TLS  *RegistryTLSConfig  `yaml:"tls,omitempty"`
-	Auth *RegistryAuthConfig `yaml:"auth,omitempty"`
+type RegistryConfig interface {
+	TLS() RegistryTLSConfig
+	Auth() RegistryAuthConfig
 }
 
 // RegistryAuthConfig specifies authentication configuration for a registry.
-type RegistryAuthConfig struct {
-	//   description: |
-	//     Optional registry authentication.
-	//     The meaning of each field is the same with the corresponding field in .docker/config.json.
-	Username string `yaml:"username"`
-	//   description: |
-	//     Optional registry authentication.
-	//     The meaning of each field is the same with the corresponding field in .docker/config.json.
-	Password string `yaml:"password"`
-	//   description: |
-	//     Optional registry authentication.
-	//     The meaning of each field is the same with the corresponding field in .docker/config.json.
-	Auth string `yaml:"auth"`
-	//   description: |
-	//     Optional registry authentication.
-	//     The meaning of each field is the same with the corresponding field in .docker/config.json.
-	IdentityToken string `yaml:"identityToken"`
+type RegistryAuthConfig interface {
+	Username() string
+	Password() string
+	Auth() string
+	IdentityToken() string
 }
 
 // RegistryTLSConfig specifies TLS config for HTTPS registries.
-type RegistryTLSConfig struct {
-	//   description: |
-	//     Enable mutual TLS authentication with the registry.
-	//     Client certificate and key should be base64-encoded.
-	//   examples:
-	//     - |
-	//       clientIdentity:
-	//         crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJIekNCMHF...
-	//         key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM...
-	ClientIdentity *x509.PEMEncodedCertificateAndKey `yaml:"clientIdentity,omitempty"`
-	//   description: |
-	//     CA registry certificate to add the list of trusted certificates.
-	//     Certificate should be base64-encoded.
-	CA []byte `yaml:"ca,omitempty"`
-	//   description: |
-	//     Skip TLS server certificate verification (not recommended).
-	InsecureSkipVerify bool `yaml:"insecureSkipVerify,omitempty"`
-}
-
-// GetTLSConfig prepares TLS configuration for connection.
-func (cfg *RegistryTLSConfig) GetTLSConfig() (*tls.Config, error) {
-	tlsConfig := &tls.Config{}
-
-	if cfg.ClientIdentity != nil {
-		cert, err := tls.X509KeyPair(cfg.ClientIdentity.Crt, cfg.ClientIdentity.Key)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing client identity: %w", err)
-		}
-
-		tlsConfig.Certificates = []tls.Certificate{cert}
-	}
-
-	if cfg.CA != nil {
-		tlsConfig.RootCAs = stdx509.NewCertPool()
-		tlsConfig.RootCAs.AppendCertsFromPEM(cfg.CA)
-	}
-
-	if cfg.InsecureSkipVerify {
-		tlsConfig.InsecureSkipVerify = true
-	}
-
-	return tlsConfig, nil
+type RegistryTLSConfig interface {
+	ClientIdentity() *x509.PEMEncodedCertificateAndKey
+	CA() []byte
+	InsecureSkipVerify() bool
+	GetTLSConfig() (*tls.Config, error)
 }
 
 // ClusterConfig defines the requirements for a config that pertains to cluster

--- a/pkg/config/types/v1alpha1/generate/generate.go
+++ b/pkg/config/types/v1alpha1/generate/generate.go
@@ -16,7 +16,6 @@ import (
 	stdlibx509 "crypto/x509"
 
 	"github.com/talos-systems/talos/internal/pkg/cis"
-	"github.com/talos-systems/talos/pkg/config"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
@@ -79,7 +78,7 @@ type Input struct {
 	NetworkConfig *v1alpha1.NetworkConfig
 	CNIConfig     *v1alpha1.CNIConfig
 
-	RegistryMirrors map[string]config.RegistryMirrorConfig
+	RegistryMirrors map[string]*v1alpha1.RegistryMirrorConfig
 
 	Debug   bool
 	Persist bool

--- a/pkg/config/types/v1alpha1/generate/options.go
+++ b/pkg/config/types/v1alpha1/generate/options.go
@@ -5,7 +5,6 @@
 package generate
 
 import (
-	"github.com/talos-systems/talos/pkg/config"
 	v1alpha1 "github.com/talos-systems/talos/pkg/config/types/v1alpha1"
 )
 
@@ -70,10 +69,10 @@ func WithNetworkConfig(network *v1alpha1.NetworkConfig) GenOption {
 func WithRegistryMirror(host string, endpoints ...string) GenOption {
 	return func(o *GenOptions) error {
 		if o.RegistryMirrors == nil {
-			o.RegistryMirrors = make(map[string]config.RegistryMirrorConfig)
+			o.RegistryMirrors = make(map[string]*v1alpha1.RegistryMirrorConfig)
 		}
 
-		o.RegistryMirrors[host] = config.RegistryMirrorConfig{Endpoints: endpoints}
+		o.RegistryMirrors[host] = &v1alpha1.RegistryMirrorConfig{MirrorEndpoints: endpoints}
 
 		return nil
 	}
@@ -124,7 +123,7 @@ type GenOptions struct {
 	AdditionalSubjectAltNames []string
 	NetworkConfig             *v1alpha1.NetworkConfig
 	CNIConfig                 *v1alpha1.CNIConfig
-	RegistryMirrors           map[string]config.RegistryMirrorConfig
+	RegistryMirrors           map[string]*v1alpha1.RegistryMirrorConfig
 	DNSDomain                 string
 	Debug                     bool
 	Persist                   bool


### PR DESCRIPTION
This make the config provider a pure interface definition by removing
all concrete internal types, and making them an interface.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2392)
<!-- Reviewable:end -->
