### PR TITLE
fix: r8169 driver, Go 1.15.4, maintenance service API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,10 @@ COPY --from=generate /pkg/machinery/api ./pkg/machinery/api
 COPY --from=generate /pkg/machinery/config ./pkg/machinery/config
 RUN go list -mod=readonly all >/dev/null
 RUN ! go mod tidy -v 2>&1 | grep .
+WORKDIR /src/pkg/machinery
+RUN go list -mod=readonly all >/dev/null
+RUN ! go mod tidy -v 2>&1 | grep .
+WORKDIR /src
 
 # The init target builds the init binary.
 
@@ -579,7 +583,7 @@ RUN --mount=type=cache,target=/.cache/go-build --mount=type=cache,target=/.cache
 WORKDIR /src/pkg/machinery
 RUN --mount=type=cache,target=/.cache/go-build --mount=type=cache,target=/.cache/golangci-lint golangci-lint run --config ../../.golangci.yml
 WORKDIR /src
-# RUN --mount=type=cache,target=/.cache/go-build importvet github.com/talos-systems/talos/...
+RUN --mount=type=cache,target=/.cache/go-build importvet github.com/talos-systems/talos/...
 RUN find . -name '*.pb.go' | xargs rm
 RUN FILES="$(gofumports -l -local github.com/talos-systems/talos .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumports -w -local github.com/talos-systems/talos .':\n${FILES}"; exit 1)
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-7-g08245ac
-PKGS ?= v0.3.0-23-gfe414af
-EXTRAS ?= v0.1.0-1-g1f7642a
+TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-8-ge86a8f3
+PKGS ?= v0.3.0-25-g27d43d0
+EXTRAS ?= v0.1.0-2-g709d580
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 IMPORTVET ?= autonomy/importvet:f6b07d9

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -113,35 +113,8 @@ func genV1Alpha1Config(args []string) error {
 		return fmt.Errorf("failed to generate config bundle: %w", err)
 	}
 
