### PR TITLE
feat: add webconfig service

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -7,7 +7,6 @@ package container
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"log"
 	"net"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 )
 
 // Container is a platform for installing Talos via an Container image.
@@ -29,9 +29,9 @@ func (c *Container) Name() string {
 func (c *Container) Configuration(context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: USERDATA environment variable")
 
-	s, ok := os.LookupEnv("USERDATA")
-	if !ok {
-		return nil, errors.New("missing USERDATA environment variable")
+	s := os.Getenv("USERDATA")
+	if s == "" {
+		return nil, errors.ErrNoConfigSource
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(s)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/errors/errors.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/errors/errors.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package errors
+
+import "errors"
+
+// ErrNoConfigSource indicates that the platform does not have a configured source for the configuration.
+var ErrNoConfigSource = errors.New("no configuration source")

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -21,6 +21,7 @@ import (
 	"github.com/talos-systems/go-blockdevice/blockdevice/probe"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/download"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
@@ -43,7 +44,7 @@ func (m *Metal) Name() string {
 func (m *Metal) Configuration(ctx context.Context) ([]byte, error) {
 	var option *string
 	if option = procfs.ProcCmdline().Get(constants.KernelParamConfig).First(); option == nil {
-		return nil, fmt.Errorf("no config option was found")
+		return nil, errors.ErrNoConfigSource
 	}
 
 	log.Printf("fetching machine config from: %q", *option)

--- a/internal/pkg/webconfig/webconfig.go
+++ b/internal/pkg/webconfig/webconfig.go
@@ -1,0 +1,296 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package webconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	ttls "github.com/talos-systems/crypto/tls"
+	"github.com/talos-systems/crypto/x509"
+	tnet "github.com/talos-systems/net"
+
+	"github.com/talos-systems/talos/pkg/grpc/gen"
+	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
+)
+
+const indexPage = `
+<html>
+	<head>
+		<title>Talos Interactive Configurator</title>
+	</head>
+	<body>
+	  <h3>Talos Interactive Configuration</h3>
+	  <form action="/" method="POST" enctype="multipart/form-data">
+	  <p>Upload YAML configuration: <input type="file" name="config.yaml" /></p>
+	  <p><input type=submit value="Upload"></button></p>
+	  </form>
+	</body>
+</html>
+`
+
+const configurationRejectedPage = `
+<html>
+  <head>
+    <title>Talos Interactive Configurtor: configuration rejected</title>
+  </head>
+  <body>
+    <p>The configuration was rejected:</p>
+	 <pre>
+	 {{ html . }}
+	 </pre>
+	 <p>Please try again from the <a href="/">main page</a>.</p>
+  </body>
+</html>
+`
+
+const configurationAcceptedPage = `
+<html>
+	<head>
+		<title>Talos Interactive Configurator: configuration accepted</title>
+	</head>
+	<body>
+		<p>Configuration accepted.  Continuing with new configuration...</p>
+	</body>
+</html>
+`
+
+// Server defines an http-based configuration receiver service.
+type Server struct {
+	logger *log.Logger
+
+	configBytes []byte
+
+	mode config.RuntimeMode
+
+	returnSignal chan struct{}
+
+	serverError error
+
+	svr *http.Server
+
+	mu sync.Mutex
+}
+
+// Stop tells the server to shut down.
+func (s *Server) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	s.mu.Lock()
+	if s.returnSignal != nil {
+		close(s.returnSignal)
+
+		s.returnSignal = nil
+	}
+
+	if s.svr != nil {
+		s.svr.Shutdown(ctx) // nolint: errcheck
+	}
+	s.mu.Unlock()
+}
+
+// ServeHTTP implements http.Handler.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Scheme != "https" {
+		r.URL.Scheme = "https"
+
+		http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
+
+		return
+	}
+
+	switch r.Method {
+	case "GET":
+		s.handleGet(w, r)
+	case "POST":
+		s.handlePost(w, r)
+	default:
+		w.WriteHeader(http.StatusBadRequest)
+	}
+}
+
+// nolint: unparam
+func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+
+	_, err := w.Write([]byte(indexPage))
+	if err != nil {
+		s.logger.Printf("webconfig: failed to write index page: %s", err.Error())
+	}
+}
+
+func (s *Server) handlePost(w http.ResponseWriter, r *http.Request) {
+	writeFailure := func(status int, err error) {
+		s.logger.Printf("webconfig: failed to handle POST request: %s", err.Error())
+
+		tmpl, err := template.New("postErr").Parse(configurationRejectedPage)
+		if err != nil {
+			s.logger.Println("failed to parse configuration rejection template:", err)
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		w.WriteHeader(status)
+
+		if err = tmpl.Execute(w, err.Error()); err != nil {
+			s.logger.Println("failed to write response to client:", err)
+		}
+	}
+
+	f, header, err := r.FormFile("config.yaml")
+	if err != nil {
+		writeFailure(http.StatusBadRequest, fmt.Errorf("failed to read POST data: %w", err))
+		return
+	}
+
+	if header.Size < 1 {
+		writeFailure(http.StatusBadRequest, fmt.Errorf("invalid header size"))
+
+		return
+	}
+
+	s.configBytes, err = ioutil.ReadAll(f)
+	if err != nil {
+		writeFailure(http.StatusInternalServerError, fmt.Errorf("failed to read file from config POST: %w", err))
+
+		return
+	}
+
+	cfgProvider, err := configloader.NewFromBytes(s.configBytes)
+	if err != nil {
+		writeFailure(http.StatusBadRequest, fmt.Errorf("failed to parse file from POST as a config: %w", err))
+
+		return
+	}
+
+	if err = cfgProvider.Validate(s.mode); err != nil {
+		writeFailure(http.StatusBadRequest, fmt.Errorf("configuration validation failed: %w", err))
+
+		return
+	}
+
+	if _, err = w.Write([]byte(configurationAcceptedPage)); err != nil {
+		writeFailure(http.StatusGone, fmt.Errorf("failed to write response to client: %w", err))
+
+		return
+	}
+
+	// Got a config
+	s.Stop()
+}
+
+// Run executes the configuration receiver, returning any configuration it receives.
+func (s *Server) Run(ctx context.Context) ([]byte, error) {
+	if s.returnSignal == nil {
+		s.returnSignal = make(chan struct{})
+	}
+
+	ips, err := tnet.IPAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get list of IPs: %w", err)
+	}
+
+	tlsConfig, err := genKeypair(ips)
+	if err != nil {
+		s.logger.Println("failed to generate keypair:", err)
+		return nil, fmt.Errorf("failed to generate self-signed keypair: %w", err)
+	}
+
+	s.svr = &http.Server{
+		Handler:   s,
+		ErrorLog:  s.logger,
+		TLSConfig: tlsConfig,
+	}
+
+	go func() {
+		if err = s.svr.ListenAndServe(); err != nil {
+			s.logger.Println("webconfig: HTTP service stopped:", err)
+		}
+
+		s.Stop()
+	}()
+
+	go func() {
+		if err = s.svr.ListenAndServeTLS("", ""); err != nil {
+			s.logger.Println("webconfig: HTTPS service stopped:", err)
+		}
+
+		s.Stop()
+	}()
+
+	fmt.Println("Webconfig started.  You may POST a configuration to:")
+
+	for _, ip := range ips {
+		fmt.Printf("\t%s\n", ip.String())
+	}
+
+	<-s.returnSignal
+
+	return s.configBytes, s.serverError
+}
+
+// Run executes the configuration receiver on the supplied address,. returning any configuration it receives.
+func Run(ctx context.Context, logger *log.Logger, mode config.RuntimeMode) ([]byte, error) {
+	s := new(Server)
+	s.mode = mode
+	s.logger = log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Llongfile)
+
+	s.logger.Println("starting webconfig")
+
+	return s.Run(ctx)
+}
+
+func genKeypair(ips []net.IP) (*tls.Config, error) {
+	ca, err := x509.NewSelfSignedCertificateAuthority()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate self-signed CA: %w", err)
+	}
+
+	ips = append(ips, net.ParseIP("127.0.0.1"), net.ParseIP("::1"))
+
+	generator, err := gen.NewLocalGenerator(ca.KeyPEM, ca.CrtPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local certificate generator: %w", err)
+	}
+
+	provider, err := ttls.NewRenewingCertificateProvider(generator, []string{"localhost"}, ips)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local certificate provider: %w", err)
+	}
+
+	caProvider, err := provider.GetCA()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tlsConfig, err := ttls.New(
+		ttls.WithClientAuthType(ttls.ServerOnly),
+		ttls.WithCACertPEM(caProvider),
+		ttls.WithServerCertificateProvider(provider),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate tlsconfig: %w", err)
+	}
+
+	// We need a broader set of ciphers to interact with browsers.
+	tlsConfig.CipherSuites = make([]uint16, len(tls.CipherSuites()))
+	for _, s := range tls.CipherSuites() {
+		tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, s.ID)
+	}
+
+	return tlsConfig, nil
+}


### PR DESCRIPTION
If no configuration source is provided (on baremetal only for now), Talos will set of a simple web service to receive its configuration via an HTTP POST request, on port 80 or 443.
It also serves a simple web form for interactive submission from the browser.

Fixes #2593

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
