### PR TITLE
test: clean up integration test code, fix flakes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,14 @@ run:
   skip-files:
     - .*\\.pb\\.go$
 
+  # list of build tags, all linters use it. Default is empty list.
+  build-tags:
+    - integration
+    - integration_api
+    - integration_cli
+    - integration_k8s
+    - integration_provision
+
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"

--- a/internal/integration/api/diskusage.go
+++ b/internal/integration/api/diskusage.go
@@ -63,27 +63,27 @@ func (suite *DiskUsageSuite) TestDiskUsageRequests() {
 	}
 
 	cases := []*testParams{
-		&testParams{
+		{
 			recursionDepth: 0,
 			all:            false,
 			paths:          defaultPaths,
 		},
-		&testParams{
+		{
 			recursionDepth: 1,
 			all:            false,
 			paths:          defaultPaths,
 		},
-		&testParams{
+		{
 			recursionDepth: 0,
 			all:            true,
 			paths:          defaultPaths,
 		},
-		&testParams{
+		{
 			recursionDepth: 1,
 			all:            true,
 			paths:          defaultPaths,
 		},
-		&testParams{
+		{
 			recursionDepth: 0,
 			all:            true,
 			paths:          append([]string{"/this/is/going/to/fail"}, defaultPaths...),
@@ -93,7 +93,6 @@ func (suite *DiskUsageSuite) TestDiskUsageRequests() {
 	sizes := map[string]int64{}
 
 	for _, params := range cases {
-
 		lookupPaths := map[string]bool{}
 		for _, path := range params.paths {
 			lookupPaths[path] = true
@@ -110,9 +109,11 @@ func (suite *DiskUsageSuite) TestDiskUsageRequests() {
 		suite.Require().NoError(err)
 
 		responseCount := 0
+
 		for {
 			info, err := stream.Recv()
 			responseCount++
+
 			if err != nil {
 				if err == io.EOF || status.Code(err) == codes.Canceled {
 					break
@@ -120,6 +121,7 @@ func (suite *DiskUsageSuite) TestDiskUsageRequests() {
 
 				suite.Require().NoError(err)
 			}
+
 			if size, ok := sizes[info.Name]; ok {
 				suite.Require().EqualValues(size, info.Size)
 			}

--- a/internal/integration/api/dmesg.go
+++ b/internal/integration/api/dmesg.go
@@ -139,6 +139,7 @@ func (suite *DmesgSuite) TestClusterHasDmesg() {
 			if err == io.EOF {
 				break
 			}
+
 			suite.Require().NoError(err)
 		}
 

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
+// EtcdSuite ...
 type EtcdSuite struct {
 	base.APISuite
 
@@ -115,7 +116,9 @@ func (suite *EtcdSuite) TestEtcdLeaveCluster() {
 	suite.Require().NoError(err)
 
 	for {
-		info, err := stream.Recv()
+		var info *machineapi.FileInfo
+
+		info, err = stream.Recv()
 		if err != nil {
 			if err == io.EOF || status.Code(err) == codes.Canceled {
 				break

--- a/internal/integration/api/logs.go
+++ b/internal/integration/api/logs.go
@@ -160,6 +160,7 @@ func (suite *LogsSuite) TestTailStreaming0() {
 	suite.testStreaming(0)
 }
 
+//nolint: gocyclo
 func (suite *LogsSuite) testStreaming(tailLines int32) {
 	if tailLines >= 0 {
 		// invoke machined enough times to generate
@@ -189,7 +190,9 @@ func (suite *LogsSuite) testStreaming(tailLines int32) {
 		defer close(respCh)
 
 		for {
-			msg, err := logsStream.Recv()
+			var msg *common.Data
+
+			msg, err = logsStream.Recv()
 			if err != nil {
 				errCh <- err
 				return

--- a/internal/integration/api/reboot.go
+++ b/internal/integration/api/reboot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
 
+// RebootSuite ...
 type RebootSuite struct {
 	base.APISuite
 
@@ -67,6 +68,8 @@ func (suite *RebootSuite) TestRebootNodeByNode() {
 }
 
 // TestRebootAllNodes reboots all cluster nodes at the same time.
+//
+//nolint: gocyclo
 func (suite *RebootSuite) TestRebootAllNodes() {
 	if !suite.Capabilities().SupportsReboot {
 		suite.T().Skip("cluster doesn't support reboots")
@@ -128,7 +131,7 @@ func (suite *RebootSuite) TestRebootAllNodes() {
 
 					if bootIDAfter == bootIDBefore {
 						// bootID should be different after reboot
-						return retry.ExpectedError(fmt.Errorf("bootID didn't change for node %q: before %s + %s, after %s", node, bootIDBefore, bootIDAfter))
+						return retry.ExpectedError(fmt.Errorf("bootID didn't change for node %q: before %s, after %s", node, bootIDBefore, bootIDAfter))
 					}
 
 					return nil

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -16,6 +16,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
+// ResetSuite ...
 type ResetSuite struct {
 	base.APISuite
 
@@ -56,6 +57,7 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 	}
 
 	initNodeAddress := ""
+
 	for _, node := range suite.Cluster.Info().Nodes {
 		if node.Type == machine.TypeInit {
 			initNodeAddress = node.PrivateIP.String()
@@ -78,13 +80,13 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 
 		suite.T().Log("Resetting node", node)
 
+		// TODO: there is no good way to assert that node was reset and disk contents were really wiped
+
 		// uptime should go down after Reset, as it reboots the node
 		suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
 			// force reboot after reset, as this is the only mode we can test
 			return suite.Client.Reset(nodeCtx, true, true)
 		}, 10*time.Minute)
-
-		// TODO: there is no good way to assert that node was reset and disk contents were really wiped
 	}
 }
 

--- a/internal/integration/api/version.go
+++ b/internal/integration/api/version.go
@@ -74,6 +74,7 @@ func (suite *VersionSuite) TestSameVersionCluster() {
 	suite.Require().Len(v.Messages, len(nodes))
 
 	expectedVersion := v.Messages[0].Version.Tag
+
 	for _, version := range v.Messages {
 		suite.Assert().Equal(expectedVersion, version.Version.Tag)
 	}

--- a/internal/integration/base/base.go
+++ b/internal/integration/base/base.go
@@ -52,8 +52,8 @@ type ConfiguredSuite interface {
 }
 
 // SetConfig implements ConfiguredSuite.
-func (suite *TalosSuite) SetConfig(config TalosSuite) {
-	*suite = config
+func (talosSuite *TalosSuite) SetConfig(config TalosSuite) {
+	*talosSuite = config
 }
 
 // NamedSuite interface provides names for test suites.

--- a/internal/integration/base/cli.go
+++ b/internal/integration/base/cli.go
@@ -52,7 +52,7 @@ func (cliSuite *CLISuite) DiscoverNodes() cluster.Info {
 	return nil
 }
 
-// RandomNode returns a random node of the specified type (or any type if no types are specified).
+// RandomDiscoveredNode returns a random node of the specified type (or any type if no types are specified).
 func (cliSuite *CLISuite) RandomDiscoveredNode(types ...machine.Type) string {
 	nodeInfo := cliSuite.DiscoverNodes()
 
@@ -97,7 +97,6 @@ func (cliSuite *CLISuite) discoverKubectl() cluster.Info {
 
 func (cliSuite *CLISuite) buildCLICmd(args []string) *exec.Cmd {
 	// TODO: add support for calling `talosctl config endpoint` before running talosctl
-
 	args = append([]string{"--talosconfig", cliSuite.TalosConfig}, args...)
 
 	return exec.Command(cliSuite.TalosctlPath, args...)
@@ -108,6 +107,7 @@ func (cliSuite *CLISuite) RunCLI(args []string, options ...RunOption) {
 	Run(&cliSuite.Suite, cliSuite.buildCLICmd(args), options...)
 }
 
+// RunAndWaitForMatch retries command until output matches.
 func (cliSuite *CLISuite) RunAndWaitForMatch(args []string, regex *regexp.Regexp, duration time.Duration, options ...retry.Option) {
 	cliSuite.Assert().NoError(retry.Constant(duration, options...).Retry(func() error {
 		stdout, _, err := RunAndWait(&cliSuite.Suite, cliSuite.buildCLICmd(args))

--- a/internal/integration/base/cluster.go
+++ b/internal/integration/base/cluster.go
@@ -25,6 +25,8 @@ func (wrapper *infoWrapper) NodesByType(t machine.Type) []string {
 		return append([]string(nil), wrapper.masterNodes...)
 	case machine.TypeJoin:
 		return append([]string(nil), wrapper.workerNodes...)
+	case machine.TypeUnknown:
+		fallthrough
 	default:
 		panic("unreachable")
 	}

--- a/internal/integration/base/discovery_k8s.go
+++ b/internal/integration/base/discovery_k8s.go
@@ -21,6 +21,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
+//nolint: gocyclo
 func discoverNodesK8s(client *client.Client, suite *TalosSuite) (cluster.Info, error) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Minute)
 	defer ctxCancel()

--- a/internal/integration/base/run.go
+++ b/internal/integration/base/run.go
@@ -100,7 +100,7 @@ func StdoutMatchFunc(f MatchFunc) RunOption {
 	}
 }
 
-// StderrtMatchFunc appends to the list of MatchFuncs to run against stderr.
+// StderrMatchFunc appends to the list of MatchFuncs to run against stderr.
 func StderrMatchFunc(f MatchFunc) RunOption {
 	return func(opts *runOptions) {
 		opts.stderrMatchers = append(opts.stderrMatchers, f)
@@ -124,6 +124,7 @@ func RunAndWait(suite *suite.Suite, cmd *exec.Cmd) (stdoutBuf, stderrBuf *bytes.
 		if index < 0 {
 			continue
 		}
+
 		switch strings.ToUpper(keyvalue[:index]) {
 		case "PATH":
 			fallthrough
@@ -142,6 +143,8 @@ func RunAndWait(suite *suite.Suite, cmd *exec.Cmd) (stdoutBuf, stderrBuf *bytes.
 }
 
 // Run executes command and asserts on its exit status/output.
+//
+//nolint: gocyclo
 func Run(suite *suite.Suite, cmd *exec.Cmd, options ...RunOption) {
 	var opts runOptions
 

--- a/internal/integration/cli/crashdump.go
+++ b/internal/integration/cli/crashdump.go
@@ -30,6 +30,7 @@ func (suite *CrashdumpSuite) TestRun() {
 	}
 
 	args := []string{}
+
 	for _, node := range suite.Cluster.Info().Nodes {
 		switch node.Type {
 		case machine.TypeInit:
@@ -38,6 +39,8 @@ func (suite *CrashdumpSuite) TestRun() {
 			args = append(args, "--control-plane-nodes", node.PrivateIP.String())
 		case machine.TypeJoin:
 			args = append(args, "--worker-nodes", node.PrivateIP.String())
+		case machine.TypeUnknown:
+			panic("unexpected")
 		}
 	}
 

--- a/internal/integration/cli/diskusage.go
+++ b/internal/integration/cli/diskusage.go
@@ -39,6 +39,7 @@ func splitLine(line string) []string {
 			columns = append(columns, strings.TrimSpace(part))
 		}
 	}
+
 	return columns
 }
 
@@ -54,7 +55,7 @@ func parseLine(line string) (*duInfo, error) {
 
 	if len(columns) == 3 {
 		res.node = columns[0]
-		offset += 1
+		offset++
 	}
 
 	size, err := strconv.ParseInt(columns[offset], 10, 64)
@@ -74,6 +75,7 @@ func (suite *DiskUsageSuite) TestSuccess() {
 	node := suite.RandomDiscoveredNode()
 
 	var folderSize int64 = 4096
+
 	suite.RunCLI([]string{"list", "--nodes", node, folder, "-l"},
 		base.StdoutMatchFunc(func(stdout string) error {
 			lines := strings.Split(strings.TrimSpace(stdout), "\n")

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -26,6 +26,7 @@ func (suite *GenSuite) SuiteName() string {
 	return "cli.GenSuite"
 }
 
+// SetupTest ...
 func (suite *GenSuite) SetupTest() {
 	var err error
 	suite.tmpDir, err = ioutil.TempDir("", "talos")
@@ -37,6 +38,7 @@ func (suite *GenSuite) SetupTest() {
 	suite.Require().NoError(os.Chdir(suite.tmpDir))
 }
 
+// TearDownTest ...
 func (suite *GenSuite) TearDownTest() {
 	if suite.savedCwd != "" {
 		suite.Require().NoError(os.Chdir(suite.savedCwd))

--- a/internal/integration/cli/health.go
+++ b/internal/integration/cli/health.go
@@ -25,6 +25,8 @@ func (suite *HealthSuite) SuiteName() string {
 }
 
 // TestClientSide does successful health check run from client-side.
+//
+//nolint: gocyclo
 func (suite *HealthSuite) TestClientSide() {
 	if suite.Cluster == nil {
 		suite.T().Skip("Cluster is not available, skipping test")
@@ -47,6 +49,8 @@ func (suite *HealthSuite) TestClientSide() {
 				args = append(args, "--control-plane-nodes", node.PrivateIP.String())
 			case machine.TypeJoin:
 				args = append(args, "--worker-nodes", node.PrivateIP.String())
+			case machine.TypeInit, machine.TypeUnknown:
+				panic("unexpected")
 			}
 		}
 	} else {
@@ -58,6 +62,8 @@ func (suite *HealthSuite) TestClientSide() {
 				args = append(args, "--control-plane-nodes", node.PrivateIP.String())
 			case machine.TypeJoin:
 				args = append(args, "--worker-nodes", node.PrivateIP.String())
+			case machine.TypeUnknown:
+				panic("unexpected")
 			}
 		}
 	}

--- a/internal/integration/cli/restart.go
+++ b/internal/integration/cli/restart.go
@@ -42,7 +42,7 @@ func (suite *RestartSuite) TestSystem() {
 	suite.RunAndWaitForMatch([]string{"service", "-n", node, "trustd"}, regexp.MustCompile(`EVENTS\s+\[Running\]: Health check successful`), 30*time.Second)
 }
 
-// TestKubernetes restarts K8s container.
+// TestK8s restarts K8s container.
 func (suite *RestartSuite) TestK8s() {
 	if testing.Short() {
 		suite.T().Skip("skipping in short mode")

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -27,6 +27,7 @@ func (suite *ValidateSuite) SuiteName() string {
 	return "cli.ValidateSuite"
 }
 
+// SetupTest ...
 func (suite *ValidateSuite) SetupTest() {
 	var err error
 	suite.tmpDir, err = ioutil.TempDir("", "talos")
@@ -38,6 +39,7 @@ func (suite *ValidateSuite) SetupTest() {
 	suite.Require().NoError(os.Chdir(suite.tmpDir))
 }
 
+// TearDownTest ...
 func (suite *ValidateSuite) TearDownTest() {
 	if suite.savedCwd != "" {
 		suite.Require().NoError(os.Chdir(suite.savedCwd))
@@ -53,7 +55,11 @@ func (suite *ValidateSuite) TestValidate() {
 	suite.RunCLI([]string{"gen", "config", "foobar", "https://10.0.0.1"})
 
 	for _, configFile := range []string{"init.yaml", "controlplane.yaml", "join.yaml"} {
+		configFile := configFile
+
 		for _, mode := range []string{"cloud", "container"} {
+			mode := mode
+
 			suite.Run(fmt.Sprintf("%s-%s", configFile, mode), func() {
 				suite.RunCLI([]string{"validate", "-m", mode, "-c", configFile})
 			})

--- a/internal/integration/cli/version.go
+++ b/internal/integration/cli/version.go
@@ -37,7 +37,7 @@ func (suite *VersionSuite) TestShortVersion() {
 	)
 }
 
-// TestClientVersion verifies only client version output.
+// TestClient verifies only client version output.
 func (suite *VersionSuite) TestClient() {
 	suite.RunCLI([]string{"version", "--client"},
 		base.StdoutShouldMatch(regexp.MustCompile(`Client:\n\s*Tag:\s*`+regexp.QuoteMeta(suite.Version))),

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -45,6 +45,9 @@ var (
 	stateDir         string
 )
 
+// TestIntegration ...
+//
+//nolint: gocyclo
 func TestIntegration(t *testing.T) {
 	if talosConfig == "" {
 		t.Error("--talos.config is not provided")
@@ -139,7 +142,8 @@ func init() {
 	flag.Int64Var(&provision_test.DefaultSettings.DiskGB, "talos.provision.disk", provision_test.DefaultSettings.DiskGB, "disk size (in GiB) for each VM (provision tests only)")
 	flag.IntVar(&provision_test.DefaultSettings.MasterNodes, "talos.provision.masters", provision_test.DefaultSettings.MasterNodes, "master node count (provision tests only)")
 	flag.IntVar(&provision_test.DefaultSettings.WorkerNodes, "talos.provision.workers", provision_test.DefaultSettings.WorkerNodes, "worker node count (provision tests only)")
-	flag.StringVar(&provision_test.DefaultSettings.TargetInstallImageRegistry, "talos.provision.target-installer-registry", provision_test.DefaultSettings.TargetInstallImageRegistry, "image registry for target installer image (provision tests only)")
+	flag.StringVar(&provision_test.DefaultSettings.TargetInstallImageRegistry, "talos.provision.target-installer-registry",
+		provision_test.DefaultSettings.TargetInstallImageRegistry, "image registry for target installer image (provision tests only)")
 	flag.StringVar(&provision_test.DefaultSettings.CustomCNIURL, "talos.provision.custom-cni-url", provision_test.DefaultSettings.CustomCNIURL, "custom CNI URL for the cluster (provision tests only)")
 
 	allSuites = append(allSuites, api.GetAllSuites()...)

--- a/internal/integration/k8s/version.go
+++ b/internal/integration/k8s/version.go
@@ -32,8 +32,8 @@ func (suite *VersionSuite) TestExpectedVersion() {
 	apiServerVersion, err := suite.DiscoveryClient.ServerVersion()
 	suite.Require().NoError(err)
 
-	expectedApiServerVersion := fmt.Sprintf("v%s", constants.DefaultKubernetesVersion)
-	suite.Assert().Equal(expectedApiServerVersion, apiServerVersion.GitVersion)
+	expectedAPIServerVersion := fmt.Sprintf("v%s", constants.DefaultKubernetesVersion)
+	suite.Assert().Equal(expectedAPIServerVersion, apiServerVersion.GitVersion)
 
 	checkKernelVersion := suite.Capabilities().RunsTalosKernel
 
@@ -51,6 +51,7 @@ func (suite *VersionSuite) TestExpectedVersion() {
 		suite.Assert().Equal("linux", node.Status.NodeInfo.OperatingSystem)
 		suite.Assert().Equal(expectedContainerRuntimeVersion, node.Status.NodeInfo.ContainerRuntimeVersion)
 		suite.Assert().Equal(expectedKubeletVersion, node.Status.NodeInfo.KubeletVersion)
+
 		if checkKernelVersion {
 			suite.Assert().Equal(expectedKernelVersion, node.Status.NodeInfo.KernelVersion)
 		}

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -131,6 +131,8 @@ func upgradeLastReleaseToCurrent() upgradeSpec {
 }
 
 // upgradeSingeNodePreserve upgrade last release of Talos to the current version of Talos for single-node cluster with preserve.
+//
+//nolint: deadcode,unused
 func upgradeSingeNodePreserve() upgradeSpec {
 	return upgradeSpec{
 		ShortName: fmt.Sprintf("preserve-%s-%s", nextVersion, DefaultSettings.CurrentVersion),
@@ -151,6 +153,7 @@ func upgradeSingeNodePreserve() upgradeSpec {
 	}
 }
 
+// UpgradeSuite ...
 type UpgradeSuite struct {
 	suite.Suite
 	base.TalosSuite
@@ -242,7 +245,7 @@ func (suite *UpgradeSuite) setupCluster() {
 	suite.stateDir, err = ioutil.TempDir("", "talos-integration")
 	suite.Require().NoError(err)
 
-	suite.T().Logf("initalizing provisioner with cluster name %q, state directory %q", clusterName, suite.stateDir)
+	suite.T().Logf("initializing provisioner with cluster name %q, state directory %q", clusterName, suite.stateDir)
 
 	request := provision.ClusterRequest{
 		Name: clusterName,
@@ -399,7 +402,7 @@ func (suite *UpgradeSuite) assertSameVersionCluster(client *talosclient.Client, 
 	}
 }
 
-func (suite *UpgradeSuite) readVersion(client *talosclient.Client, nodeCtx context.Context) (version string, err error) {
+func (suite *UpgradeSuite) readVersion(nodeCtx context.Context, client *talosclient.Client) (version string, err error) {
 	var v *machineapi.VersionResponse
 
 	v, err = client.Version(nodeCtx)
@@ -442,7 +445,7 @@ func (suite *UpgradeSuite) upgradeNode(client *talosclient.Client, node provisio
 	suite.Require().NoError(retry.Constant(10 * time.Minute).Retry(func() error {
 		var version string
 
-		version, err = suite.readVersion(client, nodeCtx)
+		version, err = suite.readVersion(nodeCtx, client)
 		if err != nil {
 			// API might be unresponsive during upgrade
 			return retry.ExpectedError(err)


### PR DESCRIPTION
This enables golangci-lint via build tags for integration tests (this
should have been done long ago!), and fixes the linting errors.

Two tests were updated to reduce flakiness:

* apply config: wait for nodes to issue "boot done" sequence event
before proceeding
* recover: kill pods even if they appear after the initial set gets
killed (potential race condition with previous test).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>


