### PR TITLE
fix: enable --removable options for GRUB

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -142,6 +142,10 @@ func (g *Grub) Install(fallback string, config interface{}, sequence runtime.Seq
 	for _, platform := range platforms {
 		args := []string{"--boot-directory=" + constants.BootMountPoint, "--efi-directory=" + constants.EFIMountPoint}
 
+		if strings.HasSuffix(platform, "-efi") {
+			args = append(args, "--removable")
+		}
+
 		if loopDevice {
 			args = append(args, "--no-nvram")
 		}


### PR DESCRIPTION
This makes EFI install path "standard" which should (hopefully) help
with some UEFI implementations.

Fixes #2556

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2564)
<!-- Reviewable:end -->
