### PR TITLE
test: implement API for QEMU VM provisioner

### DIFF
--- a/pkg/provision/internal/inmemhttp/inmemhttp.go
+++ b/pkg/provision/internal/inmemhttp/inmemhttp.go
@@ -15,6 +15,7 @@ import (
 // Server is an in-memory http web server.
 type Server interface {
 	AddFile(filename string, contents []byte) error
+	AddHandler(pattern string, handler http.Handler)
 
 	GetAddr() net.Addr
 	Serve()
@@ -70,6 +71,10 @@ func (s *server) AddFile(filename string, contents []byte) error {
 	}))
 
 	return nil
+}
+
+func (s *server) AddHandler(pattern string, handler http.Handler) {
+	s.mux.Handle(pattern, handler)
 }
 
 func (s *server) GetAddr() net.Addr {

--- a/pkg/provision/providers/firecracker/launch.go
+++ b/pkg/provision/providers/firecracker/launch.go
@@ -50,7 +50,7 @@ func Launch() error {
 
 	ctx := context.Background()
 
-	httpServer, err := vm.NewConfigServer(config.GatewayAddr, []byte(config.Config))
+	httpServer, err := vm.NewHTTPServer(config.GatewayAddr, 0, []byte(config.Config), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/provision/providers/qemu/controller.go
+++ b/pkg/provision/providers/qemu/controller.go
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"sync"
+
+	"github.com/talos-systems/talos/pkg/provision/providers/vm"
+)
+
+// PowerState is current VM power state.
+type PowerState string
+
+// Virtual machine power state.
+const (
+	PoweredOn  PowerState = "on"
+	PoweredOff PowerState = "off"
+)
+
+// VMCommand is a translated VM command.
+type VMCommand string
+
+// Virtual machine commands.
+const (
+	VMCommandStart VMCommand = "start"
+	VMCommandStop  VMCommand = "stop"
+)
+
+// Controller supports IPMI-like machine control.
+type Controller struct {
+	mu    sync.Mutex
+	state PowerState
+
+	forcePXEBoot bool
+
+	commandsCh chan VMCommand
+}
+
+// NewController initializes controller in "powered on" state.
+func NewController() *Controller {
+	return &Controller{
+		state:      PoweredOn,
+		commandsCh: make(chan VMCommand),
+	}
+}
+
+// PowerOn implements vm.Controller interface.
+func (c *Controller) PowerOn() error {
+	c.mu.Lock()
+
+	if c.state == PoweredOn {
+		c.mu.Unlock()
+
+		return nil
+	}
+
+	c.state = PoweredOn
+	c.mu.Unlock()
+
+	c.commandsCh <- VMCommandStart
+
+	return nil
+}
+
+// PowerOff implements vm.Controller interface.
+func (c *Controller) PowerOff() error {
+	c.mu.Lock()
+
+	if c.state == PoweredOff {
+		c.mu.Unlock()
+
+		return nil
+	}
+
+	c.state = PoweredOff
+	c.mu.Unlock()
+
+	c.commandsCh <- VMCommandStop
+
+	return nil
+}
+
+// Reboot implements vm.Controller interface.
+func (c *Controller) Reboot() error {
+	c.mu.Lock()
+
+	if c.state == PoweredOff {
+		c.mu.Unlock()
+
+		return nil
+	}
+
+	c.mu.Unlock()
+
+	c.commandsCh <- VMCommandStop
+
+	return nil
+}
+
+// PXEBootOnce implements vm.Controller interface.
+func (c *Controller) PXEBootOnce() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.forcePXEBoot = true
+
+	return nil
+}
+
+// Status implements vm.Controller interface.
+func (c *Controller) Status() vm.Status {
+	return vm.Status{
+		PoweredOn: c.PowerState() == PoweredOn,
+	}
+}
+
+// PowerState returns current power state.
+func (c *Controller) PowerState() PowerState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.state
+}
+
+// ForcePXEBoot returns whether next boot should be PXE boot.
+func (c *Controller) ForcePXEBoot() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.forcePXEBoot {
+		c.forcePXEBoot = false
+
+		return true
+	}
+
+	return false
+}
+
+// CommandsCh returns channel with commands.
+func (c *Controller) CommandsCh() <-chan VMCommand {
+	return c.commandsCh
+}

