### PR TITLE
chore: update ntp time headers

### DIFF
--- a/cmd/talosctl/cmd/talos/time.go
+++ b/cmd/talosctl/cmd/talos/time.go
@@ -54,7 +54,7 @@ var timeCmd = &cobra.Command{
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-			fmt.Fprintln(w, "NODE\tNTP-SERVER\tLOCAL-TIME\tREMOTE-TIME")
+			fmt.Fprintln(w, "NODE\tNTP-SERVER\tNODE-TIME\tNTP-SERVER-TIME")
 
 			defaultNode := client.AddrFromPeer(&remotePeer)
 


### PR DESCRIPTION
This PR changes the headers for issuing `talosctl time` to make it a bit
clearer which time is being reported in each column.

Will close #2341 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2530)
<!-- Reviewable:end -->
