### PR TITLE
fix: don't abort reboot sequence on bootloader meta failure

### DIFF
--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -74,19 +74,16 @@ func handle(err error) {
 		log.Print(err)
 	}
 
-	meta, err := bootloader.NewMeta()
-	if err != nil {
+	if meta, err := bootloader.NewMeta(); err == nil {
+		if err = meta.Revert(); err != nil {
+			log.Printf("failed to revert upgrade: %v", err)
+		}
+
+		//nolint: errcheck
+		meta.Close()
+	} else {
 		log.Printf("failed to open meta: %v", err)
-
-		return
 	}
-
-	if err = meta.Revert(); err != nil {
-		log.Printf("failed to revert upgrade: %v", err)
-	}
-
-	//nolint: errcheck
-	meta.Close()
 
 	if p := procfs.ProcCmdline().Get(constants.KernelParamPanic).First(); p != nil {
 		if *p == "0" {


### PR DESCRIPTION
If bootloader meta failed to be found/to be reverted, don't abort the
whole sequence of actions leading to reboot, otherwise control returns
back and machined tries to run next sequence in failed state.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2501)
<!-- Reviewable:end -->
