### PR TITLE
fix: read/write human readable representations for bytes and octals

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -498,7 +498,7 @@ func getDisks() ([]*provision.Disk, error) {
 			}
 
 			diskPartitions[partitionIndex] = &v1alpha1.DiskPartition{
-				DiskSize:       partitionSize,
+				DiskSize:       v1alpha1.DiskSize(partitionSize),
 				DiskMountPoint: partitionPath,
 			}
 			diskSize += partitionSize

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1013,7 +1013,7 @@ func (f *MachineFile) Content() string {
 
 // Permissions implements the config.Provider interface.
 func (f *MachineFile) Permissions() os.FileMode {
-	return f.FilePermissions
+	return os.FileMode(f.FilePermissions)
 }
 
 // Path implements the config.Provider interface.
@@ -1044,7 +1044,7 @@ func (d *MachineDisk) Partitions() []config.Partition {
 
 // Size implements the config.Provider interface.
 func (p *DiskPartition) Size() uint64 {
-	return p.DiskSize
+	return uint64(p.DiskSize)
 }
 
 // MountPoint implements the config.Provider interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -843,10 +843,14 @@ func init() {
 	}
 	DiskPartitionDoc.Fields = make([]encoder.Doc, 2)
 	DiskPartitionDoc.Fields[0].Name = "size"
-	DiskPartitionDoc.Fields[0].Type = "uint64"
+	DiskPartitionDoc.Fields[0].Type = "DiskSize"
 	DiskPartitionDoc.Fields[0].Note = ""
-	DiskPartitionDoc.Fields[0].Description = "This size of the partition in bytes."
-	DiskPartitionDoc.Fields[0].Comments[encoder.LineComment] = "This size of the partition in bytes."
+	DiskPartitionDoc.Fields[0].Description = "This size of partition: either bytes or human readable representation."
+	DiskPartitionDoc.Fields[0].Comments[encoder.LineComment] = "This size of partition: either bytes or human readable representation."
+
+	DiskPartitionDoc.Fields[0].AddExample("Human readable representation.", DiskSize(100000000))
+
+	DiskPartitionDoc.Fields[0].AddExample("Precise value in bytes.", 1024*1024*1024)
 	DiskPartitionDoc.Fields[1].Name = "mountpoint"
 	DiskPartitionDoc.Fields[1].Type = "string"
 	DiskPartitionDoc.Fields[1].Note = ""

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef
 	github.com/containerd/containerd v1.3.6
 	github.com/containerd/go-cni v1.0.0
+	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/protobuf v1.4.2
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -14,6 +14,8 @@ github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/website/content/docs/v0.7/Reference/configuration.md
+++ b/website/content/docs/v0.7/Reference/configuration.md
@@ -357,8 +357,14 @@ disks:
     - device: /dev/sdb # The name of the disk to use.
       # A list of partitions to create on the disk.
       partitions:
-        - size: 100000000 # This size of the partition in bytes.
-          mountpoint: /var/mnt/extra # Where to mount the partition.
+        - mountpoint: /var/mnt/extra # Where to mount the partition.
+
+          # # This size of partition: either bytes or human readable representation.
+
+          # # Human readable representation.
+          # size: 100 MB
+          # # Precise value in bytes.
+          # size: 1073741824
 ```
 
 
@@ -421,7 +427,7 @@ Examples:
 ``` yaml
 files:
     - content: '...' # The contents of file.
-      permissions: 438 # The file's permissions in octal.
+      permissions: 0o666 # The file's permissions in octal.
       path: /tmp/file.txt # The path of the file.
       op: append # The operation to use
 ```
@@ -2251,8 +2257,14 @@ Appears in:
 - device: /dev/sdb # The name of the disk to use.
   # A list of partitions to create on the disk.
   partitions:
-    - size: 100000000 # This size of the partition in bytes.
-      mountpoint: /var/mnt/extra # Where to mount the partition.
+    - mountpoint: /var/mnt/extra # Where to mount the partition.
+
+      # # This size of partition: either bytes or human readable representation.
+
+      # # Human readable representation.
+      # size: 100 MB
+      # # Precise value in bytes.
+      # size: 1073741824
 ```
 
 <hr />
@@ -2299,12 +2311,26 @@ Appears in:
 
 <div class="dd">
 
-<code>size</code>  <i>uint64</i>
+<code>size</code>  <i>DiskSize</i>
 
 </div>
 <div class="dt">
 
-This size of the partition in bytes.
+This size of partition: either bytes or human readable representation.
+
+
+
+Examples:
+
+
+``` yaml
+size: 100 MB
+```
+
+``` yaml
+size: 1073741824
+```
+
 
 </div>
 
@@ -2336,7 +2362,7 @@ Appears in:
 
 ``` yaml
 - content: '...' # The contents of file.
-  permissions: 438 # The file's permissions in octal.
+  permissions: 0o666 # The file's permissions in octal.
   path: /tmp/file.txt # The path of the file.
   op: append # The operation to use
 ```


### PR DESCRIPTION
Use octal representation to dump FileMode to yaml.
Use 100MB/1GB/1.5TB representations for partitions size, but only if
that doesn't lead to losing precision. Decoding of them should work as
well.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>