### PR TITLE
feat: implement talos.shutdown=[halt|poweroff] kernel argument

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -32,6 +32,10 @@ const (
 	// initial interface used to bootstrap the node
 	KernelParamDefaultInterface = "talos.interface"
 
+	// KernelParamShutdown is the kernel parameter for specifying the
+	// shutdown type (halt/poweroff)
+	KernelParamShutdown = "talos.shutdown"
+
 	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos
 	KernelParamNetworkInterfaceIgnore = "talos.network.interface.ignore"
 

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -71,6 +71,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	// reboot configuration
 	cmdline.Append("reboot", "k")
 	cmdline.Append("panic", "1")
+	cmdline.Append("talos.shutdown", "halt")
 
 	// Talos config
 	cmdline.Append("talos.platform", "metal")

--- a/pkg/provision/providers/qemu/qemu.go
+++ b/pkg/provision/providers/qemu/qemu.go
@@ -46,6 +46,7 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 			// reboot configuration
 			"reboot=k",
 			"panic=1",
+			"talos.shutdown=halt",
 			// Talos-specific
 			"talos.platform=metal",
 		}),


### PR DESCRIPTION
This allows to change `Shutdown()` API behavior to halt the system
instead of powering it off.

This is useful for QEMU provisioner, as it doesn't distinguiush between
power off and reboot.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

