### PR TITLE
feat: use kubeconfig merge in `talosctl kubeconfig` by default

### DIFF
--- a/docs/talosctl/talosctl_kubeconfig.md
+++ b/docs/talosctl/talosctl_kubeconfig.md
@@ -6,8 +6,8 @@ Download the admin kubeconfig from the node
 ### Synopsis
 
 Download the admin kubeconfig from the node.
-Kubeconfig will be written to PWD or [local-path] if specified.
 If merge flag is defined, config will be merged with ~/.kube/config or [local-path] if specified.
+Otherwise kubeconfig will be written to PWD or [local-path] if specified.
 
 ```
 talosctl kubeconfig [local-path] [flags]
@@ -16,9 +16,10 @@ talosctl kubeconfig [local-path] [flags]
 ### Options
 
 ```
-  -f, --force   Force overwrite of kubeconfig if already present
-  -h, --help    help for kubeconfig
-  -m, --merge   Merge with existing kubeconfig
+  -f, --force                       Force overwrite of kubeconfig if already present, force overwrite on kubeconfig merge
+      --force-context-name string   Force context name for kubeconfig merge
+  -h, --help                        help for kubeconfig
+  -m, --merge                       Merge with existing kubeconfig (default true)
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20200711001733-e1b69ee5fb33
 	github.com/jsimonetti/rtnetlink v0.0.0-20200709124027-1aae10735293
 	github.com/kubernetes-sigs/bootkube v0.14.1-0.20200817205730-0b4482256ca1
+	github.com/mattn/go-isatty v0.0.8
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 // indirect
 	github.com/mdlayher/genetlink v1.0.0
 	github.com/mdlayher/netlink v1.1.0
@@ -47,7 +48,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc92 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
-	github.com/particledecay/kconf v1.8.0
 	github.com/pin/tftp v2.1.0+incompatible
 	github.com/prometheus/procfs v0.1.3
 	github.com/rs/xid v1.2.1
@@ -72,6 +72,7 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5 // v3.4.10
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1
 	golang.org/x/text v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -617,8 +617,6 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K6Jx62mY=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
-github.com/particledecay/kconf v1.8.0 h1:DzNwbxaKJ0LW+eOcb1HhyRA9E5ztHn4PSK7uKFEaWp8=
-github.com/particledecay/kconf v1.8.0/go.mod h1:6jID/ajM4EB9aevfPTwKM61xWYu4zE1mYT6MthQscmU=
 github.com/pborman/uuid v0.0.0-20150603214016-ca53cad383ca/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -676,8 +674,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.5.0/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
-github.com/rs/zerolog v1.17.2 h1:RMRHFw2+wF7LO0QqtELQwo8hqSmqISyCJeFeAAuWcRo=
-github.com/rs/zerolog v1.17.2/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
@@ -813,7 +809,6 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
-github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.4/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
@@ -853,7 +848,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191108234033-bd318be0434a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -1020,7 +1014,6 @@ golang.org/x/tools v0.0.0-20190624190245-7f2218787638/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190909214602-067311248421/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1145,7 +1138,6 @@ inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252 h1:gmJCKidOfjKDUHF1jjke+I+2i
 inet.af/tcpproxy v0.0.0-20200125044825-b6bb9b5b8252/go.mod h1:zq+R+tLcdHugi7Jt+FtIQY6m6wtX34lr2CdQVH2fhW0=
 k8s.io/api v0.0.0-20191016110408-35e52d86657a/go.mod h1:/L5qH+AD540e7Cetbui1tuJeXdmNhO8jM6VkXeDdDhQ=
 k8s.io/api v0.0.0-20191109101513-0171b7c15da1/go.mod h1:VJq7+38rpM4TSUbRiZX4P5UVAKK2UQpNQLZClkFQkpE=
-k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
 k8s.io/api v0.18.5/go.mod h1:tN+e/2nbdGKOAH55NMV8oGrMG+3uRlA9GaRfvnCCSNk=
 k8s.io/api v0.19.1 h1:oZf4bYsBdjC49PdTwNfLmrfUFCwKUi94HY/+emXI8Qw=
