### PR TITLE
feat: add persist flag to gen config

### DIFF
--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -31,6 +31,7 @@ var (
 	installImage      string
 	outputDir         string
 	registryMirrors   []string
+	persistConfig     bool
 )
 
 // genConfigCmd represents the gen config command.
@@ -99,6 +100,7 @@ func genV1Alpha1Config(args []string) error {
 					generate.WithInstallImage(installImage),
 					generate.WithAdditionalSubjectAltNames(additionalSANs),
 					generate.WithDNSDomain(dnsDomain),
+					generate.WithPersist(persistConfig),
 				),
 			},
 		),
@@ -167,4 +169,5 @@ func init() {
 	genConfigCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 	genConfigCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "destination to output generated files")
 	genConfigCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
+	genConfigCmd.Flags().BoolVarP(&persistConfig, "persist", "p", true, "the desired persist value for configs")
 }

--- a/docs/talosctl/talosctl_gen_config.md
+++ b/docs/talosctl/talosctl_gen_config.md
@@ -24,6 +24,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --install-image string        the image used to perform an installation (default "docker.io/autonomy/installer:latest")
       --kubernetes-version string   desired kubernetes version to run (default "1.19.0-rc.3")
   -o, --output-dir string           destination to output generated files
+  -p, --persist                     the desired persist value for configs (default true)
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
       --version string              the desired machine config version to generate (default "v1alpha1")
 ```


### PR DESCRIPTION
This PR adds a flag to tweak the persistence value for talosctl gen
config.

Will close #2401.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2402)
<!-- Reviewable:end -->
