### PR TITLE
feat: bump Linux to 5.8.16, enable mpt3sas driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-7-g08245ac
-PKGS ?= v0.3.0-20-g30d1363
+PKGS ?= v0.3.0-21-g13565e2
 EXTRAS ?= v0.1.0-1-g1f7642a
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version
-	DefaultKernelVersion = "5.8.15-talos"
+	DefaultKernelVersion = "5.8.16-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL
 	// to the config.


### PR DESCRIPTION
See https://github.com/talos-systems/pkgs/pull/181

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

