### PR TITLE
chore: update machinery version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/talos-systems/go-smbios v0.0.0-20200219201045-94b8c4e489ee
 	github.com/talos-systems/grpc-proxy v0.2.0
 	github.com/talos-systems/net v0.1.0
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-00010101000000-000000000000
+	github.com/talos-systems/talos/pkg/machinery v0.0.0-20200818212414-6a7cc0264819
 	github.com/u-root/u-root v6.0.0+incompatible // indirect
 	github.com/vishvananda/netns v0.0.0-20200520041808-52d707b772fe // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20200218095840-687661b8bd8e


### PR DESCRIPTION
The version we had was pre-push to master and it's invalid version:

```
go get github.com/talos-systems/talos@master
go: github.com/talos-systems/talos master => v0.7.0-alpha.0.0.20200818212414-6a7cc0264819
go get: github.com/talos-systems/talos@v0.7.0-alpha.0.0.20200818212414-6a7cc0264819 requires
        github.com/talos-systems/talos/pkg/machinery@v0.0.0-00010101000000-000000000000:
	invalid version: unknown revision 000000000000
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2438)
<!-- Reviewable:end -->