@@ -1156,7 +1148,6 @@ k8s.io/apiextensions-apiserver v0.18.2/go.mod h1:q3faSnRGmYimiocj6cHQ1I3WpLqmDgJ
 k8s.io/apimachinery v0.0.0-20191004115801-a2eda9f80ab8/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
 k8s.io/apimachinery v0.0.0-20191109100837-dffb012825f2/go.mod h1:+6CX7hP4aLfX2sb91JYDMIp0VqDSog2kZu0BHe+lP+s=
 k8s.io/apimachinery v0.0.0-20191111054156-6eb29fdf75dc/go.mod h1:+6CX7hP4aLfX2sb91JYDMIp0VqDSog2kZu0BHe+lP+s=
-k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
@@ -1165,7 +1156,6 @@ k8s.io/apiserver v0.18.2/go.mod h1:Xbh066NqrZO8cbsoenCwyDJ1OSi8Ag8I2lezeHxzwzw=
 k8s.io/apiserver v0.19.1 h1:ZG1MoSE/seCFrqVvEMW+sNRX/tohU2JBtfANYbDqGcQ=
 k8s.io/apiserver v0.19.1/go.mod h1:iRxYIjA0X2XEyoW8KslN4gDhasfH4bWcjj6ckVeZX28=
 k8s.io/client-go v0.0.0-20191016111102-bec269661e48/go.mod h1:hrwktSwYGI4JK+TJA3dMaFyyvHVi/aLarVHpbs8bgCU=
-k8s.io/client-go v0.17.0/go.mod h1:TYgR6EUHs6k45hb6KWjVD6jFZvJV4gHDikv/It0xz+k=
 k8s.io/client-go v0.18.2/go.mod h1:Xcm5wVGXX9HAA2JJ2sSBUn3tCJ+4SVlCbl2MNNv+CIU=
 k8s.io/client-go v0.18.5/go.mod h1:EsiD+7Fx+bRckKWZXnAXRKKetm1WuzPagH4iOSC8x58=
 k8s.io/client-go v0.19.1 h1:xfFwj+YFKa8rcihlFYZABjxcy7Sm/wJQ+GxW3JyVtKI=
@@ -1200,8 +1190,6 @@ k8s.io/kubelet v0.19.1/go.mod h1:FJBxOTBiFjE3KM+0gdPpZeiaKX8lrsb6fTlyBGqPWgs=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191030222137-2b95a09bc58d/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20200109141947-94aeca20bf09/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K8Hf8whTseBgJcg=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/internal/pkg/kubeconfig/kubeconfig.go
+++ b/internal/pkg/kubeconfig/kubeconfig.go
@@ -2,5 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package kubeconfig provides Kubernetes config file generation from machine config.
+// Package kubeconfig provides Kubernetes config file handling.
 package kubeconfig

