### PR TITLE
chore: drop vmlinux from assets

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -492,7 +492,6 @@ local release = {
       '_out/talosctl-linux-arm64',
       '_out/talosctl-linux-armv7',
       '_out/vmware.ova',
-      '_out/vmlinux',
       '_out/vmlinuz',
     ],
     checksum: ['sha256', 'sha512'],

--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,6 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 
 FROM scratch AS kernel
 COPY --from=docker.io/autonomy/kernel:v0.2.0-34-g7e57ef7 /boot/vmlinuz /vmlinuz
-COPY --from=docker.io/autonomy/kernel:v0.2.0-34-g7e57ef7 /boot/vmlinux /vmlinux
 
 # The rootfs target provides the Talos rootfs.
 

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ docs: ## Generates the documentation for machine config, and talosctl.
 # Local Artifacts
 
 .PHONY: kernel
-kernel: ## Outputs the kernel package contents (vmlinuz, and vmlinux) to the artifact directory.
+kernel: ## Outputs the kernel package contents (vmlinuz) to the artifact directory.
 	@$(MAKE) local-$@ DEST=$(ARTIFACTS)
 	@-rm -rf $(ARTIFACTS)/modules
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -246,9 +246,6 @@ const (
 	// RouterdSocketPath is the path to file socket of router API.
 	RouterdSocketPath = SystemRunPath + "/routerd/routerd.sock"
 
-	// KernelUncompressedAsset defines a well known name for our uncompressed kernel filename
-	KernelUncompressedAsset = "vmlinux"
-
 	// KernelAsset defines a well known name for our kernel filename
 	KernelAsset = "vmlinuz"
 


### PR DESCRIPTION
`vmlinux` (uncompressed kernel) shouldn't be much useful to the people
as it can't be booted directly with most of the boot tools (it's too
huge). We had it enabled for firecracker, but now firecracker has
support for decompressing `vmlinuz` on the fly.

So, to reduce confusion, make assets smaller, remove `vmlinux`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2464)
<!-- Reviewable:end -->
