### PR TITLE
test: PoC for Sidero integration test

### DIFF
--- a/capi.sh
+++ b/capi.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+TIMEOUT=60
+
+rm -f kubeconfig
+talosctl -n 172.20.0.2 kubeconfig
+export KUBECONFIG=$PWD/kubeconfig
+
+kubectl taint node talos-default-master-1 node-role.kubernetes.io/master:NoSchedule-
+
+clusterctl init -b talos -c talos -i sidero
+
+timeout=$(($(date +%s) + ${TIMEOUT}))
+until kubectl wait --timeout=1s --for=condition=Ready -n sidero-system pods --all; do
+  [[ $(date +%s) -gt $timeout ]] && exit 1
+  echo 'Waiting to CABPT pod to be available...'
+  sleep 5
+done
+
+## Update args to use 9091 for port
+kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args", "value": ["--port=9091"]}]'
+
+## Tweak container port to match
+kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/ports", "value": [{"containerPort": 9091,"name": "http"}]}]'
+
+## Use host networking
+kubectl patch deploy -n sidero-system sidero-metadata-server --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'
+
+## Update args to specify the api endpoint to use for registration
+kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/1/args", "value": ["--api-endpoint=172.20.0.2","--metrics-addr=127.0.0.1:8080","--enable-leader-election"]}]'
+
+## Use host networking
+kubectl patch deploy -n sidero-system sidero-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/hostNetwork", "value": true}]'

--- a/internal/pkg/provision/providers/qemu/create.go
+++ b/internal/pkg/provision/providers/qemu/create.go
@@ -85,6 +85,17 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		return nil, err
 	}
 
+	var pxeNodeInfo []provision.NodeInfo
+
+	pxeNodes := request.Nodes.PXENodes()
+	if len(pxeNodes) > 0 {
+		fmt.Fprintln(options.LogWriter, "creating PXE nodes")
+
+		if pxeNodeInfo, err = p.createNodes(state, request, pxeNodes, &options); err != nil {
+			return nil, err
+		}
+	}
+
 	nodeInfo = append(nodeInfo, workerNodeInfo...)
 
 	state.ClusterInfo = provision.ClusterInfo{
@@ -95,7 +106,8 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 			GatewayAddr: request.Network.GatewayAddr,
 			MTU:         request.Network.MTU,
 		},
-		Nodes: nodeInfo,
+		Nodes:      nodeInfo,
+		ExtraNodes: pxeNodeInfo,
 	}
 
 	err = state.Save()

--- a/internal/pkg/provision/providers/vm/dhcpd.go
+++ b/internal/pkg/provision/providers/vm/dhcpd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/provision"
 )
 
