### PR TITLE
chore: remove unused binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ FROM ghcr.io/talos-systems/musl:${PKGS} AS pkg-musl
 FROM ghcr.io/talos-systems/open-iscsi:${PKGS} AS pkg-open-iscsi
 FROM ghcr.io/talos-systems/open-isns:${PKGS} AS pkg-open-isns
 FROM ghcr.io/talos-systems/runc:${PKGS} AS pkg-runc
-FROM ghcr.io/talos-systems/socat:${PKGS} AS pkg-socat
 FROM ghcr.io/talos-systems/xfsprogs:${PKGS} AS pkg-xfsprogs
 FROM ghcr.io/talos-systems/util-linux:${PKGS} AS pkg-util-linux
 FROM ghcr.io/talos-systems/util-linux:${PKGS} AS pkg-util-linux
@@ -378,7 +377,6 @@ COPY --from=pkg-musl / /rootfs
 COPY --from=pkg-open-iscsi / /rootfs
 COPY --from=pkg-open-isns / /rootfs
 COPY --from=pkg-runc / /rootfs
-COPY --from=pkg-socat / /rootfs
 COPY --from=pkg-xfsprogs / /rootfs
 COPY --from=pkg-util-linux /lib/libblkid.* /rootfs/lib/
 COPY --from=pkg-util-linux /lib/libuuid.* /rootfs/lib/

--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -21,6 +21,8 @@ remove_symlinks
 # Remove any archives as we do not need them since everything is dynamically linked.
 find ${PREFIX} -type f -name \*.a -print0 | xargs -0 rm -rf || true
 find ${PREFIX} -type f -name \*.la -print0 | xargs -0 rm -rf || true
+# Remove static binaries.
+find ${PREFIX} -type f -name \*.static -print0 | xargs -0 rm -rf || true
 # Strip debug symbols from all libraries and binaries.
 find ${PREFIX}/{lib,usr/lib} -type f \( -name \*.so* -a ! -name \*dbg \) -exec strip --strip-unneeded {} ';' || true
 find ${PREFIX}/{bin,sbin,usr/bin,usr/sbin} -type f -exec strip --strip-all {} ';' || true


### PR DESCRIPTION
Removes socat (no dependency in containerd since 1.4), and static binaries.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
