### PR TITLE
fix: update permissions for directories and files created via extraFiles

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -905,6 +905,11 @@ func WriteUserFiles(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 					continue
 				}
 
+				if err = os.Chmod(f.Path(), f.Permissions()); err != nil {
+					result = multierror.Append(result, err)
+					continue
+				}
+
 				continue
 			}
 
@@ -928,12 +933,17 @@ func WriteUserFiles(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 				return fmt.Errorf("create operation not allowed outside of /var: %q", f.Path())
 			}
 
-			if err = os.MkdirAll(filepath.Dir(p), os.ModeDir); err != nil {
+			if err = os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
 				result = multierror.Append(result, err)
 				continue
 			}
 
 			if err = ioutil.WriteFile(p, []byte(content), f.Permissions()); err != nil {
+				result = multierror.Append(result, err)
+				continue
+			}
+
+			if err = os.Chmod(p, f.Permissions()); err != nil {
 				result = multierror.Append(result, err)
 				continue
 			}


### PR DESCRIPTION
There were two issues:

* directories leading up to the path were created with effectively
`000` perms, as `os.ModeDirectory` is a directory flag bit, not perms

* permssions of files created via `open(2)` syscall are affected by
`umask(2)`, which in turn is `0022` by default. As `umask` gets
inherited via `fork/exec`, it's better not to change it in `machined`,
so we use explicit `chmod(2)` call which is not affected by `umask(2)`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2484)
<!-- Reviewable:end -->
