### PR TITLE
feat: make boostrap via API default choice in talosctl cluster create

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -443,7 +443,7 @@ func init() {
 		"Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)",
 	)
 	createCmd.Flags().StringVar(&dockerHostIP, "docker-host-ip", "0.0.0.0", "Host IP to forward exposed ports to (Docker provisioner only)")
-	createCmd.Flags().BoolVar(&withInitNode, "with-init-node", true, "create the cluster with an init node")
+	createCmd.Flags().BoolVar(&withInitNode, "with-init-node", false, "create the cluster with an init node")
 	createCmd.Flags().StringVar(&customCNIUrl, "custom-cni-url", "", "install custom CNI from the URL (Talos cluster)")
 	createCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	createCmd.Flags().BoolVar(&crashdumpOnFailure, "crashdump", false, "print debug crashdump to stderr when cluster startup fails")

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -44,7 +44,7 @@ talosctl cluster create [flags]
       --wait-timeout duration       timeout to wait for the cluster to be ready (default 20m0s)
       --with-bootloader             enable bootloader to load kernel and initramfs from disk image after install (default true)
       --with-debug                  enable debug in Talos config to send service logs to the console
-      --with-init-node              create the cluster with an init node (default true)
+      --with-init-node              create the cluster with an init node
       --workers int                 the number of workers to create (default 1)
 ```
 


### PR DESCRIPTION
As we're going to make API bootstrapping a preferred method of
bootstrapping Talos clusters, our defaults should reflect that.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2440)
<!-- Reviewable:end -->