--- a/internal/pkg/kubeconfig/merge.go
+++ b/internal/pkg/kubeconfig/merge.go
@@ -1,0 +1,225 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubeconfig
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// Merger handles merging of Kubernetes client config files.
+type Merger clientcmdapi.Config
+
+// Load the kubeconfig from file.
+func Load(path string) (*Merger, error) {
+	config, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*Merger)(config), err
+}
+
+// MergeOptions controls Merge process.
+type MergeOptions struct {
+	ForceContextName string
+	ActivateContext  bool
+	ConflictHandler  func(ConfigComponent, string) (ConflictDecision, error)
+	OutputWriter     io.Writer
+}
+
+// ConfigComponent identifies part of kubeconfig.
+type ConfigComponent string
+
+// Kubeconfig components.
+const (
+	Cluster  ConfigComponent = "cluster"
+	AuthInfo ConfigComponent = "auth"
+	Context  ConfigComponent = "context"
+)
+
+// ConflictDecision is returned from ConflictHandler.
+type ConflictDecision string
+
+// Conflict decisions.
+const (
+	OverwriteDecision ConflictDecision = "overwrite"
+	RenameDecision    ConflictDecision = "rename"
+)
+
+// Merge the provided kubernetes config in.
+//
+//nolint: gocyclo
+func (merger *Merger) Merge(config *clientcmdapi.Config, options MergeOptions) error {
+	mappedClusters := map[string]string{}
+	mappedAuthInfos := map[string]string{}
+	mappedContexts := map[string]string{}
+
+	for name, newCluster := range config.Clusters {
+		mergedName := name
+
+		oldCluster, exists := merger.Clusters[mergedName]
+
+		newCluster.LocationOfOrigin = ""
+
+		if oldCluster != nil {
+			oldCluster.LocationOfOrigin = ""
+		}
+
+		if exists && !reflect.DeepEqual(oldCluster, newCluster) {
+			decision, err := options.ConflictHandler(Cluster, name)
+			if err != nil {
+				return err
+			}
+
+			if decision == RenameDecision {
+				mergedName = merger.rename(Cluster, mergedName)
+			}
+		}
+
+		mappedClusters[name] = mergedName
+	}
+
+	for name, newAuthInfo := range config.AuthInfos {
+		mergedName := name
+
+		// apply previous mappings done to cluster names
+		for oldName, newName := range mappedClusters {
+			mergedName = strings.ReplaceAll(mergedName, oldName, newName)
+		}
+
+		oldAuthInfo, exists := merger.AuthInfos[mergedName]
+
+		newAuthInfo.LocationOfOrigin = ""
+
+		if oldAuthInfo != nil {
+			oldAuthInfo.LocationOfOrigin = ""
+		}
+
+		if exists && !reflect.DeepEqual(oldAuthInfo, newAuthInfo) {
+			decision, err := options.ConflictHandler(AuthInfo, name)
+			if err != nil {
+				return err
+			}
+
+			if decision == RenameDecision {
+				mergedName = merger.rename(AuthInfo, mergedName)
+			}
+		}
+
+		mappedAuthInfos[name] = mergedName
+	}
+
+	for name, newContext := range config.Contexts {
+		mergedName := name
+
+		// apply mappings done to authInfo, as authInfo has same format as context in Talos
+		for oldName, newName := range mappedAuthInfos {
+			mergedName = strings.ReplaceAll(mergedName, oldName, newName)
+		}
+
+		if options.ForceContextName != "" {
+			mergedName = options.ForceContextName
+		}
+
+		oldContext, exists := merger.Clusters[mergedName]
+
+		newContext.LocationOfOrigin = ""
+
+		if oldContext != nil {
+			oldContext.LocationOfOrigin = ""
+		}
+
+		if exists && !reflect.DeepEqual(oldContext, newContext) {
+			decision, err := options.ConflictHandler(Cluster, name)
+			if err != nil {
+				return err
+			}
+
+			if decision == RenameDecision {
+				mergedName = merger.rename(Cluster, mergedName)
+			}
+		}
+
+		mappedContexts[name] = mergedName
+	}
+
+	for name, cluster := range config.Clusters {
+		newName := mappedClusters[name]
+
+		if newName != name {
+			fmt.Fprintf(options.OutputWriter, "renamed cluster %q -> %q\n", name, newName)
+		}
+
+		merger.Clusters[newName] = cluster
+	}
+
+	for name, authInfo := range config.AuthInfos {
+		newName := mappedAuthInfos[name]
+
+		if newName != name {
+			fmt.Fprintf(options.OutputWriter, "renamed auth info %q -> %q\n", name, newName)
+		}
+
+		merger.AuthInfos[newName] = authInfo
+	}
+
+	for name, context := range config.Contexts {
+		contextCopy := *context
+
+		newName := mappedContexts[name]
+
+		if newName != name {
+			fmt.Fprintf(options.OutputWriter, "renamed context %q -> %q\n", name, newName)
+		}
+
+		contextCopy.AuthInfo = mappedAuthInfos[contextCopy.AuthInfo]
+		contextCopy.Cluster = mappedClusters[contextCopy.Cluster]
+
+		merger.Contexts[newName] = &contextCopy
+
+		if options.ActivateContext {
+			merger.CurrentContext = newName
+		}
+	}
+
+	return nil
+}
+
+// rename the config component until it gets unique.
+func (merger *Merger) rename(component ConfigComponent, name string) (newName string) {
+	i := 0
+	newName = name
+
+	for {
+		var exists bool
+
+		switch component {
+		case Cluster:
+			_, exists = merger.Clusters[newName]
+		case AuthInfo:
+			_, exists = merger.AuthInfos[newName]
+		case Context:
+			_, exists = merger.Contexts[newName]
+		}
+
+		if !exists {
+			return newName
+		}
+
+		i++
+		newName = fmt.Sprintf("%s-%d", name, i)
+	}
+}
+
+// Write the kubeconfig back to the file.
+func (merger *Merger) Write(path string) error {
+	return clientcmd.WriteToFile(clientcmdapi.Config(*merger), path)
+}

