### PR TITLE
refactor: extract cluster bootstrapper via API as common component

### DIFF
--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/retry"
+)
+
+// APIBoostrapper bootstraps cluster via Talos API.
+type APIBoostrapper struct {
+	ClientProvider
+	Info
+}
+
+// Bootstrap the cluster via the API.
+//
+// Bootstrap implements Bootstrapper interface.
+func (s *APIBoostrapper) Bootstrap(ctx context.Context, out io.Writer) error {
+	cli, err := s.Client()
+	if err != nil {
+		return err
+	}
+
+	controlPlaneNodes := s.NodesByType(machine.TypeControlPlane)
+	if len(controlPlaneNodes) == 0 {
+		return fmt.Errorf("no control plane nodes to bootstrap")
+	}
+
+	sort.Strings(controlPlaneNodes)
+
+	node := controlPlaneNodes[0]
+	nodeCtx := client.WithNodes(ctx, node)
+
+	fmt.Fprintln(out, "waiting for API")
+
+	err = retry.Constant(5*time.Minute, retry.WithUnits(500*time.Millisecond)).Retry(func() error {
+		retryCtx, cancel := context.WithTimeout(nodeCtx, 500*time.Millisecond)
+		defer cancel()
+
+		if _, err = cli.Version(retryCtx); err != nil {
+			return retry.ExpectedError(err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "bootstrapping cluster")
+
+	bootstrapCtx, cancel := context.WithTimeout(nodeCtx, 30*time.Second)
+	defer cancel()
+
+	return cli.Bootstrap(bootstrapCtx)
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -43,3 +43,8 @@ type Info interface {
 	// NodesByType return list of node endpoints by type.
 	NodesByType(machine.Type) []string
 }
+
+// Bootstrapper performs Talos cluster bootstrap.
+type Bootstrapper interface {
+	Bootstrap(ctx context.Context, out io.Writer) error
+}

--- a/pkg/provision/access/adapter.go
+++ b/pkg/provision/access/adapter.go
@@ -15,6 +15,7 @@ type Adapter struct {
 	cluster.ConfigClientProvider
 	cluster.KubernetesClient
 	cluster.APICrashDumper
+	cluster.APIBoostrapper
 	cluster.Info
 }
 
@@ -54,6 +55,8 @@ func NewAdapter(clusterInfo provision.Cluster, opts ...provision.Option) *Adapte
 		}
 	}
 
+	info := &infoWrapper{clusterInfo: clusterInfo.Info()}
+
 	configProvider := cluster.ConfigClientProvider{
 		DefaultClient: options.TalosClient,
 		TalosConfig:   options.TalosConfig,
@@ -67,8 +70,12 @@ func NewAdapter(clusterInfo provision.Cluster, opts ...provision.Option) *Adapte
 		},
 		APICrashDumper: cluster.APICrashDumper{
 			ClientProvider: &configProvider,
-			Info:           &infoWrapper{clusterInfo: clusterInfo.Info()},
+			Info:           info,
 		},
-		Info: &infoWrapper{clusterInfo: clusterInfo.Info()},
+		APIBoostrapper: cluster.APIBoostrapper{
+			ClientProvider: &configProvider,
+			Info:           info,
+		},
+		Info: info,
 	}
 }


### PR DESCRIPTION
It should be useful in any project provisioning Talos clusters.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2439)
<!-- Reviewable:end -->
