### PR TITLE
docs: improve search bar

### DIFF
--- a/website/content/docs/v0.7/Introduction/quickstart.md
+++ b/website/content/docs/v0.7/Introduction/quickstart.md
@@ -33,8 +33,8 @@ Verify that you can reach Kubernetes:
 ```bash
 $ kubectl get nodes -o wide
 NAME                     STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION   CONTAINER-RUNTIME
-talos-default-master-1   Ready    master   115s   v1.19.1   10.5.0.2      <none>        Talos (v0.7.0)   <host kernel>    containerd://1.4.0
-talos-default-worker-1   Ready    <none>   115s   v1.19.1   10.5.0.3      <none>        Talos (v0.7.0)   <host kernel>    containerd://1.4.0
+talos-default-master-1   Ready    master   115s   v1.19.3   10.5.0.2      <none>        Talos (v0.7.0)   <host kernel>    containerd://1.4.1
+talos-default-worker-1   Ready    <none>   115s   v1.19.3   10.5.0.3      <none>        Talos (v0.7.0)   <host kernel>    containerd://1.4.1
 ```
 
 ## Destroy the Cluster

--- a/website/src/components/LayoutHeader.vue
+++ b/website/src/components/LayoutHeader.vue
@@ -2,9 +2,7 @@
   <div class="border-ui-primary w-full">
     <div class="container">
       <div class="flex items-center justify-between -mx-2 sm:-mx-4">
-        <div
-          class="flex flex-row items-center px-2 mr-auto sm:px-4 sm:flex-row"
-        >
+        <div class="flex flex-row items-center px-2 sm:px-4 sm:flex-row">
           <div v-if="$page" class="z-50 p-2 lg:hidden">
             <button
               class="p-2 text-ui-primary rounded-full"
@@ -23,7 +21,10 @@
             </span>
           </g-link>
 
-          <div v-if="settings.nav.links.length > 0" class="ml-2 mr-2 sm:block">
+          <div
+            v-if="settings.nav.links.length > 0"
+            class="lg:ml-8 lg:mr-8 ml-2 mr-2 sm:block"
+          >
             <g-link
               v-for="link in settings.nav.links"
               :key="link.path"
@@ -33,12 +34,6 @@
               {{ link.title }}
             </g-link>
           </div>
-        </div>
-
-        <div class="w-full px-2 sm:px-4 max-w-screen-xs">
-          <ClientOnly>
-            <Search />
-          </ClientOnly>
         </div>
 
         <div class="flex items-center justify-end px-2 sm:px-4">
@@ -122,15 +117,9 @@ import {
   XIcon,
 } from "vue-feather-icons";
 
-const Search = () =>
-  import(
-    /* webpackChunkName: "search" */ "@/components/Search"
-  ).catch((error) => console.warn(error));
-
 export default {
   components: {
     Logo,
-    Search,
     ToggleDarkMode,
     SunIcon,
     MoonIcon,

--- a/website/src/components/Search.vue
+++ b/website/src/components/Search.vue
@@ -81,6 +81,7 @@ query Search {
         id
         path
         title
+        version
         headings {
         	depth
           value
@@ -120,9 +121,11 @@ export default {
     },
     headings() {
       let result = [];
-      const allPages = this.$static.allMarkdownPage.edges.map(
-        (edge) => edge.node
-      );
+      const allPages = this.$static.allMarkdownPage.edges
+        .map((edge) => edge.node)
+        .filter((node) => {
+          return node.version === this.$page.markdownPage.version;
+        });
 
       // Create the array of all headings of all pages.
       allPages.forEach((page) => {
@@ -173,6 +176,8 @@ export default {
       // Unfocus the input and reset the query.
       this.$refs.input.blur();
       this.query = "";
+
+      this.$store.commit("toggleSidebarIsOpen");
     },
   },
 };

--- a/website/src/components/Sidebar.vue
+++ b/website/src/components/Sidebar.vue
@@ -1,7 +1,11 @@
 <template>
   <div ref="sidebar" class="px-4 pt-8 lg:pt-12">
-    <div class="mb-6">
-      <SidebarDropdown />
+    <SidebarDropdown />
+
+    <div class="pr-2 pt-2 pb-10 max-w-lg max-w-screen-xs">
+      <ClientOnly>
+        <Search />
+      </ClientOnly>
     </div>
 
     <div
@@ -34,10 +38,16 @@ query Sidebar {
 import SidebarDropdown from "~/components/SidebarDropdown.vue";
 import SidebarSection from "~/components/SidebarSection.vue";
 
+const Search = () =>
+  import(
+    /* webpackChunkName: "search" */ "@/components/Search"
+  ).catch((error) => console.warn(error));
+
 export default {
   components: {
     SidebarDropdown,
     SidebarSection,
+    Search,
   },
 
   computed: {

--- a/website/src/components/SidebarDropdown.vue
+++ b/website/src/components/SidebarDropdown.vue
@@ -2,7 +2,7 @@
   <div @mouseleave="active = false">
     <button
       @mouseover="active = true"
-      class="font-semibold my-2 rounded inline-flex items-center"
+      class="font-semibold mb-2 rounded inline-flex items-center"
     >
       <span class="mr-1 text-ui-typo">{{ $page.markdownPage.version }}</span>
       <svg

--- a/website/src/layouts/Default.vue
+++ b/website/src/layouts/Default.vue
@@ -268,7 +268,8 @@ table {
 }
 
 .sidebar {
-  @apply fixed bg-ui-background px-4 inset-x-0 bottom-0 w-full border-r border-ui-border overflow-y-auto transition-all z-40;
+  @apply fixed bg-ui-background px-4 inset-x-0 bottom-0 w-full border-r border-ui-border overflow-y-auto transition-all z-50;
+  height: calc(100vh - 80px);
   transform: translateX(-100%);
   top: 5rem;
 
@@ -277,7 +278,7 @@ table {
   }
 
   @screen lg {
-    @apply w-1/4 px-0 bg-transparent top-0 bottom-auto inset-x-auto sticky z-0;
+    @apply w-1/4 px-0 bg-transparent bottom-auto inset-x-auto sticky z-0;
     transform: translateX(0);
   }
 }

--- a/website/src/templates/MarkdownPage.vue
+++ b/website/src/templates/MarkdownPage.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap items-start justify-start">
       <div
         class="order-2 w-full md:w-1/3 sm:pl-4 md:pl-6 lg:pl-8 sticky"
-        style="top: 4rem"
+        style="top: 5rem"
       >
         <OnThisPage />
       </div>


### PR DESCRIPTION
The search bar was taking too much space in the header. This moves it
to the sidebar. The search query now filters based on the current version
of docs.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
