### PR TITLE
feat: add support for disabling time

### DIFF
--- a/docs/website/content/v0.7/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.7/en/configuration/v1alpha1.md
@@ -870,6 +870,13 @@ Valid Values:
 
 ### TimeConfig
 
+#### enabled
+
+Indicates if time (ntp) is enabled for the machine
+Defaults to `true`.
+
+Type: `bool`
+
 #### servers
 
 Specifies time (ntp) servers to use for setting system time.

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -613,7 +613,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 			&services.Kubelet{},
 		)
 
-		if r.State().Platform().Mode() != runtime.ModeContainer {
+		if r.State().Platform().Mode() != runtime.ModeContainer && r.Config().Machine().Time().Enabled() {
 			svcs.Load(
 				&services.Timed{},
 			)

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -63,7 +63,7 @@ func (o *APID) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *APID) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer {
+	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
 		return []string{"containerd", "networkd"}
 	}
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -85,7 +85,7 @@ func (e *Etcd) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (e *Etcd) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer {
+	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
 		return []string{"containerd", "networkd"}
 	}
 

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -136,7 +136,7 @@ func (k *Kubelet) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (k *Kubelet) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer {
+	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
 		return []string{"cri", "networkd"}
 	}
 

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -51,7 +51,7 @@ func (t *Trustd) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (t *Trustd) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer {
+	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
 		return []string{"containerd", "networkd"}
 	}
 

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -167,6 +167,7 @@ type Route interface {
 // Time defines the requirements for a config that pertains to time related
 // options.
 type Time interface {
+	Enabled() bool
 	Servers() []string
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -113,7 +113,9 @@ func (m *MachineConfig) Network() config.MachineNetwork {
 // Time implements the config.Provider interface.
 func (m *MachineConfig) Time() config.Time {
 	if m.MachineTime == nil {
-		return &TimeConfig{}
+		return &TimeConfig{
+			TimeEnabled: true,
+		}
 	}
 
 	return m.MachineTime
@@ -918,6 +920,11 @@ func (v *Vlan) DHCP() bool {
 // ID implements the MachineNetwork interface.
 func (v *Vlan) ID() uint16 {
 	return v.VlanID
+}
+
+// Enabled implements the config.Provider interface.
+func (t *TimeConfig) Enabled() bool {
+	return t.TimeEnabled
 }
 
 // Servers implements the config.Provider interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -531,6 +531,10 @@ type InstallConfig struct {
 // TimeConfig represents the options for configuring time on a node.
 type TimeConfig struct {
 	//   description: |
+	//     Indicates if time (ntp) is enabled for the machine
+	//     Defaults to `true`.
+	TimeEnabled bool `yaml:"enabled"`
+	//   description: |
 	//     Specifies time (ntp) servers to use for setting system time.
 	//     Defaults to `pool.ntp.org`
 	//


### PR DESCRIPTION
Adds the capability to diasable NTP when it cannot be provided in the deployed network

Signed-off-by: Niklas Wik <niklas.wik@nokia.com>

# Pull Request

## What? (description)

## Why? (reasoning)

When a cluster is deployed in environment where NTP cannot be provided Talos can be enabled to run without NTP server.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2583)
<!-- Reviewable:end -->
