### PR TITLE
fix: nil pointer panic in talosctl dashboard

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard/components/tables.go
+++ b/cmd/talosctl/cmd/talos/dashboard/components/tables.go
@@ -70,12 +70,14 @@ func (widget *ProcessTable) Update(node string, data *data.Data) {
 			totalWeightedCPU = 1
 		}
 
-		sort.Slice(nodeData.Processes.Processes, func(i, j int) bool {
-			proc1 := nodeData.Processes.Processes[i]
-			proc2 := nodeData.Processes.Processes[j]
+		if nodeData.ProcsDiff != nil {
+			sort.Slice(nodeData.Processes.Processes, func(i, j int) bool {
+				proc1 := nodeData.Processes.Processes[i]
+				proc2 := nodeData.Processes.Processes[j]
 
-			return nodeData.ProcsDiff[proc1.Pid].CpuTime > nodeData.ProcsDiff[proc2.Pid].CpuTime
-		})
+				return nodeData.ProcsDiff[proc1.Pid].CpuTime > nodeData.ProcsDiff[proc2.Pid].CpuTime
+			})
+		}
 
 		for _, proc := range nodeData.Processes.Processes {
 			var args string


### PR DESCRIPTION
The problem was that process stats diff is only available on the second
poll from the Talos API, while list of processes might be availalbe
immediately. So on the first poll we can't sort the processes, but still
talosctl shouldn't crash.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

