### PR TITLE
fix: pass config via stdin

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -20,21 +20,16 @@ import (
 	"github.com/talos-systems/talos/internal/app/apid/pkg/provider"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/grpc/proxy/backend"
-	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
-var (
-	configPath *string
-	endpoints  *string
-)
+var endpoints *string
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
-	configPath = flag.String("config", "", "the path to the config")
 	endpoints = flag.String("endpoints", "", "the IPs of the control plane nodes")
 
 	flag.Parse()
@@ -45,7 +40,7 @@ func main() {
 		log.Fatalf("failed to seed RNG: %v", err)
 	}
 
-	config, err := loadConfig()
+	config, err := configloader.NewFromStdin()
 	if err != nil {
 		log.Fatalf("open config: %v", err)
 	}
@@ -129,8 +124,4 @@ func main() {
 	if err := errGroup.Wait(); err != nil {
 		log.Fatalf("listen: %v", err)
 	}
-}
-
-func loadConfig() (config.Provider, error) {
-	return configloader.NewFromFile(*configPath)
 }

--- a/internal/app/bootkube/main.go
+++ b/internal/app/bootkube/main.go
@@ -18,7 +18,6 @@ import (
 )
 
 var (
-	configPath    *string
 	strict        *bool
 	recover       *bool
 	recoverSource *string
@@ -27,7 +26,6 @@ var (
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
-	configPath = flag.String("config", "", "the path to the config")
 	strict = flag.Bool("strict", true, "require all manifests to cleanly apply")
 	recover = flag.Bool("recover", false, "run recovery instead of generate")
 	recoverSource = flag.String("recover-source", "ETCD", "recovery source to use")
@@ -103,9 +101,9 @@ func main() {
 
 	defer util.FlushLogs()
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	if *recover {

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -211,7 +211,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 		return nil, fmt.Errorf("error validating installer image %q: %w", in.GetImage(), err)
 	}
 
-	if err = etcd.ValidateForUpgrade(in.GetPreserve()); err != nil {
+	if err = etcd.ValidateForUpgrade(s.Controller.Runtime().Config(), in.GetPreserve()); err != nil {
 		return nil, fmt.Errorf("error validating etcd for upgrade: %w", err)
 	}
 

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -53,6 +54,8 @@ type Options struct {
 	// GracefulShutdownTimeout is the time to wait for process to exit after SIGTERM
 	// before sending SIGKILL
 	GracefulShutdownTimeout time.Duration
+	// Stdin is the process standard input.
+	Stdin io.ReadSeeker
 }
 
 // Option is the functional option func.
@@ -66,6 +69,7 @@ func DefaultOptions() *Options {
 		Namespace:               constants.SystemContainerdNamespace,
 		GracefulShutdownTimeout: 10 * time.Second,
 		ContainerdAddress:       constants.ContainerdAddress,
+		Stdin:                   nil,
 	}
 }
 
@@ -122,5 +126,12 @@ func WithLoggingManager(manager runtime.LoggingManager) Option {
 func WithGracefulShutdownTimeout(timeout time.Duration) Option {
 	return func(args *Options) {
 		args.GracefulShutdownTimeout = timeout
+	}
+}
+
+// WithStdin sets the standard input.
+func WithStdin(stdin io.ReadSeeker) Option {
+	return func(args *Options) {
+		args.Stdin = stdin
 	}
 }

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -15,12 +15,8 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
-var configPath *string
-
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
-
-	configPath = flag.String("config", "", "the path to the config")
 
 	flag.Parse()
 }
@@ -28,9 +24,9 @@ func init() {
 func main() {
 	log.Println("starting initial network configuration")
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	nwd, err := networkd.New(config)

--- a/internal/app/timed/main.go
+++ b/internal/app/timed/main.go
@@ -25,12 +25,8 @@ const (
 	DefaultServer = "pool.ntp.org"
 )
 
-var configPath *string
-
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
-
-	configPath = flag.String("config", "", "the path to the config")
 
 	flag.Parse()
 }
@@ -44,9 +40,9 @@ func main() {
 
 	server := DefaultServer
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	// Check if ntp servers are defined

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -26,12 +26,8 @@ import (
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
-var configPath *string
-
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
-
-	configPath = flag.String("config", "", "the path to the config")
 
 	flag.Parse()
 }
@@ -44,9 +40,9 @@ func main() {
 		log.Fatalf("startup: %s", err)
 	}
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	ips, err := net.IPAddrs()

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -19,7 +19,7 @@ import (
 	"github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/kubernetes"
-	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
+	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
@@ -75,12 +75,7 @@ func NewClientFromControlPlaneIPs(ctx context.Context, creds *x509.PEMEncodedCer
 
 // ValidateForUpgrade validates the etcd cluster state to ensure that performing
 // an upgrade is safe.
-func ValidateForUpgrade(preserve bool) error {
-	config, err := configloader.NewFromFile(constants.ConfigPath)
-	if err != nil {
-		return err
-	}
-
+func ValidateForUpgrade(config config.Provider, preserve bool) error {
 	if config.Machine().Type() != machine.TypeJoin {
 		client, err := NewClientFromControlPlaneIPs(context.TODO(), config.Cluster().CA(), config.Cluster().Endpoint())
 		if err != nil {

--- a/pkg/machinery/config/configloader/configloader.go
+++ b/pkg/machinery/config/configloader/configloader.go
@@ -6,8 +6,11 @@
 package configloader
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/decoder"
@@ -42,6 +45,23 @@ func NewFromFile(filepath string) (config.Provider, error) {
 	}
 
 	return newConfig(source)
+}
+
+// NewFromStdin initializes a config provider by reading from stdin.
+func NewFromStdin() (config.Provider, error) {
+	buf := bytes.NewBuffer(nil)
+
+	_, err := io.Copy(buf, os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := NewFromBytes(buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed load config from stdin: %v", err)
+	}
+
+	return config, nil
 }
 
 // NewFromBytes will take a byteslice and attempt to parse a config file from it.


### PR DESCRIPTION
In order to perform upgrades the way we would like, it is important that
we avoid any bind mounts into containers. This change ensures that all
system services get their config via stdin.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2443)
<!-- Reviewable:end -->
