### PR TITLE
fix: address nil pointer panic

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -124,6 +124,10 @@ func (m *MachineConfig) Time() config.Time {
 
 // Kubelet implements the config.Provider interface.
 func (m *MachineConfig) Kubelet() config.Kubelet {
+	if m.MachineKubelet == nil {
+		return &KubeletConfig{}
+	}
+
 	return m.MachineKubelet
 }
 


### PR DESCRIPTION
If the config does not have the kubelet field, we should return a default struct.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
