### PR TITLE
fix: default endpoint to 127.0.0.1 for Docker/OS X

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -206,7 +206,7 @@ func create(ctx context.Context) (err error) {
 			}))
 		}
 
-		defaultInternalLB, _ := provisioner.GetLoadBalancers(request.Network)
+		defaultInternalLB, defaultEndpoint := provisioner.GetLoadBalancers(request.Network)
 
 		if defaultInternalLB == "" {
 			// provisioner doesn't provide internal LB, so use first master node
@@ -216,6 +216,12 @@ func create(ctx context.Context) (err error) {
 		var endpointList []string
 
 		switch {
+		case defaultEndpoint != "":
+			if forceEndpoint == "" {
+				forceEndpoint = defaultEndpoint
+			}
+
+			fallthrough
 		case forceEndpoint != "":
 			endpointList = []string{forceEndpoint}
 			provisionOptions = append(provisionOptions, provision.WithEndpoint(forceEndpoint))

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -7,6 +7,7 @@ package docker
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/docker/docker/client"
 
@@ -74,6 +75,11 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 // GetLoadBalancers returns internal/external loadbalancer endpoints.
 func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
 	// docker doesn't provide internal LB, so return empty string
-	// external LB is always localhost where docker exposes ports
-	return "", "127.0.0.1"
+	// external LB is always localhost for OS X where docker exposes ports
+	switch runtime.GOOS {
+	case "darwin":
+		return "", "127.0.0.1"
+	default:
+		return "", ""
+	}
 }

--- a/pkg/provision/providers/firecracker/firecracker.go
+++ b/pkg/provision/providers/firecracker/firecracker.go
@@ -70,6 +70,6 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 
 // GetLoadBalancers returns internal/external loadbalancer endpoints.
 func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
-	// firecracker runs loadbalancer on the bridge, which is good for both internal & external access
-	return networkReq.GatewayAddr.String(), networkReq.GatewayAddr.String()
+	// firecracker runs loadbalancer on the bridge, which is good for both internal access, external access goes via round-robin
+	return networkReq.GatewayAddr.String(), ""
 }

--- a/pkg/provision/providers/qemu/qemu.go
+++ b/pkg/provision/providers/qemu/qemu.go
@@ -54,6 +54,6 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 
 // GetLoadBalancers returns internal/external loadbalancer endpoints.
 func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (internalEndpoint, externalEndpoint string) {
-	// firecracker runs loadbalancer on the bridge, which is good for both internal & external access
-	return networkReq.GatewayAddr.String(), networkReq.GatewayAddr.String()
+	// qemu runs loadbalancer on the bridge, which is good for both internal access, external access goes via round-robin
+	return networkReq.GatewayAddr.String(), ""
 }


### PR DESCRIPTION
Docker for OS X doesn't leave any other option, as node IPs are not
routeable from the host, and current default was to use all the control
plane node IPs in round-robin LB.

Fixes #2495

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2496)
<!-- Reviewable:end -->