+//nolint: gocyclo
 func handler(serverIP net.IP, statePath string) server4.Handler {
 	return func(conn net.PacketConn, peer net.Addr, m *dhcpv4.DHCPv4) {
 		if m.OpCode != dhcpv4.OpcodeBootRequest {
@@ -45,7 +46,6 @@ func handler(serverIP net.IP, statePath string) server4.Handler {
 
 		resp, err := dhcpv4.NewReplyFromRequest(m,
 			dhcpv4.WithNetmask(match.Netmask),
-			dhcpv4.WithServerIP(serverIP),
 			dhcpv4.WithYourIP(match.IP),
 			dhcpv4.WithOption(dhcpv4.OptHostName(match.Hostname)),
 			dhcpv4.WithOption(dhcpv4.OptDNS(match.Nameservers...)),
@@ -56,6 +56,26 @@ func handler(serverIP net.IP, statePath string) server4.Handler {
 		if err != nil {
 			log.Printf("failure building response: %s", err)
 			return
+		}
+
+		if m.IsOptionRequested(dhcpv4.OptionBootfileName) {
+			log.Printf("received PXE boot request from %s", m.ClientHWAddr)
+
+			if match.TFTPServer != "" {
+				bootFilename := match.BootFilename
+
+				for _, userClass := range m.UserClass() {
+					if userClass == "iPXE" {
+						bootFilename = match.IPXEBootFilename
+					}
+				}
+
+				log.Printf("sending PXE response to %s: %s/%s", m.ClientHWAddr, match.TFTPServer, bootFilename)
+
+				resp.ServerIPAddr = net.ParseIP(match.TFTPServer)
+				resp.UpdateOption(dhcpv4.OptTFTPServerName(match.TFTPServer))
+				resp.UpdateOption(dhcpv4.OptBootFileName(bootFilename))
+			}
 		}
 
 		resp.UpdateOption(dhcpv4.OptGeneric(dhcpv4.OptionInterfaceMTU, dhcpv4.Uint16(match.MTU).ToBytes()))

--- a/internal/pkg/provision/providers/vm/ipam.go
+++ b/internal/pkg/provision/providers/vm/ipam.go
@@ -22,6 +22,10 @@ type IPAMRecord struct {
 	Gateway     net.IP
 	MTU         int
 	Nameservers []net.IP
+
+	TFTPServer       string
+	BootFilename     string
+	IPXEBootFilename string
 }
 
 // IPAMDatabase is a mapping from MAC address to records.

--- a/internal/pkg/provision/providers/vm/node.go
+++ b/internal/pkg/provision/providers/vm/node.go
@@ -16,7 +16,9 @@ import (
 func (p *Provisioner) DestroyNodes(cluster provision.ClusterInfo, options *provision.Options) error {
 	errCh := make(chan error)
 
-	for _, node := range cluster.Nodes {
+	nodes := append(cluster.Nodes, cluster.ExtraNodes...)
+
+	for _, node := range nodes {
 		go func(node provision.NodeInfo) {
 			fmt.Fprintln(options.LogWriter, "stopping VM", node.Name)
 
@@ -26,7 +28,7 @@ func (p *Provisioner) DestroyNodes(cluster provision.ClusterInfo, options *provi
 
 	var multiErr *multierror.Error
 
-	for range cluster.Nodes {
+	for range nodes {
 		multiErr = multierror.Append(multiErr, <-errCh)
 	}
 

--- a/internal/pkg/provision/request.go
+++ b/internal/pkg/provision/request.go
@@ -57,6 +57,10 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 	found := false
 
 	for i := range reqs {
+		if reqs[i].Config == nil {
+			continue
+		}
+
 		if reqs[i].Config.Machine().Type() == machine.TypeInit {
 			if found {
 				err = fmt.Errorf("duplicate init node in requests")
@@ -78,6 +82,10 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 // MasterNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 	for i := range reqs {
+		if reqs[i].Config == nil {
+			continue
+		}
+
 		if reqs[i].Config.Machine().Type() == machine.TypeInit || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
 			nodes = append(nodes, reqs[i])
 		}
@@ -89,7 +97,22 @@ func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 // WorkerNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 	for i := range reqs {
+		if reqs[i].Config == nil {
+			continue
+		}
+
 		if reqs[i].Config.Machine().Type() == machine.TypeJoin {
+			nodes = append(nodes, reqs[i])
+		}
+	}
+
+	return
+}
+
+// PXENodes returns subset of nodes which are PXE booted.
+func (reqs NodeRequests) PXENodes() (nodes []NodeRequest) {
+	for i := range reqs {
+		if reqs[i].PXEBooted {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -111,4 +134,10 @@ type NodeRequest struct {
 	DiskSize int64
 	// Ports
 	Ports []string
+
+	// PXE-booted VMs
+	PXEBooted        bool
+	TFTPServer       string
+	BootFilename     string
+	IPXEBootFilename string
 }

--- a/internal/pkg/provision/result.go
+++ b/internal/pkg/provision/result.go
@@ -26,6 +26,9 @@ type ClusterInfo struct {
 
 	Network NetworkInfo
 	Nodes   []NodeInfo
+
+	// ExtraNodes are not part of the cluster.
+	ExtraNodes []NodeInfo
 }
 
 // NetworkInfo describes cluster network.


### PR DESCRIPTION
Code is a mess, just PoC for now.

Changes:

1. Added "PXE" nodes to provisioner, qemu support for it.

2. dhcpd in qemu can hand over TFTP-related options, in fact I guess we
need even less for qemu (it already has UEFI iPXE built-in).

3. Script based on Spencer's notes which works up to server registration
in Sidero.

Lots of stuff to fix, e.g. we need to generate node UUID and put that to
SMBIOS for qemu, additional data we might want to set, etc.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2406)
<!-- Reviewable:end -->
