### PR TITLE
chore: enable gci linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,8 @@ linters-settings:
     simple: true
     range-loops: true # Report preallocation suggestions on range loops, true by default
     for-loops: false # Report preallocation suggestions on for loops, false by default
+  gci:
+    local-prefixes: github.com/talos-systems/talos
 
 linters:
   enable-all: true
@@ -122,7 +124,6 @@ linters:
     - gomnd
     - goerr113
     - nestif
-    - gci
     - exhaustivestruct
     - errorlint
     - wrapcheck

--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -17,13 +17,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/talos-systems/go-retry/retry"
-	"golang.org/x/sys/unix"
-
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/table"
 	"github.com/talos-systems/go-blockdevice/blockdevice/table/gpt/partition"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util"
+	"github.com/talos-systems/go-retry/retry"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/mount"

--- a/cmd/installer/pkg/install/manifest_test.go
+++ b/cmd/installer/pkg/install/manifest_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/loopback"
 	"github.com/talos-systems/go-blockdevice/blockdevice/table/gpt/partition"

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -20,9 +20,8 @@ import (
 
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
-
 	talosnet "github.com/talos-systems/net"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"
 	"github.com/talos-systems/talos/internal/pkg/kubeconfig"

--- a/cmd/talosctl/cmd/mgmt/gen.go
+++ b/cmd/talosctl/cmd/mgmt/gen.go
@@ -5,6 +5,7 @@
 package mgmt
 
 import (
+	stdlibx509 "crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
@@ -13,10 +14,7 @@ import (
 	"strings"
 	"time"
 
-	stdlibx509 "crypto/x509"
-
 	"github.com/spf13/cobra"
-
 	"github.com/talos-systems/crypto/x509"
 
 	"github.com/talos-systems/talos/pkg/cli"

--- a/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
+++ b/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-
 	"github.com/talos-systems/go-loadbalancer/loadbalancer"
 )
 

--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -11,11 +11,10 @@ import (
 	"os"
 	"text/tabwriter"
 
+	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	humanize "github.com/dustin/go-humanize"
 
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"

--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -14,10 +14,9 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/talos-systems/talos/internal/pkg/kubeconfig"

--- a/cmd/talosctl/pkg/talos/helpers/helpers_test.go
+++ b/cmd/talosctl/pkg/talos/helpers/helpers_test.go
@@ -8,9 +8,8 @@ import (
 	"os"
 	"testing"
 
-	yaml "gopkg.in/yaml.v3"
-
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
 )

--- a/internal/app/apid/pkg/backend/apid.go
+++ b/internal/app/apid/pkg/backend/apid.go
@@ -10,13 +10,12 @@ import (
 	"sync"
 
 	"github.com/talos-systems/grpc-proxy/proxy"
+	"github.com/talos-systems/net"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/machinery/api/common"
 	"github.com/talos-systems/talos/pkg/machinery/constants"

--- a/internal/app/apid/pkg/provider/tls.go
+++ b/internal/app/apid/pkg/provider/tls.go
@@ -6,14 +6,12 @@
 package provider
 
 import (
-	"fmt"
-
 	stdlibtls "crypto/tls"
+	"fmt"
 	stdlibnet "net"
 
-	"github.com/talos-systems/net"
-
 	"github.com/talos-systems/crypto/tls"
+	"github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/grpc/gen"
 	"github.com/talos-systems/talos/pkg/machinery/config"

--- a/internal/app/bootkube/assets.go
+++ b/internal/app/bootkube/assets.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/kubernetes-sigs/bootkube/pkg/tlsutil"
 	"github.com/talos-systems/bootkube-plugin/pkg/asset"
-
 	tnet "github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/internal/app/bootkube/images"

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -13,9 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/talos-systems/go-procfs/procfs"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/internal/pkg/mount"

--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -17,9 +17,8 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
-
 	"github.com/talos-systems/go-procfs/procfs"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/internal/pkg/kmsg"

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
@@ -9,12 +9,11 @@ import (
 	"fmt"
 	"strings"
 
-	clusterapi "github.com/talos-systems/talos/pkg/machinery/api/cluster"
-	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
-
 	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/cluster/check"
 	"github.com/talos-systems/talos/pkg/conditions"
+	clusterapi "github.com/talos-systems/talos/pkg/machinery/api/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
 // HealthCheck implements the cluster.ClusterServer interface.

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -16,10 +16,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/talos-systems/go-procfs/procfs"
 	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/sys/unix"
-
-	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1"

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/syslinux/syslinux.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/syslinux/syslinux.go
@@ -16,12 +16,12 @@ import (
 	"regexp"
 	"text/template"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader"
 	"github.com/talos-systems/talos/pkg/cmd"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
-
-	"golang.org/x/sys/unix"
 )
 
 const syslinuxCfgTpl = `DEFAULT {{ .Default }}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/fullsailor/pkcs7"
-
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -13,12 +13,10 @@ import (
 	"net/url"
 	"path/filepath"
 
-	"golang.org/x/sys/unix"
-
+	"github.com/talos-systems/go-blockdevice/blockdevice/probe"
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-smbios/smbios"
-
-	"github.com/talos-systems/go-blockdevice/blockdevice/probe"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -14,10 +14,9 @@ import (
 	"log"
 	"net"
 
+	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/vmware/vmw-guestinfo/rpcvmx"
 	"github.com/vmware/vmw-guestinfo/vmcheck"
-
-	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/constants"

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -23,17 +23,15 @@ import (
 	"text/template"
 	"time"
 
-	"go.etcd.io/etcd/clientv3"
-	"golang.org/x/sys/unix"
-	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
-
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/talos-systems/go-procfs/procfs"
-	"github.com/talos-systems/go-retry/retry"
-
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/table"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util"
+	"github.com/talos-systems/go-procfs/procfs"
+	"github.com/talos-systems/go-retry/retry"
+	"go.etcd.io/etcd/clientv3"
+	"golang.org/x/sys/unix"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
 	installer "github.com/talos-systems/talos/cmd/installer/pkg/install"
 	"github.com/talos-systems/talos/internal/app/machined/internal/install"

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
@@ -9,9 +9,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sync"
-
 	stdlibruntime "runtime"
+	"sync"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/talos-systems/go-retry/retry"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"

--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -15,10 +15,9 @@ import (
 
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/talos-systems/go-retry/retry"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
-
-	"github.com/talos-systems/go-retry/retry"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -6,28 +6,26 @@ package services
 
 import (
 	"context"
+	stdlibx509 "crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	stdlibnet "net"
 	"os"
 	goruntime "runtime"
 	"strings"
 	"time"
 
-	stdlibx509 "crypto/x509"
-	stdlibnet "net"
-
 	containerdapi "github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"go.etcd.io/etcd/clientv3"
-
 	"github.com/talos-systems/crypto/x509"
 	"github.com/talos-systems/go-retry/retry"
 	"github.com/talos-systems/net"
+	"go.etcd.io/etcd/clientv3"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader"

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -24,11 +24,10 @@ import (
 	criconstants "github.com/containerd/cri/pkg/constants"
 	cni "github.com/containerd/go-cni"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	tnet "github.com/talos-systems/net"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	kubeletconfig "k8s.io/kubelet/config/v1beta1"
-
-	tnet "github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"

--- a/internal/app/networkd/pkg/address/dhcp.go
+++ b/internal/app/networkd/pkg/address/dhcp.go
@@ -14,9 +14,8 @@ import (
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/nclient4"
-	"golang.org/x/sys/unix"
-
 	"github.com/talos-systems/go-procfs/procfs"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/constants"

--- a/internal/app/networkd/pkg/networkd/misc.go
+++ b/internal/app/networkd/pkg/networkd/misc.go
@@ -14,9 +14,8 @@ import (
 	"text/template"
 
 	"github.com/jsimonetti/rtnetlink"
-	"golang.org/x/sys/unix"
-
 	talosnet "github.com/talos-systems/net"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
 )

--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -17,10 +17,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/talos-systems/go-procfs/procfs"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform"

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -20,11 +20,10 @@ import (
 	"github.com/jsimonetti/rtnetlink"
 	"github.com/jsimonetti/rtnetlink/rtnl"
 	"github.com/mdlayher/netlink"
-	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-retry/retry"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/address"
 	"github.com/talos-systems/talos/pkg/machinery/constants"

--- a/internal/app/routerd/main.go
+++ b/internal/app/routerd/main.go
@@ -7,9 +7,8 @@ package main
 import (
 	"log"
 
-	"google.golang.org/grpc"
-
 	"github.com/talos-systems/grpc-proxy/proxy"
+	"google.golang.org/grpc"
 
 	"github.com/talos-systems/talos/internal/app/routerd/pkg/director"
 	"github.com/talos-systems/talos/pkg/grpc/factory"

--- a/internal/app/routerd/pkg/director/director.go
+++ b/internal/app/routerd/pkg/director/director.go
@@ -10,11 +10,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/talos-systems/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/talos-systems/grpc-proxy/proxy"
 )
 
 // Router wraps grpc-proxy StreamDirector.

--- a/internal/app/routerd/pkg/director/director_test.go
+++ b/internal/app/routerd/pkg/director/director_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"google.golang.org/grpc/metadata"
-
 	"github.com/talos-systems/grpc-proxy/proxy"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/talos-systems/talos/internal/app/routerd/pkg/director"
 )

--- a/internal/app/trustd/internal/reg/reg.go
+++ b/internal/app/trustd/internal/reg/reg.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"path"
 
-	"google.golang.org/grpc"
-
 	"github.com/talos-systems/crypto/x509"
+	"google.golang.org/grpc"
 
 	securityapi "github.com/talos-systems/talos/pkg/machinery/api/security"
 	"github.com/talos-systems/talos/pkg/machinery/config"

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -7,15 +7,12 @@ package main
 import (
 	"flag"
 	"log"
-
 	stdlibnet "net"
 
+	"github.com/talos-systems/crypto/tls"
+	"github.com/talos-systems/net"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-
-	"github.com/talos-systems/net"
-
-	"github.com/talos-systems/crypto/tls"
 
 	"github.com/talos-systems/talos/internal/app/trustd/internal/reg"
 	"github.com/talos-systems/talos/pkg/grpc/factory"

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
 	"github.com/talos-systems/crypto/x509"
 
 	"github.com/talos-systems/talos/internal/pkg/containers/cri/containerd"

--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -12,15 +12,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/talos-systems/crypto/x509"
+	"github.com/talos-systems/net"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes"
 	"go.etcd.io/etcd/etcdserver/etcdserverpb"
 	"go.etcd.io/etcd/pkg/transport"
 	"google.golang.org/grpc"
-
-	"github.com/talos-systems/crypto/x509"
-
-	"github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/pkg/kubernetes"

--- a/internal/pkg/kernel/kspp/kspp.go
+++ b/internal/pkg/kernel/kspp/kspp.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
-
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/pkg/sysctl"

--- a/internal/pkg/kubeconfig/admin_test.go
+++ b/internal/pkg/kubeconfig/admin_test.go
@@ -12,9 +12,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/talos-systems/crypto/x509"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/talos-systems/talos/internal/pkg/kubeconfig"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -13,11 +13,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/talos-systems/go-retry/retry"
-	"golang.org/x/sys/unix"
-
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util"
+	"github.com/talos-systems/go-retry/retry"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/makefs"

--- a/internal/pkg/mount/system.go
+++ b/internal/pkg/mount/system.go
@@ -8,9 +8,8 @@ import (
 	"fmt"
 	"log"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/talos-systems/go-blockdevice/blockdevice/probe"
+	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )

--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -11,14 +11,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/talos-systems/go-retry/retry"
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/talos-systems/go-retry/retry"
 
 	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/constants"

--- a/pkg/grpc/factory/factory.go
+++ b/pkg/grpc/factory/factory.go
@@ -15,10 +15,9 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"google.golang.org/grpc"
-
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"google.golang.org/grpc"
 
 	grpclog "github.com/talos-systems/talos/pkg/grpc/middleware/log"
 )

--- a/pkg/grpc/gen/remote.go
+++ b/pkg/grpc/gen/remote.go
@@ -11,9 +11,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"google.golang.org/grpc"
-
 	"github.com/talos-systems/crypto/x509"
+	"google.golang.org/grpc"
 
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	securityapi "github.com/talos-systems/talos/pkg/machinery/api/security"

--- a/pkg/grpc/middleware/auth/basic/basic.go
+++ b/pkg/grpc/middleware/auth/basic/basic.go
@@ -8,10 +8,9 @@ import (
 	"crypto/tls"
 	"fmt"
 
+	"github.com/talos-systems/net"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-
-	"github.com/talos-systems/net"
 )
 
 // Credentials describes an authorization method.

--- a/pkg/grpc/proxy/backend/local_test.go
+++ b/pkg/grpc/proxy/backend/local_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/metadata"
-
 	"github.com/talos-systems/grpc-proxy/proxy"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/talos-systems/talos/pkg/grpc/proxy/backend"
 )

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -6,6 +6,7 @@ package kubernetes
 
 import (
 	"context"
+	stdlibx509 "crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -15,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	stdlibx509 "crypto/x509"
-
+	"github.com/talos-systems/crypto/x509"
+	"github.com/talos-systems/go-retry/retry"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,9 +28,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/talos-systems/crypto/x509"
-	"github.com/talos-systems/go-retry/retry"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -19,15 +19,13 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	grpctls "github.com/talos-systems/crypto/tls"
+	"github.com/talos-systems/net"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
-
-	grpctls "github.com/talos-systems/crypto/tls"
-
-	"github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	clusterapi "github.com/talos-systems/talos/pkg/machinery/api/cluster"

--- a/pkg/machinery/client/resolver.go
+++ b/pkg/machinery/client/resolver.go
@@ -9,9 +9,8 @@ import (
 	"math/rand"
 	"strings"
 
-	"google.golang.org/grpc/resolver"
-
 	"github.com/talos-systems/net"
+	"google.golang.org/grpc/resolver"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )

--- a/pkg/machinery/config/encoder/encoder_test.go
+++ b/pkg/machinery/config/encoder/encoder_test.go
@@ -7,9 +7,8 @@ package encoder_test
 import (
 	"testing"
 
-	yaml "gopkg.in/yaml.v3"
-
 	"github.com/stretchr/testify/suite"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 )

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -7,16 +7,14 @@ package generate
 import (
 	"bufio"
 	"crypto/rand"
+	stdlibx509 "crypto/x509"
 	"encoding/pem"
 	"errors"
 	"net"
 	"net/url"
 	"time"
 
-	stdlibx509 "crypto/x509"
-
 	"github.com/talos-systems/crypto/x509"
-
 	tnet "github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/machinery/config/internal/cis"

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/talos-systems/crypto/x509"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -13,9 +13,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/hashicorp/go-multierror"
-
 	valid "github.com/asaskevich/govalidator"
+	"github.com/hashicorp/go-multierror"
 	talosnet "github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"

--- a/pkg/provision/providers/firecracker/node.go
+++ b/pkg/provision/providers/firecracker/node.go
@@ -18,9 +18,8 @@ import (
 	firecracker "github.com/firecracker-microvm/firecracker-go-sdk"
 	models "github.com/firecracker-microvm/firecracker-go-sdk/client/models"
 	multierror "github.com/hashicorp/go-multierror"
-	"k8s.io/apimachinery/pkg/util/json"
-
 	"github.com/talos-systems/go-procfs/procfs"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/provision"

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/google/uuid"
-
 	"github.com/talos-systems/go-blockdevice/blockdevice/table/gpt"
 
 	"github.com/talos-systems/talos/pkg/provision"

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -20,13 +20,12 @@ import (
 
 	"github.com/google/uuid"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers/vm"
-
-	"github.com/talos-systems/go-procfs/procfs"
 )
 
 //nolint: gocyclo

--- a/pkg/provision/providers/vm/network.go
+++ b/pkg/provision/providers/vm/network.go
@@ -18,7 +18,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/google/uuid"
 	"github.com/jsimonetti/rtnetlink"
-
 	talosnet "github.com/talos-systems/net"
 
 	"github.com/talos-systems/talos/pkg/provision"

--- a/pkg/provision/providers/vm/state.go
+++ b/pkg/provision/providers/vm/state.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
-	yaml "gopkg.in/yaml.v3"
-
 	"github.com/containernetworking/cni/libcni"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/talos-systems/talos/pkg/provision"
 )

--- a/pkg/startup/rand.go
+++ b/pkg/startup/rand.go
@@ -5,11 +5,10 @@
 package startup
 
 import (
+	cryptorand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math/rand"
-
-	cryptorand "crypto/rand"
 )
 
 // RandSeed default math/rand PRNG.


### PR DESCRIPTION
Fixes were applied automatically.

Import ordering might be questionable, but it's strict:

* stdlib
* other packages
* same package imports

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
