### PR TITLE
fix: update vmware image and platform

### DIFF
--- a/cmd/installer/pkg/ova/ova.go
+++ b/cmd/installer/pkg/ova/ova.go
@@ -20,7 +20,8 @@ import (
 )
 
 const mfTpl = `SHA256({{ .VMDK }})= {{ .VMDKSHA }}
-SHA256({{ .OVF }})= {{ .OVFSHA }}`
+SHA256({{ .OVF }})= {{ .OVFSHA }}
+`
 
 // OVF format reference: https://www.dmtf.org/standards/ovf.
 //nolint: lll
@@ -113,7 +114,6 @@ const ovfTpl = `<?xml version="1.0" encoding="UTF-8"?>
         <rasd:ResourceSubType>vmware.vmci</rasd:ResourceSubType>
         <rasd:ResourceType>1</rasd:ResourceType>
       </Item>
-      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
       <vmw:Config ovf:required="false" vmw:key="tools.syncTimeWithHost" vmw:value="false"/>
       <vmw:Config ovf:required="false" vmw:key="tools.afterPowerOn" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="tools.afterResume" vmw:value="true"/>
@@ -184,7 +184,7 @@ func CreateOVAFromRAW(name, src, out string) (err error) {
 		return err
 	}
 
-	if _, err = cmd.Run("tar", "-cvf", filepath.Join(out, "vmware.ova"), ".", "-C", dir); err != nil {
+	if _, err = cmd.Run("tar", "-cvf", filepath.Join(out, "vmware.ova"), "-C", dir, name+".ovf", name+".mf", name+".vmdk"); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -57,7 +57,7 @@ func (v *VMware) Configuration() ([]byte, error) {
 		}
 
 		if val == "" {
-			return nil, fmt.Errorf("config is required, no value found for guestinfo.%s: %w", constants.VMwareGuestInfoConfigKey, err)
+			return nil, fmt.Errorf("config is required, no value found for guestinfo: %q", constants.VMwareGuestInfoConfigKey)
 		}
 
 		b, err := base64.StdEncoding.DecodeString(val)
@@ -89,7 +89,7 @@ func (v *VMware) ExternalIPs() (addrs []net.IP, err error) {
 // KernelArgs implements the runtime.Platform interface.
 func (v *VMware) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("tty0"),
+		procfs.NewParameter("console").Append("tty0").Append("ttyS0"),
 		procfs.NewParameter("earlyprintk").Append("ttyS0,115200"),
 	}
 }


### PR DESCRIPTION
Multiple fixes from local testing:

* `.ova` file shouldn't contain `./` entries
* fix error message (`err` is `nil` at that point)
* drop `efi` boot key (BIOS mode works fine)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2502)
<!-- Reviewable:end -->
