### PR TITLE
feat: show cluster state when `talosctl cluster create` finishes

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -320,7 +320,7 @@ func create(ctx context.Context) (err error) {
 		return err
 	}
 
-	return nil
+	return showCluster(cluster)
 }
 
 func postCreate(ctx context.Context, clusterAccess *access.Adapter) error {

--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/talos-systems/talos/pkg/cli"
+	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers"
 )
 
@@ -42,6 +43,10 @@ func show(ctx context.Context) error {
 		return err
 	}
 
+	return showCluster(cluster)
+}
+
+func showCluster(cluster provision.Cluster) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintf(w, "PROVISIONER\t%s\n", cluster.Provisioner())
 	fmt.Fprintf(w, "NAME\t%s\n", cluster.Info().ClusterName)
@@ -52,7 +57,7 @@ func show(ctx context.Context) error {
 	fmt.Fprintf(w, "NETWORK GATEWAY\t%s\n", cluster.Info().Network.GatewayAddr)
 	fmt.Fprintf(w, "NETWORK MTU\t%d\n", cluster.Info().Network.MTU)
 
-	if err = w.Flush(); err != nil {
+	if err := w.Flush(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This shows cluster state along with the IPs, resources, node roles, etc.

Example (with Docker):

```
$ talosctl cluster create
validating CIDR and reserving IPs
generating PKI and tokens
creating network talos-default
creating master nodes
creating worker nodes
waiting for API
bootstrapping cluster
waiting for etcd to be healthy: ...
waiting for etcd to be healthy: 1 error occurred:
        * 10.5.0.2: service "etcd" not in expected state "Running": current state [Preparing] Running pre state
waiting for etcd to be healthy: 1 error occurred:
        * 10.5.0.2: service is not healthy: etcd
waiting for etcd to be healthy: OK
waiting for bootkube to finish: ...
waiting for bootkube to finish: 1 error occurred:
        * 10.5.0.2: service "bootkube" not in expected state ["Finished" "Skipped"]: current state [Running] Started task bootkube (PID 436) for container bootkube
waiting for bootkube to finish: OK
waiting for apid to be ready: ...
waiting for apid to be ready: OK
waiting for all k8s nodes to report: ...
waiting for all k8s nodes to report: Get "https://10.5.0.2:6443/api/v1/nodes": dial tcp 10.5.0.2:6443: connect: connection refused
waiting for all k8s nodes to report: OK
waiting for all k8s nodes to report ready: ...
waiting for all k8s nodes to report ready: OK
waiting for all control plane components to be ready: ...
waiting for all control plane components to be ready: expected number available for kube-apiserver to be 1, got 0
waiting for all control plane components to be ready: OK
waiting for kube-proxy to report ready: ...
waiting for kube-proxy to report ready: OK
waiting for coredns to report ready: ...
waiting for coredns to report ready: OK
waiting for all k8s nodes to report schedulable: ...
waiting for all k8s nodes to report schedulable: OK
PROVISIONER       docker
NAME              talos-default
NETWORK NAME      talos-default
NETWORK CIDR      10.5.0.0/24
NETWORK GATEWAY   10.5.0.1
NETWORK MTU       1500

NODES:

NAME                      TYPE           IP         CPU    RAM      DISK
/talos-default-master-1   controlplane   10.5.0.2   2.00   2.1 GB   -
/talos-default-worker-1   join           10.5.0.3   2.00   2.1 GB   -
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

