### PR TITLE
fix: prevent blind mode boot

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -46,11 +46,15 @@ set fallback="{{ . }}"
 {{- end }}
 set timeout=0
 
+insmod all_video
+
 terminal_input console
 terminal_output console
 
 {{ range $label := .Labels -}}
 menuentry "{{ $label.Root }}" {
+	set gfxmode=auto
+	set gfxpayload=text
   linux {{ $label.Kernel }} {{ $label.Append }}
   initrd {{ $label.Initrd }}
 }


### PR DESCRIPTION
Adds options to the grub.cfg that prevents booting in blind mode.