### PR TITLE
feat: bump CoreDNS to 1.7.0

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -16,8 +16,6 @@ import (
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/talos-systems/bootkube-plugin/pkg/asset"
-
 	"github.com/talos-systems/crypto/x509"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
@@ -980,7 +978,7 @@ func (i *InstallConfig) WithBootloader() bool {
 
 // Image implements the config.Provider interface.
 func (c *CoreDNS) Image() string {
-	coreDNSImage := asset.DefaultImages.CoreDNS
+	coreDNSImage := fmt.Sprintf("%s:%s", constants.CoreDNSImage, constants.DefaultCoreDNSVersion)
 
 	if c.CoreDNSImage != "" {
 		coreDNSImage = c.CoreDNSImage

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -183,6 +183,12 @@ const (
 	// KubernetesSchedulerImage is the enforced scheduler image to use for the control plane.
 	KubernetesSchedulerImage = "k8s.gcr.io/kube-scheduler"
 
+	// CoreDNSImage is the enforced CoreDNS image to use.
+	CoreDNSImage = "k8s.gcr.io/coredns"
+
+	// DefaultCoreDNSVersion is the default version for the CoreDNS.
+	DefaultCoreDNSVersion = "1.7.0"
+
 	// RecoveryKubeconfig is the path to kubeconfig used temporarily while recovering control plane.
 	RecoveryKubeconfig = "/etc/kubernetes/kubeconfig"
 


### PR DESCRIPTION
This is the recommended version for K8s 1.19.x:

https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

