### PR TITLE
fix: update qemu launcher on arm64 to boot Talos properly

### DIFF
--- a/internal/pkg/provision/providers/qemu/arch.go
+++ b/internal/pkg/provision/providers/qemu/arch.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+// Arch abstracts away differences between different architectures.
+type Arch string
+
+// Arch constants.
+const (
+	ArchAmd64 Arch = "amd64"
+	ArchArm64 Arch = "arm64"
+)
+
+// Valid checks whether the architecture is supported.
+func (arch Arch) Valid() bool {
+	switch arch {
+	case ArchAmd64, ArchArm64:
+		return true
+	default:
+		return false
+	}
+}
+
+// QemuArch defines which qemu binary to use.
+func (arch Arch) QemuArch() string {
+	switch arch {
+	case ArchAmd64:
+		return "x86_64"
+	case ArchArm64:
+		return "aarch64"
+	default:
+		panic("unsupported architecture")
+	}
+}
+
+// QemuMachine defines the machine type for qemu.
+func (arch Arch) QemuMachine() string {
+	switch arch {
+	case ArchAmd64:
+		return "q35"
+	case ArchArm64:
+		return "virt,gic-version=max"
+	default:
+		panic("unsupported architecture")
+	}
+}
+
+// Console defines proper argument for the kernel to send logs to serial console.
+func (arch Arch) Console() string {
+	switch arch {
+	case ArchAmd64:
+		return "ttyS0"
+	case ArchArm64:
+		return "ttyAMA0,115200n8"
+	default:
+		panic("unsupported architecture")
+	}
+}
+
+// PFlash for UEFI boot.
+type PFlash struct {
+	Size       int64
+	SourcePath string
+}
+
+// PFlash returns settings for parallel flash.
+func (arch Arch) PFlash() []PFlash {
+	switch arch {
+	case ArchArm64:
+		return []PFlash{
+			{
+				Size:       64 * 1024 * 1024,
+				SourcePath: "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd",
+			},
+			{
+				Size: 64 * 1024 * 1024,
+			},
+		}
+	case ArchAmd64:
+		fallthrough
+	default:
+		return nil
+	}
+}

--- a/internal/pkg/provision/providers/qemu/pflash.go
+++ b/internal/pkg/provision/providers/qemu/pflash.go
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
+)
+
+func (p *provisioner) createPFlashImages(state *vm.State, pflashSpec []PFlash) error {
+	for i, pflash := range pflashSpec {
+		if err := func(i int, pflash PFlash) error {
+			path := state.GetRelativePath(fmt.Sprintf("flash%d.img", i))
+
+			f, err := os.Create(path)
+			if err != nil {
+				return nil
+			}
+
+			defer f.Close() //nolint: errcheck
+
+			if err := f.Truncate(pflash.Size); err != nil {
+				return err
+			}
+
+			if pflash.SourcePath != "" {
+				src, err := os.Open(pflash.SourcePath)
+				if err != nil {
+					return nil
+				}
+
+				defer src.Close() //nolint: errcheck
+
+				if _, err := io.Copy(f, src); err != nil {
+					return err
+				}
+			}
+
+			state.PFlashImages = append(state.PFlashImages, path)
+
+			return nil
+		}(i, pflash); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/pkg/provision/providers/qemu/qemu.go
+++ b/internal/pkg/provision/providers/qemu/qemu.go
@@ -6,7 +6,6 @@ package qemu
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/talos-systems/talos/internal/pkg/provision"
 	"github.com/talos-systems/talos/internal/pkg/provision/providers/vm"
@@ -43,7 +42,7 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 	return []generate.GenOption{
 		generate.WithInstallDisk("/dev/vda"),
 		generate.WithInstallExtraKernelArgs([]string{
-			"console=ttyS0",
+			"console=ttyS0", // TODO: should depend on arch
 			// reboot configuration
 			"reboot=k",
 			"panic=1",
@@ -57,15 +56,4 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
 	// firecracker runs loadbalancer on the bridge, which is good for both internal & external access
 	return networkReq.GatewayAddr.String(), networkReq.GatewayAddr.String()
-}
-
-func qemuArchFromGoArch(arch string) (string, string, error) {
-	switch arch {
-	case "amd64":
-		return "x86_64", "q35", nil
-	case "arm64":
-		return "aarch64", "virt", nil
-	default:
-		return "", "", fmt.Errorf("architecture %q is not supported", arch)
-	}
 }

--- a/internal/pkg/provision/providers/vm/state.go
+++ b/internal/pkg/provision/providers/vm/state.go
@@ -24,7 +24,10 @@ type State struct {
 	ClusterInfo provision.ClusterInfo
 
 	VMCNIConfig *libcni.NetworkConfigList
-	statePath   string
+
+	PFlashImages []string
+
+	statePath string
 }
 
 // NewState create new vm provisioner state.


### PR DESCRIPTION
This includes better machine args, support for UEFI parallel flash
images required as low-level bootloader, and miscallenous cleanups.

Qemu support was enabled for mapping host random source to the guest as
entropy source to prevent stalls on the boot waiting for the entropy.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2397)
<!-- Reviewable:end -->
