### PR TITLE
fix: add syslinux to create ISO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -384,8 +384,10 @@ RUN apk add --no-cache --update \
     cdrkit \
     efibootmgr \
     qemu-img \
+    syslinux \
     util-linux \
     xfsprogs
+COPY --from=docker.io/autonomy/syslinux:v0.2.0-35-g8be6358 / /
 COPY --from=docker.io/autonomy/grub:v0.2.0-35-g8be6358   / /
 COPY --from=kernel /vmlinuz /usr/install/vmlinuz
 COPY --from=initramfs /initramfs.xz /usr/install/initramfs.xz


### PR DESCRIPTION
We need syslinux to create an ISO.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2475)
<!-- Reviewable:end -->
