### PR TITLE
feat: allow specifying user-disks in talosctl cluster create

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/show.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/show.go
@@ -83,7 +83,7 @@ func showCluster(cluster provision.Cluster) error {
 
 		disk := "-"
 		if node.DiskSize > 0 {
-			disk = humanize.Bytes(uint64(node.DiskSize))
+			disk = humanize.Bytes(node.DiskSize)
 		}
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -2,6 +2,8 @@
 
 set -eou pipefail
 
+export USER_DISKS_MOUNTS="/var/lib/extra,/var/lib/p1,/var/lib/p2"
+
 source ./hack/test/e2e.sh
 
 PROVISIONER=qemu
@@ -44,6 +46,8 @@ function create_cluster {
     --memory 2048 \
     --cpus 2.0 \
     --cidr 172.20.1.0/24 \
+    --user-disk /var/lib/extra:100MB \
+    --user-disk /var/lib/p1:100MB:/var/lib/p2:100MB \
     --install-image ${REGISTRY:-ghcr.io}/talos-systems/installer:${INSTALLER_TAG} \
     --with-init-node=false \
     --crashdump \

--- a/internal/integration/cli/mounts.go
+++ b/internal/integration/cli/mounts.go
@@ -7,7 +7,9 @@
 package cli
 
 import (
+	"os"
 	"regexp"
+	"strings"
 
 	"github.com/talos-systems/talos/internal/integration/base"
 )
@@ -25,7 +27,21 @@ func (suite *MountsSuite) SuiteName() string {
 // TestSuccess verifies successful execution.
 func (suite *MountsSuite) TestSuccess() {
 	suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNode()},
-		base.StdoutShouldMatch(regexp.MustCompile(`FILESYSTEM`)))
+		base.StdoutShouldMatch(regexp.MustCompile(`(?s)FILESYSTEM.*`)))
+}
+
+// TestUserDisksMounted verifies user disk mounts created.
+func (suite *MountsSuite) TestUserDisksMounted() {
+	paths := os.Getenv("USER_DISKS_MOUNTS")
+
+	if paths == "" {
+		return
+	}
+
+	for _, path := range strings.Split(paths, ",") {
+		suite.RunCLI([]string{"mounts", "--nodes", suite.RandomDiscoveredNode()},
+			base.StdoutShouldMatch(regexp.MustCompile(path)))
+	}
 }
 
 func init() {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -140,7 +140,7 @@ func init() {
 	flag.IntVar(&provision_test.DefaultSettings.MTU, "talos.provision.mtu", provision_test.DefaultSettings.MTU, "MTU to use for cluster network (provision tests only)")
 	flag.Int64Var(&provision_test.DefaultSettings.CPUs, "talos.provision.cpu", provision_test.DefaultSettings.CPUs, "CPU count for each VM (provision tests only)")
 	flag.Int64Var(&provision_test.DefaultSettings.MemMB, "talos.provision.mem", provision_test.DefaultSettings.MemMB, "memory (in MiB) for each VM (provision tests only)")
-	flag.Int64Var(&provision_test.DefaultSettings.DiskGB, "talos.provision.disk", provision_test.DefaultSettings.DiskGB, "disk size (in GiB) for each VM (provision tests only)")
+	flag.Uint64Var(&provision_test.DefaultSettings.DiskGB, "talos.provision.disk", provision_test.DefaultSettings.DiskGB, "disk size (in GiB) for each VM (provision tests only)")
 	flag.IntVar(&provision_test.DefaultSettings.MasterNodes, "talos.provision.masters", provision_test.DefaultSettings.MasterNodes, "master node count (provision tests only)")
 	flag.IntVar(&provision_test.DefaultSettings.WorkerNodes, "talos.provision.workers", provision_test.DefaultSettings.WorkerNodes, "worker node count (provision tests only)")
 	flag.StringVar(&provision_test.DefaultSettings.TargetInstallImageRegistry, "talos.provision.target-installer-registry",

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -33,7 +33,7 @@ type Settings struct {
 	// VM parameters
 	CPUs   int64
 	MemMB  int64
-	DiskGB int64
+	DiskGB uint64
 	// Node count for the tests
 	MasterNodes int
 	WorkerNodes int

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -315,8 +315,12 @@ func (suite *UpgradeSuite) setupCluster() {
 				IP:       ips[i],
 				Memory:   DefaultSettings.MemMB * 1024 * 1024,
 				NanoCPUs: DefaultSettings.CPUs * 1000 * 1000 * 1000,
-				DiskSize: DefaultSettings.DiskGB * 1024 * 1024 * 1024,
-				Config:   suite.configBundle.ControlPlane(),
+				Disks: []*provision.Disk{
+					{
+						Size: DefaultSettings.DiskGB * 1024 * 1024 * 1024,
+					},
+				},
+				Config: suite.configBundle.ControlPlane(),
 			})
 	}
 
@@ -327,8 +331,12 @@ func (suite *UpgradeSuite) setupCluster() {
 				IP:       ips[suite.spec.MasterNodes+i-1],
 				Memory:   DefaultSettings.MemMB * 1024 * 1024,
 				NanoCPUs: DefaultSettings.CPUs * 1000 * 1000 * 1000,
-				DiskSize: DefaultSettings.DiskGB * 1024 * 1024 * 1024,
-				Config:   suite.configBundle.Join(),
+				Disks: []*provision.Disk{
+					{
+						Size: DefaultSettings.DiskGB * 1024 * 1024 * 1024,
+					},
+				},
+				Config: suite.configBundle.Join(),
 			})
 	}
 

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -85,6 +85,7 @@ type Input struct {
 
 	RegistryMirrors map[string]*v1alpha1.RegistryMirrorConfig
 	RegistryConfig  map[string]*v1alpha1.RegistryConfig
+	MachineDisks    []*v1alpha1.MachineDisk
 
 	Debug   bool
 	Persist bool
@@ -332,6 +333,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, opts ...GenOption
 		RegistryConfig:            options.RegistryConfig,
 		Debug:                     options.Debug,
 		Persist:                   options.Persist,
+		MachineDisks:              options.MachineDisks,
 	}
 
 	return input, nil

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -38,6 +38,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			RegistryMirrors: in.RegistryMirrors,
 			RegistryConfig:  in.RegistryConfig,
 		},
