### PR TITLE
fix: stop CRI pods on upgrade with preserve

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -358,6 +358,10 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 			!in.GetPreserve(),
 			"cleanup",
 			RemoveAllPods,
+		).AppendWhen(
+			in.GetPreserve(),
+			"cleanup",
+			StopAllPods,
 		).Append(
 			"stopServices",
 			StopServicesForUpgrade,


### PR DESCRIPTION
Talos always stops and removes CRI pods before stopping CRI containerd
when upgrading with wipe (force), but on "preserve" code paths pods were
never stopped (we can't remove them to keep preserve guarantees). This
PR makes sure pods are stopped on upgrade in any case.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

