### PR TITLE
fix: tell grub to use console output

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -45,6 +45,9 @@ set fallback="{{ . }}"
 {{- end }}
 set timeout=0
 
+terminal_input console
+terminal_output console
+
 {{ range $label := .Labels -}}
 menuentry "{{ $label.Root }}" {
   linux {{ $label.Kernel }} {{ $label.Append }}


### PR DESCRIPTION
This PR fixes some small bugs we were seeing where grub was booting in
blind mode. Let's keep grub from trying to get too fancy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2513)
<!-- Reviewable:end -->
