### PR TITLE
feat: skip resizing ephemeral partition if not required

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3
 	github.com/talos-systems/crypto v0.2.0
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201027150448-ceae64edb3a5
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201030204209-b4e67d73d70d
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-retry v0.1.1-0.20200922131245-752f081252cf

--- a/go.sum
+++ b/go.sum
@@ -816,8 +816,8 @@ github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3 h1:L
 github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j8UNYE=
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201027150448-ceae64edb3a5 h1:GqMXsflZDjDQn7e92KLVAQq04ApAU6UTnhlyilDcQwo=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201027150448-ceae64edb3a5/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201030204209-b4e67d73d70d h1:sziRi0JYiHhJ6BECcnjLFwARzT9LmJ8CsEhrQvUciDM=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201030204209-b4e67d73d70d/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=


### PR DESCRIPTION
This skips writing partition table if partition doesn't have to be
resized (already resized or max size from the beginning).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

