### PR TITLE
chore: add a method to merge Talos client config

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -295,7 +295,7 @@ func create(ctx context.Context) (err error) {
 	}
 
 	// Create and save the talosctl configuration file.
-	if err = saveConfig(cluster, configBundle.TalosConfig()); err != nil {
+	if err = saveConfig(configBundle.TalosConfig()); err != nil {
 		return err
 	}
 
@@ -331,19 +331,13 @@ func postCreate(ctx context.Context, clusterAccess *access.Adapter) error {
 	return check.Wait(checkCtx, clusterAccess, append(check.DefaultClusterChecks(), check.ExtraClusterChecks()...), check.StderrReporter())
 }
 
-func saveConfig(cluster provision.Cluster, talosConfigObj *clientconfig.Config) (err error) {
+func saveConfig(talosConfigObj *clientconfig.Config) (err error) {
 	c, err := clientconfig.Open(talosconfig)
 	if err != nil {
 		return err
 	}
 
-	if c.Contexts == nil {
-		c.Contexts = map[string]*clientconfig.Context{}
-	}
-
-	c.Contexts[cluster.Info().ClusterName] = talosConfigObj.Contexts[cluster.Info().ClusterName]
-
-	c.Context = cluster.Info().ClusterName
+	c.Merge(talosConfigObj)
 
 	return c.Save(talosconfig)
 }


### PR DESCRIPTION
This should simplify the code when new clusters are created and Talos
client config is injected.

Also refactored client config to have `ReadFrom` as common denominator.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2449)
<!-- Reviewable:end -->
