### PR TITLE
refactor: move udevadm trigger/settle to udevd healthcheck

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -596,17 +596,6 @@ func StartUdevd(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 			return err
 		}
 
-		if _, err = cmd.Run("/sbin/udevadm", "trigger"); err != nil {
-			return err
-		}
-
-		// This ensures that `udevd` finishes processing kernel events, triggered by
-		// `udevd trigger`, to prevent a race condition when a user specifies a path
-		// under `/dev/disk/*` in any disk definitions.
-		if _, err = cmd.Run("/sbin/udevadm", "settle"); err != nil {
-			return err
-		}
-
 		return nil
 	}, "startUdevd"
 }

--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -7,9 +7,11 @@ package services
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/health"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
@@ -19,7 +21,9 @@ import (
 
 // Udevd implements the Service interface. It serves as the concrete type with
 // the required methods.
-type Udevd struct{}
+type Udevd struct {
+	triggered bool
+}
 
 // ID implements the Service interface.
 func (c *Udevd) ID(r runtime.Runtime) string {
@@ -77,4 +81,33 @@ func (c *Udevd) Runner(r runtime.Runtime) (runner.Runner, error) {
 	),
 		restart.WithType(restart.Forever),
 	), nil
+}
+
+// HealthFunc implements the HealthcheckedService interface.
+func (c *Udevd) HealthFunc(runtime.Runtime) health.Check {
+	return func(ctx context.Context) error {
+		if !c.triggered {
+			if _, err := cmd.RunContext(ctx, "/sbin/udevadm", "trigger"); err != nil {
+				return err
+			}
+
+			c.triggered = true
+		}
+
+		// This ensures that `udevd` finishes processing kernel events, triggered by
+		// `udevd trigger`, to prevent a race condition when a user specifies a path
+		// under `/dev/disk/*` in any disk definitions.
+		_, err := cmd.RunContext(ctx, "/sbin/udevadm", "settle", "--timeout=50") // timeout here should be less than health.Settings.Timeout
+
+		return err
+	}
+}
+
+// HealthSettings implements the HealthcheckedService interface.
+func (c *Udevd) HealthSettings(runtime.Runtime) *health.Settings {
+	return &health.Settings{
+		InitialDelay: 100 * time.Millisecond,
+		Period:       time.Minute,
+		Timeout:      55 * time.Second,
+	}
 }

--- a/internal/app/machined/pkg/system/services/udevd_test.go
+++ b/internal/app/machined/pkg/system/services/udevd_test.go
@@ -1,0 +1,18 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+)
+
+func TestUdevdInterfaces(t *testing.T) {
+	assert.Implements(t, (*system.HealthcheckedService)(nil), new(services.Udevd))
+}

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 
@@ -18,7 +19,12 @@ const MaxStderrLen = 4096
 
 // Run executes a command.
 func Run(name string, args ...string) (string, error) {
-	cmd := exec.Command(name, args...)
+	return RunContext(context.Background(), name, args...)
+}
+
+// RunContext executes a command with context.
+func RunContext(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
 
 	stdout, err := circbuf.NewBuffer(MaxStderrLen)
 	if err != nil {


### PR DESCRIPTION
Experimental PR to move those actions to udevd healthchecks for
automatic retries and better error reporting.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2480)
<!-- Reviewable:end -->
