### PR TITLE
feat: use latest packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -288,34 +288,34 @@ COPY --from=talosctl-darwin-build /talosctl-darwin-amd64 /talosctl-darwin-amd64
 # The kernel target is the linux kernel.
 
 FROM scratch AS kernel
-COPY --from=docker.io/autonomy/kernel:v0.3.0-4-gd3f55f3 /boot/vmlinuz /vmlinuz
+COPY --from=docker.io/autonomy/kernel:v0.3.0-5-gec61a1d /boot/vmlinuz /vmlinuz
 
 # The rootfs target provides the Talos rootfs.
 
 FROM build AS rootfs-base
-COPY --from=docker.io/autonomy/fhs:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/ca-certificates:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/containerd:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/dosfstools:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/eudev:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/iptables:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/libressl:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/libseccomp:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/linux-firmware:v0.3.0-4-gd3f55f3 /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
-COPY --from=docker.io/autonomy/linux-firmware:v0.3.0-4-gd3f55f3 /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
-COPY --from=docker.io/autonomy/lvm2:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/libaio:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/musl:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/open-iscsi:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/open-isns:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/runc:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/socat:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/xfsprogs:v0.3.0-4-gd3f55f3 / /rootfs
-COPY --from=docker.io/autonomy/util-linux:v0.3.0-4-gd3f55f3 /lib/libblkid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.3.0-4-gd3f55f3 /lib/libuuid.* /rootfs/lib/
-COPY --from=docker.io/autonomy/util-linux:v0.3.0-4-gd3f55f3 /lib/libmount.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kmod:v0.3.0-4-gd3f55f3 /usr/lib/libkmod.* /rootfs/lib/
-COPY --from=docker.io/autonomy/kernel:v0.3.0-4-gd3f55f3 /lib/modules /rootfs/lib/modules
+COPY --from=docker.io/autonomy/fhs:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/ca-certificates:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/containerd:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/dosfstools:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/eudev:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/iptables:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/libressl:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/libseccomp:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/linux-firmware:v0.3.0-5-gec61a1d /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2
+COPY --from=docker.io/autonomy/linux-firmware:v0.3.0-5-gec61a1d /lib/firmware/bnx2x /rootfs/lib/firmware/bnx2x
+COPY --from=docker.io/autonomy/lvm2:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/libaio:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/musl:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/open-iscsi:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/open-isns:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/runc:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/socat:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/xfsprogs:v0.3.0-5-gec61a1d / /rootfs
+COPY --from=docker.io/autonomy/util-linux:v0.3.0-5-gec61a1d /lib/libblkid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.3.0-5-gec61a1d /lib/libuuid.* /rootfs/lib/
+COPY --from=docker.io/autonomy/util-linux:v0.3.0-5-gec61a1d /lib/libmount.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kmod:v0.3.0-5-gec61a1d /usr/lib/libkmod.* /rootfs/lib/
+COPY --from=docker.io/autonomy/kernel:v0.3.0-5-gec61a1d /lib/modules /rootfs/lib/modules
 COPY --from=machined /machined /rootfs/sbin/init
 COPY --from=apid-image /apid.tar /rootfs/usr/images/
 COPY --from=bootkube-image /bootkube.tar /rootfs/usr/images/
@@ -385,7 +385,7 @@ RUN apk add --no-cache --update \
     qemu-img \
     util-linux \
     xfsprogs
-COPY --from=docker.io/autonomy/grub:v0.3.0-4-gd3f55f3 / /
+COPY --from=docker.io/autonomy/grub:v0.3.0-5-gec61a1d / /
 COPY --from=kernel /vmlinuz /usr/install/vmlinuz
 COPY --from=initramfs /initramfs.xz /usr/install/initramfs.xz
 COPY --from=installer-build /installer /bin/installer


### PR DESCRIPTION
This brings in a version of packages that have been built with gcc 10.2.0.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2497)
<!-- Reviewable:end -->
