### PR TITLE
fix: pass config via stdin

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -173,7 +173,7 @@ function build_registry_mirrors {
 
     for registry in docker.io k8s.gcr.io quay.io gcr.io; do
       local service="registry-${registry//./-}.ci.svc"
-      local addr=`python -c "import socket; print socket.gethostbyname('${service}')"`
+      local addr=`python3 -c "import socket; print(socket.gethostbyname('${service}'))"`
 
       REGISTRY_MIRROR_FLAGS="${REGISTRY_MIRROR_FLAGS} --registry-mirror ${registry}=http://${addr}:5000"
     done

--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -18,7 +18,6 @@ import (
 	apidbackend "github.com/talos-systems/talos/internal/app/apid/pkg/backend"
 	"github.com/talos-systems/talos/internal/app/apid/pkg/director"
 	"github.com/talos-systems/talos/internal/app/apid/pkg/provider"
-	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/configloader"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
@@ -26,15 +25,11 @@ import (
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
-var (
-	configPath *string
-	endpoints  *string
-)
+var endpoints *string
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
-	configPath = flag.String("config", "", "the path to the config")
 	endpoints = flag.String("endpoints", "", "the IPs of the control plane nodes")
 
 	flag.Parse()
@@ -45,7 +40,7 @@ func main() {
 		log.Fatalf("failed to seed RNG: %v", err)
 	}
 
-	config, err := loadConfig()
+	config, err := configloader.NewFromStdin()
 	if err != nil {
 		log.Fatalf("open config: %v", err)
 	}
@@ -129,8 +124,4 @@ func main() {
 	if err := errGroup.Wait(); err != nil {
 		log.Fatalf("listen: %v", err)
 	}
-}
-
-func loadConfig() (config.Provider, error) {
-	return configloader.NewFromFile(*configPath)
 }

--- a/internal/app/bootkube/main.go
+++ b/internal/app/bootkube/main.go
@@ -17,15 +17,11 @@ import (
 	"github.com/talos-systems/talos/pkg/constants"
 )
 
-var (
-	configPath *string
-	strict     *bool
-)
+var strict *bool
 
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
-	configPath = flag.String("config", "", "the path to the config")
 	strict = flag.Bool("strict", true, "require all manifests to cleanly apply")
 
 	flag.Parse()
@@ -95,9 +91,9 @@ func main() {
 
 	defer util.FlushLogs()
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	if err := generateAssets(config); err != nil {

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -211,7 +211,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 		return nil, fmt.Errorf("error validating installer image %q: %w", in.GetImage(), err)
 	}
 
-	if err = etcd.ValidateForUpgrade(in.GetPreserve()); err != nil {
+	if err = etcd.ValidateForUpgrade(s.Controller.Runtime().Config(), in.GetPreserve()); err != nil {
 		return nil, fmt.Errorf("error validating etcd for upgrade: %w", err)
 	}
 

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -7,6 +7,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -53,6 +54,8 @@ type Options struct {
 	// GracefulShutdownTimeout is the time to wait for process to exit after SIGTERM
 	// before sending SIGKILL
 	GracefulShutdownTimeout time.Duration
+	// Stdin is the process standard input.
+	Stdin io.ReadSeeker
 }
 
 // Option is the functional option func.
@@ -66,6 +69,7 @@ func DefaultOptions() *Options {
 		Namespace:               constants.SystemContainerdNamespace,
 		GracefulShutdownTimeout: 10 * time.Second,
 		ContainerdAddress:       constants.ContainerdAddress,
+		Stdin:                   nil,
 	}
 }
 
@@ -122,5 +126,12 @@ func WithLoggingManager(manager runtime.LoggingManager) Option {
 func WithGracefulShutdownTimeout(timeout time.Duration) Option {
 	return func(args *Options) {
 		args.GracefulShutdownTimeout = timeout
+	}
+}
+
+// WithStdin sets the standard input.
+func WithStdin(stdin io.ReadSeeker) Option {
+	return func(args *Options) {
+		args.Stdin = stdin
 	}
 }

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -5,6 +5,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -161,7 +162,6 @@ func (b *Bootkube) Runner(r runtime.Runtime) (runner.Runner, error) {
 		ID: b.ID(r),
 		ProcessArgs: []string{
 			"/bootkube",
-			"--config=" + constants.ConfigPath,
 			"--strict=" + strconv.FormatBool(!b.Recover),
 		},
 	}
@@ -174,13 +174,20 @@ func (b *Bootkube) Runner(r runtime.Runtime) (runner.Runner, error) {
 	// Set the required kubelet mounts.
 	mounts := []specs.Mount{
 		{Type: "bind", Destination: "/etc/ssl", Source: "/etc/ssl", Options: []string{"bind", "ro"}},
-		{Type: "bind", Destination: constants.ConfigPath, Source: constants.ConfigPath, Options: []string{"rbind", "ro"}},
 		{Type: "bind", Destination: "/etc/kubernetes", Source: "/etc/kubernetes", Options: []string{"bind", "rshared", "rw"}},
 	}
+
+	bb, err := r.Config().Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	stdin := bytes.NewReader(bb)
 
 	return containerd.NewRunner(
 		r.Config().Debug(),
 		&args,
+		runner.WithStdin(stdin),
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithContainerdAddress(constants.SystemContainerdAddress),
 		runner.WithContainerImage(image),

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -15,12 +15,8 @@ import (
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 )
 
-var configPath *string
-
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
-
-	configPath = flag.String("config", "", "the path to the config")
 
 	flag.Parse()
 }
@@ -28,9 +24,9 @@ func init() {
 func main() {
 	log.Println("starting initial network configuration")
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	nwd, err := networkd.New(config)

--- a/internal/app/timed/main.go
+++ b/internal/app/timed/main.go
@@ -25,12 +25,8 @@ const (
 	DefaultServer = "pool.ntp.org"
 )
 
-var configPath *string
-
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
-
-	configPath = flag.String("config", "", "the path to the config")
 
 	flag.Parse()
 }
@@ -44,9 +40,9 @@ func main() {
 
 	server := DefaultServer
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	// Check if ntp servers are defined

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -23,12 +23,8 @@ import (
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
-var configPath *string
-
 func init() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
-
-	configPath = flag.String("config", "", "the path to the config")
 
 	flag.Parse()
 }
@@ -41,9 +37,9 @@ func main() {
 		log.Fatalf("startup: %s", err)
 	}
 
-	config, err := configloader.NewFromFile(*configPath)
+	config, err := configloader.NewFromStdin()
 	if err != nil {
-		log.Fatalf("failed to create config from file: %v", err)
+		log.Fatal(err)
 	}
 
 	ips, err := net.IPAddrs()

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -13,7 +13,7 @@ import (
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/pkg/transport"
 
-	"github.com/talos-systems/talos/pkg/config/configloader"
+	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/constants"
 	"github.com/talos-systems/talos/pkg/crypto/x509"
@@ -71,12 +71,7 @@ func NewClientFromControlPlaneIPs(ctx context.Context, creds *x509.PEMEncodedCer
 
 // ValidateForUpgrade validates the etcd cluster state to ensure that performing
 // an upgrade is safe.
-func ValidateForUpgrade(preserve bool) error {
-	config, err := configloader.NewFromFile(constants.ConfigPath)
-	if err != nil {
-		return err
-	}
-
+func ValidateForUpgrade(config config.Provider, preserve bool) error {
 	if config.Machine().Type() != machine.TypeJoin {
 		client, err := NewClientFromControlPlaneIPs(context.TODO(), config.Cluster().CA(), config.Cluster().Endpoint())
 		if err != nil {

--- a/pkg/config/configloader/configloader.go
+++ b/pkg/config/configloader/configloader.go
@@ -6,8 +6,11 @@
 package configloader
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/talos-systems/talos/pkg/config"
 	"github.com/talos-systems/talos/pkg/config/decoder"
@@ -42,6 +45,23 @@ func NewFromFile(filepath string) (config.Provider, error) {
 	}
 
 	return newConfig(source)
+}
+
+// NewFromStdin initializes a config provider by reading from stdin.
+func NewFromStdin() (config.Provider, error) {
+	buf := bytes.NewBuffer(nil)
+
+	_, err := io.Copy(buf, os.Stdin)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := NewFromBytes(buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed load config from stdin: %v", err)
+	}
+
+	return config, nil
 }
 
 // NewFromBytes will take a byteslice and attempt to parse a config file from it.


### PR DESCRIPTION
In order to perform upgrades the way we would like, it is important that
we avoid any bind mounts into containers. This change ensures that all
system services get their config via stdin.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
(cherry picked from commit d4f103ffcb10d6afa7fd976a56e407d64a93a1e8)

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2445)
<!-- Reviewable:end -->
