### PR TITLE
test: potential fix for talosctl cluster destroy being stuck

### DIFF
--- a/pkg/provision/internal/inmemhttp/inmemhttp.go
+++ b/pkg/provision/internal/inmemhttp/inmemhttp.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 )
 
 // Server is an in-memory http web server.
@@ -86,5 +87,8 @@ func (s *server) Serve() {
 }
 
 func (s *server) Shutdown(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
 	return s.srv.Shutdown(ctx)
 }

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -332,7 +332,7 @@ func Launch() error {
 				case <-config.controller.CommandsCh():
 					// machine might have been powered on
 				case sig := <-config.c:
-					fmt.Fprintf(os.Stderr, "exiting VM as signal %s was received\n", sig)
+					fmt.Fprintf(os.Stderr, "exiting stopped launcher as signal %s was received\n", sig)
 
 					return fmt.Errorf("process stopped")
 				}


### PR DESCRIPTION
Missing timeout in shutdown is the only reason I could find for Sfyra
tests being stuck on teardown.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

