### PR TITLE
fix: set environment variable for etcd on arm64

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -107,6 +108,10 @@ func (e *Etcd) Runner(r runtime.Runtime) (runner.Runner, error) {
 	env := []string{}
 	for key, val := range r.Config().Machine().Env() {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
+	}
+
+	if goruntime.GOARCH == "arm64" {
+		env = append(env, "ETCD_UNSUPPORTED_ARCH=arm64")
 	}
 
 	return restart.New(containerd.NewRunner(


### PR DESCRIPTION
Required to start etcd on arm64.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2528)
<!-- Reviewable:end -->
