### PR TITLE
docs: graduate v0.6 docs

### DIFF
--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -35,7 +35,7 @@ export default {
   data() {
     return {
       options: [
-        { version: 'v0.6', url: '/docs/v0.6', prerelease: true },
+        { version: 'v0.6', url: '/docs/v0.6', prerelease: false },
         { version: 'v0.5', url: '/docs/v0.5', prerelease: false },
         { version: 'v0.4', url: '/docs/v0.4', prerelease: false }
       ],

--- a/docs/website/components/Header.vue
+++ b/docs/website/components/Header.vue
@@ -7,7 +7,7 @@
       <div class="flex py-6 ml-auto">
         <ul class="header-menu">
           <li>
-            <a href="/docs/v0.5">
+            <a href="/docs/v0.6">
               <span class="font-semibold mr-1">Documentation</span>
             </a>
           </li>


### PR DESCRIPTION
This promotes the v0.6 docs from pre-release status to stable, and make v0.6
the default docs.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2477)
<!-- Reviewable:end -->
