### PR TITLE
fix: clean up e2e TMP dir

### DIFF
--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -8,8 +8,9 @@ REGION="us-east-1"
 BUCKET="talos-ci-e2e"
 
 function setup {
+  make_tmp
+
   # Setup svc account
-  mkdir -p ${TMP}
 
   # Untar image
   tar -C ${TMP} -xf ${ARTIFACTS}/aws.tar.gz

--- a/hack/test/e2e-azure.sh
+++ b/hack/test/e2e-azure.sh
@@ -5,6 +5,8 @@ set -eou pipefail
 source ./hack/test/e2e.sh
 
 function setup {
+  make_tmp
+
   AZURE_STORAGE_ACCOUNT=talostesting
   AZURE_STORAGE_CONTAINER=talostesting
   AZURE_GROUP=talos

--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -4,6 +4,8 @@ set -eou pipefail
 
 source ./hack/test/e2e.sh
 
+make_tmp
+
 export CABPT_VERSION="0.2.0-alpha.0"
 export CACPPT_VERSION="0.1.0-alpha.2"
 export CAPA_VERSION="0.5.4"

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -2,12 +2,15 @@
 
 set -eou pipefail
 
+export PROVISIONER=docker
+export CLUSTER_NAME=e2e-${PROVISIONER}
+
 source ./hack/test/e2e.sh
 
-PROVISIONER=docker
-CLUSTER_NAME=e2e-${PROVISIONER}
 
 function create_cluster {
+  make_tmp
+
   build_registry_mirrors
 
   "${TALOSCTL}" cluster create \
@@ -29,8 +32,10 @@ function create_cluster {
 
 function destroy_cluster() {
   "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}"
+   clean_tmp
 }
 
+destroy_cluster
 create_cluster
 get_kubeconfig
 ${KUBECTL} config set-cluster e2e-docker --server https://10.5.0.2:6443

--- a/hack/test/e2e-firecracker.sh
+++ b/hack/test/e2e-firecracker.sh
@@ -32,6 +32,8 @@ case "${CUSTOM_CNI_URL:-false}" in
 esac
 
 function create_cluster {
+  make_tmp
+
   build_registry_mirrors
 
   "${TALOSCTL}" cluster create \
@@ -54,8 +56,10 @@ function create_cluster {
 
 function destroy_cluster() {
   "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+  clean_tmp
 }
 
+destroy_cluster
 create_cluster
 get_kubeconfig
 run_talos_integration_test

--- a/hack/test/e2e-gcp.sh
+++ b/hack/test/e2e-gcp.sh
@@ -5,6 +5,7 @@ set -eou pipefail
 source ./hack/test/e2e.sh
 
 function setup {
+  make_tmp
   echo ${GCE_SVC_ACCT} | base64 -d > ${TMP}/svc-acct.json
   gcloud auth activate-service-account --key-file ${TMP}/svc-acct.json
   gsutil cp ${ARTIFACTS}/gcp.tar.gz gs://talos-e2e/gcp-${SHA}.tar.gz

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -38,6 +38,7 @@ case "${WITH_UEFI:-false}" in
 esac
 
 function create_cluster {
+  make_tmp
   build_registry_mirrors
 
   "${TALOSCTL}" cluster create \
@@ -60,6 +61,7 @@ function create_cluster {
 
 function destroy_cluster() {
   "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+  clean_tmp
 }
 
 create_cluster

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -17,7 +17,6 @@
 set -eoux pipefail
 
 TMP="/tmp/e2e/${PLATFORM}"
-mkdir -p "${TMP}"
 
 # Talos
 
@@ -36,8 +35,19 @@ export TIMEOUT=1200
 export NUM_NODES=6
 
 # default values, overridden by talosctl cluster create tests
-PROVISIONER=
-CLUSTER_NAME=
+PROVISIONER=${PROVISIONER:-""}
+CLUSTER_NAME=${CLUSTER_NAME:-""}
+
+function clean_tmp {
+   # Clean up the old, if it exists
+   if [ -e $TMP ]; then
+      rm -Rf $TMP
+   fi
+}
+
+function make_tmp {
+   mkdir -p "${TMP}"
+}
 
 cleanup_capi() {
   ${KUBECTL} --kubeconfig /tmp/e2e/docker/kubeconfig delete cluster ${NAME_PREFIX}


### PR DESCRIPTION
Before each e2e test, we should clean up the TMP dir, if it is exists, as well as tearing down any existing potentially-conflicting cluster.

Additionally, this modifies the `e2e.sh` script so that it is side-effect-free.
Originally, the TMP dir would be created any time the file was sourced.
While in this particular case, that was reasonably inoffensive, the idea is to only export variables and functions from within a sourced script include.

Additional scrutiny is probably in order, as a result.

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2531)
<!-- Reviewable:end -->
