### PR TITLE
feat: build talosctl-cni-bundle, use it in talosctl for QEMU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 ARG TOOLS
 ARG IMPORTVET
 ARG PKGS
+ARG EXTRAS
 
 # Resolve package images using ${PKGS} to be used later in COPY --from=.
 
@@ -32,6 +33,10 @@ FROM ghcr.io/talos-systems/util-linux:${PKGS} AS pkg-util-linux
 FROM ghcr.io/talos-systems/util-linux:${PKGS} AS pkg-util-linux
 FROM ghcr.io/talos-systems/kmod:${PKGS} AS pkg-kmod
 FROM ghcr.io/talos-systems/kernel:${PKGS} AS pkg-kernel
+
+# Resolve package images using ${EXTRAS} to be used later in COPY --from=.
+
+FROM ghcr.io/talos-systems/talosctl-cni-bundle-install:${EXTRAS} AS extras-talosctl-cni-bundle-install
 
 # The tools target provides base toolchain for the build.
 
@@ -630,3 +635,9 @@ FROM scratch AS docs
 COPY --from=docs-build /tmp/configuration.md /website/content/docs/v0.7/Reference/
 COPY --from=docs-build /tmp/cli.md /website/content/docs/v0.7/Reference/
 COPY --from=proto-docs-build /tmp/api.md /website/content/docs/v0.7/Reference/
+
+# The talosctl-cni-bundle builds the CNI bundle for talosctl.
+
+FROM scratch AS talosctl-cni-bundle
+ARG TARGETARCH
+COPY --from=extras-talosctl-cni-bundle-install /opt/cni/bin/ /talosctl-cni-bundle-${TARGETARCH}/

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 
 , := ,
+space := $(subst ,, )
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64
 MULTI_PLATFORM = $(findstring $(,),$(PLATFORM))
@@ -180,6 +181,15 @@ boot: ## Creates a compressed tarball that includes vmlinuz-{amd64,arm64} and in
 		arch=`basename "$${platform}"` ; \
 		tar  -C $(ARTIFACTS) --transform=s/-$${arch}// -czf $(ARTIFACTS)/boot-$${arch}.tar.gz vmlinuz-$${arch} initramfs-$${arch}.xz ; \
 	done
+
+.PHONY: talosctl-cni-bundle
+talosctl-cni-bundle: ## Creates a compressed tarball that includes CNI bundle for talosctl.
+	@$(MAKE) local-$@ DEST=$(ARTIFACTS)
+	@for platform in $(subst $(,),$(space),$(PLATFORM)); do \
+		arch=`basename "$${platform}"` ; \
+		tar  -C $(ARTIFACTS)/talosctl-cni-bundle-$${arch} -czf $(ARTIFACTS)/talosctl-cni-bundle-$${arch}.tar.gz . ; \
+	done
+	@rm -rf $(ARTIFACTS)/talosctl-cni-bundle-*/
 
 # Code Quality
 

