### PR TITLE
chore: bump pkgs version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-6-g7b00e69
-PKGS ?= v0.3.0-12-g90722c3
+PKGS ?= v0.3.0-14-g5f4cff9
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 IMPORTVET ?= autonomy/importvet:f6b07d9


### PR DESCRIPTION
This brings in new kernel configs which includes the following PRs:

* https://github.com/talos-systems/pkgs/pull/174
* https://github.com/talos-systems/pkgs/pull/171

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

