### PR TITLE
feat: support MTU and route changes for DHCP

### DIFF
--- a/docs/website/content/v0.7/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.7/en/configuration/v1alpha1.md
@@ -1288,6 +1288,8 @@ Type: `string`
 #### routes
 
 A list of routes associated with the interface.
+If used in combination with DHCP, these routes will be appended to routes returned by DHCP server.
+
 Type: `array`
 
 #### bond
@@ -1303,6 +1305,8 @@ Type: `array`
 #### mtu
 
 The interface's MTU.
+If used in combination with DHCP, this will override any MTU settings returned from DHCP server.
+
 Type: `int`
 
 #### dhcp

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -46,7 +46,7 @@ func buildOptions(device config.Device, hostname string) (name string, opts []ni
 
 		opts = append(opts, nic.WithAddressing(s))
 	case device.DHCP():
-		d := &address.DHCP{DHCPOptions: device.DHCPOptions()}
+		d := &address.DHCP{DHCPOptions: device.DHCPOptions(), RouteList: device.Routes(), Mtu: device.MTU()}
 		opts = append(opts, nic.WithAddressing(d))
 	default:
 		// Allow master interface without any addressing if VLANs exist

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -818,13 +818,17 @@ type Device struct {
 	DeviceInterface string `yaml:"interface"`
 	//   description: The CIDR to use.
 	DeviceCIDR string `yaml:"cidr"`
-	//   description: A list of routes associated with the interface.
+	//   description: |
+	//     A list of routes associated with the interface.
+	//     If used in combination with DHCP, these routes will be appended to routes returned by DHCP server.
 	DeviceRoutes []*Route `yaml:"routes"`
 	//   description: Bond specific options.
 	DeviceBond *Bond `yaml:"bond"`
 	//   description: VLAN specific options.
 	DeviceVlans []*Vlan `yaml:"vlans"`
-	//   description: The interface's MTU.
+	//   description: |
+	//     The interface's MTU.
+	//     If used in combination with DHCP, this will override any MTU settings returned from DHCP server.
 	DeviceMTU int `yaml:"mtu"`
 	//   description: Indicates if DHCP should be used.
 	DeviceDHCP bool `yaml:"dhcp"`


### PR DESCRIPTION
This PR updates the behavior of our machine configs with respect to
DHCP-enabled interfaces. Now, if MTU is specified by the user, that
value will take precedence over any setting provided by the DHCP server.

Additionally, any routes specified will be appended to routes specified
by the DHCP server.

Will close #2533 