### PR TITLE
fix: implement preserving contents of partition on install

### DIFF
--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -41,5 +41,4 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&options.Upgrade, "upgrade", false, "Indicates that the install is being performed by an upgrade")
 	rootCmd.PersistentFlags().BoolVar(&options.Force, "force", false, "Indicates that the install should forcefully format the partition")
 	rootCmd.PersistentFlags().BoolVar(&options.Zero, "zero", false, "Indicates that the install should write zeros to the disk before installing")
-	rootCmd.PersistentFlags().BoolVar(&options.Save, "save", false, "Indicates that the install should write the config to disk (only supports file:// scheme)")
 }

--- a/cmd/talosctl/cmd/talos/rollback.go
+++ b/cmd/talosctl/cmd/talos/rollback.go
@@ -21,7 +21,7 @@ var rollbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			if err := c.Rollback(ctx); err != nil {
-				return fmt.Errorf("error executing rollbacky: %s", err)
+				return fmt.Errorf("error executing rollback: %s", err)
 			}
 
 			return nil

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1437,99 +1437,57 @@ func SyncNonVolatileStorageBuffers() {
 // MountBootPartition mounts the boot partition.
 func MountBootPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mountSystemPartition(constants.BootPartitionLabel)
+		return mount.SystemPartitionMount(constants.BootPartitionLabel)
 	}, "mountBootPartition"
 }
 
 // UnmountBootPartition unmounts the boot partition.
 func UnmountBootPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return unmountSystemPartition(constants.BootPartitionLabel)
+		return mount.SystemPartitionUnmount(constants.BootPartitionLabel)
 	}, "unmountBootPartition"
 }
 
 // MountEFIPartition mounts the EFI partition.
 func MountEFIPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mountSystemPartition(constants.EFIPartitionLabel)
+		return mount.SystemPartitionMount(constants.EFIPartitionLabel)
 	}, "mountEFIPartition"
 }
 
 // UnmountEFIPartition unmounts the EFI partition.
 func UnmountEFIPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return unmountSystemPartition(constants.EFIPartitionLabel)
+		return mount.SystemPartitionUnmount(constants.EFIPartitionLabel)
 	}, "unmountEFIPartition"
 }
 
 // MountStatePartition mounts the system partition.
 func MountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mountSystemPartition(constants.StatePartitionLabel, mount.WithSkipIfMounted(true))
+		return mount.SystemPartitionMount(constants.StatePartitionLabel, mount.WithSkipIfMounted(true))
 	}, "mountStatePartition"
 }
 
 // UnmountStatePartition unmounts the system partition.
 func UnmountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return unmountSystemPartition(constants.StatePartitionLabel)
+		return mount.SystemPartitionUnmount(constants.StatePartitionLabel)
 	}, "unmountStatePartition"
 }
 
 // MountEphermeralPartition mounts the ephemeral partition.
 func MountEphermeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mountSystemPartition(constants.EphemeralPartitionLabel)
+		return mount.SystemPartitionMount(constants.EphemeralPartitionLabel)
 	}, "mountEphermeralPartition"
 }
 
 // UnmountEphemeralPartition unmounts the ephemeral partition.
 func UnmountEphemeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return unmountSystemPartition(constants.EphemeralPartitionLabel)
+		return mount.SystemPartitionUnmount(constants.EphemeralPartitionLabel)
 	}, "unmountEphemeralPartition"
