### PR TITLE
fix: update handling of ntp disable

### DIFF
--- a/docs/website/content/v0.7/en/configuration/v1alpha1.md
+++ b/docs/website/content/v0.7/en/configuration/v1alpha1.md
@@ -870,10 +870,10 @@ Valid Values:
 
 ### TimeConfig
 
-#### enabled
+#### disabled
 
-Indicates if time (ntp) is enabled for the machine
-Defaults to `true`.
+Indicates if time (ntp) is disabled for the machine
+Defaults to `false`.
 
 Type: `bool`
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -622,7 +622,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 			&services.Kubelet{},
 		)
 
-		if r.State().Platform().Mode() != runtime.ModeContainer && r.Config().Machine().Time().Enabled() {
+		if r.State().Platform().Mode() != runtime.ModeContainer && !r.Config().Machine().Time().Disabled() {
 			svcs.Load(
 				&services.Timed{},
 			)

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -63,7 +63,7 @@ func (o *APID) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (o *APID) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
+	if r.State().Platform().Mode() == runtime.ModeContainer || r.Config().Machine().Time().Disabled() {
 		return []string{"containerd", "networkd"}
 	}
 

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -85,7 +85,7 @@ func (e *Etcd) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (e *Etcd) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
+	if r.State().Platform().Mode() == runtime.ModeContainer || r.Config().Machine().Time().Disabled() {
 		return []string{"containerd", "networkd"}
 	}
 

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -136,7 +136,7 @@ func (k *Kubelet) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (k *Kubelet) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
+	if r.State().Platform().Mode() == runtime.ModeContainer || r.Config().Machine().Time().Disabled() {
 		return []string{"cri", "networkd"}
 	}
 

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -51,7 +51,7 @@ func (t *Trustd) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (t *Trustd) DependsOn(r runtime.Runtime) []string {
-	if r.State().Platform().Mode() == runtime.ModeContainer || !r.Config().Machine().Time().Enabled() {
+	if r.State().Platform().Mode() == runtime.ModeContainer || r.Config().Machine().Time().Disabled() {
 		return []string{"containerd", "networkd"}
 	}
 

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -171,7 +171,7 @@ type Route interface {
 // Time defines the requirements for a config that pertains to time related
 // options.
 type Time interface {
-	Enabled() bool
+	Disabled() bool
 	Servers() []string
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -114,9 +114,7 @@ func (m *MachineConfig) Network() config.MachineNetwork {
 // Time implements the config.Provider interface.
 func (m *MachineConfig) Time() config.Time {
 	if m.MachineTime == nil {
-		return &TimeConfig{
-			TimeEnabled: true,
-		}
+		return &TimeConfig{}
 	}
 
 	return m.MachineTime
@@ -949,9 +947,9 @@ func (v *Vlan) ID() uint16 {
 	return v.VlanID
 }
 
-// Enabled implements the config.Provider interface.
-func (t *TimeConfig) Enabled() bool {
-	return t.TimeEnabled
+// Disabled implements the config.Provider interface.
+func (t *TimeConfig) Disabled() bool {
+	return t.TimeDisabled
 }
 
 // Servers implements the config.Provider interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -530,9 +530,9 @@ type InstallConfig struct {
 // TimeConfig represents the options for configuring time on a node.
 type TimeConfig struct {
 	//   description: |
-	//     Indicates if time (ntp) is enabled for the machine
-	//     Defaults to `true`.
-	TimeEnabled bool `yaml:"enabled"`
+	//     Indicates if time (ntp) is disabled for the machine
+	//     Defaults to `false`.
+	TimeDisabled bool `yaml:"disabled"`
 	//   description: |
 	//     Specifies time (ntp) servers to use for setting system time.
 	//     Defaults to `pool.ntp.org`


### PR DESCRIPTION
This PR changes the bool for disabling ntp to `disable` instead of the
previous `enable`. We need to do this because customers were seeing
failure in cases where they were defining time servers only, which
results in `enabled: false` when configs get unmarshalled. Users wishing
to disable ntp altogether should now use `disabled: true`.