### PR TITLE
test: add support for PXE nodes in qemu provision library

### DIFF
--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -85,6 +85,17 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		return nil, err
 	}
 
+	var pxeNodeInfo []provision.NodeInfo
+
+	pxeNodes := request.Nodes.PXENodes()
+	if len(pxeNodes) > 0 {
+		fmt.Fprintln(options.LogWriter, "creating PXE nodes")
+
+		if pxeNodeInfo, err = p.createNodes(state, request, pxeNodes, &options); err != nil {
+			return nil, err
+		}
+	}
+
 	nodeInfo = append(nodeInfo, workerNodeInfo...)
 
 	state.ClusterInfo = provision.ClusterInfo{
@@ -95,7 +106,8 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 			GatewayAddr: request.Network.GatewayAddr,
 			MTU:         request.Network.MTU,
 		},
-		Nodes: nodeInfo,
+		Nodes:      nodeInfo,
+		ExtraNodes: pxeNodeInfo,
 	}
 
 	err = state.Save()

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -16,8 +16,10 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/google/uuid"
 	multierror "github.com/hashicorp/go-multierror"
 
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers/vm"
 
@@ -61,23 +63,28 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	cmdline.Append("talos.platform", "metal")
 	cmdline.Append("talos.config", "{TALOS_CONFIG_URL}") // to be patched by launcher
 
-	nodeConfig, err := nodeReq.Config.String()
-	if err != nil {
-		return provision.NodeInfo{}, err
+	var nodeConfig string
+
+	if nodeReq.Config != nil {
+		nodeConfig, err = nodeReq.Config.String()
+		if err != nil {
+			return provision.NodeInfo{}, err
+		}
 	}
+
+	nodeUUID := uuid.New()
 
 	launchConfig := LaunchConfig{
 		QemuExecutable:    fmt.Sprintf("qemu-system-%s", arch.QemuArch()),
 		DiskPath:          diskPath,
 		VCPUCount:         vcpuCount,
 		MemSize:           memSize,
-		KernelImagePath:   clusterReq.KernelPath,
 		KernelArgs:        cmdline.String(),
-		InitrdPath:        clusterReq.InitramfsPath,
 		MachineType:       arch.QemuMachine(),
 		PFlashImages:      state.PFlashImages,
 		EnableKVM:         opts.TargetArch == runtime.GOARCH,
 		BootloaderEnabled: opts.BootloaderEnabled,
+		NodeUUID:          nodeUUID,
 		Config:            nodeConfig,
 		NetworkConfig:     state.VMCNIConfig,
 		CNI:               clusterReq.Network.CNI,
@@ -87,6 +94,13 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		GatewayAddr:       clusterReq.Network.GatewayAddr,
 		MTU:               clusterReq.Network.MTU,
 		Nameservers:       clusterReq.Network.Nameservers,
+		TFTPServer:        nodeReq.TFTPServer,
+		IPXEBootFileName:  nodeReq.IPXEBootFilename,
+	}
+
+	if !nodeReq.PXEBooted {
+		launchConfig.KernelImagePath = clusterReq.KernelPath
+		launchConfig.InitrdPath = clusterReq.InitramfsPath
 	}
 
 	launchConfig.StatePath, err = state.StatePath()
@@ -127,10 +141,16 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	// no need to wait here, as cmd has all the Stdin/out/err via *os.File
 
+	nodeType := machine.Type(-1) // HACK!
+	if nodeReq.Config != nil {
+		nodeType = nodeReq.Config.Machine().Type()
+	}
+
 	nodeInfo := provision.NodeInfo{
 		ID:   pidPath,
+		UUID: nodeUUID,
 		Name: nodeReq.Name,
-		Type: nodeReq.Config.Machine().Type(),
+		Type: nodeType,
 
 		NanoCPUs: nodeReq.NanoCPUs,
 		Memory:   nodeReq.Memory,

--- a/pkg/provision/providers/vm/ipam.go
+++ b/pkg/provision/providers/vm/ipam.go
@@ -22,6 +22,9 @@ type IPAMRecord struct {
 	Gateway     net.IP
 	MTU         int
 	Nameservers []net.IP
+
+	TFTPServer       string
+	IPXEBootFilename string
 }
 
 // IPAMDatabase is a mapping from MAC address to records.

--- a/pkg/provision/providers/vm/node.go
+++ b/pkg/provision/providers/vm/node.go
@@ -16,7 +16,9 @@ import (
 func (p *Provisioner) DestroyNodes(cluster provision.ClusterInfo, options *provision.Options) error {
 	errCh := make(chan error)
 
-	for _, node := range cluster.Nodes {
+	nodes := append(cluster.Nodes, cluster.ExtraNodes...)
+
+	for _, node := range nodes {
 		go func(node provision.NodeInfo) {
 			fmt.Fprintln(options.LogWriter, "stopping VM", node.Name)
 
@@ -26,7 +28,7 @@ func (p *Provisioner) DestroyNodes(cluster provision.ClusterInfo, options *provi
 
 	var multiErr *multierror.Error
 
-	for range cluster.Nodes {
+	for range nodes {
 		multiErr = multierror.Append(multiErr, <-errCh)
 	}
 

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -57,6 +57,10 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 	found := false
 
 	for i := range reqs {
+		if reqs[i].Config == nil {
+			continue
+		}
+
 		if reqs[i].Config.Machine().Type() == machine.TypeInit {
 			if found {
 				err = fmt.Errorf("duplicate init node in requests")
@@ -78,6 +82,10 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 // MasterNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 	for i := range reqs {
+		if reqs[i].Config == nil {
+			continue
+		}
+
 		if reqs[i].Config.Machine().Type() == machine.TypeInit || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
 			nodes = append(nodes, reqs[i])
 		}
@@ -89,7 +97,22 @@ func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 // WorkerNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 	for i := range reqs {
+		if reqs[i].Config == nil {
+			continue
+		}
+
 		if reqs[i].Config.Machine().Type() == machine.TypeJoin {
+			nodes = append(nodes, reqs[i])
+		}
+	}
+
+	return
+}
+
+// PXENodes returns subset of nodes which are PXE booted.
+func (reqs NodeRequests) PXENodes() (nodes []NodeRequest) {
+	for i := range reqs {
+		if reqs[i].PXEBooted {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -111,4 +134,9 @@ type NodeRequest struct {
 	DiskSize int64
 	// Ports
 	Ports []string
+
+	// PXE-booted VMs
+	PXEBooted        bool
+	TFTPServer       string
+	IPXEBootFilename string
 }

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -7,6 +7,8 @@ package provision
 import (
 	"net"
 
+	"github.com/google/uuid"
+
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
@@ -26,6 +28,9 @@ type ClusterInfo struct {
 
 	Network NetworkInfo
 	Nodes   []NodeInfo
+
+	// ExtraNodes are not part of the cluster.
+	ExtraNodes []NodeInfo
 }
 
 // NetworkInfo describes cluster network.
@@ -39,6 +44,7 @@ type NetworkInfo struct {
 // NodeInfo describes a node.
 type NodeInfo struct {
 	ID   string
+	UUID uuid.UUID
 	Name string
 	Type machine.Type
 


### PR DESCRIPTION
This isn't supposed to be used ever in Talos directly, but rather only
in integration tests for Sidero.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

