### PR TITLE
fix: provide unique username in generated kubeconfig

### DIFF
--- a/internal/pkg/kubeconfig/admin.go
+++ b/internal/pkg/kubeconfig/admin.go
@@ -25,7 +25,7 @@ clusters:
     server: {{ .Server }}
     certificate-authority-data: {{ .CACert }}
 users:
-- name: admin
+- name: admin@{{ .Cluster }}
   user:
     client-certificate-data: {{ .AdminCert }}
     client-key-data: {{ .AdminKey }}
@@ -33,7 +33,7 @@ contexts:
 - context:
     cluster: {{ .Cluster }}
     namespace: default
-    user: admin
+    user: admin@{{ .Cluster }}
   name: admin@{{ .Cluster }}
 current-context: admin@{{ .Cluster }}
 `


### PR DESCRIPTION
This allows for more clean merge of multiple kubeconfigs from different
Talos clusters.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/2584)
<!-- Reviewable:end -->
