### PR TITLE
feat: ugrade Linux kernel to 5.8.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
-TOOLS ?= autonomy/tools:v0.3.0-3-g6b491a6
-PKGS ?= v0.3.0-5-gec61a1d
+TOOLS ?= autonomy/tools:v0.3.0-4-gfb8cfaa
+PKGS ?= v0.3.0-9-gaef28aa
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 IMPORTVET ?= autonomy/importvet:f6b07d9

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -34,7 +34,7 @@ var (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version
-	DefaultKernelVersion = "5.8.5-talos"
+	DefaultKernelVersion = "5.8.10-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL
 	// to the config.


### PR DESCRIPTION
This addresses CVE-2020-14386.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2537)
<!-- Reviewable:end -->
