### PR TITLE
fix: retry non-HTTP errors from API server

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -257,6 +257,11 @@ func (h *Client) WaitUntilReady(name string) error {
 				return retry.ExpectedError(err)
 			}
 
+			if apierrors.ReasonForError(err) == metav1.StatusReasonUnknown {
+				// non-API error, e.g. networking error
+				return retry.ExpectedError(err)
+			}
+
 			return retry.UnexpectedError(err)
 		}
 


### PR DESCRIPTION
While waiting for node ready condition, API server endpoint might return
networking errors (e.g. if endpoint is a RR DNS record).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2410)
<!-- Reviewable:end -->
