### PR TITLE
chore: add Context as param to some methods of `Platform` interface

### DIFF
--- a/internal/app/machined/pkg/runtime/platform.go
+++ b/internal/app/machined/pkg/runtime/platform.go
@@ -5,6 +5,7 @@
 package runtime
 
 import (
+	"context"
 	"net"
 
 	"github.com/talos-systems/go-procfs/procfs"
@@ -13,9 +14,9 @@ import (
 // Platform defines the requirements for a platform.
 type Platform interface {
 	Name() string
-	Configuration() ([]byte, error)
-	Hostname() ([]byte, error)
+	Configuration(context.Context) ([]byte, error)
+	Hostname(context.Context) ([]byte, error)
 	Mode() Mode
-	ExternalIPs() ([]net.IP, error)
+	ExternalIPs(context.Context) ([]net.IP, error)
 	KernelArgs() procfs.Parameters
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -133,10 +133,10 @@ func (a *AWS) Name() string {
 }
 
 // Configuration implements the runtime.Platform interface.
-func (a *AWS) Configuration() ([]byte, error) {
+func (a *AWS) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", AWSUserDataEndpoint)
 
-	return download.Download(AWSUserDataEndpoint)
+	return download.Download(ctx, AWSUserDataEndpoint)
 }
 
 // Mode implements the runtime.Platform interface.
@@ -145,10 +145,7 @@ func (a *AWS) Mode() runtime.Mode {
 }
 
 // Hostname implements the runtime.Platform interface.
-func (a *AWS) Hostname() (hostname []byte, err error) {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
-
+func (a *AWS) Hostname(ctx context.Context) (hostname []byte, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, AWSHostnameEndpoint, nil)
 	if err != nil {
 		return nil, err
@@ -169,15 +166,12 @@ func (a *AWS) Hostname() (hostname []byte, err error) {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (a *AWS) ExternalIPs() (addrs []net.IP, err error) {
+func (a *AWS) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	var (
 		body []byte
 		req  *http.Request
 		resp *http.Response
 	)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	if req, err = http.NewRequestWithContext(ctx, "GET", AWSExternalIPEndpoint, nil); err != nil {
 		return

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"time"
 
 	"github.com/talos-systems/go-procfs/procfs"
 	"golang.org/x/sys/unix"
@@ -57,12 +56,12 @@ func (a *Azure) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (a *Azure) Configuration() ([]byte, error) {
+func (a *Azure) Configuration(ctx context.Context) ([]byte, error) {
 	// attempt to download from metadata endpoint
 	// disabled by default
 	log.Printf("fetching machine config from: %q", AzureUserDataEndpoint)
 
-	config, err := download.Download(AzureUserDataEndpoint, download.WithHeaders(map[string]string{"Metadata": "true"}), download.WithFormat("base64"))
+	config, err := download.Download(ctx, AzureUserDataEndpoint, download.WithHeaders(map[string]string{"Metadata": "true"}), download.WithFormat("base64"))
 	if err != nil {
 		fmt.Printf("metadata download failed, falling back to ovf-env.xml file. err: %s", err.Error())
 	}
@@ -77,7 +76,7 @@ func (a *Azure) Configuration() ([]byte, error) {
 		}
 	}
 
-	if err := linuxAgent(); err != nil {
+	if err := linuxAgent(ctx); err != nil {
 		return nil, err
 	}
 
@@ -85,14 +84,11 @@ func (a *Azure) Configuration() ([]byte, error) {
 }
 
 // Hostname implements the platform.Platform interface.
-func (a *Azure) Hostname() (hostname []byte, err error) {
+func (a *Azure) Hostname(ctx context.Context) (hostname []byte, err error) {
 	var (
 		req  *http.Request
 		resp *http.Response
 	)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	req, err = http.NewRequestWithContext(ctx, "GET", AzureHostnameEndpoint, nil)
 	if err != nil {
@@ -124,15 +120,12 @@ func (a *Azure) Mode() runtime.Mode {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (a *Azure) ExternalIPs() (addrs []net.IP, err error) {
+func (a *Azure) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	var (
 		body []byte
 		req  *http.Request
 		resp *http.Response
 	)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	if req, err = http.NewRequestWithContext(ctx, "GET", AzureInterfacesEndpoint, nil); err != nil {
 		return

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/register.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/register.go
@@ -11,30 +11,26 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"time"
 )
 
 // This should provide the bare minimum to trigger a node in ready condition to allow
 // azure to be happy with the node and let it on it's lawn.
-func linuxAgent() (err error) {
+func linuxAgent(ctx context.Context) (err error) {
 	var gs *GoalState
 
-	gs, err = goalState()
+	gs, err = goalState(ctx)
 	if err != nil {
 		return err
 	}
 
-	return reportHealth(gs.Incarnation, gs.Container.ContainerID, gs.Container.RoleInstanceList.RoleInstance.InstanceID)
+	return reportHealth(ctx, gs.Incarnation, gs.Container.ContainerID, gs.Container.RoleInstanceList.RoleInstance.InstanceID)
 }
 
-func goalState() (gs *GoalState, err error) {
+func goalState(ctx context.Context) (gs *GoalState, err error) {
 	u, err := url.Parse(AzureInternalEndpoint + "/machine/?comp=goalstate")
 	if err != nil {
 		return gs, nil
 	}
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
@@ -64,7 +60,7 @@ func goalState() (gs *GoalState, err error) {
 	return gs, err
 }
 
-func reportHealth(gsIncarnation, gsContainerID, gsInstanceID string) (err error) {
+func reportHealth(ctx context.Context, gsIncarnation, gsContainerID, gsInstanceID string) (err error) {
 	// Construct health response
 	h := &Health{
 		Xsi: "http://www.w3.org/2001/XMLSchema-instance",
@@ -105,9 +101,6 @@ func reportHealth(gsIncarnation, gsContainerID, gsInstanceID string) (err error)
 		req  *http.Request
 		resp *http.Response
 	)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	req, err = http.NewRequestWithContext(ctx, "POST", u.String(), b)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -5,6 +5,7 @@
 package container
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"log"
@@ -25,7 +26,7 @@ func (c *Container) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (c *Container) Configuration() ([]byte, error) {
+func (c *Container) Configuration(context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: USERDATA environment variable")
 
 	s, ok := os.LookupEnv("USERDATA")
@@ -42,7 +43,7 @@ func (c *Container) Configuration() ([]byte, error) {
 }
 
 // Hostname implements the platform.Platform interface.
-func (c *Container) Hostname() (hostname []byte, err error) {
+func (c *Container) Hostname(context.Context) (hostname []byte, err error) {
 	return nil, nil
 }
 
@@ -52,7 +53,7 @@ func (c *Container) Mode() runtime.Mode {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (c *Container) ExternalIPs() (addrs []net.IP, err error) {
+func (c *Container) ExternalIPs(context.Context) (addrs []net.IP, err error) {
 	return addrs, err
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/talos-systems/go-procfs/procfs"
 
@@ -37,10 +36,10 @@ func (d *DigitalOcean) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (d *DigitalOcean) Configuration() ([]byte, error) {
+func (d *DigitalOcean) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", DigitalOceanUserDataEndpoint)
 
-	return download.Download(DigitalOceanUserDataEndpoint)
+	return download.Download(ctx, DigitalOceanUserDataEndpoint)
 }
 
 // Mode implements the platform.Platform interface.
@@ -49,10 +48,7 @@ func (d *DigitalOcean) Mode() runtime.Mode {
 }
 
 // Hostname implements the platform.Platform interface.
-func (d *DigitalOcean) Hostname() (hostname []byte, err error) {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
-
+func (d *DigitalOcean) Hostname(ctx context.Context) (hostname []byte, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, DigitalOceanHostnameEndpoint, nil)
 	if err != nil {
 		return nil, err
@@ -73,15 +69,12 @@ func (d *DigitalOcean) Hostname() (hostname []byte, err error) {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (d *DigitalOcean) ExternalIPs() (addrs []net.IP, err error) {
+func (d *DigitalOcean) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	var (
 		body []byte
 		req  *http.Request
 		resp *http.Response
 	)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	if req, err = http.NewRequestWithContext(ctx, "GET", DigitalOceanExternalIPEndpoint, nil); err != nil {
 		return

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -12,7 +12,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/talos-systems/go-procfs/procfs"
 
@@ -38,14 +37,14 @@ func (g *GCP) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (g *GCP) Configuration() ([]byte, error) {
+func (g *GCP) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", GCUserDataEndpoint)
 
-	return download.Download(GCUserDataEndpoint, download.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
+	return download.Download(ctx, GCUserDataEndpoint, download.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
 }
 
 // Hostname implements the platform.Platform interface.
-func (g *GCP) Hostname() (hostname []byte, err error) {
+func (g *GCP) Hostname(context.Context) (hostname []byte, err error) {
 	return nil, nil
 }
 
@@ -55,15 +54,12 @@ func (g *GCP) Mode() runtime.Mode {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (g *GCP) ExternalIPs() (addrs []net.IP, err error) {
+func (g *GCP) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	var (
 		body []byte
 		req  *http.Request
 		resp *http.Response
 	)
-
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
 
 	if req, err = http.NewRequestWithContext(ctx, "GET", GCExternalIPEndpoint, nil); err != nil {
 		return

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -5,6 +5,7 @@
 package metal
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -39,7 +40,7 @@ func (m *Metal) Name() string {
 // Configuration implements the platform.Platform interface.
 //
 // nolint: gocyclo
-func (m *Metal) Configuration() ([]byte, error) {
+func (m *Metal) Configuration(ctx context.Context) ([]byte, error) {
 	var option *string
 	if option = procfs.ProcCmdline().Get(constants.KernelParamConfig).First(); option == nil {
 		return nil, fmt.Errorf("no config option was found")
@@ -83,12 +84,12 @@ func (m *Metal) Configuration() ([]byte, error) {
 	case constants.MetalConfigISOLabel:
 		return readConfigFromISO()
 	default:
-		return download.Download(*option)
+		return download.Download(ctx, *option)
 	}
 }
 
 // Hostname implements the platform.Platform interface.
-func (m *Metal) Hostname() (hostname []byte, err error) {
+func (m *Metal) Hostname(context.Context) (hostname []byte, err error) {
 	return nil, nil
 }
 
@@ -98,7 +99,7 @@ func (m *Metal) Mode() runtime.Mode {
 }
 
 // ExternalIPs implements the platform.Platform interface.
-func (m *Metal) ExternalIPs() (addrs []net.IP, err error) {
+func (m *Metal) ExternalIPs(context.Context) (addrs []net.IP, err error) {
 	return addrs, err
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
@@ -5,6 +5,7 @@
 package packet
 
 import (
+	"context"
 	"log"
 	"net"
 
@@ -28,10 +29,10 @@ func (p *Packet) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (p *Packet) Configuration() ([]byte, error) {
+func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", PacketUserDataEndpoint)
 
-	return download.Download(PacketUserDataEndpoint)
+	return download.Download(ctx, PacketUserDataEndpoint)
 }
 
 // Mode implements the platform.Platform interface.
@@ -40,12 +41,12 @@ func (p *Packet) Mode() runtime.Mode {
 }
 
 // Hostname implements the platform.Platform interface.
-func (p *Packet) Hostname() (hostname []byte, err error) {
+func (p *Packet) Hostname(context.Context) (hostname []byte, err error) {
 	return nil, nil
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (p *Packet) ExternalIPs() (addrs []net.IP, err error) {
+func (p *Packet) ExternalIPs(context.Context) (addrs []net.IP, err error) {
 	return addrs, err
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -7,6 +7,7 @@
 package vmware
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -31,7 +32,7 @@ func (v *VMware) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (v *VMware) Configuration() ([]byte, error) {
+func (v *VMware) Configuration(context.Context) ([]byte, error) {
 	var option *string
 	if option = procfs.ProcCmdline().Get(constants.KernelParamConfig).First(); option == nil {
 		return nil, fmt.Errorf("no config option was found")
@@ -72,7 +73,7 @@ func (v *VMware) Configuration() ([]byte, error) {
 }
 
 // Hostname implements the platform.Platform interface.
-func (v *VMware) Hostname() (hostname []byte, err error) {
+func (v *VMware) Hostname(context.Context) (hostname []byte, err error) {
 	return nil, nil
 }
 
@@ -82,7 +83,7 @@ func (v *VMware) Mode() runtime.Mode {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (v *VMware) ExternalIPs() (addrs []net.IP, err error) {
+func (v *VMware) ExternalIPs(context.Context) (addrs []net.IP, err error) {
 	return addrs, err
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_other.go
@@ -7,6 +7,7 @@
 package vmware
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -24,12 +25,12 @@ func (v *VMware) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-func (v *VMware) Configuration() ([]byte, error) {
+func (v *VMware) Configuration(context.Context) ([]byte, error) {
 	return nil, fmt.Errorf("arch not supported")
 }
 
 // Hostname implements the platform.Platform interface.
-func (v *VMware) Hostname() (hostname []byte, err error) {
+func (v *VMware) Hostname(context.Context) (hostname []byte, err error) {
 	return nil, fmt.Errorf("arch not supported")
 }
 
@@ -39,7 +40,7 @@ func (v *VMware) Mode() runtime.Mode {
 }
 
 // ExternalIPs implements the runtime.Platform interface.
-func (v *VMware) ExternalIPs() (addrs []net.IP, err error) {
+func (v *VMware) ExternalIPs(context.Context) (addrs []net.IP, err error) {
 	return addrs, err
 }
 

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -8,16 +8,18 @@
 package networkd
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
-	"github.com/hashicorp/go-multierror"
 	"golang.org/x/sys/unix"
 
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -324,11 +326,14 @@ func (n *Networkd) decideHostname() (hostname, domainname string, address net.IP
 	// Platform
 	var p runtime.Platform
 
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer ctxCancel()
+
 	p, err = platform.CurrentPlatform()
 	if err == nil {
 		var pHostname []byte
 
-		if pHostname, err = p.Hostname(); err == nil && string(pHostname) != "" {
+		if pHostname, err = p.Hostname(ctx); err == nil && string(pHostname) != "" {
 			hostname = string(pHostname)
 		}
 	}


### PR DESCRIPTION
Context is passed there for proper cancellation and timeouts.

https://github.com/talos-systems/talos/issues/2318

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>