### PR TITLE
docs: add note around link-local addressing

### DIFF
--- a/docs/website/content/v0.7/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.7/en/configuration/v1alpha1.md
@@ -732,6 +732,10 @@ The following DHCP options are supported:
 
 > Note: This option is mutually exclusive with CIDR.
 
+> Note: To configure an interface with *only* IPv6 SLAAC addressing, CIDR should be set to "" and DHCP to false
+> in order for Talos to skip configuration of addresses.
+> All other options will still apply.
+
 ##### machine.network.interfaces.ignore
 
 `ignore` is used to exclude a specific interface from configuration.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -443,6 +443,10 @@ type NetworkConfig struct {
 	//
 	//     > Note: This option is mutually exclusive with CIDR.
 	//
+	//     > Note: To configure an interface with *only* IPv6 SLAAC addressing, CIDR should be set to "" and DHCP to false
+	//     > in order for Talos to skip configuration of addresses.
+	//     > All other options will still apply.
+	//
 	//     ##### machine.network.interfaces.ignore
 	//
 	//     `ignore` is used to exclude a specific interface from configuration.


### PR DESCRIPTION
This PR adds a small note to the config docs to detail how to do link
local networking like SLAAC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2567)
<!-- Reviewable:end -->
