### PR TITLE
docs: add reset doc

### DIFF
--- a/docs/website/content/v0.4.en.json
+++ b/docs/website/content/v0.4.en.json
@@ -88,6 +88,10 @@
       {
         "title": "PKI",
         "path": "v0.4/en/troubleshooting/pki"
+      },
+      {
+        "title": "Machine Reset",
+        "path": "v0.4/en/troubleshooting/machine-reset"
       }
     ]
   },

--- a/docs/website/content/v0.4/en/troubleshooting/machine-reset.md
+++ b/docs/website/content/v0.4/en/troubleshooting/machine-reset.md
@@ -1,0 +1,21 @@
+---
+title: 'Machine Reset'
+---
+
+From time to time, it may be beneficial to reset a Talos machine to its "original" state.
+Bear in mind that this is a destructive action for the given machine.
+Doing this means removing the machine from Kubernetes, Etcd (if applicable), and clears any data on the machine that would normally persist a reboot.
+
+The API command for doing this is `talosctl reset`.
+There are a couple of flags as part of this command:
+
+```bash
+Flags:
+      --graceful   if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
+      --reboot     if true, reboot the node after resetting instead of shutting down
+```
+
+The `graceful` flag is especially important when considering HA vs. non-HA Talos clusters.
+If the machine is part of an HA cluster, a normal, graceful reset should work just fine right out of the box as long as the cluster is in a good state.
+However, if this is a single node cluster being used for testing purposes, a graceful reset is not an option since Etcd cannot be "left" if there is only a single member.
+In this case, reset should be used with `--graceful=false` to skip performing checks that would normally block the reset.

--- a/docs/website/content/v0.5.en.json
+++ b/docs/website/content/v0.5.en.json
@@ -73,7 +73,8 @@
     "path": "v0.5/en/troubleshooting",
     "items": [
       { "title": "Overview", "path": "v0.5/en/troubleshooting/overview" },
-      { "title": "PKI", "path": "v0.5/en/troubleshooting/pki" }
+      { "title": "PKI", "path": "v0.5/en/troubleshooting/pki" },
+      { "title": "Machine Reset", "path": "v0.5/en/troubleshooting/machine-reset" }
     ]
   },
   {

--- a/docs/website/content/v0.5/en/troubleshooting/machine-reset.md
+++ b/docs/website/content/v0.5/en/troubleshooting/machine-reset.md
@@ -1,0 +1,21 @@
+---
+title: 'Machine Reset'
+---
+
+From time to time, it may be beneficial to reset a Talos machine to its "original" state.
+Bear in mind that this is a destructive action for the given machine.
+Doing this means removing the machine from Kubernetes, Etcd (if applicable), and clears any data on the machine that would normally persist a reboot.
+
+The API command for doing this is `talosctl reset`.
+There are a couple of flags as part of this command:
+
+```bash
+Flags:
+      --graceful   if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
+      --reboot     if true, reboot the node after resetting instead of shutting down
+```
+
+The `graceful` flag is especially important when considering HA vs. non-HA Talos clusters.
+If the machine is part of an HA cluster, a normal, graceful reset should work just fine right out of the box as long as the cluster is in a good state.
+However, if this is a single node cluster being used for testing purposes, a graceful reset is not an option since Etcd cannot be "left" if there is only a single member.
+In this case, reset should be used with `--graceful=false` to skip performing checks that would normally block the reset.

--- a/docs/website/content/v0.6.en.json
+++ b/docs/website/content/v0.6.en.json
@@ -117,6 +117,10 @@
       {
         "title": "PKI",
         "path": "v0.6/en/troubleshooting/pki"
+      },
+      {
+        "title": "Machine Reset",
+        "path": "v0.6/en/troubleshooting/machine-reset"
       }
     ]
   },

--- a/docs/website/content/v0.6/en/troubleshooting/machine-reset.md
+++ b/docs/website/content/v0.6/en/troubleshooting/machine-reset.md
@@ -1,0 +1,21 @@
+---
+title: 'Machine Reset'
+---
+
+From time to time, it may be beneficial to reset a Talos machine to its "original" state.
+Bear in mind that this is a destructive action for the given machine.
+Doing this means removing the machine from Kubernetes, Etcd (if applicable), and clears any data on the machine that would normally persist a reboot.
+
+The API command for doing this is `talosctl reset`.
+There are a couple of flags as part of this command:
+
+```bash
+Flags:
+      --graceful   if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
+      --reboot     if true, reboot the node after resetting instead of shutting down
+```
+
+The `graceful` flag is especially important when considering HA vs. non-HA Talos clusters.
+If the machine is part of an HA cluster, a normal, graceful reset should work just fine right out of the box as long as the cluster is in a good state.
+However, if this is a single node cluster being used for testing purposes, a graceful reset is not an option since Etcd cannot be "left" if there is only a single member.
+In this case, reset should be used with `--graceful=false` to skip performing checks that would normally block the reset.


### PR DESCRIPTION
This PR adds a simple doc on how to do a talos machine reset. This
command was introduced all the way back on v0.4 so the docs are added
everywhere.

Will close #2095 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2463)
<!-- Reviewable:end -->
