### PR TITLE
fix: change apid container image name to expected value

### DIFF
--- a/docs/website/content/v0.5/en/guides/getting-started/talosctl.md
+++ b/docs/website/content/v0.5/en/guides/getting-started/talosctl.md
@@ -122,7 +122,7 @@ This can be achieved by the `containers` subcommand:
 ```bash
 $ talosctl containers
 NODE          NAMESPACE   ID         IMAGE            PID    STATUS
-192.168.2.44   system      apid       talos/pkg/machinery/apid       4021   RUNNING
+192.168.2.44   system      apid       talos/apid       4021   RUNNING
 192.168.2.44   system      networkd   talos/networkd   3893   RUNNING
 192.168.2.44   system      ntpd       talos/ntpd       4144   RUNNING
 192.168.2.44   system      osd        talos/osd        4086   RUNNING

--- a/docs/website/content/v0.6/en/guides/getting-started/talosctl.md
+++ b/docs/website/content/v0.6/en/guides/getting-started/talosctl.md
@@ -118,7 +118,7 @@ This can be achieved by the `containers` subcommand:
 ```bash
 $ talosctl containers
 NODE          NAMESPACE   ID         IMAGE            PID    STATUS
-192.168.2.44   system      apid       talos/pkg/machinery/apid       4021   RUNNING
+192.168.2.44   system      apid       talos/apid       4021   RUNNING
 192.168.2.44   system      networkd   talos/networkd   3893   RUNNING
 192.168.2.44   system      ntpd       talos/ntpd       4144   RUNNING
 192.168.2.44   system      routerd    talos/routerd    3907   RUNNING

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -49,7 +49,7 @@ func (o *APID) PreFunc(ctx context.Context, r runtime.Runtime) error {
 	return importer.Import(&containerd.ImportRequest{
 		Path: "/usr/images/apid.tar",
 		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/pkg/machinery/apid"),
+			containerdapi.WithIndexName("talos/apid"),
 		},
 	})
 }
@@ -81,7 +81,7 @@ func (o *APID) DependsOn(r runtime.Runtime) []string {
 //
 //nolint: gocyclo
 func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
-	image := "talos/pkg/machinery/apid"
+	image := "talos/apid"
 
 	endpoints := []string{"127.0.0.1"}
 


### PR DESCRIPTION
This is what happens when massive find-replace goes wrong...

Change should be cosmetic though, it doesn't affect operations.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2478)
<!-- Reviewable:end -->
