### PR TITLE
feat: support custom filename for talosctl kubeconfig

### DIFF
--- a/docs/talosctl/talosctl_kubeconfig.md
+++ b/docs/talosctl/talosctl_kubeconfig.md
@@ -6,7 +6,7 @@ Download the admin kubeconfig from the node
 ### Synopsis
 
 Download the admin kubeconfig from the node.
-Kubeconfig will be written to PWD/kubeconfig or [local-path]/kubeconfig if specified.
+Kubeconfig will be written to PWD or [local-path] if specified.
 If merge flag is defined, config will be merged with ~/.kube/config or [local-path] if specified.
 
 ```

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -65,6 +65,19 @@ func (suite *KubeconfigSuite) TestCwd() {
 	suite.Require().FileExists(filepath.Join(tempDir, "kubeconfig"))
 }
 
+// TestCustomName generates kubeconfig with custom name.
+func (suite *KubeconfigSuite) TestCustomName() {
+	tempDir, err := ioutil.TempDir("", "talos")
+	suite.Require().NoError(err)
+
+	defer os.RemoveAll(tempDir) //nolint: errcheck
+
+	suite.RunCLI([]string{"kubeconfig", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), filepath.Join(tempDir, "k8sconfig")},
+		base.StdoutEmpty())
+
+	suite.Require().FileExists(filepath.Join(tempDir, "k8sconfig"))
+}
+
 // TestMultiNodeFail verifies that command fails with multiple nodes.
 func (suite *KubeconfigSuite) TestMultiNodeFail() {
 	suite.RunCLI([]string{"kubeconfig", "--nodes", "127.0.0.1", "--nodes", "127.0.0.1", "."},


### PR DESCRIPTION
This also refactors much of the CLI code for the `talosctl kubeconfig`:

1. Do all the checks before fetching kubeconfig from the server: as
kubeconfig generation takes a few seconds, it doesn't make sense to
generate it if it's not going to be used.

2. Unify most of merge & write directly features.

3. Don't use ExtractTarGz method to be more flexible.

4. Allow custom paths for kubeconfig, whether it is a directory or full
path to the file to be created.

Fixes #2151

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

