### PR TITLE
chore: move to newer release of rtnetlink with fn args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/hashicorp/go-getter v1.5.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/insomniacslk/dhcp v0.0.0-20200922210017-67c425063dca
-	github.com/jsimonetti/rtnetlink v0.0.0-20201014071711-e1a37f341155
+	github.com/jsimonetti/rtnetlink v0.0.0-20201022080559-7cf95b6356e5
 	github.com/kubernetes-sigs/bootkube v0.14.1-0.20200817205730-0b4482256ca1
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mdlayher/genetlink v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -519,11 +519,10 @@ github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
-github.com/jsimonetti/rtnetlink v0.0.0-20200726165900-d699427278d3 h1:7NSGy5xafjzYIlow0WAVgTLgMi+EdtTVJAoSbv9HXWA=
 github.com/jsimonetti/rtnetlink v0.0.0-20200726165900-d699427278d3/go.mod h1:HrWYfaMfyH5ODyA6hVxnedRaY7Jr4ctlyZf1xJt8gsw=
 github.com/jsimonetti/rtnetlink v0.0.0-20201009170750-9c6f07d100c1/go.mod h1:hqoO/u39cqLeBLebZ8fWdE96O7FxrAsRYhnVOdgHxok=
-github.com/jsimonetti/rtnetlink v0.0.0-20201014071711-e1a37f341155 h1:CgywZaldlwth3+2cqGAYXngsdEfhN+qMgq9WDp351OY=
-github.com/jsimonetti/rtnetlink v0.0.0-20201014071711-e1a37f341155/go.mod h1:7ORQCsYaISgEHn4UiFcTjVdB76gV0S4r1cPtipYOQgs=
+github.com/jsimonetti/rtnetlink v0.0.0-20201022080559-7cf95b6356e5 h1:cVTM4YjicoLY6xdhPwK/TlRoJKZX23TgBFLPdBQ4XgU=
+github.com/jsimonetti/rtnetlink v0.0.0-20201022080559-7cf95b6356e5/go.mod h1:7ORQCsYaISgEHn4UiFcTjVdB76gV0S4r1cPtipYOQgs=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
This PR makes use of a new merge into the upstream rtnetlink library
that introduces functional args for adding routes.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>