### PR TITLE
feat: extend etcd health check on upgrade

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"go.etcd.io/etcd/clientv3"
-	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 
 	"github.com/talos-systems/crypto/x509"
 	"github.com/talos-systems/go-retry/retry"
@@ -141,20 +140,7 @@ func (e *Etcd) HealthFunc(runtime.Runtime) health.Check {
 
 		defer client.Close() //nolint: errcheck
 
-		// Get a random key. As long as we can get the response without an error, the
-		// endpoint is healthy.
-
-		_, err = client.Get(ctx, "health")
-		if err == rpctypes.ErrPermissionDenied {
-			// Permission denied is OK since proposal goes through consensus to get this error.
-			err = nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		return client.Close()
+		return client.ValidateQuorum(ctx)
 	}
 }
 


### PR DESCRIPTION
When an etcd node is upgraded, we now perform additional quorum checks.
This is necessary because when etcd nodes are upgraded, they are removed
from membership.  If, for instance, two etcd nodes were to upgrade
simultaneously, quorum may be lost.  This, of course, does not apply to
single-node etcd clusters.

Fixes #1422

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
