### PR TITLE
fix: gracefully handle invalid interfaces in bond

### DIFF
--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -156,6 +156,11 @@ func New(config config.Provider) (*Networkd, error) {
 		}
 
 		for _, subif := range netif.SubInterfaces {
+			if _, ok := interfaces[subif.Name]; !ok {
+				result = multierror.Append(result, fmt.Errorf("bond subinterface %s does not exist", subif.Name))
+				continue
+			}
+
 			interfaces[subif.Name].Ignore = true
 		}
 	}


### PR DESCRIPTION
An invalid interface set as a bond's subinterface should produce an
error, but it should not panic.

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2532)
<!-- Reviewable:end -->
