### PR TITLE
fix: remove default time server in time command

### DIFF
--- a/cmd/talosctl/cmd/talos/time.go
+++ b/cmd/talosctl/cmd/talos/time.go
@@ -70,6 +70,7 @@ var timeCmd = &cobra.Command{
 				if err != nil {
 					return fmt.Errorf("error parsing local time: %w", err)
 				}
+
 				remotetime, err = ptypes.Timestamp(msg.Remotetime)
 				if err != nil {
 					return fmt.Errorf("error parsing remote time: %w", err)
@@ -84,6 +85,6 @@ var timeCmd = &cobra.Command{
 }
 
 func init() {
-	timeCmd.Flags().StringP("check", "c", "pool.ntp.org", "checks server time against specified ntp server")
+	timeCmd.Flags().String("check", "c", "checks server time against specified ntp server")
 	addCommand(timeCmd)
 }

--- a/website/content/docs/v0.7/Reference/cli.md
+++ b/website/content/docs/v0.7/Reference/cli.md
@@ -1400,7 +1400,7 @@ talosctl time [--check server] [flags]
 ### Options
 
 ```
-  -c, --check string   checks server time against specified ntp server (default "pool.ntp.org")
+      --check string   checks server time against specified ntp server (default "c")
   -h, --help           help for time
 ```
 


### PR DESCRIPTION
This was causing the ntp query to always use pool.ntp.org.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