-	for _, t := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin} {
-		name := strings.ToLower(t.String()) + ".yaml"
-		fullFilePath := filepath.Join(outputDir, name)
-
-		var configString string
-
-		switch t { //nolint: exhaustive
-		case machine.TypeInit:
-			configString, err = configBundle.Init().String()
-			if err != nil {
-				return err
-			}
-		case machine.TypeControlPlane:
-			configString, err = configBundle.ControlPlane().String()
-			if err != nil {
-				return err
-			}
-		case machine.TypeJoin:
-			configString, err = configBundle.Join().String()
-			if err != nil {
-				return err
-			}
-		}
-
-		if err = ioutil.WriteFile(fullFilePath, []byte(configString), 0o644); err != nil {
-			return err
-		}
-
-		fmt.Printf("created %s\n", fullFilePath)
+	if err = configBundle.Write(outputDir, machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin); err != nil {
+		return err
 	}
 
 	// We set the default endpoint to localhost for configs generated, with expectation user will tweak later

--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -6,6 +6,7 @@ package talos
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 
@@ -47,9 +48,9 @@ var applyConfigCmd = &cobra.Command{
 				return fmt.Errorf("insecure mode requires one and only one node, got %d", len(Nodes))
 			}
 
-			addr := Nodes[0]
-
-			c, err := client.NewInsecureTokenClient(ctx, addr)
+			c, err := client.New(ctx, client.WithTLSConfig(&tls.Config{
+				InsecureSkipVerify: true,
+			}), client.WithEndpoints(Nodes...))
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/vmware/vmw-guestinfo v0.0.0-20200218095840-687661b8bd8e
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200819165624-17cef6e3e9d5 // v3.4.10
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
-	golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
 	golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13

--- a/go.sum
+++ b/go.sum
@@ -996,8 +996,8 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 h1:5kGOVHlq0euqwzgTC9Vu15p6fV1Wi0ArVi8da2urnVg=
-golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/internal/app/maintenance/main.go
+++ b/internal/app/maintenance/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/maintenance/server"
 	"github.com/talos-systems/talos/pkg/grpc/factory"
 	"github.com/talos-systems/talos/pkg/grpc/gen"
-	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
@@ -42,13 +41,9 @@ func Run(ctx context.Context, logger *log.Logger, r runtime.Runtime) ([]byte, er
 	s := server.New(r, logger, cfgCh)
 
 	// Start the server.
-
-	creds := basic.NewTokenCredentials("")
-
 	server := factory.NewServer(
 		s,
 		factory.WithDefaultLog(),
-		factory.WithUnaryInterceptor(creds.UnaryInterceptor()),
 		factory.ServerOptions(
 			grpc.Creds(
 				credentials.NewTLS(tlsConfig),

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -312,6 +312,7 @@ func (suite *UpgradeSuite) setupCluster() {
 		request.Nodes = append(request.Nodes,
 			provision.NodeRequest{
 				Name:     fmt.Sprintf("master-%d", i+1),
+				Type:     machine.TypeControlPlane,
 				IP:       ips[i],
 				Memory:   DefaultSettings.MemMB * 1024 * 1024,
 				NanoCPUs: DefaultSettings.CPUs * 1000 * 1000 * 1000,
@@ -328,6 +329,7 @@ func (suite *UpgradeSuite) setupCluster() {
 		request.Nodes = append(request.Nodes,
 			provision.NodeRequest{
 				Name:     fmt.Sprintf("worker-%d", i),
+				Type:     machine.TypeJoin,
 				IP:       ips[suite.spec.MasterNodes+i-1],
 				Memory:   DefaultSettings.MemMB * 1024 * 1024,
 				NanoCPUs: DefaultSettings.CPUs * 1000 * 1000 * 1000,

--- a/pkg/grpc/middleware/auth/basic/token.go
+++ b/pkg/grpc/middleware/auth/basic/token.go
@@ -48,11 +48,9 @@ func (b *TokenCredentials) authorize(ctx context.Context) error {
 		if len(md["token"]) > 0 && md["token"][0] == b.Token {
 			return nil
 		}
-
-		return fmt.Errorf("%s", codes.Unauthenticated.String())
 	}
 
-	return nil
+	return fmt.Errorf("%s", codes.Unauthenticated.String())
 }
 
 // UnaryInterceptor sets the UnaryServerInterceptor for the server and enforces

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/talos-systems/net"
 
-	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	clusterapi "github.com/talos-systems/talos/pkg/machinery/api/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/api/common"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -146,24 +145,6 @@ func New(ctx context.Context, opts ...OptionFunc) (c *Client, err error) {
 	c.TimeClient = timeapi.NewTimeServiceClient(c.conn)
 	c.NetworkClient = networkapi.NewNetworkServiceClient(c.conn)
 	c.ClusterClient = clusterapi.NewClusterServiceClient(c.conn)
-
-	return c, nil
-}
-
-// NewInsecureTokenClient returns a new Client configured with an empty basic
-// token credentials.
-func NewInsecureTokenClient(ctx context.Context, addr string, opts ...grpc.DialOption) (c *Client, err error) {
-	c = new(Client)
-
-	addr = net.FormatAddress(addr)
-
-	creds := basic.NewTokenCredentials("")
-
-	c.conn, err = basic.NewConnection(addr, constants.ApidPort, creds)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client connection: %w", err)
-	}
-
 	c.MaintenanceServiceClient = machineapi.NewMaintenanceServiceClient(c.conn)
 
 	return c, nil

--- a/pkg/provision/providers/firecracker/node.go
+++ b/pkg/provision/providers/firecracker/node.go
@@ -92,8 +92,18 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	// Talos config
 	cmdline.Append("talos.platform", "metal")
-	cmdline.Append("talos.config", "{TALOS_CONFIG_URL}") // to be patched by launcher
 	cmdline.Append("talos.hostname", nodeReq.Name)
+
+	var nodeConfig string
+
+	if nodeReq.Config != nil {
+		cmdline.Append("talos.config", "{TALOS_CONFIG_URL}") // to be patched by launcher
+
+		nodeConfig, err = nodeReq.Config.String()
+		if err != nil {
+			return provision.NodeInfo{}, err
+		}
+	}
 
 	ones, _ := clusterReq.Network.CIDR.Mask.Size()
 
@@ -145,11 +155,6 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	defer logFile.Close() //nolint: errcheck
 
-	nodeConfig, err := nodeReq.Config.String()
-	if err != nil {
-		return provision.NodeInfo{}, err
-	}
-
 	launchConfig := LaunchConfig{
 		FirecrackerConfig:   cfg,
 		Config:              nodeConfig,
@@ -193,7 +198,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	nodeInfo := provision.NodeInfo{
 		ID:   pidPath,
 		Name: nodeReq.Name,
-		Type: nodeReq.Config.Machine().Type(),
+		Type: nodeReq.Type,
 
 		NanoCPUs: nodeReq.NanoCPUs,
 		Memory:   nodeReq.Memory,

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/uuid"
 	multierror "github.com/hashicorp/go-multierror"
 
-	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers/vm"
@@ -75,11 +74,12 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	// Talos config
 	cmdline.Append("talos.platform", "metal")
-	cmdline.Append("talos.config", "{TALOS_CONFIG_URL}") // to be patched by launcher
 
 	var nodeConfig string
 
 	if nodeReq.Config != nil {
+		cmdline.Append("talos.config", "{TALOS_CONFIG_URL}") // to be patched by launcher
+
 		nodeConfig, err = nodeReq.Config.String()
 		if err != nil {
 			return provision.NodeInfo{}, err
@@ -161,16 +161,11 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	// no need to wait here, as cmd has all the Stdin/out/err via *os.File
 
-	nodeType := machine.TypeUnknown
-	if nodeReq.Config != nil {
-		nodeType = nodeReq.Config.Machine().Type()
-	}
-
 	nodeInfo := provision.NodeInfo{
 		ID:   pidPath,
 		UUID: nodeUUID,
 		Name: nodeReq.Name,
-		Type: nodeType,
+		Type: nodeReq.Type,
 
 		NanoCPUs: nodeReq.NanoCPUs,
 		Memory:   nodeReq.Memory,

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -85,11 +85,7 @@ func (reqs NodeRequests) FindInitNode() (req NodeRequest, err error) {
 // MasterNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Config == nil {
-			continue
-		}
-
-		if reqs[i].Config.Machine().Type() == machine.TypeInit || reqs[i].Config.Machine().Type() == machine.TypeControlPlane {
+		if reqs[i].Type == machine.TypeInit || reqs[i].Type == machine.TypeControlPlane {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -100,11 +96,7 @@ func (reqs NodeRequests) MasterNodes() (nodes []NodeRequest) {
 // WorkerNodes returns subset of nodes which are Init/ControlPlane type.
 func (reqs NodeRequests) WorkerNodes() (nodes []NodeRequest) {
 	for i := range reqs {
-		if reqs[i].Config == nil {
-			continue
-		}
-
-		if reqs[i].Config.Machine().Type() == machine.TypeJoin {
+		if reqs[i].Type == machine.TypeJoin {
 			nodes = append(nodes, reqs[i])
 		}
 	}
@@ -136,6 +128,7 @@ type NodeRequest struct {
 	Name   string
 	IP     net.IP
 	Config config.Provider
+	Type   machine.Type
 
 	// Share of CPUs, in 1e-9 fractions
 	NanoCPUs int64

--- a/website/content/docs/v0.7/Reference/cli.md
+++ b/website/content/docs/v0.7/Reference/cli.md
@@ -98,6 +98,7 @@ talosctl cluster create [flags]
       --nameservers strings                     list of nameservers to use (default [8.8.8.8,1.1.1.1])
       --registry-insecure-skip-verify strings   list of registry hostnames to skip TLS verification for
       --registry-mirror strings                 list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --skip-injecting-config                   skip injecting config from embedded metadata server, write config files to current directory
       --skip-kubeconfig                         skip merging kubeconfig from the created cluster
       --user-disk strings                       list of disks to create for each VM in format: <mount_point1>:<size1>:<mount_point2>:<size2>
       --vmlinuz-path string                     the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")


### PR DESCRIPTION
This backports PRs #2733 #2738 #2745 #2747

Fixes #2736 

fix: update packages

Brings in the R8169 driver.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
(cherry picked from commit 4d9555a3ac11760410f925e15f979c7804a3e4ec)

chore: bump Go to 1.15.4

See:

* https://github.com/talos-systems/pkgs/pull/185
* https://github.com/talos-systems/tools/pull/111
* https://github.com/talos-systems/extras/pull/3

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit 5fca20e137fa10cff18c2bcc367f728b10b181e2)

fix: remove 'token creds' from maintenance service

This fixes the reverse Go dependency from `pkg/machinery` to `talos`
package.

Add a check to `Dockerfile` to prevent `pkg/machinery/go.mod` getting
out of sync, this should prevent problems in the future.

Fix potential security issue in `token` authorizer to deny requests
without grpc metadata.

In provisioner, add support for launching nodes without the config
(config is not delivered to the provisioned nodes).

Breaking change in `pkg/provision`: now `NodeRequest.Type` should be set
to the node type (as config can be missing now).

In `talosctl cluster create` add a flag to skip providing config to the
nodes so that they enter maintenance mode, while the generated configs
are written down to disk (so they can be tweaked and applied easily).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit b2b86a622eed51cb6d94e16e0971a4bb70d01bef)

chore: bump version of `x/net` module

Fixes #2746

This should cover the `x/net/http2` fixes which were backported in Go
1.15.4.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit 4c42e22dbf722c20e7dbaba43a2bd7f0f540eb78)