+		MachineDisks: in.MachineDisks,
 	}
 
 	certSANs := in.GetAPIServerSANs()

--- a/pkg/machinery/config/types/v1alpha1/generate/join.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/join.go
@@ -39,6 +39,7 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 			RegistryMirrors: in.RegistryMirrors,
 			RegistryConfig:  in.RegistryConfig,
 		},
+		MachineDisks: in.MachineDisks,
 	}
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -144,6 +144,15 @@ func WithArchitecture(arch string) GenOption {
 	}
 }
 
+// WithUserDisks generates user partitions config.
+func WithUserDisks(disks []*v1alpha1.MachineDisk) GenOption {
+	return func(o *GenOptions) error {
+		o.MachineDisks = disks
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
@@ -159,6 +168,7 @@ type GenOptions struct {
 	Architecture              string
 	Debug                     bool
 	Persist                   bool
+	MachineDisks              []*v1alpha1.MachineDisk
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -83,3 +83,8 @@ func (p *provisioner) GetLoadBalancers(networkReq provision.NetworkRequest) (int
 		return "", ""
 	}
 }
+
+// UserDiskName not implemented for docker.
+func (p *provisioner) UserDiskName(index int) string {
+	return ""
+}

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -51,7 +51,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	memSize := nodeReq.Memory / 1024 / 1024
 
-	diskPath, err := p.CreateDisk(state, nodeReq)
+	diskPaths, err := p.CreateDisks(state, nodeReq)
 	if err != nil {
 		return provision.NodeInfo{}, err
 	}
@@ -95,7 +95,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	launchConfig := LaunchConfig{
 		QemuExecutable:    fmt.Sprintf("qemu-system-%s", arch.QemuArch()),
-		DiskPath:          diskPath,
+		DiskPaths:         diskPaths,
 		VCPUCount:         vcpuCount,
 		MemSize:           memSize,
 		KernelArgs:        cmdline.String(),
@@ -174,7 +174,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 		NanoCPUs: nodeReq.NanoCPUs,
 		Memory:   nodeReq.Memory,
-		DiskSize: nodeReq.DiskSize,
+		DiskSize: nodeReq.Disks[0].Size,
 
 		PrivateIP: nodeReq.IP,
 

--- a/pkg/provision/providers/vm/disk.go
+++ b/pkg/provision/providers/vm/disk.go
@@ -11,20 +11,52 @@ import (
 	"github.com/talos-systems/talos/pkg/provision"
 )
 
-// CreateDisk creates an empty disk file.
-func (p *Provisioner) CreateDisk(state *State, nodeReq provision.NodeRequest) (diskPath string, err error) {
-	diskPath = state.GetRelativePath(fmt.Sprintf("%s.disk", nodeReq.Name))
+// UserDiskName returns disk device path.
+func (p *Provisioner) UserDiskName(index int) string {
+	res := "/dev/vd"
 
-	var diskF *os.File
+	var convert func(i int) string
 
-	diskF, err = os.Create(diskPath)
-	if err != nil {
-		return
+	convert = func(i int) string {
+		remainder := i % 26
+		divider := i / 26
+
+		prefix := ""
+
+		if divider != 0 {
+			prefix = convert(divider - 1)
+		}
+
+		return fmt.Sprintf("%s%s", prefix, string(rune('a'+remainder)))
 	}
 
-	defer diskF.Close() //nolint: errcheck
+	return res + convert(index)
+}
 
-	err = diskF.Truncate(nodeReq.DiskSize)
+// CreateDisks creates empty disk files for each disk.
+func (p *Provisioner) CreateDisks(state *State, nodeReq provision.NodeRequest) (diskPaths []string, err error) {
+	diskPaths = make([]string, len(nodeReq.Disks))
+
+	for i, disk := range nodeReq.Disks {
+		diskPath := state.GetRelativePath(fmt.Sprintf("%s-%d.disk", nodeReq.Name, i))
+
+		var diskF *os.File
+
+		diskF, err = os.Create(diskPath)
+		if err != nil {
+			return
+		}
+
+		defer diskF.Close() //nolint: errcheck
+
+		err = diskF.Truncate(int64(disk.Size))
+		diskPaths[i] = diskPath
+	}
+
+	if len(diskPaths) == 0 {
+		err = fmt.Errorf("node request must have at least one disk defined to be used as primary disk")
+		return
+	}
 
 	return
 }

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -25,4 +25,6 @@ type Provisioner interface {
 	GetLoadBalancers(NetworkRequest) (internalEndpoint, externalEndpoint string)
 
 	Close() error
+
+	UserDiskName(index int) string
 }

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
@@ -120,6 +121,14 @@ func (reqs NodeRequests) PXENodes() (nodes []NodeRequest) {
 	return
 }
 
+// Disk represents a disk size and name in NodeRequest.
+type Disk struct {
+	// Size in bytes.
+	Size uint64
+	// Partitions represents the list of partitions.
+	Partitions []*v1alpha1.DiskPartition
+}
+
 // NodeRequest describes a request for a node.
 type NodeRequest struct {
 	Name   string
@@ -130,8 +139,8 @@ type NodeRequest struct {
 	NanoCPUs int64
 	// Memory limit in bytes
 	Memory int64
-	// Disk (volume) size in bytes, if applicable
-	DiskSize int64
+	// Disks (volumes), if applicable
+	Disks []*Disk
 	// Ports
 	Ports []string
 

--- a/pkg/provision/result.go
+++ b/pkg/provision/result.go
@@ -53,7 +53,7 @@ type NodeInfo struct {
 	// Memory limit in bytes
 	Memory int64
 	// Disk (volume) size in bytes, if applicable
-	DiskSize int64
+	DiskSize uint64
 
 	PublicIP  net.IP
 	PrivateIP net.IP

--- a/website/content/docs/v0.7/Reference/cli.md
+++ b/website/content/docs/v0.7/Reference/cli.md
@@ -78,7 +78,7 @@ talosctl cluster create [flags]
       --cpus string                             the share of CPUs as fraction (each container/VM) (default "2.0")
       --crashdump                               print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string                   install custom CNI from the URL (Talos cluster)
-      --disk int                                the limit on disk size in MB (each VM) (default 6144)
+      --disk int                                default limit on disk size in MB (each VM) (default 6144)
       --dns-domain string                       the dns domain to use for cluster (default "cluster.local")
       --docker-host-ip string                   Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
       --endpoint string                         use endpoint instead of provider defaults
@@ -97,6 +97,7 @@ talosctl cluster create [flags]
       --registry-insecure-skip-verify strings   list of registry hostnames to skip TLS verification for
       --registry-mirror strings                 list of registry mirrors to use in format: <registry host>=<mirror URL>
       --skip-kubeconfig                         skip merging kubeconfig from the created cluster
+      --user-disk strings                       list of disks to create for each VM in format: <mount_point1>:<size1>:<mount_point2>:<size2>
       --vmlinuz-path string                     the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")
       --wait                                    wait for the cluster to be ready before returning (default true)
       --wait-timeout duration                   timeout to wait for the cluster to be ready (default 20m0s)


### PR DESCRIPTION
User-disks are supported by QEMU and Firecracker providers.
Can be defined by using the following parameters:
```
--user-disk /mount/path:1GB
```

Can get more than 1 user disk.
Same set of user disks will be created for all master and worker nodes.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>