### PR TITLE
docs: fix latest tag

### DIFF
--- a/docs/website/components/DocumentationDropdown.vue
+++ b/docs/website/components/DocumentationDropdown.vue
@@ -51,7 +51,7 @@ export default {
       }
 
       if (option.latest) {
-        return `${option.version} (pre-release)`
+        return `${option.version} (latest)`
       }
 
       return option.version


### PR DESCRIPTION
Latest release was tagged as "pre-release". It should be "latest".

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