-}
-
-func mountSystemPartition(label string, opts ...mount.Option) (err error) {
-	mountpoints := mount.NewMountPoints()
-
-	mountpoint, err := mount.SystemMountPointForLabel(label, opts...)
-	if err != nil {
-		return err
-	}
-
-	if mountpoint == nil {
-		return fmt.Errorf("no mountpoints for label %q", label)
-	}
-
-	mountpoints.Set(label, mountpoint)
-
-	if err = mount.Mount(mountpoints); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func unmountSystemPartition(label string) (err error) {
-	mountpoints := mount.NewMountPoints()
-
-	mountpoint, err := mount.SystemMountPointForLabel(label)
-	if err != nil {
-		return err
-	}
-
-	if mountpoint == nil {
-		return fmt.Errorf("no mountpoints for label %q", label)
-	}
-
-	mountpoints.Set(label, mountpoint)
-
-	if err = mount.Unmount(mountpoints); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // Install mounts or installs the system partitions.

--- a/internal/integration/base/api.go
+++ b/internal/integration/base/api.go
@@ -185,7 +185,7 @@ func (apiSuite *APISuite) ReadBootID(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	bootID := string(body)
+	bootID := strings.TrimSpace(string(body))
 
 	_, err = io.Copy(ioutil.Discard, reader)
 	if err != nil {

--- a/internal/pkg/mount/system.go
+++ b/internal/pkg/mount/system.go
@@ -96,3 +96,47 @@ func SystemMountPointForLabel(label string, opts ...Option) (mountpoint *Point, 
 
 	return mountpoint, nil
 }
+
+// SystemPartitionMount mounts a system partition by the label.
+func SystemPartitionMount(label string, opts ...Option) (err error) {
+	mountpoints := NewMountPoints()
+
+	mountpoint, err := SystemMountPointForLabel(label, opts...)
+	if err != nil {
+		return err
+	}
+
+	if mountpoint == nil {
+		return fmt.Errorf("no mountpoints for label %q", label)
+	}
+
+	mountpoints.Set(label, mountpoint)
+
+	if err = Mount(mountpoints); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SystemPartitionUnmount unmounts a system partition by the label.
+func SystemPartitionUnmount(label string) (err error) {
+	mountpoints := NewMountPoints()
+
+	mountpoint, err := SystemMountPointForLabel(label)
+	if err != nil {
+		return err
+	}
+
+	if mountpoint == nil {
+		return fmt.Errorf("no mountpoints for label %q", label)
+	}
+
+	mountpoints.Set(label, mountpoint)
+
+	if err = Unmount(mountpoints); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/archiver/archiver.go
+++ b/pkg/archiver/archiver.go
@@ -29,3 +29,21 @@ func TarGz(ctx context.Context, rootPath string, output io.Writer) error {
 
 	return zw.Close()
 }
+
+// UntarGz extracts .tar.gz archive to the rootPath.
+func UntarGz(ctx context.Context, input io.Reader, rootPath string) error {
+	zr, err := gzip.NewReader(input)
+	if err != nil {
+		return err
+	}
+
+	//nolint: errcheck
+	defer zr.Close()
+
+	err = Untar(ctx, zr, rootPath)
+	if err != nil {
+		return err
+	}
+
+	return zr.Close()
+}

--- a/pkg/archiver/untar.go
+++ b/pkg/archiver/untar.go
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package archiver
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/talos-systems/talos/pkg/safepath"
+)
+
+// Untar extracts .tar archive from r into filesystem under rootPath.
+//
+//nolint: gocyclo
+func Untar(ctx context.Context, r io.Reader, rootPath string) error {
+	tr := tar.NewReader(r)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		hdr, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return fmt.Errorf("error reading tar header: %s", err)
+		}
+
+		hdrPath := safepath.CleanPath(hdr.Name)
+		if hdrPath == "" {
+			return fmt.Errorf("empty tar header path")
+		}
+
+		path := filepath.Join(rootPath, hdrPath)
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			mode := hdr.FileInfo().Mode()
+			mode |= 0o700 // make rwx for the owner
+
+			if err = os.Mkdir(path, mode); err != nil {
+				return fmt.Errorf("error creating directory %q mode %s: %w", path, mode, err)
+			}
+
+			if err = os.Chmod(path, mode); err != nil {
+				return fmt.Errorf("error updating mode %s for %q: %w", mode, path, err)
+			}
+
+		case tar.TypeSymlink:
+			if err = os.Symlink(hdr.Linkname, path); err != nil {
+				return fmt.Errorf("error creating symlink %q -> %q: %w", path, hdr.Linkname, err)
+			}
+
+		default:
+			mode := hdr.FileInfo().Mode()
+
+			fp, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, mode)
+			if err != nil {
+				return fmt.Errorf("error creating file %q mode %s: %w", path, mode, err)
+			}
+
+			_, err = io.Copy(fp, tr)
+			if err != nil {
+				return fmt.Errorf("error copying data to %q: %w", path, err)
+			}
+
+			if err = fp.Close(); err != nil {
+				return fmt.Errorf("error closing %q: %w", path, err)
+			}
+
+			if err = os.Chmod(path, mode); err != nil {
+				return fmt.Errorf("error updating mode %s for %q: %w", mode, path, err)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This fixes A/B upgrades and rollback API.

Installer manifest supports now an option to preserve partition contents
while disk is being re-partitioned and partitions are re-formatted.

Mount `/boot` partition as needed (to find current label before starting
the installation and in the rollback API).

Fix upgrade API for non-master nodes.

Contents of `/boot`, `/system/state` and META partitions are preserved
in memory while the disk is re-partitioned.

Remove `--save` flag from the installer as it's not being used.

Fixes #2521

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