--- a/cmd/talosctl/cmd/mgmt/cluster/cluster.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/cluster.go
@@ -24,12 +24,16 @@ var (
 	provisionerName string
 	stateDir        string
 	clusterName     string
+
+	defaultStateDir string
+	defaultCNIDir   string
 )
 
 func init() {
-	defaultStateDir, err := clientconfig.GetTalosDirectory()
+	talosDir, err := clientconfig.GetTalosDirectory()
 	if err == nil {
-		defaultStateDir = filepath.Join(defaultStateDir, "clusters")
+		defaultStateDir = filepath.Join(talosDir, "clusters")
+		defaultCNIDir = filepath.Join(talosDir, "cni")
 	}
 
 	Cmd.PersistentFlags().StringVar(&provisionerName, "provisioner", "docker", "Talos cluster provisioner to use")

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/containerd/typeurl v1.0.1
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
+	github.com/coreos/go-iptables v0.4.5
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.12+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
+github.com/coreos/go-iptables v0.4.5 h1:DpHb9vJrZQEFMcVLFKAAGMUVX0XoRC0ptCthinRYm38=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -50,6 +50,7 @@ function create_cluster {
     --user-disk /var/lib/p1:100MB:/var/lib/p2:100MB \
     --install-image ${REGISTRY:-ghcr.io}/talos-systems/installer:${INSTALLER_TAG} \
     --with-init-node=false \
+    --cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
     --crashdump \
     ${REGISTRY_MIRROR_FLAGS} \
     ${QEMU_FLAGS} \

--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -4,6 +4,8 @@
 
 package qemu
 
+import "fmt"
+
 // Arch abstracts away differences between different architectures.
 type Arch string
 
@@ -92,4 +94,9 @@ func (arch Arch) PFlash(uefiEnabled bool) []PFlash {
 	default:
 		return nil
 	}
+}
+
+// QemuExecutable returns name of qemu executable for the arch.
+func (arch Arch) QemuExecutable() string {
+	return fmt.Sprintf("qemu-system-%s", arch.QemuArch())
 }

--- a/pkg/provision/providers/qemu/create.go
+++ b/pkg/provision/providers/qemu/create.go
@@ -30,6 +30,10 @@ func (p *provisioner) Create(ctx context.Context, request provision.ClusterReque
 		return nil, fmt.Errorf("unsupported arch: %q", options.TargetArch)
 	}
 
+	if err := p.preflightChecks(ctx, request, options, arch); err != nil {
+		return nil, err
+	}
+
 	statePath := filepath.Join(request.StateDirectory, request.Name)
 
 	fmt.Fprintf(options.LogWriter, "creating state directory in %q\n", statePath)

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -94,7 +94,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	}
 
 	launchConfig := LaunchConfig{
-		QemuExecutable:    fmt.Sprintf("qemu-system-%s", arch.QemuArch()),
+		QemuExecutable:    arch.QemuExecutable(),
 		DiskPaths:         diskPaths,
 		VCPUCount:         vcpuCount,
 		MemSize:           memSize,

--- a/pkg/provision/providers/qemu/preflight.go
+++ b/pkg/provision/providers/qemu/preflight.go
@@ -1,0 +1,181 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package qemu
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/hashicorp/go-getter"
+
+	"github.com/talos-systems/talos/pkg/cmd"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/provision"
+)
+
+func (p *provisioner) preflightChecks(ctx context.Context, request provision.ClusterRequest, options provision.Options, arch Arch) error {
+	checkContext := preflightCheckContext{
+		request: request,
+		options: options,
+		arch:    arch,
+	}
+
+	for _, check := range []func(ctx context.Context) error{
+		checkContext.verifyRoot,
+		checkContext.checkKVM,
+		checkContext.qemuExecutable,
+		checkContext.checkFlashImages,
+		checkContext.cniDirectories,
+		checkContext.cniBundle,
+		checkContext.checkIptables,
+	} {
+		if err := check(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type preflightCheckContext struct {
+	request provision.ClusterRequest
+	options provision.Options
+	arch    Arch
+}
+
+func (check *preflightCheckContext) verifyRoot(ctx context.Context) error {
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("error: please run as root user (CNI requirement), we recommend running with `sudo -E`")
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) checkKVM(ctx context.Context) error {
+	f, err := os.OpenFile("/dev/kvm", os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("error opening /dev/kvm, please make sure KVM support is enabled in Linux kernel: %w", err)
+	}
+
+	return f.Close()
+}
+
+func (check *preflightCheckContext) qemuExecutable(ctx context.Context) error {
+	if _, err := cmd.Run(check.arch.QemuExecutable(), "--version"); err != nil {
+		return fmt.Errorf("error running QEMU %q, please install QEMU with package manager: %w", check.arch.QemuExecutable(), err)
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) checkFlashImages(ctx context.Context) error {
+	for _, flashImage := range check.arch.PFlash(check.options.UEFIEnabled) {
+		found := false
+
+		for _, path := range flashImage.SourcePaths {
+			_, err := os.Stat(path)
+			if err == nil {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("the required flash image was not found in any of the expected paths for (%q), please install it with the package manager", flashImage.SourcePaths)
+		}
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) cniDirectories(ctx context.Context) error {
+	cniDirs := append(check.request.Network.CNI.BinPath, check.request.Network.CNI.CacheDir, check.request.Network.CNI.ConfDir)
+
+	for _, cniDir := range cniDirs {
+		st, err := os.Stat(cniDir)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("error checking CNI directory %q: %w", cniDir, err)
+			}
+
+			fmt.Printf("creating %q\n", cniDir)
+
+			err = os.MkdirAll(cniDir, 0o777)
+			if err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		if !st.IsDir() {
+			return fmt.Errorf("CNI path %q exists, but it's not a directory", cniDir)
+		}
+	}
+
+	return nil
+}
+
+func (check *preflightCheckContext) cniBundle(ctx context.Context) error {
+	var missing bool
+
+	requiredCNIPlugins := []string{"bridge", "firewall", "static", "tc-redirect-tap"}
+
+	for _, cniPlugin := range requiredCNIPlugins {
+		missing = true
+
+		for _, binPath := range check.request.Network.CNI.BinPath {
+			_, err := os.Stat(filepath.Join(binPath, cniPlugin))
+			if err == nil {
+				missing = false
+
+				break
+			}
+		}
+
+		if missing {
+			break
+		}
+	}
+
+	if !missing {
+		return nil
+	}
+
+	if check.request.Network.CNI.BundleURL == "" {
+		return fmt.Errorf("error: required CNI plugins %q were not found in %q", requiredCNIPlugins, check.request.Network.CNI.BinPath)
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	client := getter.Client{
+		Ctx:  ctx,
+		Src:  strings.ReplaceAll(check.request.Network.CNI.BundleURL, constants.ArchVariable, check.options.TargetArch),
+		Dst:  check.request.Network.CNI.BinPath[0],
+		Pwd:  pwd,
+		Mode: getter.ClientModeDir,
+	}
+
+	fmt.Printf("downloading CNI bundle from %q to %q\n", client.Src, client.Dst)
+
+	return client.Get()
+}
+
+func (check *preflightCheckContext) checkIptables(ctx context.Context) error {
+	_, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("error accessing iptables: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -36,6 +36,8 @@ type CNIConfig struct {
 	BinPath  []string
 	ConfDir  string
 	CacheDir string
+
+	BundleURL string
 }
 
 // NetworkRequest describes cluster network.

--- a/website/content/docs/v0.7/Local Platforms/firecracker.md
+++ b/website/content/docs/v0.7/Local Platforms/firecracker.md
@@ -4,6 +4,8 @@ title: Firecracker
 
 In this guide we will create a Kubernetes cluster using Firecracker.
 
+> Note: Talos on [QEMU](../qemu/) offers easier way to run Talos in a set of VMs.
+
 ## Requirements
 
 - Linux

--- a/website/content/docs/v0.7/Reference/cli.md
+++ b/website/content/docs/v0.7/Reference/cli.md
@@ -72,9 +72,10 @@ talosctl cluster create [flags]
 ```
       --arch string                             cluster architecture (default "amd64")
       --cidr string                             CIDR of the cluster network (default "10.5.0.0/24")
-      --cni-bin-path strings                    search path for CNI binaries (VM only) (default [/opt/cni/bin])
-      --cni-cache-dir string                    CNI cache directory path (VM only) (default "/var/lib/cni")
-      --cni-conf-dir string                     CNI config directory path (VM only) (default "/etc/cni/conf.d")
+      --cni-bin-path strings                    search path for CNI binaries (VM only) (default [/home/user/.talos/cni/bin])
+      --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.7.0-alpha.8/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-cache-dir string                    CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
+      --cni-conf-dir string                     CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
       --cpus string                             the share of CPUs as fraction (each container/VM) (default "2.0")
       --crashdump                               print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string                   install custom CNI from the URL (Talos cluster)


### PR DESCRIPTION
This builds a bundle with CNI plugins for talosctl which is
automatically downloaded by `talosctl` if CNI plugins are missing.

CNI directories are moved by default to the `~/.talos/cni` path.

Also add a bunch of pre-flight checks to the QEMU provisioner to make it
easier to bootstrap the Talos QEMU cluster.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

