### PR TITLE
feat: update Flannel to 0.12, support for arm64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
-	github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e
+	github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3
 	github.com/talos-systems/crypto v0.2.0
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45

--- a/go.sum
+++ b/go.sum
@@ -750,6 +750,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e h1:Zxo/QrqZANuOBrMBwKq5L2kLrelF4jUKnrWAUfiCgbw=
 github.com/talos-systems/bootkube-plugin v0.0.0-20200729203641-12d463a3e54e/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
+github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3 h1:Lp/MzZ7QzHjkE0uR9FYAGiOrVX55BEfvdukv6MynCZU=
+github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j8UNYE=
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=

--- a/internal/app/bootkube/assets.go
+++ b/internal/app/bootkube/assets.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/hashicorp/go-getter"
@@ -127,6 +128,7 @@ func generateAssets(config config.Provider) (err error) {
 	images := asset.DefaultImages
 
 	// Override all kube-related images with default val or specified image locations
+	images.Flannel = fmt.Sprintf("quay.io/coreos/flannel:v0.12.0-%s", runtime.GOARCH)
 	images.Kubelet = config.Machine().Kubelet().Image()
 	images.KubeAPIServer = config.Cluster().APIServer().Image()
 	images.KubeControllerManager = config.Cluster().ControllerManager().Image()


### PR DESCRIPTION
This updates bootkube-plugin with PR
https://github.com/talos-systems/bootkube-plugin/pull/21.

Flannel image is chosen based on host architecture.

Fixes #2510

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2519)
<!-- Reviewable:end -->
