### PR TITLE
feat: allow for link local networking

### DIFF
--- a/internal/app/networkd/pkg/address/static.go
+++ b/internal/app/networkd/pkg/address/static.go
@@ -38,9 +38,15 @@ func (s *Static) Name() string {
 
 // Address returns the IP address.
 func (s *Static) Address() *net.IPNet {
-	// nolint: errcheck
-	ip, ipn, _ := net.ParseCIDR(s.CIDR)
-	ipn.IP = ip
+	var ip net.IP
+
+	var ipn *net.IPNet
+
+	if s.CIDR != "" {
+		// nolint: errcheck
+		ip, ipn, _ = net.ParseCIDR(s.CIDR)
+		ipn.IP = ip
+	}
 
 	return ipn
 }
@@ -70,6 +76,10 @@ func (s *Static) TTL() time.Duration {
 
 // Family qualifies the address as ipv4 or ipv6.
 func (s *Static) Family() int {
+	if s.Address() == nil {
+		panic("unable to determine address family as address is nil")
+	}
+
 	if s.Address().IP.To4() != nil {
 		return unix.AF_INET
 	}

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -55,8 +55,10 @@ func buildOptions(device config.Device, hostname string) (name string, opts []ni
 
 			opts = append(opts, nic.WithNoAddressing())
 		} else {
-			d := &address.DHCP{}
-			opts = append(opts, nic.WithAddressing(d))
+			// No CIDR and DHCP==false results in a static without an IP.
+			// This handles cases like slaac addressing.
+			s := &address.Static{RouteList: device.Routes(), Mtu: device.MTU()}
+			opts = append(opts, nic.WithAddressing(s))
 		}
 	}
 

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -336,30 +336,32 @@ func (n *NetworkInterface) configureInterface(method address.Addressing, link *n
 		return err
 	}
 
-	// Check to see if we need to configure the address
-	addrs, err := n.rtnlConn.Addrs(method.Link(), method.Family())
-	if err != nil {
-		return err
-	}
-
-	addressExists := false
-
-	for _, addr := range addrs {
-		if method.Address().String() == addr.String() {
-			addressExists = true
-			break
+	if method.Address() != nil {
+		// Check to see if we need to configure the address
+		addrs, err := n.rtnlConn.Addrs(method.Link(), method.Family())
+		if err != nil {
+			return err
 		}
-	}
 
-	if !addressExists {
-		if err = n.rtnlConn.AddrAdd(method.Link(), method.Address()); err != nil {
-			switch err := err.(type) {
-			case *netlink.OpError:
-				if !os.IsExist(err.Err) && err.Err != syscall.ESRCH {
-					return err
+		addressExists := false
+
+		for _, addr := range addrs {
+			if method.Address().String() == addr.String() {
+				addressExists = true
+				break
+			}
+		}
+
+		if !addressExists && method.Address() != nil {
+			if err = n.rtnlConn.AddrAdd(method.Link(), method.Address()); err != nil {
+				switch err := err.(type) {
+				case *netlink.OpError:
+					if !os.IsExist(err.Err) && err.Err != syscall.ESRCH {
+						return err
+					}
+				default:
+					return fmt.Errorf("failed to add address (already exists) %+v to %s: %v", method.Address(), method.Link().Name, err)
 				}
-			default:
-				return fmt.Errorf("failed to add address (already exists) %+v to %s: %v", method.Address(), method.Link().Name, err)
 			}
 		}
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -172,11 +172,6 @@ func CheckDeviceAddressing(d *Device) error {
 		result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device", d.DeviceInterface, ErrBadAddressing))
 	}
 
-	// test for neither dhcp nor cidr specified
-	if !d.DeviceDHCP && d.DeviceCIDR == "" && len(d.DeviceVlans) == 0 {
-		result = multierror.Append(result, fmt.Errorf("[%s] %q: %w", "networking.os.device", d.DeviceInterface, ErrBadAddressing))
-	}
-
 	// ensure cidr is a valid address
 	if d.DeviceCIDR != "" {
 		if _, _, err := net.ParseCIDR(d.DeviceCIDR); err != nil {


### PR DESCRIPTION
This PR allows for the ability to specify neither CIDR nor DHCP in the
talos machine config. The result here should allow for things like SLAAC
addressing with ipv6.

Will close #2486 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2518)
<!-- Reviewable:end -->
