### PR TITLE
test: bump Talos version for upgrade tests, bump Cilium version

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -329,12 +329,12 @@ local integration_provision_tests_prepare = Step("provision-tests-prepare", priv
 local integration_provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[integration_provision_tests_prepare], environment={"REGISTRY": local_registry});
 local integration_provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[integration_provision_tests_prepare], environment={"REGISTRY": local_registry});
 local integration_provision_tests_track_0_cilium = Step("provision-tests-track-0-cilium", target="provision-tests-track-0", privileged=true, depends_on=[integration_provision_tests_track_0], environment={
-        "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.2/install/kubernetes/quick-install.yaml",
+        "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
         "REGISTRY": local_registry,
 });
-local integration_cilium = Step("e2e-cilium-1.8.2", target="e2e-qemu", privileged=true, depends_on=[integration_qemu], environment={
+local integration_cilium = Step("e2e-cilium-1.8.5", target="e2e-qemu", privileged=true, depends_on=[integration_qemu], environment={
         "SHORT_INTEGRATION_TEST": "yes",
-        "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.2/install/kubernetes/quick-install.yaml",
+        "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
         "REGISTRY": local_registry,
 });
 local integration_uefi = Step("e2e-uefi", target="e2e-qemu", privileged=true, depends_on=[integration_cilium], environment={

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.18.4
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.6.2 v0.7.0-alpha.3
+RELEASES ?= v0.6.3 v0.7.0-alpha.3
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -65,7 +65,7 @@ type upgradeSpec struct {
 }
 
 const (
-	stableVersion = "v0.6.2-1-g6fd29ebb"
+	stableVersion = "v0.6.3"
 	nextVersion   = "v0.7.0-alpha.3"
 
 	stableK8sVersion  = "1.19.0"


### PR DESCRIPTION
Use 0.6.3 as upgrade source version, use latest Cilium release.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

