### PR TITLE
fix: allow static pod manifests in files

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -916,7 +916,15 @@ func WriteUserFiles(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 			// We do not want to support creating new files anywhere outside of
 			// /var. If a valid use case comes up, we can reconsider then.
 			if !inVar && f.Op == "create" {
-				return fmt.Errorf("create operation not allowed outside of /var: %q", f.Path)
+				var abs string
+
+				if abs, err = filepath.Abs(f.Path); err != nil {
+					return err
+				}
+
+				if !strings.HasPrefix(abs, constants.ManifestsDirectory) {
+					return fmt.Errorf("create operation not allowed outside of /var: %q", f.Path)
+				}
 			}
 
 			if err = os.MkdirAll(filepath.Dir(p), os.ModeDir); err != nil {


### PR DESCRIPTION
This adds an exception for files in `/etc/kubernetes/manifests`. This
allows users to create static pods.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2400)
<!-- Reviewable:end -->
