### PR TITLE
fix: ignore eth0 interface in docker provisioner

### DIFF
--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -48,18 +48,25 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 		generate.WithPersist(false),
 	}
 
+	networkConfig := &v1alpha1.NetworkConfig{
+		NetworkInterfaces: []*v1alpha1.Device{
+			{
+				DeviceInterface: "eth0",
+				DeviceIgnore:    true,
+			},
+		},
+	}
+
 	if len(networkReq.Nameservers) > 0 {
 		nameservers := make([]string, len(networkReq.Nameservers))
 		for i := range nameservers {
 			nameservers[i] = networkReq.Nameservers[i].String()
 		}
 
-		ret = append(ret, generate.WithNetworkConfig(
-			&v1alpha1.NetworkConfig{
-				NameServers: nameservers,
-			}),
-		)
+		networkConfig.NameServers = nameservers
 	}
+
+	ret = append(ret, generate.WithNetworkConfig(networkConfig))
 
 	return ret
 }


### PR DESCRIPTION
This avoids pause on container startup when `networkd` tries to do DHCP
over `eth0` (which fails for obvious reasons). Interfaces are
pre-configured in Docker.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2420)
<!-- Reviewable:end -->
