### PR TITLE
feat: colorize output of cluster health checks

### DIFF
--- a/cmd/talosctl/cmd/talos/health.go
+++ b/cmd/talosctl/cmd/talos/health.go
@@ -31,12 +31,22 @@ type clusterNodes struct {
 }
 
 func (cluster *clusterNodes) Nodes() []string {
-	return append([]string{cluster.InitNode}, append(cluster.ControlPlaneNodes, cluster.WorkerNodes...)...)
+	var initNodes []string
+
+	if cluster.InitNode != "" {
+		initNodes = []string{cluster.InitNode}
+	}
+
+	return append(initNodes, append(cluster.ControlPlaneNodes, cluster.WorkerNodes...)...)
 }
 
 func (cluster *clusterNodes) NodesByType(t machine.Type) []string {
 	switch t {
 	case machine.TypeInit:
+		if cluster.InitNode == "" {
+			return nil
+		}
+
 		return []string{cluster.InitNode}
 	case machine.TypeControlPlane:
 		return cluster.ControlPlaneNodes

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0
+	github.com/fatih/color v1.7.0
 	github.com/firecracker-microvm/firecracker-go-sdk v0.21.0
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/gizak/termui/v3 v3.1.0

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -8,7 +8,6 @@ package cli
 
 import (
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/talos-systems/talos/internal/integration/base"
@@ -42,25 +41,13 @@ func (suite *HealthSuite) TestClientSide() {
 	}
 
 	if bootstrapAPIIsUsed {
-		nodes := []string{}
-
 		for _, node := range suite.Cluster.Info().Nodes {
 			switch node.Type {
 			case machine.TypeControlPlane:
-				nodes = append(nodes, node.PrivateIP.String())
+				args = append(args, "--control-plane-nodes", node.PrivateIP.String())
 			case machine.TypeJoin:
 				args = append(args, "--worker-nodes", node.PrivateIP.String())
 			}
-		}
-
-		sort.Strings(nodes)
-
-		if len(nodes) > 0 {
-			args = append(args, "--init-node", nodes[0])
-		}
-
-		if len(nodes) > 1 {
-			args = append(args, "--control-plane-nodes", strings.Join(nodes[1:], ","))
 		}
 	} else {
 		for _, node := range suite.Cluster.Info().Nodes {

--- a/pkg/cluster/check/reporter.go
+++ b/pkg/cluster/check/reporter.go
@@ -6,30 +6,88 @@ package check
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strings"
+
+	"github.com/fatih/color"
+	"github.com/mattn/go-isatty"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/talos-systems/talos/pkg/conditions"
 )
 
 type writerReporter struct {
-	w        io.Writer
-	lastLine string
+	w                 *os.File
+	lastLine          string
+	lastLineTemporary bool
+
+	colorized  bool
+	spinnerIdx int
 }
 
-func (wr *writerReporter) Update(condition conditions.Condition) {
-	line := fmt.Sprintf("waiting for %s", condition)
+var spinner = []string{"◰", "◳", "◲", "◱"}
 
-	if line != wr.lastLine {
-		fmt.Fprintln(wr.w, strings.TrimSpace(line))
-		wr.lastLine = line
+//nolint: gocyclo
+func (wr *writerReporter) Update(condition conditions.Condition) {
+	line := strings.TrimSpace(fmt.Sprintf("waiting for %s", condition))
+
+	if !wr.colorized {
+		if line != wr.lastLine {
+			fmt.Fprintln(wr.w, line)
+			wr.lastLine = line
+		}
+
+		return
 	}
+
+	var coloredLine string
+
+	showSpinner := false
+	prevLineTemporary := wr.lastLineTemporary
+
+	switch {
+	case strings.HasSuffix(line, "..."):
+		coloredLine = color.YellowString("%s %s", spinner[wr.spinnerIdx], line)
+		wr.lastLineTemporary = true
+		showSpinner = true
+	case strings.HasSuffix(line, "OK"):
+		coloredLine = line
+		wr.lastLineTemporary = false
+	default:
+		coloredLine = color.RedString("%s %s", spinner[wr.spinnerIdx], line)
+		wr.lastLineTemporary = true
+		showSpinner = true
+	}
+
+	if !showSpinner && line == wr.lastLine {
+		return
+	}
+
+	if showSpinner {
+		wr.spinnerIdx = (wr.spinnerIdx + 1) % len(spinner)
+	}
+
+	if prevLineTemporary {
+		w, _, _ := terminal.GetSize(int(wr.w.Fd())) //nolint: errcheck
+		if w <= 0 {
+			w = 80
+		}
+
+		for _, outputLine := range strings.Split(wr.lastLine, "\n") {
+			for i := 0; i < (len(outputLine)+w-1)/w; i++ {
+				fmt.Fprint(wr.w, "\033[A\033[K") // cursor up, clear line
+			}
+		}
+	}
+
+	fmt.Fprintln(wr.w, coloredLine)
+	wr.lastLine = line
 }
 
 // StderrReporter returns console reporter with stderr output.
 func StderrReporter() Reporter {
 	return &writerReporter{
-		w: os.Stderr,
+		w:         os.Stderr,
+		colorized: isatty.IsTerminal(os.Stderr.Fd()),
 	}
 }


### PR DESCRIPTION
It only gets enabled if output is a terminal. Failures which resolve
themselves are removed from the final output. Small spinner to indicate
progress.

While I was at it, I fixed client-side `talosctl health` when init node
is missing.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

