### PR TITLE
fix: retry container image import

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -382,7 +382,7 @@ func (suite *ContainerdSuite) TestImportSuccess() {
 		},
 	}
 	suite.Assert().NoError(containerdrunner.NewImporter(
-		suite.containerdNamespace, containerdrunner.WithContainerdAddress(suite.containerdAddress)).Import(reqs...))
+		suite.containerdNamespace, containerdrunner.WithContainerdAddress(suite.containerdAddress)).Import(context.Background(), reqs...))
 
 	ctx := namespaces.WithNamespace(context.Background(), suite.containerdNamespace)
 
@@ -409,7 +409,7 @@ func (suite *ContainerdSuite) TestImportFail() {
 		},
 	}
 	suite.Assert().Error(containerdrunner.NewImporter(
-		suite.containerdNamespace, containerdrunner.WithContainerdAddress(suite.containerdAddress)).Import(reqs...))
+		suite.containerdNamespace, containerdrunner.WithContainerdAddress(suite.containerdAddress)).Import(context.Background(), reqs...))
 }
 
 func (suite *ContainerdSuite) TestContainerStdin() {

--- a/internal/app/machined/pkg/system/runner/containerd/import.go
+++ b/internal/app/machined/pkg/system/runner/containerd/import.go
@@ -61,13 +61,13 @@ func NewImporter(namespace string, options ...ImporterOption) *Importer {
 }
 
 // Import imports the images specified by the import requests.
-func (i *Importer) Import(reqs ...*ImportRequest) (err error) {
+func (i *Importer) Import(ctx context.Context, reqs ...*ImportRequest) (err error) {
 	err = conditions.WaitForFileToExist(i.options.containerdAddress).Wait(context.Background())
 	if err != nil {
 		return err
 	}
 
-	ctx := namespaces.WithNamespace(context.Background(), i.namespace)
+	ctx = namespaces.WithNamespace(ctx, i.namespace)
 
 	client, err := containerd.New(i.options.containerdAddress)
 	if err != nil {
@@ -120,6 +120,6 @@ func (i *Importer) Import(reqs ...*ImportRequest) (err error) {
 }
 
 // Import imports the images specified by the import requests.
-func Import(namespace string, reqs ...*ImportRequest) error {
-	return NewImporter(namespace).Import(reqs...)
+func Import(ctx context.Context, namespace string, reqs ...*ImportRequest) error {
+	return NewImporter(namespace).Import(ctx, reqs...)
 }

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/kubernetes"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
@@ -44,14 +44,7 @@ func (o *APID) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (o *APID) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
-
-	return importer.Import(&containerd.ImportRequest{
-		Path: "/usr/images/apid.tar",
-		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/apid"),
-		},
-	})
+	return image.Import(ctx, "/usr/images/apid.tar", "talos/apid")
 }
 
 // PostFunc implements the Service interface.

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"time"
 
-	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"go.etcd.io/etcd/clientv3"
@@ -25,6 +24,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/internal/pkg/etcd"
 	"github.com/talos-systems/talos/pkg/conditions"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -94,14 +94,7 @@ func (b *Bootkube) PreFunc(ctx context.Context, r runtime.Runtime) (err error) {
 		}
 	}
 
-	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
-
-	return importer.Import(&containerd.ImportRequest{
-		Path: "/usr/images/bootkube.tar",
-		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/bootkube"),
-		},
-	})
+	return image.Import(ctx, "/usr/images/bootkube.tar", "talos/bootkube")
 }
 
 // PostFunc implements the Service interface.

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/golang/protobuf/ptypes/empty"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -28,6 +27,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
 	healthapi "github.com/talos-systems/talos/pkg/machinery/api/health"
@@ -45,14 +45,7 @@ func (n *Networkd) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (n *Networkd) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
-
-	return importer.Import(&containerd.ImportRequest{
-		Path: "/usr/images/networkd.tar",
-		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/networkd"),
-		},
-	})
+	return image.Import(ctx, "/usr/images/networkd.tar", "talos/networkd")
 }
 
 // PostFunc implements the Service interface.

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"google.golang.org/grpc"
@@ -23,6 +22,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
@@ -39,14 +39,7 @@ func (o *Routerd) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (o *Routerd) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
-
-	return importer.Import(&containerd.ImportRequest{
-		Path: "/usr/images/routerd.tar",
-		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/routerd"),
-		},
-	})
+	return image.Import(ctx, "/usr/images/routerd.tar", "talos/routerd")
 }
 
 // PostFunc implements the Service interface.

--- a/internal/app/machined/pkg/system/services/timed.go
+++ b/internal/app/machined/pkg/system/services/timed.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	"github.com/golang/protobuf/ptypes/empty"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -27,6 +26,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
 	healthapi "github.com/talos-systems/talos/pkg/machinery/api/health"
@@ -44,14 +44,7 @@ func (n *Timed) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (n *Timed) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
-
-	return importer.Import(&containerd.ImportRequest{
-		Path: "/usr/images/timed.tar",
-		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/timed"),
-		},
-	})
+	return image.Import(ctx, "/usr/images/timed.tar", "talos/timed")
 }
 
 // PostFunc implements the Service interface.

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net"
 
-	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
+	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
@@ -36,14 +36,7 @@ func (t *Trustd) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (t *Trustd) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	importer := containerd.NewImporter(constants.SystemContainerdNamespace, containerd.WithContainerdAddress(constants.SystemContainerdAddress))
-
-	return importer.Import(&containerd.ImportRequest{
-		Path: "/usr/images/trustd.tar",
-		Options: []containerdapi.ImportOpt{
-			containerdapi.WithIndexName("talos/trustd"),
-		},
-	})
+	return image.Import(ctx, "/usr/images/trustd.tar", "talos/trustd")
 }
 
 // PostFunc implements the Service interface.

--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -7,19 +7,29 @@ package image
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/talos-systems/go-retry/retry"
 
+	containerdrunner "github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 // Image pull retry settings.
 const (
 	PullTimeout       = 20 * time.Minute
 	PullRetryInterval = 5 * time.Second
+)
+
+// Image import retry settings.
+const (
+	ImportTimeout       = 5 * time.Minute
+	ImportRetryInterval = 5 * time.Second
+	ImportRetryJitter   = time.Second
 )
 
 // Pull is a convenience function that wraps the containerd image pull func with
@@ -46,4 +56,24 @@ func Pull(ctx context.Context, reg config.Registries, client *containerd.Client,
 	}
 
 	return img, nil
+}
+
+// Import is a convenience function that wraps containerd image import with retries.
+func Import(ctx context.Context, imagePath, indexName string) error {
+	importer := containerdrunner.NewImporter(constants.SystemContainerdNamespace, containerdrunner.WithContainerdAddress(constants.SystemContainerdAddress))
+
+	return retry.Exponential(ImportTimeout, retry.WithUnits(ImportRetryInterval), retry.WithJitter(ImportRetryJitter), retry.WithErrorLogging(true)).Retry(func() error {
+		err := retry.ExpectedError(importer.Import(ctx, &containerdrunner.ImportRequest{
+			Path: imagePath,
+			Options: []containerd.ImportOpt{
+				containerd.WithIndexName(indexName),
+			},
+		}))
+
+		if err != nil && os.IsNotExist(err) {
+			return retry.UnexpectedError(err)
+		}
+
+		return retry.ExpectedError(err)
+	})
 }


### PR DESCRIPTION
This bug is sometimes reproducible with QEMU/arm64, as it runs really
slow. Looks like multiple concurrent image unpacks sharing some layers
might fail unexpectedly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2575)
<!-- Reviewable:end -->
