### PR TITLE
chore: remove extra COPY from rootfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -339,7 +339,6 @@ RUN ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates
 RUN ln -s /etc/ssl /rootfs/etc/ca-certificates
 
 FROM rootfs-base AS rootfs-squashfs
-COPY --from=rootfs / /rootfs
 RUN mksquashfs /rootfs /rootfs.sqsh -all-root -noappend -comp xz -Xdict-size 100% -no-progress
 
 FROM scratch AS squashfs


### PR DESCRIPTION
This stage is already derived from `rootfs-base`, so this copy statement
should be doing nothing.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2483)
<!-- Reviewable:end -->
