### PR TITLE
fix: bump type for `DiskSize` to be 64-bit

### DIFF
--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -58,7 +58,7 @@ type Target struct {
 	FileSystemType     FileSystemType
 	LegacyBIOSBootable bool
 
-	Size   uint
+	Size   uint64
 	Force  bool
 	Assets []*Asset
 
@@ -634,7 +634,7 @@ func (t *Target) Partition(pt table.PartitionTable, pos int, bd *blockdevice.Blo
 		opts = append(opts, partition.WithLegacyBIOSBootableAttribute(true))
 	}
 
-	part, err := pt.InsertAt(pos, uint64(t.Size), opts...)
+	part, err := pt.InsertAt(pos, t.Size, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -53,7 +53,7 @@ type Disk interface {
 
 // Partition represents the options for a device partition.
 type Partition interface {
-	Size() uint
+	Size() uint64
 	MountPoint() string
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1043,7 +1043,7 @@ func (d *MachineDisk) Partitions() []config.Partition {
 }
 
 // Size implements the config.Provider interface.
-func (p *DiskPartition) Size() uint {
+func (p *DiskPartition) Size() uint64 {
 	return p.DiskSize
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -866,7 +866,7 @@ type MachineDisk struct {
 type DiskPartition struct {
 	//   description: |
 	//     This size of the partition in bytes.
-	DiskSize uint `yaml:"size,omitempty"`
+	DiskSize uint64 `yaml:"size,omitempty"`
 	//   description:
 	//     Where to mount the partition.
 	DiskMountPoint string `yaml:"mountpoint,omitempty"`

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -681,7 +681,7 @@ func init() {
 	DiskPartitionDoc.Description = ""
 	DiskPartitionDoc.Fields = make([]encoder.Doc, 2)
 	DiskPartitionDoc.Fields[0].Name = "size"
-	DiskPartitionDoc.Fields[0].Type = "uint"
+	DiskPartitionDoc.Fields[0].Type = "uint64"
 	DiskPartitionDoc.Fields[0].Note = ""
 	DiskPartitionDoc.Fields[0].Description = "This size of the partition in bytes."
 	DiskPartitionDoc.Fields[0].Comments[encoder.LineComment] = "This size of the partition in bytes."

--- a/website/content/docs/v0.7/Reference/configuration.md
+++ b/website/content/docs/v0.7/Reference/configuration.md
@@ -1169,7 +1169,7 @@ A list of partitions to create on the disk.
 
 ### size
 
-Type: <code>uint</code>
+Type: <code>uint64</code>
 
 This size of the partition in bytes.
 


### PR DESCRIPTION
Otherwise we're bound with 4GiB partititions.

Discovered by @Unix4ever.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