--- a/internal/pkg/kubeconfig/merge_test.go
+++ b/internal/pkg/kubeconfig/merge_test.go
@@ -1,0 +1,375 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubeconfig_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/talos-systems/talos/internal/pkg/kubeconfig"
+)
+
+func TestMerger(t *testing.T) {
+	errorAlways := func(kubeconfig.ConfigComponent, string) (kubeconfig.ConflictDecision, error) {
+		return "", fmt.Errorf("shouldn't be here")
+	}
+	renameAlways := func(kubeconfig.ConfigComponent, string) (kubeconfig.ConflictDecision, error) {
+		return kubeconfig.RenameDecision, nil
+	}
+	overwriteAlways := func(kubeconfig.ConfigComponent, string) (kubeconfig.ConflictDecision, error) {
+		return kubeconfig.OverwriteDecision, nil
+	}
+
+	for _, tt := range []struct {
+		name     string
+		initial  clientcmdapi.Config
+		new      clientcmdapi.Config
+		expected clientcmdapi.Config
+		options  kubeconfig.MergeOptions
+	}{
+		{ // MergeIntoEmpty
+			name: "MergeIntoEmpty",
+			initial: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{},
+				Clusters:  map[string]*clientcmdapi.Cluster{},
+				Contexts:  map[string]*clientcmdapi.Context{},
+			},
+			new: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "nothing",
+			},
+			expected: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+			},
+			options: kubeconfig.MergeOptions{
+				ConflictHandler: errorAlways,
+				OutputWriter:    os.Stdout,
+			},
+		},
+		{ // MergeClean
+			name: "MergeClean",
+			initial: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			new: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"fiz@buzz": {
+						ClientCertificate: "cert2",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"buzz": {
+						Server: "another.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"fiz@buzz": {
+						Cluster:  "buzz",
+						AuthInfo: "fiz@buzz",
+					},
+				},
+			},
+			expected: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+					"fiz@buzz": {
+						ClientCertificate: "cert2",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+					"buzz": {
+						Server: "another.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+					"fiz@buzz": {
+						Cluster:  "buzz",
+						AuthInfo: "fiz@buzz",
+					},
+				},
+				CurrentContext: "fiz@buzz",
+			},
+			options: kubeconfig.MergeOptions{
+				ActivateContext: true,
+				ConflictHandler: errorAlways,
+				OutputWriter:    os.Stdout,
+			},
+		},
+		{ // MergeRename
+			name: "MergeRename",
+			initial: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			new: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert2",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "another.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+			},
+			expected: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+					"foo@bar-1": {
+						ClientCertificate: "cert2",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+					"bar-1": {
+						Server: "another.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+					"foo@bar-1": {
+						Cluster:  "bar-1",
+						AuthInfo: "foo@bar-1",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			options: kubeconfig.MergeOptions{
+				ConflictHandler: renameAlways,
+				OutputWriter:    os.Stdout,
+			},
+		},
+		{ // MergeOverwrite
+			name: "MergeOverwrite",
+			initial: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			new: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert2",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "another.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+			},
+			expected: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert2",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "another.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			options: kubeconfig.MergeOptions{
+				ConflictHandler: overwriteAlways,
+				OutputWriter:    os.Stdout,
+			},
+		},
+		{ // MergeEqual
+			name: "MergeEqual",
+			initial: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			new: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			expected: clientcmdapi.Config{
+				AuthInfos: map[string]*clientcmdapi.AuthInfo{
+					"foo@bar": {
+						ClientCertificate: "cert1",
+					},
+				},
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"bar": {
+						Server: "example.com",
+					},
+				},
+				Contexts: map[string]*clientcmdapi.Context{
+					"foo@bar": {
+						Cluster:  "bar",
+						AuthInfo: "foo@bar",
+					},
+				},
+				CurrentContext: "foo@bar",
+			},
+			options: kubeconfig.MergeOptions{
+				ConflictHandler: errorAlways,
+				OutputWriter:    os.Stdout,
+			},
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			merger := kubeconfig.Merger(*tt.initial.DeepCopy())
+
+			err := merger.Merge(&tt.new, tt.options)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected.Clusters, merger.Clusters)
+			assert.Equal(t, tt.expected.AuthInfos, merger.AuthInfos)
+			assert.Equal(t, tt.expected.Contexts, merger.Contexts)
+			assert.Equal(t, tt.expected.CurrentContext, merger.CurrentContext)
+		})
+	}
+}


### PR DESCRIPTION
Kubeconfig merge was completely rewritten to be "smarter":

* automatically apply renames done at previous stages to avoid asking
over and over again (in general should ask just once)

* skip checks if parts of the config match exactly

* allow overwrite as an option

* flexible way to control the output

* activating context in the end

* custom merged context name

Fixes #2578

Fixes #2587

Fixes #2577

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

