### PR TITLE
chore: fix 'push' targets

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -254,6 +254,7 @@ local push = {
   environment: {
     GHCR_USERNAME: { from_secret: 'ghcr_username' },
     GHCR_PASSWORD: { from_secret: 'ghcr_token' },
+    PLATFORM: "linux/amd64,linux/arm64",
   },
   commands: ['make push'],
   volumes: volumes.ForStep(),
@@ -276,6 +277,7 @@ local push_latest = {
   environment: {
     GHCR_USERNAME: { from_secret: 'ghcr_username' },
     GHCR_PASSWORD: { from_secret: 'ghcr_token' },
+    PLATFORM: "linux/amd64,linux/arm64",
   },
   commands: ['make push-latest'],
   volumes: volumes.ForStep(),


### PR DESCRIPTION
These targets don't inherit from the common step definition, so they
were missing correct platform list which was in turn making them fail.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2574)
<!-- Reviewable:end -->
