### PR TITLE
feat: add images command

### DIFF
--- a/cmd/talosctl/cmd/talos/images.go
+++ b/cmd/talosctl/cmd/talos/images.go
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/internal/app/bootkube/images"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+)
+
+// imagesCmd represents the images command.
+var imagesCmd = &cobra.Command{
+	Use:   "images",
+	Short: "List the default images used by Talos",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		images := images.List(&v1alpha1.Config{
+			MachineConfig: &v1alpha1.MachineConfig{
+				MachineKubelet: &v1alpha1.KubeletConfig{},
+			},
+			ClusterConfig: &v1alpha1.ClusterConfig{
+				EtcdConfig:              &v1alpha1.EtcdConfig{},
+				APIServerConfig:         &v1alpha1.APIServerConfig{},
+				ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{},
+				SchedulerConfig:         &v1alpha1.SchedulerConfig{},
+				CoreDNSConfig:           &v1alpha1.CoreDNS{},
+				ProxyConfig:             &v1alpha1.ProxyConfig{},
+				PodCheckpointerConfig:   &v1alpha1.PodCheckpointer{},
+			},
+		})
+
+		fmt.Printf("%s\n", images.Flannel)
+		fmt.Printf("%s\n", images.FlannelCNI)
+		fmt.Printf("%s\n", images.CoreDNS)
+		fmt.Printf("%s\n", images.Etcd)
+		fmt.Printf("%s\n", images.KubeAPIServer)
+		fmt.Printf("%s\n", images.KubeControllerManager)
+		fmt.Printf("%s\n", images.KubeScheduler)
+		fmt.Printf("%s\n", images.KubeProxy)
+		fmt.Printf("%s\n", images.Kubelet)
+		fmt.Printf("%s\n", constants.DefaultInstallerImage)
+
+		return nil
+	},
+}
+
+func init() {
+	addCommand(imagesCmd)
+}

--- a/docs/talosctl/talosctl.md
+++ b/docs/talosctl/talosctl.md
@@ -31,6 +31,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl events](talosctl_events.md)	 - Stream runtime events
 * [talosctl gen](talosctl_gen.md)	 - Generate CAs, certificates, and private keys
 * [talosctl health](talosctl_health.md)	 - Check cluster health
+* [talosctl images](talosctl_images.md)	 - List the default images used by Talos
 * [talosctl interfaces](talosctl_interfaces.md)	 - List network interfaces
 * [talosctl kubeconfig](talosctl_kubeconfig.md)	 - Download the admin kubeconfig from the node
 * [talosctl list](talosctl_list.md)	 - Retrieve a directory listing

--- a/docs/talosctl/talosctl_images.md
+++ b/docs/talosctl/talosctl_images.md
@@ -1,0 +1,32 @@
+<!-- markdownlint-disable -->
+## talosctl images
+
+List the default images used by Talos
+
+### Synopsis
+
+List the default images used by Talos
+
+```
+talosctl images [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for images
+```
+
+### Options inherited from parent commands
+
+```
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
+```
+
+### SEE ALSO
+
+* [talosctl](talosctl.md)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
+

--- a/internal/app/bootkube/assets.go
+++ b/internal/app/bootkube/assets.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/hashicorp/go-getter"
@@ -27,6 +26,7 @@ import (
 
 	tnet "github.com/talos-systems/net"
 
+	"github.com/talos-systems/talos/internal/app/bootkube/images"
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
@@ -125,19 +125,7 @@ func generateAssets(config config.Provider) (err error) {
 		return fmt.Errorf("failed to calculate DNS service IP: %w", err)
 	}
 
-	images := asset.DefaultImages
-
-	// Override all kube-related images with default val or specified image locations
-	images.Flannel = fmt.Sprintf("quay.io/coreos/flannel:v0.12.0-%s", runtime.GOARCH)
-	images.Kubelet = config.Machine().Kubelet().Image()
-	images.KubeAPIServer = config.Cluster().APIServer().Image()
-	images.KubeControllerManager = config.Cluster().ControllerManager().Image()
-	images.KubeProxy = config.Cluster().Proxy().Image()
-	images.KubeScheduler = config.Cluster().Scheduler().Image()
-
-	// Allow for overriding by users via config data
-	images.CoreDNS = config.Cluster().CoreDNS().Image()
-	images.PodCheckpointer = config.Cluster().PodCheckpointer().Image()
+	images := images.List(config)
 
 	conf := asset.Config{
 		ClusterName:                config.Cluster().Name(),

--- a/internal/app/bootkube/images/images.go
+++ b/internal/app/bootkube/images/images.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package images
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/talos-systems/bootkube-plugin/pkg/asset"
+
+	"github.com/talos-systems/talos/pkg/machinery/config"
+)
+
+// List returns a list of images used.
+func List(config config.Provider) asset.ImageVersions {
+	images := asset.DefaultImages
+
+	// Override all kube-related images with default val or specified image locations
+	images.Flannel = fmt.Sprintf("quay.io/coreos/flannel:v0.12.0-%s", runtime.GOARCH)
+	images.Kubelet = config.Machine().Kubelet().Image()
+	images.KubeAPIServer = config.Cluster().APIServer().Image()
+	images.KubeControllerManager = config.Cluster().ControllerManager().Image()
+	images.KubeProxy = config.Cluster().Proxy().Image()
+	images.KubeScheduler = config.Cluster().Scheduler().Image()
+	images.Etcd = config.Cluster().Etcd().Image()
+
+	// Allow for overriding by users via config data
+	images.CoreDNS = config.Cluster().CoreDNS().Image()
+	images.PodCheckpointer = config.Cluster().PodCheckpointer().Image()
+
+	return images
+}

--- a/internal/integration/cli/images.go
+++ b/internal/integration/cli/images.go
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// ImagesSuite verifies the images command.
+type ImagesSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *ImagesSuite) SuiteName() string {
+	return "cli.ImagesSuite"
+}
+
+// TestSuccess verifies successful execution.
+func (suite *ImagesSuite) TestSuccess() {
+	suite.RunCLI([]string{"images"})
+}
+
+func init() {
+	allSuites = append(allSuites, new(ImagesSuite))
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -10,6 +10,8 @@ import (
 	"github.com/containerd/containerd/defaults"
 	cni "github.com/containerd/go-cni"
 	"github.com/talos-systems/crypto/x509"
+
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 var (
@@ -26,6 +28,9 @@ var (
 	// DefaultInstallerImageRepository is the default container repository for
 	// the installer.
 	DefaultInstallerImageRepository = Registry + "/" + DefaultInstallerImageName
+
+	// DefaultInstallerImage is the default installer image.
+	DefaultInstallerImage = DefaultInstallerImageRepository + ":" + version.Tag
 
 	// DefaultTalosImageRepository is the default container repository for
 	// the talos image.


### PR DESCRIPTION
This adds a command that lists all of the images used by Talos. This is
useful in the case of airgap installs, so that users will know which images
to pull.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2543)
<!-- Reviewable:end -->
