### PR TITLE
feat: upgrade kernel to v5.9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-7-g08245ac
-PKGS ?= v0.3.0-22-g8434031
+PKGS ?= v0.3.0-23-gfe414af
 EXTRAS ?= v0.1.0-1-g1f7642a
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.8.16-talos"
+	DefaultKernelVersion = "5.9.3-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This PR brings in an upgraded pkgs version that contains https://github.com/talos-systems/pkgs/commit/fe414af3b4779196a18b5bc401003deba081e456