### PR TITLE
chore: update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,11 @@ linters:
     - gomnd
     - goerr113
     - nestif
+    - gci
+    - nlreturn
+    - exhaustivestruct
+    - errorlint
+    - wrapcheck
   disable-all: false
   fast: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV PATH /toolchain/bin:/toolchain/go/bin
 RUN ["/toolchain/bin/mkdir", "/bin", "/tmp"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/bin/bash", "/bin/sh"]
 RUN ["/toolchain/bin/ln", "-svf", "/toolchain/etc/ssl", "/etc/ssl"]
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.28.3
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /toolchain/bin v1.32.2
 ARG GOFUMPT_VERSION
 RUN cd $(mktemp -d) \
     && go mod init tmp \

--- a/cmd/installer/cmd/iso.go
+++ b/cmd/installer/cmd/iso.go
@@ -105,21 +105,21 @@ func runISOCmd() error {
 
 	from, err := os.Open(out)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	// nolint: errcheck
 	defer from.Close()
 
 	to, err := os.OpenFile(filepath.Join(outputArg, filepath.Base(out)), os.O_RDWR|os.O_CREATE, 0o666)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	// nolint: errcheck
 	defer to.Close()
 
 	_, err = io.Copy(to, from)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	return nil

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	// AWSExternalIPEndpoint displays all external addresses associated with the instance
+	// AWSExternalIPEndpoint displays all external addresses associated with the instance.
 	AWSExternalIPEndpoint = "http://169.254.169.254/latest/meta-data/public-ipv4"
 	// AWSHostnameEndpoint is the local EC2 endpoint for the hostname.
 	AWSHostnameEndpoint = "http://169.254.169.254/latest/meta-data/hostname"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -28,7 +28,7 @@ import (
 const (
 	// AzureUserDataEndpoint is the local endpoint for the config.
 	// By specifying format=text and drilling down to the actual key we care about
-	// we get a base64 encoded config response
+	// we get a base64 encoded config response.
 	AzureUserDataEndpoint = "http://169.254.169.254/metadata/instance/compute/customData?api-version=2019-06-01&format=text"
 	// AzureHostnameEndpoint is the local endpoint for the hostname.
 	AzureHostnameEndpoint = "http://169.254.169.254/metadata/instance/compute/name?api-version=2019-06-01&format=text"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	// DigitalOceanExternalIPEndpoint displays all external addresses associated with the instance
+	// DigitalOceanExternalIPEndpoint displays all external addresses associated with the instance.
 	DigitalOceanExternalIPEndpoint = "http://169.254.169.254/metadata/v1/interfaces/public/0/ipv4/address"
 	// DigitalOceanHostnameEndpoint is the local endpoint for the hostname.
 	DigitalOceanHostnameEndpoint = "http://169.254.169.254/metadata/v1/hostname"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -22,9 +22,9 @@ import (
 // Ref: https://cloud.google.com/compute/docs/storing-retrieving-metadata
 // ex, curl -H "Metadata-Flavor: Google" 'http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/?recursive=true'
 const (
-	// GCUserDataEndpoint is the local metadata endpoint inside of DO
+	// GCUserDataEndpoint is the local metadata endpoint inside of DO.
 	GCUserDataEndpoint = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/user-data"
-	// GCExternalIPEndpoint displays all external addresses associated with the instance
+	// GCExternalIPEndpoint displays all external addresses associated with the instance.
 	GCExternalIPEndpoint = "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/?recursive=true"
 )
 

--- a/internal/app/machined/pkg/system/runner/restart/restart.go
+++ b/internal/app/machined/pkg/system/runner/restart/restart.go
@@ -41,7 +41,7 @@ func New(wrapRunner runner.Runner, opts ...Option) runner.Runner {
 type Options struct {
 	// Type describes the service's restart policy.
 	Type Type
-	// RestartInterval is the interval between restarts for failed runs
+	// RestartInterval is the interval between restarts for failed runs.
 	RestartInterval time.Duration
 }
 
@@ -54,9 +54,9 @@ type Type int
 const (
 	// Forever will always restart a process.
 	Forever Type = iota
-	// Once will run process exactly once
+	// Once will run process exactly once.
 	Once
-	// UntilSuccess will restart process until run succeeds
+	// UntilSuccess will restart process until run succeeds.
 	UntilSuccess
 )
 

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -33,9 +33,9 @@ import (
 const (
 	// ref: https://tools.ietf.org/html/rfc791
 
-	// MinimumMTU is the lowest allowed MTU for an interface
+	// MinimumMTU is the lowest allowed MTU for an interface.
 	MinimumMTU = 68
-	// MaximumMTU is the highest allowed MTU for an interface
+	// MaximumMTU is the highest allowed MTU for an interface.
 	MaximumMTU = 65536
 )
 

--- a/internal/app/timed/pkg/ntp/options.go
+++ b/internal/app/timed/pkg/ntp/options.go
@@ -13,11 +13,11 @@ import (
 type Option func(*NTP) error
 
 const (
-	// MaxAllowablePoll is the 'recommended' interval for querying a time server
+	// MaxAllowablePoll is the 'recommended' interval for querying a time server.
 	MaxAllowablePoll = 1024
-	// MinAllowablePoll is the minimum time allowed for a client to query a time server
+	// MinAllowablePoll is the minimum time allowed for a client to query a time server.
 	MinAllowablePoll = 4
-	// AdjustTimeLimit is a maximum time drift to compensate via adjtimex()
+	// AdjustTimeLimit is a maximum time drift to compensate via adjtimex().
 	AdjustTimeLimit = 128 * time.Millisecond
 )
 

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	busyboxImage = "docker.io/library/busybox:1.30.1"
-	// busyboxImageDigest = "sha256:64f5d945efcc0f39ab11b3cd4ba403cc9fefe1fa3613123ca016cf3708e8cafb"
-	// pauseImage         = "k8s.gcr.io/pause:3.1"
-	// pauseImageDigest   = "sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e"
+	// busyboxImageDigest = "sha256:64f5d945efcc0f39ab11b3cd4ba403cc9fefe1fa3613123ca016cf3708e8cafb".
+	// pauseImage         = "k8s.gcr.io/pause:3.1".
+	// pauseImageDigest   = "sha256:da86e6ba6ca197bf6bc5e9d900febd906b133eaa4750e6bed647b0fbe50ed43e".
 )
 
 func MockEventSink(state events.ServiceState, message string, args ...interface{}) {

--- a/pkg/machinery/config/decoder/decoder.go
+++ b/pkg/machinery/config/decoder/decoder.go
@@ -22,7 +22,7 @@ var (
 	ErrMissingKind = errors.New("missing kind")
 	// ErrMissingSpec indicates that the manifest is missing a spec.
 	ErrMissingSpec = errors.New("missing spec")
-	// ErrMissingSpecConent indicates that the manifest spec is empty
+	// ErrMissingSpecConent indicates that the manifest spec is empty.
 	ErrMissingSpecConent = errors.New("missing spec content")
 )
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -24,33 +24,33 @@ import (
 )
 
 var (
-	// General
+	// General.
 
-	// ErrRequiredSection denotes a section is required
+	// ErrRequiredSection denotes a section is required.
 	ErrRequiredSection = errors.New("required config section")
-	// ErrInvalidVersion denotes that the config file version is invalid
+	// ErrInvalidVersion denotes that the config file version is invalid.
 	ErrInvalidVersion = errors.New("invalid config version")
 
-	// Security
+	// Security.
 
-	// ErrInvalidCert denotes that the certificate specified is invalid
+	// ErrInvalidCert denotes that the certificate specified is invalid.
 	ErrInvalidCert = errors.New("certificate is invalid")
-	// ErrInvalidCertType denotes that the certificate type is invalid
+	// ErrInvalidCertType denotes that the certificate type is invalid.
 	ErrInvalidCertType = errors.New("certificate type is invalid")
 
-	// Services
+	// Services.
 
-	// ErrUnsupportedCNI denotes that the specified CNI is invalid
+	// ErrUnsupportedCNI denotes that the specified CNI is invalid.
 	ErrUnsupportedCNI = errors.New("unsupported CNI driver")
-	// ErrInvalidTrustdToken denotes that a trustd token has not been specified
+	// ErrInvalidTrustdToken denotes that a trustd token has not been specified.
 	ErrInvalidTrustdToken = errors.New("trustd token is invalid")
 
-	// Networking
+	// Networking.
 
 	// ErrBadAddressing denotes that an incorrect combination of network
-	// address methods have been specified
+	// address methods have been specified.
 	ErrBadAddressing = errors.New("invalid network device addressing method")
-	// ErrInvalidAddress denotes that a bad address was provided
+	// ErrInvalidAddress denotes that a bad address was provided.
 	ErrInvalidAddress = errors.New("invalid network address")
 )
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,10 +13,10 @@ import (
 )
 
 const (
-	// DefaultKernelVersion is the default Linux kernel version
+	// DefaultKernelVersion is the default Linux kernel version.
 	DefaultKernelVersion = "5.8.16-talos"
 
-	// KernelParamConfig is the kernel parameter name for specifying the URL
+	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.
 	KernelParamConfig = "talos.config"
 
@@ -29,14 +29,14 @@ const (
 	KernelParamHostname = "talos.hostname"
 
 	// KernelParamDefaultInterface is the kernel parameter for specifying the
-	// initial interface used to bootstrap the node
+	// initial interface used to bootstrap the node.
 	KernelParamDefaultInterface = "talos.interface"
 
 	// KernelParamShutdown is the kernel parameter for specifying the
-	// shutdown type (halt/poweroff)
+	// shutdown type (halt/poweroff).
 	KernelParamShutdown = "talos.shutdown"
 
-	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos
+	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos.
 	KernelParamNetworkInterfaceIgnore = "talos.network.interface.ignore"
 
 	// KernelParamPanic is the kernel parameter name for specifying the time to wait until rebooting after kernel panic (0 disables reboot).
@@ -134,19 +134,19 @@ const (
 	// KubernetesEtcdPeerKey is the path to the etcd CA private key.
 	KubernetesEtcdPeerKey = EtcdPKIPath + "/" + "peer.key"
 
-	// KubernetesEtcdServerCert defines etcd's server certificate name
+	// KubernetesEtcdServerCert defines etcd's server certificate name.
 	KubernetesEtcdServerCert = EtcdPKIPath + "/" + "client.crt"
 
-	// KubernetesEtcdServerKey defines etcd's server key name
+	// KubernetesEtcdServerKey defines etcd's server key name.
 	KubernetesEtcdServerKey = EtcdPKIPath + "/" + "client.key"
 
-	// KubernetesEtcdListenClientPort defines the port etcd listen on for client traffic
+	// KubernetesEtcdListenClientPort defines the port etcd listen on for client traffic.
 	KubernetesEtcdListenClientPort = "2379"
 
-	// KubernetesAPIServerEtcdClientCert defines apiserver's etcd client certificate name
+	// KubernetesAPIServerEtcdClientCert defines apiserver's etcd client certificate name.
 	KubernetesAPIServerEtcdClientCert = DefaultCertificatesDir + "/" + "apiserver-etcd-client.crt"
 
-	// KubernetesAPIServerEtcdClientKey defines apiserver's etcd client key name
+	// KubernetesAPIServerEtcdClientKey defines apiserver's etcd client key name.
 	KubernetesAPIServerEtcdClientKey = DefaultCertificatesDir + "/" + "apiserver-etcd-client.key"
 
 	// KubernetesAdminCertCommonName defines CN property of Kubernetes admin certificate.
@@ -207,10 +207,10 @@ const (
 	// DefaultEtcdVersion is the default target version of etcd.
 	DefaultEtcdVersion = "v3.4.12"
 
-	// EtcdRootTalosKey is the root etcd key for Talos-specific storage
+	// EtcdRootTalosKey is the root etcd key for Talos-specific storage.
 	EtcdRootTalosKey = "talos:v1"
 
-	// EtcdTalosEtcdUpgradeMutex is the etcd mutex prefix to be used to set an etcd upgrade lock
+	// EtcdTalosEtcdUpgradeMutex is the etcd mutex prefix to be used to set an etcd upgrade lock.
 	EtcdTalosEtcdUpgradeMutex = EtcdRootTalosKey + ":etcdUpgradeMutex"
 
 	// EtcdImage is the reposistory for the etcd image.
@@ -300,7 +300,7 @@ const (
 	// InitramfsAssetPath is the path to the initramfs on disk.
 	InitramfsAssetPath = "/usr/install/" + InitramfsAsset
 
-	// RootfsAsset defines a well known name for our rootfs filename
+	// RootfsAsset defines a well known name for our rootfs filename.
 	RootfsAsset = "rootfs.sqsh"
 
 	// DefaultCertificateValidityDuration is the default duration for a certificate.

--- a/pkg/sysctl/sysctl.go
+++ b/pkg/sysctl/sysctl.go
@@ -28,5 +28,5 @@ func ReadSystemProperty(prop *SystemProperty) ([]byte, error) {
 
 // Path returns the path to the systctl file under /proc/sys.
 func (prop *SystemProperty) Path() string {
-	return path.Join("/proc/sys", strings.Replace(prop.Key, ".", "/", -1))
+	return path.Join("/proc/sys", strings.ReplaceAll(prop.Key, ".", "/"))
 }


### PR DESCRIPTION
Brings in the latest version of golangci-lint and addresses errors.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
