### PR TITLE
docs: fix cluster name in docker docs

### DIFF
--- a/docs/website/content/v0.6/en/guides/local/docker.md
+++ b/docs/website/content/v0.6/en/guides/local/docker.md
@@ -30,7 +30,7 @@ Once the above finishes successfully, your talosconfig(`~/.talos/config`) will b
 
 ```bash
 talosctl kubeconfig .
-kubectl --kubeconfig kubeconfig config set-cluster talos_default --server https://127.0.0.1:6443
+kubectl --kubeconfig kubeconfig config set-cluster talos-default --server https://127.0.0.1:6443
 ```
 
 ## Using the Cluster

--- a/docs/website/content/v0.7/en/guides/local/docker.md
+++ b/docs/website/content/v0.7/en/guides/local/docker.md
@@ -30,7 +30,7 @@ Once the above finishes successfully, your talosconfig(`~/.talos/config`) will b
 
 ```bash
 talosctl kubeconfig .
-kubectl --kubeconfig kubeconfig config set-cluster talos_default --server https://127.0.0.1:6443
+kubectl --kubeconfig kubeconfig config set-cluster talos-default --server https://127.0.0.1:6443
 ```
 
 ## Using the Cluster


### PR DESCRIPTION
This PR fixes a docs bug where we were still referencing `talos_default`
as the cluster name. It should be `talos-default` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2579)
<!-- Reviewable:end -->
