### PR TITLE
feat: pull kubeconfig from the cluster on successful `cluster create`

### DIFF
--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -52,14 +51,10 @@ Otherwise kubeconfig will be written to PWD or [local-path] if specified.`,
 				var err error
 
 				if merge {
-					var usr *user.User
-					usr, err = user.Current()
-
+					localPath, err = kubeconfig.DefaultPath()
 					if err != nil {
 						return err
 					}
-
-					localPath = filepath.Join(usr.HomeDir, ".kube/config")
 				} else {
 					localPath, err = os.Getwd()
 					if err != nil {

--- a/docs/talosctl/talosctl_cluster.md
+++ b/docs/talosctl/talosctl_cluster.md
@@ -28,7 +28,7 @@ A collection of commands for managing local docker-based or firecracker-based cl
 ### SEE ALSO
 
 * [talosctl](talosctl.md)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
-* [talosctl cluster create](talosctl_cluster_create.md)	 - Creates a local docker-based or firecracker-based kubernetes cluster
+* [talosctl cluster create](talosctl_cluster_create.md)	 - Creates a local docker-based or QEMU-based kubernetes cluster
 * [talosctl cluster destroy](talosctl_cluster_destroy.md)	 - Destroys a local docker-based or firecracker-based kubernetes cluster
 * [talosctl cluster show](talosctl_cluster_show.md)	 - Shows info about a local provisioned kubernetes cluster
 

--- a/docs/talosctl/talosctl_cluster_create.md
+++ b/docs/talosctl/talosctl_cluster_create.md
@@ -1,11 +1,11 @@
 <!-- markdownlint-disable -->
 ## talosctl cluster create
 
-Creates a local docker-based or firecracker-based kubernetes cluster
+Creates a local docker-based or QEMU-based kubernetes cluster
 
 ### Synopsis
 
-Creates a local docker-based or firecracker-based kubernetes cluster
+Creates a local docker-based or QEMU-based kubernetes cluster
 
 ```
 talosctl cluster create [flags]
@@ -40,6 +40,7 @@ talosctl cluster create [flags]
       --nameservers strings                     list of nameservers to use (default [8.8.8.8,1.1.1.1])
       --registry-insecure-skip-verify strings   list of registry hostnames to skip TLS verification for
       --registry-mirror strings                 list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --skip-kubeconfig                         skip merging kubeconfig from the created cluster
       --vmlinuz-path string                     the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")
       --wait                                    wait for the cluster to be ready before returning (default true)
       --wait-timeout duration                   timeout to wait for the cluster to be ready (default 20m0s)

--- a/internal/pkg/kubeconfig/kubeconfig.go
+++ b/internal/pkg/kubeconfig/kubeconfig.go
@@ -4,3 +4,18 @@
 
 // Package kubeconfig provides Kubernetes config file handling.
 package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultPath returns path to ~/.kube/config.
+func DefaultPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".kube/config"), nil
+}


### PR DESCRIPTION
Kubeconfig is merged into `~/.kube/config` with rename option
(existing configuration is never overwritten).

If endpoint was used, it is automatically put into the `kubeconfig`.

This should make OS X experience literally `talosctl cluster create`
followed by any `kubectl get ...`.

Fixes #2603 

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

