### PR TITLE
docs: add link to latest docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some of the capabilities and benefits provided by Talos include:
 
 ## Documentation
 
-For instructions on deploying and managing Talos, see the [Documentation](https://www.talos.dev/docs/v0.4/).
+For instructions on deploying and managing Talos, see the [Documentation](https://www.talos.dev/docs/latest/).
 
 ## Community
 

--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -36,7 +36,7 @@ export default {
     return {
       options: [
         { version: 'v0.7', url: '/docs/v0.7', prerelease: true },
-        { version: 'v0.6', url: '/docs/v0.6', prerelease: false },
+        { version: 'v0.6', url: '/docs/v0.6', prerelease: false, latest: true },
         { version: 'v0.5', url: '/docs/v0.5', prerelease: false },
         { version: 'v0.4', url: '/docs/v0.4', prerelease: false }
       ],
@@ -47,6 +47,10 @@ export default {
   methods: {
     version(option) {
       if (option.prerelease) {
+        return `${option.version} (pre-release)`
+      }
+
+      if (option.latest) {
         return `${option.version} (pre-release)`
       }
 

--- a/docs/website/components/Header.vue
+++ b/docs/website/components/Header.vue
@@ -7,7 +7,7 @@
       <div class="flex py-6 ml-auto">
         <ul class="header-menu">
           <li>
-            <a href="/docs/v0.6">
+            <a href="/docs/latest">
               <span class="font-semibold mr-1">Documentation</span>
             </a>
           </li>

--- a/docs/website/nuxt.config.js
+++ b/docs/website/nuxt.config.js
@@ -100,6 +100,18 @@ export default {
         }
 
         generatedRoutes.push(r)
+
+        if (version === 'v0.6') {
+          const latest = {
+            route: '/docs/latest/',
+            payload: {
+              sections: require(`${__dirname}/static/${version}.sections.${lang}.json`),
+              menu: require(`${__dirname}/static/${version}.menu.${lang}.json`)
+            }
+          }
+
+          generatedRoutes.push(latest)
+        }
       })
 
       callback(null, generatedRoutes)


### PR DESCRIPTION
We need a way for users to get to the latest stable docs easily.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
