### PR TITLE
chore: publish list of images to release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ conformance: ## Performs policy checks against the commit and source code.
 
 .PHONY: release-notes
 release-notes:
-	./hack/release.sh $@ $(ARTIFACTS)/RELEASE_NOTES.md $(TAG)
+	ARTIFACTS=$(ARTIFACTS) ./hack/release.sh $@ $(ARTIFACTS)/RELEASE_NOTES.md $(TAG)
 
 .PHONY: login
 login: ## Logs in to the configured container registry.

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -15,6 +15,10 @@ function changelog {
 
 function release-notes {
   git-chglog --output ${1} -c ./hack/chglog/config.yml "${2}"
+
+  echo -e '## Images\n\n```' >> ${1}
+  ${ARTIFACTS}/talosctl-linux-amd64 images >> ${1}
+  echo -e '```\n' >> ${1}
 }
 
 function cherry-pick {


### PR DESCRIPTION
This uses `talosctl images`. This way it's easy to find installer image
or talos image for any release.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

