### PR TITLE
chore: output more logs from the installer

### DIFF
--- a/cmd/installer/cmd/install.go
+++ b/cmd/installer/cmd/install.go
@@ -5,11 +5,14 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 
 	"github.com/talos-systems/talos/cmd/installer/pkg/install"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 // installCmd represents the install command.
@@ -33,6 +36,8 @@ func init() {
 }
 
 func runInstallCmd() (err error) {
+	log.Printf("running Talos installer %s", version.NewVersion().Tag)
+
 	seq := runtime.SequenceInstall
 
 	if options.Upgrade {

--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -580,6 +580,8 @@ func (m *Manifest) SystemMountpoints() (*mount.Points, error) {
 func (m *Manifest) zeroDevice(device Device) (err error) {
 	var bd *blockdevice.BlockDevice
 
+	log.Printf("wiping %q", device.Device)
+
 	if bd, err = blockdevice.Open(device.Device); err != nil {
 		return err
 	}


### PR DESCRIPTION
This will make it more obvious when installer got started, and when it
starts to wipe a disk (which might take some time).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

