### PR TITLE
feat: implement command `talosctl upgrade-k8s`

### DIFF
--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/pkg/cli"
+	"github.com/talos-systems/talos/pkg/cluster"
+	k8s "github.com/talos-systems/talos/pkg/cluster/kubernetes"
+	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+)
+
+// upgradeK8sCmd represents the upgrade-k8s command.
+var upgradeK8sCmd = &cobra.Command{
+	Use:   "upgrade-k8s",
+	Short: "Upgrade Kubernetes control plane in the Talos cluster.",
+	Long:  `Command runs upgrade of Kubernetes control plane components between specified versions. Pod-checkpointer is handled in a special way to speed up kube-apisever upgrades.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return WithClient(upgradeKubernetes)
+	},
+}
+
+var upgradeK8sCmdFlags struct {
+	fromVersion string
+	toVersion   string
+}
+
+func init() {
+	upgradeK8sCmd.Flags().StringVar(&upgradeK8sCmdFlags.fromVersion, "from", "", "the Kubernetes control plane version to upgrade from")
+	upgradeK8sCmd.Flags().StringVar(&upgradeK8sCmdFlags.toVersion, "to", constants.DefaultKubernetesVersion, "the Kubernetes control plane version to upgrade to")
+	cli.Should(upgradeK8sCmd.MarkFlagRequired("from"))
+	cli.Should(upgradeK8sCmd.MarkFlagRequired("to"))
+	addCommand(upgradeK8sCmd)
+}
+
+func upgradeKubernetes(ctx context.Context, c *client.Client) error {
+	clientProvider := &cluster.ConfigClientProvider{
+		DefaultClient: c,
+	}
+	defer clientProvider.Close() //nolint: errcheck
+
+	state := struct {
+		cluster.K8sProvider
+	}{
+		K8sProvider: &cluster.KubernetesClient{
+			ClientProvider: clientProvider,
+			ForceEndpoint:  healthCmdFlags.forceEndpoint,
+		},
+	}
+
+	return k8s.Upgrade(ctx, &state, upgradeK8sCmdFlags.fromVersion, upgradeK8sCmdFlags.toVersion)
+}

--- a/docs/talosctl/talosctl.md
+++ b/docs/talosctl/talosctl.md
@@ -50,6 +50,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl stats](talosctl_stats.md)	 - Get container stats
 * [talosctl time](talosctl_time.md)	 - Gets current server time
 * [talosctl upgrade](talosctl_upgrade.md)	 - Upgrade Talos on the target node
+* [talosctl upgrade-k8s](talosctl_upgrade-k8s.md)	 - Upgrade Kubernetes control plane in the Talos cluster.
 * [talosctl validate](talosctl_validate.md)	 - Validate config
 * [talosctl version](talosctl_version.md)	 - Prints the version
 

--- a/docs/talosctl/talosctl_upgrade-k8s.md
+++ b/docs/talosctl/talosctl_upgrade-k8s.md
@@ -1,0 +1,34 @@
+<!-- markdownlint-disable -->
+## talosctl upgrade-k8s
+
+Upgrade Kubernetes control plane in the Talos cluster.
+
+### Synopsis
+
+Command runs upgrade of Kubernetes control plane components between specified versions. Pod-checkpointer is handled in a special way to speed up kube-apisever upgrades.
+
+```
+talosctl upgrade-k8s [flags]
+```
+
+### Options
+
+```
+      --from string   the Kubernetes control plane version to upgrade from
+  -h, --help          help for upgrade-k8s
+      --to string     the Kubernetes control plane version to upgrade to (default "1.19.0")
+```
+
+### Options inherited from parent commands
+
+```
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
+```
+
+### SEE ALSO
+
+* [talosctl](talosctl.md)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
+

--- a/pkg/cluster/kubernetes/kubernetes.go
+++ b/pkg/cluster/kubernetes/kubernetes.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package kubernetes provides cluster-wide kubernetes utilities.
+package kubernetes

--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -1,0 +1,214 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/talos-systems/go-retry/retry"
+
+	"github.com/talos-systems/talos/pkg/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+)
+
+const (
+	namespace              = "kube-system"
+	checkpointerAnnotation = "checkpointer.alpha.coreos.com/checkpoint"
+
+	kubeAPIServer         = "kube-apiserver"
+	kubeControllerManager = "kube-controller-manager"
+	kubeScheduler         = "kube-scheduler"
+	kubeProxy             = "kube-proxy"
+)
+
+// Upgrade the Kubernetes control plane.
+func Upgrade(ctx context.Context, cluster cluster.K8sProvider, fromVersion, toVersion string) error {
+	switch {
+	case strings.HasPrefix(fromVersion, "1.18.") && strings.HasPrefix(toVersion, "1.19."):
+		return hyperkubeUpgrade(ctx, cluster, toVersion)
+	case strings.HasPrefix(fromVersion, "1.19.") && strings.HasPrefix(toVersion, "1.19."):
+		return hyperkubeUpgrade(ctx, cluster, toVersion)
+	default:
+		return fmt.Errorf("unsupported upgrade from %q to %q", fromVersion, toVersion)
+	}
+}
+
+// hyperkubeUpgrade upgrades from hyperkube-based to distroless images in 1.19.
+func hyperkubeUpgrade(ctx context.Context, cluster cluster.K8sProvider, targetVersion string) error {
+	clientset, err := cluster.K8sClient(ctx)
+	if err != nil {
+		return fmt.Errorf("error building K8s client: %w", err)
+	}
+
+	if err = podCheckpointerGracePeriod(ctx, clientset, "0m"); err != nil {
+		return fmt.Errorf("error setting pod-checkpointer grace period: %w", err)
+	}
+
+	graceTimeout := 5 * time.Minute
+
+	fmt.Printf("sleeping %s to let the pod-checkpointer self-scheckpoint be updated\n", graceTimeout.String())
+	time.Sleep(graceTimeout)
+
+	daemonsets := []string{kubeAPIServer, kubeControllerManager, kubeScheduler, kubeProxy}
+
+	for _, ds := range daemonsets {
+		if err = hyperkubeUpgradeDs(ctx, clientset, ds, targetVersion); err != nil {
+			return fmt.Errorf("failed updating daemonset %q: %w", ds, err)
+		}
+	}
+
+	if err = podCheckpointerGracePeriod(ctx, clientset, graceTimeout.String()); err != nil {
+		return fmt.Errorf("error setting pod-checkpointer grace period: %w", err)
+	}
+
+	return nil
+}
+
+//nolint: gocyclo
+func updateDaemonset(ctx context.Context, clientset *kubernetes.Clientset, ds string, updateFunc func(daemonset *appsv1.DaemonSet) error) error {
+	daemonset, err := clientset.AppsV1().DaemonSets(namespace).Get(ctx, ds, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error fetching daemonset: %w", err)
+	}
+
+	oldData, err := json.Marshal(daemonset)
+	if err != nil {
+		return fmt.Errorf("error marshaling deployment: %w", err)
+	}
+
+	if err = updateFunc(daemonset); err != nil {
+		return err
+	}
+
+	newData, err := json.Marshal(daemonset)
+	if err != nil {
+		return fmt.Errorf("error marshaling new deployment: %w", err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, appsv1.DaemonSet{})
+	if err != nil {
+		return fmt.Errorf("failed to create two way merge patch: %w", err)
+	}
+
+	_, err = clientset.AppsV1().DaemonSets(namespace).Patch(ctx, daemonset.Name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{
+		FieldManager: "talos",
+	})
+	if err != nil {
+		return fmt.Errorf("error patching deployment: %w", err)
+	}
+
+	// give k8s some time
+	time.Sleep(10 * time.Second)
+
+	return retry.Constant(5*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
+		daemonset, err = clientset.AppsV1().DaemonSets(namespace).Get(ctx, ds, metav1.GetOptions{})
+		if err != nil {
+			return retry.UnexpectedError(fmt.Errorf("error fetching daemonset: %w", err))
+		}
+
+		if daemonset.Status.UpdatedNumberScheduled != daemonset.Status.DesiredNumberScheduled {
+			return retry.ExpectedError(fmt.Errorf("expected current number up-to-date for %s to be %d, got %d", ds, daemonset.Status.UpdatedNumberScheduled, daemonset.Status.CurrentNumberScheduled))
+		}
+
+		if daemonset.Status.CurrentNumberScheduled != daemonset.Status.DesiredNumberScheduled {
+			return retry.ExpectedError(fmt.Errorf("expected current number scheduled for %s to be %d, got %d", ds, daemonset.Status.DesiredNumberScheduled, daemonset.Status.CurrentNumberScheduled))
+		}
+
+		if daemonset.Status.NumberAvailable != daemonset.Status.DesiredNumberScheduled {
+			return retry.ExpectedError(fmt.Errorf("expected number available for %s to be %d, got %d", ds, daemonset.Status.DesiredNumberScheduled, daemonset.Status.NumberAvailable))
+		}
+
+		if daemonset.Status.NumberReady != daemonset.Status.DesiredNumberScheduled {
+			return retry.ExpectedError(fmt.Errorf("expected number ready for %s to be %d, got %d", ds, daemonset.Status.DesiredNumberScheduled, daemonset.Status.NumberReady))
+		}
+
+		return nil
+	})
+}
+
+func podCheckpointerGracePeriod(ctx context.Context, clientset *kubernetes.Clientset, gracePeriod string) error {
+	fmt.Printf("updating pod-checkpointer grace period to %q\n", gracePeriod)
+
+	return updateDaemonset(ctx, clientset, "pod-checkpointer", func(daemonset *appsv1.DaemonSet) error {
+		if len(daemonset.Spec.Template.Spec.Containers) != 1 {
+			return fmt.Errorf("unexpected number of containers: %d", len(daemonset.Spec.Template.Spec.Containers))
+		}
+
+		args := daemonset.Spec.Template.Spec.Containers[0].Command
+		for i := range args {
+			if strings.HasPrefix(args[i], "--checkpoint-grace-period=") {
+				args[i] = fmt.Sprintf("--checkpoint-grace-period=%s", gracePeriod)
+			}
+		}
+
+		return nil
+	})
+}
+
+//nolint: gocyclo
+func hyperkubeUpgradeDs(ctx context.Context, clientset *kubernetes.Clientset, ds, targetVersion string) error {
+	if ds == kubeAPIServer {
+		fmt.Printf("temporarily taking %q out of pod-checkpointer control\n", ds)
+
+		if err := updateDaemonset(ctx, clientset, ds, func(daemonset *appsv1.DaemonSet) error {
+			delete(daemonset.Spec.Template.Annotations, checkpointerAnnotation)
+
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("updating daemonset %q to version %q\n", ds, targetVersion)
+
+	return updateDaemonset(ctx, clientset, ds, func(daemonset *appsv1.DaemonSet) error {
+		if len(daemonset.Spec.Template.Spec.Containers) != 1 {
+			return fmt.Errorf("unexpected number of containers: %d", len(daemonset.Spec.Template.Spec.Containers))
+		}
+
+		args := daemonset.Spec.Template.Spec.Containers[0].Command
+		if args[0] == "./hyperkube" || args[0] == "/hyperkube" {
+			args[0] = "/go-runner"
+			args[1] = fmt.Sprintf("/usr/local/bin/%s", ds)
+
+			if ds == kubeProxy {
+				daemonset.Spec.Template.Spec.Containers[0].Command = daemonset.Spec.Template.Spec.Containers[0].Command[1:]
+			}
+		}
+
+		switch ds {
+		case kubeAPIServer:
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, targetVersion)
+		case kubeControllerManager:
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, targetVersion)
+		case kubeScheduler:
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, targetVersion)
+		case kubeProxy:
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesProxyImage, targetVersion)
+		default:
+			return fmt.Errorf("failed to build new image spec")
+		}
+
+		if ds == kubeAPIServer {
+			if daemonset.Spec.Template.Annotations == nil {
+				daemonset.Spec.Template.Annotations = make(map[string]string)
+			}
+
+			daemonset.Spec.Template.Annotations[checkpointerAnnotation] = "true"
+		}
+
+		return nil
+	})
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -196,6 +196,9 @@ const (
 	// KubernetesControllerManagerImage is the enforced controllermanager image to use for the control plane.
 	KubernetesControllerManagerImage = "k8s.gcr.io/kube-controller-manager"
 
+	// KubernetesProxyImage is the enforced proxy image to use for the control plane.
+	KubernetesProxyImage = "k8s.gcr.io/kube-proxy"
+
 	// KubernetesSchedulerImage is the enforced scheduler image to use for the control plane.
 	KubernetesSchedulerImage = "k8s.gcr.io/kube-scheduler"
 


### PR DESCRIPTION
This command handles upgrading Kubernetes control plane from 1.18.x and
1.19.x to 1.19.x.

There's automatic handling of pod-checkpointer to speed up
kube-apiserver upgrades.

Separate PR will add K8s upgrade to integration tests.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2505)
<!-- Reviewable:end -->