--- a/pkg/provision/providers/vm/controller.go
+++ b/pkg/provision/providers/vm/controller.go
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package vm
+
+// Controller interface should be implemented by the VM to be controlled via the API.
+type Controller interface {
+	PowerOn() error
+	PowerOff() error
+	Reboot() error
+	PXEBootOnce() error
+	Status() Status
+}
+
+// Status describes current VM status.
+type Status struct {
+	PoweredOn bool
+}

--- a/pkg/provision/providers/vm/launch.go
+++ b/pkg/provision/providers/vm/launch.go
@@ -7,7 +7,10 @@ package vm
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -43,15 +46,93 @@ func ConfigureSignals() chan os.Signal {
 	return c
 }
 
-// NewConfigServer creates new inmemhttp.Server and mounts config file into it.
-func NewConfigServer(gatewayAddr net.IP, config []byte) (inmemhttp.Server, error) {
-	httpServer, err := inmemhttp.NewServer(fmt.Sprintf("%s:0", gatewayAddr))
+func httpPostWrapper(f func() error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Body != nil {
+			_, _ = io.Copy(ioutil.Discard, req.Body) //nolint: errcheck
+			req.Body.Close()                         //nolint: errcheck
+		}
+
+		if req.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotImplemented)
+
+			return
+		}
+
+		err := f()
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			fmt.Fprint(w, err.Error())
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func httpGetWrapper(f func(w io.Writer)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.Body != nil {
+			_, _ = io.Copy(ioutil.Discard, req.Body) //nolint: errcheck
+			req.Body.Close()                         //nolint: errcheck
+		}
+
+		switch req.Method {
+		case http.MethodHead:
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			f(w)
+		default:
+			w.WriteHeader(http.StatusNotImplemented)
+		}
+	})
+}
+
+// NewHTTPServer creates new inmemhttp.Server and mounts config file into it.
+func NewHTTPServer(gatewayAddr net.IP, port int, config []byte, controller Controller) (inmemhttp.Server, error) {
+	httpServer, err := inmemhttp.NewServer(fmt.Sprintf("%s:%d", gatewayAddr, port))
 	if err != nil {
 		return nil, fmt.Errorf("error launching in-memory HTTP server: %w", err)
 	}
 
 	if err = httpServer.AddFile("config.yaml", config); err != nil {
 		return nil, err
+	}
+
+	if controller != nil {
+		for _, method := range []struct {
+			pattern string
+			f       func() error
+		}{
+			{
+				pattern: "/poweron",
+				f:       controller.PowerOn,
+			},
+			{
+				pattern: "/poweroff",
+				f:       controller.PowerOff,
+			},
+			{
+				pattern: "/reboot",
+				f:       controller.Reboot,
+			},
+			{
+				pattern: "/pxeboot",
+				f:       controller.PXEBootOnce,
+			},
+		} {
+			httpServer.AddHandler(method.pattern, httpPostWrapper(method.f))
+		}
+
+		httpServer.AddHandler("/status", httpGetWrapper(func(w io.Writer) {
+			json.NewEncoder(w).Encode(controller.Status()) //nolint: errcheck
+		}))
 	}
 
 	return httpServer, nil

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -57,4 +57,6 @@ type NodeInfo struct {
 
 	PublicIP  net.IP
 	PrivateIP net.IP
+
+	APIPort int
 }


### PR DESCRIPTION
Fixes #2515

This implements simple HTTP API which should cover same methods as IPMI
methods in Sidero.

Examples:

```
$ curl http://172.20.0.1:34791/status
{"PoweredOn":false}
```

```
$ curl -X POST http://172.20.0.1:34791/poweroff
```

API listens on bridge address, each VM has unique port which can be
found in cluster state as `apiport: NNNN`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2516)
<!-- Reviewable:end -->
