### PR TITLE
fix: apply --removable option always to get standard UEFI filename

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -141,11 +141,7 @@ func (g *Grub) Install(fallback string, config interface{}, sequence runtime.Seq
 	}
 
 	for _, platform := range platforms {
-		args := []string{"--boot-directory=" + constants.BootMountPoint, "--efi-directory=" + constants.EFIMountPoint}
-
-		if strings.HasSuffix(platform, "-efi") {
-			args = append(args, "--removable")
-		}
+		args := []string{"--boot-directory=" + constants.BootMountPoint, "--efi-directory=" + constants.EFIMountPoint, "--removable"}
 
 		if loopDevice {
 			args = append(args, "--no-nvram")


### PR DESCRIPTION
Prior fix was incorrect as the platform is empty when installing to real
hardware. Looks like `--removable` does nothing when platform is not
UEFI, so we can have it always enabled.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

