### PR TITLE
fix: update e2e scripts to work with python3

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -192,7 +192,7 @@ function build_registry_mirrors {
 
     for registry in docker.io k8s.gcr.io quay.io gcr.io; do
       local service="registry-${registry//./-}.ci.svc"
-      local addr=`python -c "import socket; print socket.gethostbyname('${service}')"`
+      local addr=`python3 -c "import socket; print(socket.gethostbyname('${service}'))"`
 
       REGISTRY_MIRROR_FLAGS="${REGISTRY_MIRROR_FLAGS} --registry-mirror ${registry}=http://${addr}:5000"
     done


### PR DESCRIPTION
This PR replaces python with python3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2415)
<!-- Reviewable:end -->
