### PR TITLE
feat: handle unsupported commands being called for docker

### DIFF
--- a/internal/app/machined/pkg/runtime/mode.go
+++ b/internal/app/machined/pkg/runtime/mode.go
@@ -11,6 +11,9 @@ import (
 // Mode is a runtime mode.
 type Mode int
 
+// ModeCapability describes mode capability flags.
+type ModeCapability uint64
+
 const (
 	// ModeCloud is the cloud runtime mode.
 	ModeCloud Mode = iota
@@ -18,6 +21,17 @@ const (
 	ModeContainer
 	// ModeMetal is the metal runtime mode.
 	ModeMetal
+)
+
+const (
+	// Reboot node reboot.
+	Reboot ModeCapability = 1 << iota
+	// Rollback node rollback.
+	Rollback
+	// Shutdown node shutdown.
+	Shutdown
+	// Upgrade node upgrade.
+	Upgrade
 )
 
 const (
@@ -36,6 +50,11 @@ func (m Mode) RequiresInstall() bool {
 	return m == ModeMetal
 }
 
+// Supports returns mode capability.
+func (m Mode) Supports(feature ModeCapability) bool {
+	return (m.capabilities() & uint64(feature)) != 0
+}
+
 // ParseMode returns a `Mode` that matches the specified string.
 func ParseMode(s string) (mod Mode, err error) {
 	switch s {
@@ -50,4 +69,17 @@ func ParseMode(s string) (mod Mode, err error) {
 	}
 
 	return mod, nil
+}
+
+func (m Mode) capabilities() uint64 {
+	all := ^uint64(0)
+
+	return [...]uint64{
+		// metal
+		all,
+		// container
+		all ^ uint64(Reboot|Shutdown|Upgrade|Rollback),
+		// cloud
+		all,
+	}[m]
 }

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -402,48 +402,82 @@ func (c *Client) Containers(ctx context.Context, namespace string, driver common
 
 // Restart implements the proto.OSClient interface.
 func (c *Client) Restart(ctx context.Context, namespace string, driver common.ContainerDriver, id string, callOptions ...grpc.CallOption) (err error) {
-	_, err = c.MachineClient.Restart(ctx, &machineapi.RestartRequest{
+	resp, err := c.MachineClient.Restart(ctx, &machineapi.RestartRequest{
 		Id:        id,
 		Namespace: namespace,
 		Driver:    driver,
 	})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
 
 	return
 }
 
 // Reset implements the proto.OSClient interface.
 func (c *Client) Reset(ctx context.Context, graceful, reboot bool) (err error) {
-	_, err = c.MachineClient.Reset(ctx, &machineapi.ResetRequest{Graceful: graceful, Reboot: reboot})
+	resp, err := c.MachineClient.Reset(ctx, &machineapi.ResetRequest{Graceful: graceful, Reboot: reboot})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
 	return
 }
 
 // Reboot implements the proto.OSClient interface.
 func (c *Client) Reboot(ctx context.Context) (err error) {
-	_, err = c.MachineClient.Reboot(ctx, &empty.Empty{})
+	resp, err := c.MachineClient.Reboot(ctx, &empty.Empty{})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
 	return
 }
 
 // Recover implements the proto.OSClient interface.
 func (c *Client) Recover(ctx context.Context, source machineapi.RecoverRequest_Source) (err error) {
-	_, err = c.MachineClient.Recover(ctx, &machineapi.RecoverRequest{Source: source})
+	resp, err := c.MachineClient.Recover(ctx, &machineapi.RecoverRequest{Source: source})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
 	return
 }
 
 // Rollback implements the proto.OSClient interface.
 func (c *Client) Rollback(ctx context.Context) (err error) {
-	_, err = c.MachineClient.Rollback(ctx, &machineapi.RollbackRequest{})
+	resp, err := c.MachineClient.Rollback(ctx, &machineapi.RollbackRequest{})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
 	return
 }
 
 // Bootstrap implements the proto.OSClient interface.
 func (c *Client) Bootstrap(ctx context.Context) (err error) {
-	_, err = c.MachineClient.Bootstrap(ctx, &machineapi.BootstrapRequest{})
+	resp, err := c.MachineClient.Bootstrap(ctx, &machineapi.BootstrapRequest{})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
 	return
 }
 
 // Shutdown implements the proto.OSClient interface.
 func (c *Client) Shutdown(ctx context.Context) (err error) {
-	_, err = c.MachineClient.Shutdown(ctx, &empty.Empty{})
+	resp, err := c.MachineClient.Shutdown(ctx, &empty.Empty{})
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
 	return
 }
 


### PR DESCRIPTION
Return proper message back to the client in case if called method is not
supported by mode any particular node runs in.

Fixes: https://github.com/talos-systems/talos/issues/2629

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>