### PR TITLE
feat: add TUI based talos interactive installer

### DIFF
--- a/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
+++ b/cmd/talosctl/cmd/mgmt/loadbalancer_launch.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/go-loadbalancer/loadbalancer"
+
+	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 var loadbalancerLaunchCmdFlags struct {
@@ -27,7 +29,7 @@ var loadbalancerLaunchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var lb loadbalancer.TCP
 
-		for _, port := range []int{6443} { // TODO: need to put 6443 as constant or use config?
+		for _, port := range []int{constants.DefaultControlPlanePort} {
 			upstreams := make([]string, len(loadbalancerLaunchCmdFlags.upstreams))
 			for i := range upstreams {
 				upstreams[i] = fmt.Sprintf("%s:%d", loadbalancerLaunchCmdFlags.upstreams[i], port)

--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -13,14 +13,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/crypto/x509"
 
+	"github.com/talos-systems/talos/internal/pkg/tui/installer"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
 
 var applyConfigCmdFlags struct {
+	certFingerprints []string
 	filename         string
 	insecure         bool
-	certFingerprints []string
+	interactive      bool
 }
 
 // applyConfigCmd represents the applyConfiguration command.
@@ -30,61 +32,81 @@ var applyConfigCmd = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if applyConfigCmdFlags.filename == "" {
+		var (
+			cfgBytes []byte
+			e        error
+		)
+
+		if applyConfigCmdFlags.filename != "" {
+			cfgBytes, e = ioutil.ReadFile(applyConfigCmdFlags.filename)
+			if e != nil {
+				return fmt.Errorf("failed to read configuration from %q: %w", applyConfigCmdFlags.filename, e)
+			}
+
+			if len(cfgBytes) < 1 {
+				return fmt.Errorf("no configuration data read")
+			}
+		} else if !applyConfigCmdFlags.interactive {
 			return fmt.Errorf("no filename supplied for configuration")
 		}
 
-		cfgBytes, err := ioutil.ReadFile(applyConfigCmdFlags.filename)
-		if err != nil {
-			return fmt.Errorf("failed to read configuration from %q: %w", applyConfigCmdFlags.filename, err)
-		}
+		withClient := func(f func(context.Context, *client.Client) error) error {
+			if applyConfigCmdFlags.insecure {
+				ctx := context.Background()
 
-		if len(cfgBytes) < 1 {
-			return fmt.Errorf("no configuration data read")
-		}
-
-		if applyConfigCmdFlags.insecure {
-			ctx := context.Background()
-
-			if len(Nodes) != 1 {
-				return fmt.Errorf("insecure mode requires one and only one node, got %d", len(Nodes))
-			}
-
-			tlsConfig := &tls.Config{
-				InsecureSkipVerify: true,
-			}
-
-			if len(applyConfigCmdFlags.certFingerprints) > 0 {
-				fingerprints := make([]x509.Fingerprint, len(applyConfigCmdFlags.certFingerprints))
-
-				for i, stringFingerprint := range applyConfigCmdFlags.certFingerprints {
-					fingerprints[i], err = x509.ParseFingerprint(stringFingerprint)
-					if err != nil {
-						return fmt.Errorf("error parsing certificate fingerprint %q: %v", stringFingerprint, err)
-					}
+				if len(Nodes) != 1 {
+					return fmt.Errorf("insecure mode requires one and only one node, got %d", len(Nodes))
 				}
 
-				tlsConfig.VerifyConnection = x509.MatchSPKIFingerprints(fingerprints...)
+				c, err := client.New(ctx, client.WithTLSConfig(&tls.Config{
+					InsecureSkipVerify: true,
+				}), client.WithEndpoints(Nodes...))
+				if err != nil {
+					return err
+				}
+
+				//nolint: errcheck
+				defer c.Close()
+
+				tlsConfig := &tls.Config{
+					InsecureSkipVerify: true,
+				}
+
+				if len(applyConfigCmdFlags.certFingerprints) > 0 {
+					fingerprints := make([]x509.Fingerprint, len(applyConfigCmdFlags.certFingerprints))
+
+					for i, stringFingerprint := range applyConfigCmdFlags.certFingerprints {
+						fingerprints[i], err = x509.ParseFingerprint(stringFingerprint)
+						if err != nil {
+							return fmt.Errorf("error parsing certificate fingerprint %q: %v", stringFingerprint, err)
+						}
+					}
+
+					tlsConfig.VerifyConnection = x509.MatchSPKIFingerprints(fingerprints...)
+				}
+
+				c, err = client.New(ctx, client.WithTLSConfig(tlsConfig), client.WithEndpoints(Nodes...))
+				if err != nil {
+					return err
+				}
+
+				return f(ctx, c)
 			}
 
-			c, err := client.New(ctx, client.WithTLSConfig(tlsConfig), client.WithEndpoints(Nodes...))
-			if err != nil {
-				return err
-			}
-
-			//nolint: errcheck
-			defer c.Close()
-
-			if _, err := c.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
-				Data: cfgBytes,
-			}); err != nil {
-				return fmt.Errorf("error applying new configuration: %s", err)
-			}
-
-			return nil
+			return WithClient(f)
 		}
 
-		return WithClient(func(ctx context.Context, c *client.Client) error {
+		return withClient(func(ctx context.Context, c *client.Client) error {
+			if applyConfigCmdFlags.interactive {
+				installer := installer.NewInstaller()
+				err := installer.Run(Nodes[0], c)
+				if e != nil {
+					return err
+				}
+
+				return nil
+			}
+
 			if _, err := c.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
 				Data: cfgBytes,
 			}); err != nil {
@@ -100,6 +122,7 @@ func init() {
 	applyConfigCmd.Flags().StringVarP(&applyConfigCmdFlags.filename, "file", "f", "", "the filename of the updated configuration")
 	applyConfigCmd.Flags().BoolVarP(&applyConfigCmdFlags.insecure, "insecure", "i", false, "apply the config using the insecure (encrypted with no auth) maintenance service")
 	applyConfigCmd.Flags().StringSliceVar(&applyConfigCmdFlags.certFingerprints, "cert-fingerprint", nil, "list of server certificate fingeprints to accept (defaults to no check)")
+	applyConfigCmd.Flags().BoolVarP(&applyConfigCmdFlags.interactive, "interactive", "", false, "apply the config using text based interactive mode")
 
 	addCommand(applyConfigCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/fatih/color v1.9.0
 	github.com/firecracker-microvm/firecracker-go-sdk v0.21.0
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
+	github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/protobuf v1.4.3
@@ -49,6 +50,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200728170252-4d89ac9fbff6
 	github.com/pin/tftp v2.1.0+incompatible
 	github.com/prometheus/procfs v0.2.0
+	github.com/rivo/tview v0.0.0-20201018122409-d551c850a743
 	github.com/rs/xid v1.2.1
 	github.com/ryanuber/columnize v2.1.2+incompatible
 	github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014
@@ -57,7 +59,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3
 	github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201118151932-8076344a9502
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,10 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa h1:RDBNVkRviHZtvDvId8XSGPu3rmpmSe+wKRcEWNgsfWU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
+github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
+github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591 h1:0WWUDZ1oxq7NxVyGo8M3KI5jbkiwNAdZFFzAdC68up4=
+github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -559,6 +563,8 @@ github.com/kubernetes-sigs/bootkube v0.14.1-0.20200817205730-0b4482256ca1 h1:kjw
 github.com/kubernetes-sigs/bootkube v0.14.1-0.20200817205730-0b4482256ca1/go.mod h1:tgR06vqFs3qxPEkOFmiMDy9UbQ0PMcee/FK6dOyiHFs=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
+github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -586,6 +592,9 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
@@ -725,6 +734,10 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5 h1:mZHayPoR0lNmnHyvtYjDeq0zlVHn9K/ZXoy17ylucdo=
 github.com/rifflock/lfshook v0.0.0-20180920164130-b9218ef580f5/go.mod h1:GEXHk5HgEKCvEIIrSpFI3ozzG5xOKA2DVlEX/gGnewM=
+github.com/rivo/tview v0.0.0-20201018122409-d551c850a743 h1:9BBjVJTRxuYBeCAv9DFH2hSzY0ujLx5sxMg5D3K/Xeg=
+github.com/rivo/tview v0.0.0-20201018122409-d551c850a743/go.mod h1:t7mcA3nlK9dxD1DMoz/DQRMWFMkGBUj6rJBM5VNfLFA=
+github.com/rivo/uniseg v0.1.0 h1:+2KBaVoUmb9XzDsrx/Ct0W/EYOSFf/nWTauy++DprtY=
+github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-charset v0.0.0-20190617161244-0dc95cdf6f31/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
@@ -818,8 +831,8 @@ github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3/go.m
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b h1:EctcXxyT5hTXnrUbdKvN8oxZLxc8HOJ9E8paAkv3yRg=
 github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f h1:DiWsa6+uyi9fuxWBs9NpLYDCs3OIg+HwEvSlVjkAm0U=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201118151932-8076344a9502 h1:6LpnCu7wEF2LGmxavbdtiM+YZX2vMPVKtZCaZynQqwM=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201118151932-8076344a9502/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
@@ -1038,6 +1051,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626150813-e07cf5db2756/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1072,6 +1086,7 @@ golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201017003518-b09fb700fbb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13 h1:5jaG59Zhd+8ZXe8C+lgiAGqkOaZBruqrWclLkgAww34=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -91,7 +91,7 @@ func (s *Server) Register(obj *grpc.Server) {
 	cluster.RegisterClusterServiceServer(obj, s)
 }
 
-// ApplyConfiguration implements machine.MachineServer.
+// ApplyConfiguration implements machine.MachineService.
 func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfigurationRequest) (reply *machine.ApplyConfigurationResponse, err error) {
 	if err = s.Controller.Runtime().SetConfig(in.GetData()); err != nil {
 		return nil, err

--- a/internal/app/maintenance/server/server.go
+++ b/internal/app/maintenance/server/server.go
@@ -20,7 +20,7 @@ import (
 	v1alpha1machine "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
-// Server implements machine.MaintenanceService.
+// Server implements machine.MachineService.
 type Server struct {
 	machine.UnimplementedMachineServiceServer
 	storaged.Server

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -294,7 +294,7 @@ func (suite *UpgradeSuite) setupCluster() {
 	suite.configBundle, err = bundle.NewConfigBundle(bundle.WithInputOptions(
 		&bundle.InputOptions{
 			ClusterName: clusterName,
-			Endpoint:    fmt.Sprintf("https://%s:6443", defaultInternalLB),
+			Endpoint:    fmt.Sprintf("https://%s:%d", defaultInternalLB, constants.DefaultControlPlanePort),
 			KubeVersion: "", // keep empty so that default version is used per Talos version
 			GenOptions: append(
 				genOptions,

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -32,7 +32,7 @@ func Generate(ctx context.Context, in *machine.GenerateConfigurationRequest) (re
 
 		options := []generate.GenOption{}
 
-		if in.MachineConfig.NetworkConfig != nil {
+		if in.MachineConfig.NetworkConfig != nil && in.MachineConfig.NetworkConfig.Hostname != "" {
 			options = append(options, generate.WithNetworkConfig(
 				&v1alpha1.NetworkConfig{
 					NetworkHostname: in.MachineConfig.NetworkConfig.Hostname,

--- a/internal/pkg/tui/components/formlabel.go
+++ b/internal/pkg/tui/components/formlabel.go
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// NewFormLabel creates a new FormLabel.
+func NewFormLabel(label string) *FormLabel {
+	res := &FormLabel{
+		tview.NewTextView().SetText(label),
+	}
+
+	res.SetWordWrap(true)
+
+	return res
+}
+
+// FormLabel text paragraph that can be used in form.
+type FormLabel struct {
+	*tview.TextView
+}
+
+// GetLabel implements FormItem interface.
+func (fl *FormLabel) GetLabel() string {
+	return ""
+}
+
+// SetFormAttributes implements FormItem interface.
+func (fl *FormLabel) SetFormAttributes(labelWidth int, labelColor, bgColor, fieldTextColor, fieldBgColor tcell.Color) tview.FormItem {
+	fl.SetBackgroundColor(bgColor)
+
+	return fl
+}
+
+// GetFieldWidth implements FormItem interface.
+func (fl *FormLabel) GetFieldWidth() int {
+	return 0
+}
+
+// SetFinishedFunc implements FormItem interface.
+func (fl *FormLabel) SetFinishedFunc(handler func(key tcell.Key)) tview.FormItem {
+	return fl
+}

--- a/internal/pkg/tui/components/group.go
+++ b/internal/pkg/tui/components/group.go
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components
+
+import "github.com/rivo/tview"
+
+// NewGroup creates new Group.
+func NewGroup(app *tview.Application) *Group {
+	return &Group{
+		app:      app,
+		current:  -1,
+		elements: []tview.Primitive{},
+	}
+}
+
+// Group is an attempt to straighten out built-in tview TAB focus sequence.
+type Group struct {
+	app      *tview.Application
+	elements []tview.Primitive
+	current  int
+	focus    tview.Primitive
+}
+
+// AddElement to the group.
+func (eg *Group) AddElement(element tview.Primitive) tview.Primitive {
+	eg.elements = append(eg.elements, element)
+
+	return element
+}
+
+// NextFocus switch focus to the next element.
+func (eg *Group) NextFocus() {
+	eg.detectFocus()
+	eg.current = (eg.current + 1) % (len(eg.elements))
+	eg.focus = eg.elements[eg.current]
+	eg.app.SetFocus(eg.focus)
+}
+
+// PrevFocus switch focus to the prev element.
+func (eg *Group) PrevFocus() {
+	eg.detectFocus()
+	eg.current--
+
+	if eg.current < 0 {
+		eg.current = len(eg.elements) - 1
+	}
+
+	eg.focus = eg.elements[eg.current]
+	eg.app.SetFocus(eg.focus)
+}
+
+func (eg *Group) detectFocus() {
+	focused := eg.app.GetFocus()
+	if eg.focus == nil || focused != eg.focus {
+		for i, e := range eg.elements {
+			if e == focused {
+				eg.current = i
+
+				break
+			}
+		}
+	}
+}

--- a/internal/pkg/tui/components/menubutton.go
+++ b/internal/pkg/tui/components/menubutton.go
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// NewMenuButton creates new menu button.
+func NewMenuButton(label string) *MenuButton {
+	button := &MenuButton{
+		Button: tview.NewButton(label),
+		label:  label,
+		colors: [4]tcell.Color{
+			tcell.ColorBlack,
+			tcell.ColorBlack,
+			tcell.ColorBlack,
+			tcell.ColorBlack,
+		},
+		active: false,
+	}
+
+	button.updateColors()
+
+	return button
+}
+
+const (
+	menuButtonBgColor = iota
+	menuButtonLabelColor
+	menuButtonActiveBgColor
+	menuButtonActiveLabelColor
+)
+
+// MenuButton creates a new menu button.
+type MenuButton struct {
+	*tview.Button
+	label  string
+	colors [4]tcell.Color
+	active bool
+}
+
+// SetActiveColors sets active state colors.
+// 1st value is bg color.
+// 2nd value is label color.
+func (b *MenuButton) SetActiveColors(colors ...tcell.Color) {
+	for i, color := range colors {
+		b.colors[i+2] = color
+	}
+
+	b.updateColors()
+}
+
+// SetInactiveColors sets inactive state colors.
+// 1st value is bg color.
+// 2nd value is label color.
+func (b *MenuButton) SetInactiveColors(colors ...tcell.Color) {
+	for i, color := range colors {
+		b.colors[i] = color
+	}
+
+	b.updateColors()
+}
+
+// SetActive changes menu button active state.
+func (b *MenuButton) SetActive(active bool) {
+	b.active = active
+	b.updateColors()
+
+	format := "%s"
+
+	if b.active {
+		format = "[::u]%s[::-]"
+	}
+
+	b.SetLabel(fmt.Sprintf(format, b.label))
+}
+
+func (b *MenuButton) updateColors() {
+	if b.active {
+		b.SetLabelColor(b.colors[menuButtonActiveLabelColor])
+		b.SetLabelColorActivated(b.colors[menuButtonActiveLabelColor])
+		b.SetBackgroundColor(b.colors[menuButtonActiveBgColor])
+		b.SetBackgroundColorActivated(b.colors[menuButtonActiveBgColor])
+	} else {
+		b.SetLabelColor(b.colors[menuButtonLabelColor])
+		b.SetLabelColorActivated(b.colors[menuButtonLabelColor])
+		b.SetBackgroundColor(b.colors[menuButtonBgColor])
+		b.SetBackgroundColorActivated(b.colors[menuButtonBgColor])
+	}
+}

--- a/internal/pkg/tui/components/spinner.go
+++ b/internal/pkg/tui/components/spinner.go
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package components
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+// NewSpinner creates a new spinner.
+func NewSpinner(label string, spinner []string, app *tview.Application) *Spinner {
+	s := &Spinner{
+		Box:      tview.NewBox(),
+		spinner:  spinner,
+		label:    label,
+		ticker:   time.NewTicker(time.Millisecond * 50),
+		shutdown: make(chan struct{}),
+		stopped:  make(chan struct{}),
+	}
+
+	go func() {
+		defer func() {
+			app.Draw()
+			close(s.stopped)
+		}()
+
+		for {
+			select {
+			case <-s.shutdown:
+				return
+			case <-s.ticker.C:
+				app.Draw()
+			}
+		}
+	}()
+
+	return s
+}
+
+const (
+	spinnerStateInProgress = iota
+	spinnerStateComplete
+	spinnerStateFailed
+)
+
+var spinnerStatusSymbols = []string{
+	"",
+	"[green::]✓[-::]",
+	"[red::]✖[-::]",
+}
+
+// Spinner a unicode spinner primitive.
+type Spinner struct {
+	*tview.Box
+	spinner  []string
+	label    string
+	index    int
+	shutdown chan struct{}
+	stopped  chan struct{}
+	ticker   *time.Ticker
+	state    int
+}
+
+// Draw draws this primitive onto the screen.
+func (s *Spinner) Draw(screen tcell.Screen) {
+	s.Box.Draw(screen)
+	x, y, width, _ := s.GetInnerRect()
+
+	var spinner string
+
+	if s.state == spinnerStateInProgress {
+		spinner = s.spinner[s.index]
+	} else {
+		spinner = spinnerStatusSymbols[s.state]
+	}
+
+	line := fmt.Sprintf(s.label+" %s", spinner)
+	tview.Print(screen, line, x, y, width, tview.AlignLeft, tcell.ColorWhite)
+	s.index++
+
+	if s.index == len(s.spinner) {
+		s.index = 0
+	}
+}
+
+// Stop should be always called to stop the spinner background routine.
+func (s *Spinner) Stop(success bool) <-chan struct{} {
+	s.state = spinnerStateInProgress
+	if success {
+		s.state = spinnerStateComplete
+	} else {
+		s.state = spinnerStateFailed
+	}
+
+	s.ticker.Stop()
+	s.shutdown <- struct{}{}
+
+	return s.stopped
+}

--- a/internal/pkg/tui/installer/installer.go
+++ b/internal/pkg/tui/installer/installer.go
@@ -1,0 +1,674 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package installer contains terminal UI based talos interactive installer parts.
+package installer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+	"gopkg.in/yaml.v3"
+
+	"github.com/talos-systems/talos/internal/pkg/tui/components"
+	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
+	"github.com/talos-systems/talos/pkg/machinery/client"
+	clientconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
+	"github.com/talos-systems/talos/pkg/version"
+)
+
+// NewPage creates a new installer page.
+func NewPage(name string, items ...*Item) *Page {
+	return &Page{
+		name:  name,
+		items: items,
+	}
+}
+
+// Page represents a single installer page.
+type Page struct {
+	name  string
+	items []*Item
+}
+
+// Item represents a single form item.
+type Item struct {
+	name        string
+	description string
+	dest        interface{}
+	options     []interface{}
+}
+
+// NewItem creates new form item.
+func NewItem(name, description string, dest interface{}, options ...interface{}) *Item {
+	return &Item{
+		dest:        dest,
+		name:        name,
+		description: description,
+		options:     options,
+	}
+}
+
+func (item *Item) assign(value string) error {
+	// rely on yaml parser to decode value into the right type
+	return yaml.Unmarshal([]byte(value), item.dest)
+}
+
+// createFormItems dynamically creates tview.FormItem list based on the wrapped type.
+// nolint:gocyclo
+func (item *Item) createFormItems() ([]tview.FormItem, error) {
+	res := []tview.FormItem{}
+
+	v := reflect.ValueOf(item.dest)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	if item.description != "" {
+		parts := strings.Split(item.description, "\n")
+		for _, part := range parts {
+			res = append(res, components.NewFormLabel(part))
+		}
+	}
+
+	var formItem tview.FormItem
+
+	// nolint:exhaustive
+	switch v.Kind() {
+	case reflect.Bool:
+		// use checkbox for boolean fields
+		checkbox := tview.NewCheckbox()
+		checkbox.SetChangedFunc(func(checked bool) {
+			reflect.ValueOf(item.dest).Set(reflect.ValueOf(checked))
+		})
+		checkbox.SetChecked(v.Bool())
+		checkbox.SetLabel(item.name)
+		formItem = checkbox
+	default:
+		if len(item.options) > 0 {
+			dropdown := tview.NewDropDown()
+
+			if len(item.options)%2 != 0 {
+				return nil, fmt.Errorf("wrong amount of arguments for options: should be even amount of key, value pairs")
+			}
+
+			for i := 0; i < len(item.options); i += 2 {
+				if optionName, ok := item.options[i].(string); ok {
+					selected := -1
+
+					func(index int) {
+						dropdown.AddOption(optionName, func() {
+							v.Set(reflect.ValueOf(item.options[index]))
+						})
+
+						if v.Interface() == item.options[index] {
+							selected = i / 2
+						}
+					}(i + 1)
+
+					if selected != -1 {
+						dropdown.SetCurrentOption(selected)
+					}
+				} else {
+					return nil, fmt.Errorf("expected string option name, got %s", item.options[i])
+				}
+			}
+
+			dropdown.SetLabel(item.name)
+
+			formItem = dropdown
+		} else {
+			input := tview.NewInputField()
+			formItem = input
+			input.SetLabel(item.name)
+			text, err := yaml.Marshal(item.dest)
+			if err != nil {
+				return nil, err
+			}
+			input.SetText(string(text))
+			input.SetChangedFunc(func(text string) {
+				if err := item.assign(text); err != nil {
+					// TODO: highlight red
+					return
+				}
+			})
+		}
+	}
+
+	res = append(res, formItem)
+
+	return res, nil
+}
+
+// Installer interactive installer text based UI.
+type Installer struct {
+	pages      *tview.Pages
+	app        *tview.Application
+	wg         sync.WaitGroup
+	err        error
+	ctx        context.Context
+	cancel     context.CancelFunc
+	addedPages map[string]bool
+	state      *State
+}
+
+// NewInstaller creates a new text based installer.
+func NewInstaller() *Installer {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Installer{
+		pages:  tview.NewPages(),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+const (
+	color         = tcell.Color238
+	frameBGColor  = tcell.Color235
+	inactiveColor = tcell.Color236
+)
+
+var spinner = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+const (
+	phaseInit = iota
+	phaseConfigure
+	phaseApply
+)
+
+// Run starts interactive installer.
+func (installer *Installer) Run(endpoint string, c *client.Client) error {
+	installer.startApp()
+	defer installer.stopApp()
+
+	var (
+		err         error
+		description string
+	)
+
+	for phase := phaseInit; phase <= phaseApply; {
+		switch phase {
+		case phaseInit:
+			description = "get the node information"
+			err = installer.init(endpoint, c)
+		case phaseConfigure:
+			description = "generate the configuration"
+			err = installer.configure()
+		case phaseApply:
+			description = "apply the configuration"
+			err = installer.apply(c)
+		}
+
+		if err != nil && err != context.Canceled {
+			choice := installer.showModal(
+				fmt.Sprintf("Failed to %s", description),
+				err.Error(),
+				"Quit", "Retry",
+			)
+
+			if choice == 1 {
+				// apply should be retried from configure
+				if phase == phaseApply {
+					phase = phaseConfigure
+				}
+
+				continue
+			}
+		}
+
+		if err != nil {
+			return err
+		}
+
+		phase++
+	}
+
+	return nil
+}
+
+func (installer *Installer) startApp() {
+	if installer.app != nil {
+		return
+	}
+
+	installer.wg.Add(1)
+	installer.app = tview.NewApplication()
+
+	go func() {
+		defer installer.wg.Done()
+		defer installer.cancel()
+
+		if err := installer.app.SetRoot(installer.pages, true).EnableMouse(true).Run(); err != nil {
+			installer.err = err
+		}
+	}()
+}
+
+func (installer *Installer) stopApp() {
+	if installer.app == nil {
+		return
+	}
+
+	installer.app.Stop()
+	installer.wg.Wait()
+	installer.app = nil
+}
+
+func (installer *Installer) init(endpoint string, c *client.Client) (err error) {
+	installer.startApp()
+
+	s := components.NewSpinner(
+		fmt.Sprintf("Connecting to the maintenance service at [green::]%s[white::]", endpoint),
+		spinner,
+		installer.app,
+	)
+
+	s.SetBackgroundColor(color)
+	installer.addPage("Gathering the node information", s, true, nil)
+
+	installer.state, err = NewState(
+		installer.ctx,
+		endpoint,
+		c,
+	)
+
+	select {
+	case <-s.Stop(err == nil):
+	case <-installer.ctx.Done():
+		return context.Canceled
+	}
+
+	return err
+}
+
+// nolint:gocyclo
+func (installer *Installer) configure() error {
+	var (
+		currentGroup *components.Group
+		err          error
+	)
+
+	groups := []*components.Group{}
+	currentPage := 0
+	menuButtons := []*components.MenuButton{}
+
+	done := make(chan struct{})
+	state := installer.state
+
+	setPage := func(index int) {
+		if index < 0 || index >= len(state.pages) {
+			return
+		}
+
+		menuButtons[currentPage].SetActive(false)
+		currentPage = index
+		menuButtons[currentPage].SetActive(true)
+
+		installer.pages.SwitchToPage(state.pages[currentPage].name)
+		currentGroup = groups[currentPage]
+	}
+
+	capture := installer.app.GetInputCapture()
+	installer.app.SetInputCapture(func(e *tcell.EventKey) *tcell.EventKey {
+		if currentGroup == nil {
+			return e
+		}
+
+		//nolint:exhaustive
+		switch e.Key() {
+		case tcell.KeyTAB:
+			currentGroup.NextFocus()
+		case tcell.KeyBacktab:
+			currentGroup.PrevFocus()
+		case tcell.KeyCtrlN:
+			setPage(currentPage + 1)
+		case tcell.KeyCtrlB:
+			setPage(currentPage - 1)
+		}
+
+		// page jump by ctrl/alt + N
+		if e.Rune() >= '1' && e.Rune() < '9' {
+			if e.Modifiers()&(tcell.ModAlt|tcell.ModCtrl) != 0 {
+				setPage(int(e.Rune()) - 49)
+			}
+		}
+
+		if capture != nil {
+			return capture(e)
+		}
+
+		return e
+	})
+
+	defer installer.app.SetInputCapture(capture)
+
+	menu := tview.NewFlex()
+	menu.SetBackgroundColor(frameBGColor)
+
+	addMenuItem := func(name string, index int) {
+		button := components.NewMenuButton(name)
+		button.SetActiveColors(color, tcell.ColorIvory)
+		button.SetInactiveColors(inactiveColor, tcell.ColorIvory)
+
+		func(page int) {
+			button.SetSelectedFunc(func() {
+				setPage(page)
+			})
+		}(index)
+
+		menu.AddItem(button, len(name)+4, 1, false)
+		menuButtons = append(menuButtons, button)
+
+		if currentPage == index {
+			button.SetActive(true)
+		}
+	}
+
+	for i, p := range state.pages {
+		eg := components.NewGroup(installer.app)
+		groups = append(groups, eg)
+
+		err = func(index int) error {
+			form := tview.NewForm()
+
+			for _, item := range p.items {
+				formItems, e := item.createFormItems()
+				if e != nil {
+					return e
+				}
+
+				for _, formItem := range formItems {
+					if _, ok := formItem.(*components.FormLabel); !ok {
+						eg.AddElement(formItem)
+					}
+
+					form.AddFormItem(formItem)
+				}
+			}
+
+			flex := tview.NewFlex().SetDirection(tview.FlexRow)
+			flex.AddItem(form, 0, 1, false)
+
+			content := tview.NewFlex()
+
+			if index > 0 {
+				back := tview.NewButton("[::u]B[::-]ack")
+				back.SetSelectedFunc(func() {
+					setPage(index - 1)
+				})
+
+				content.AddItem(eg.AddElement(back), 10, 1, false)
+			}
+
+			addMenuItem(p.name, index)
+
+			content.AddItem(tview.NewBox().SetBackgroundColor(color), 0, 1, false)
+			flex.SetBackgroundColor(color)
+			form.SetBackgroundColor(color)
+			content.SetBackgroundColor(color)
+
+			if index < len(state.pages)-1 {
+				next := tview.NewButton("[::u]N[::-]ext")
+				next.SetSelectedFunc(func() {
+					setPage(index + 1)
+				})
+
+				content.AddItem(eg.AddElement(next), 10, 1, false)
+			} else {
+				install := tview.NewButton("Install")
+				install.SetBackgroundColor(tcell.ColorGreen)
+				install.SetTitleAlign(tview.AlignCenter)
+				install.SetSelectedFunc(func() {
+					close(done)
+				})
+				content.AddItem(eg.AddElement(install), 11, 1, false)
+			}
+
+			flex.AddItem(content, 1, 1, false)
+
+			installer.addPage(p.name, flex, index == 0, menu)
+
+			return nil
+		}(i)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	setPage(0)
+
+	select {
+	case <-installer.ctx.Done():
+		return context.Canceled
+	case <-done: // nothing here, just waiting
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (installer *Installer) apply(c *client.Client) error {
+	var (
+		config      []byte
+		talosconfig *clientconfig.Config
+		err         error
+		response    *machineapi.GenerateConfigurationResponse
+	)
+
+	list := tview.NewFlex().SetDirection(tview.FlexRow)
+	list.SetBackgroundColor(color)
+	installer.addPage("Installing Talos", list, true, nil)
+
+	{
+		s := components.NewSpinner(
+			"Generating configuration...",
+			spinner,
+			installer.app,
+		)
+		s.SetBackgroundColor(color)
+
+		list.AddItem(s, 1, 1, false)
+
+		response, err = installer.state.GenConfig(installer.ctx)
+
+		s.Stop(err == nil)
+
+		if err != nil {
+			return err
+		}
+
+		config = response.Data[0]
+		talosconfig, err = clientconfig.FromBytes(response.Talosconfig)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	{
+		s := components.NewSpinner(
+			"Applying configuration...",
+			spinner,
+			installer.app,
+		)
+		s.SetBackgroundColor(color)
+
+		// TODO: progress bar, logs?
+		list.AddItem(s, 1, 1, false)
+		_, err = c.ApplyConfiguration(installer.ctx, &machineapi.ApplyConfigurationRequest{
+			Data: config,
+		})
+
+		s.Stop(err == nil)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return installer.writeTalosconfig(list, talosconfig)
+}
+
+func (installer *Installer) writeTalosconfig(list *tview.Flex, talosconfig *clientconfig.Config) error {
+	path, err := clientconfig.GetDefaultPath()
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(path)
+
+	var config *clientconfig.Config
+
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err == nil {
+		config, err = clientconfig.ReadFrom(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	text := tview.NewTextView()
+	addLines := func(lines ...string) {
+		t := text.GetText(false)
+		t += strings.Join(lines, "\n")
+		text.SetText(t)
+		installer.app.Draw()
+	}
+
+	addLines(
+		"",
+		fmt.Sprintf("Merging talosconfig into %s...", path),
+	)
+	text.SetBackgroundColor(color)
+	list.AddItem(text, 0, 1, false)
+
+	renames := []clientconfig.Rename{}
+	if config != nil {
+		renames = config.Merge(talosconfig)
+	} else {
+		config = talosconfig
+	}
+
+	for _, rename := range renames {
+		addLines(fmt.Sprintf("Renamed %s.", rename.String()))
+	}
+
+	context := talosconfig.Context
+	if len(renames) != 0 {
+		context = renames[0].To
+	}
+
+	config.Context = context
+	addLines(fmt.Sprintf("Set current context to %q.", context))
+
+	err = config.Save(path)
+	if err != nil {
+		return err
+	}
+
+	addLines(
+		"",
+		"Press any key to exit.",
+	)
+
+	installer.awaitKey()
+
+	return nil
+}
+
+func (installer *Installer) awaitKey(keys ...tcell.Key) {
+	done := make(chan struct{})
+
+	installer.app.SetInputCapture(func(e *tcell.EventKey) *tcell.EventKey {
+		for _, key := range keys {
+			if e.Key() == key {
+				close(done)
+			}
+		}
+
+		if len(keys) == 0 {
+			close(done)
+		}
+
+		return e
+	})
+
+	select {
+	case <-done:
+	case <-installer.ctx.Done():
+	}
+}
+
+// showModal block execution and show modal window.
+func (installer *Installer) showModal(title, text string, buttons ...string) int {
+	done := make(chan struct{})
+
+	index := -1
+
+	modal := tview.NewModal().
+		SetText(text).
+		AddButtons(buttons).
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			index = buttonIndex
+			close(done)
+		})
+
+	installer.addPage(title, modal, true, nil)
+	installer.app.SetFocus(modal)
+	installer.app.Draw()
+
+	select {
+	case <-done:
+	case <-installer.ctx.Done():
+	}
+
+	return index
+}
+
+func (installer *Installer) addPage(name string, primitive tview.Primitive, switchToPage bool, menu tview.Primitive) {
+	if !installer.addedPages[name] {
+		content := tview.NewFlex().SetDirection(tview.FlexRow)
+		page := tview.NewFrame(primitive).SetBorders(1, 1, 1, 1, 2, 2)
+		page.SetBackgroundColor(color)
+
+		if menu != nil {
+			content.AddItem(menu, 3, 1, false)
+		}
+
+		content.AddItem(page, 0, 1, false)
+
+		frame := tview.NewFrame(content).SetBorders(1, 1, 1, 1, 2, 2).
+			AddText(name, true, tview.AlignLeft, tcell.ColorWhite).
+			AddText("Talos Interactive Installer", true, tview.AlignCenter, tcell.ColorWhite).
+			AddText(version.Tag, true, tview.AlignRight, tcell.ColorIvory)
+
+		frame.SetBackgroundColor(frameBGColor)
+
+		installer.pages.AddPage(name,
+			frame, true, false)
+		installer.app.Draw()
+	}
+
+	if switchToPage {
+		installer.pages.SwitchToPage(name)
+	}
+}

--- a/internal/pkg/tui/installer/state.go
+++ b/internal/pkg/tui/installer/state.go
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package installer contains terminal UI based talos interactive installer parts.
+package installer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/talos-systems/talos/pkg/images"
+	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
+	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+)
+
+// NewState creates new installer state.
+func NewState(ctx context.Context, endpoint string, c *client.Client) (*State, error) {
+	opts := &machineapi.GenerateConfigurationRequest{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &machineapi.MachineConfig{
+			Type:              machineapi.MachineConfig_MachineType(machine.TypeInit),
+			NetworkConfig:     &machineapi.NetworkConfig{},
+			KubernetesVersion: constants.DefaultKubernetesVersion,
+			InstallConfig: &machineapi.InstallConfig{
+				InstallImage: images.DefaultInstallerImage,
+			},
+		},
+		ClusterConfig: &machineapi.ClusterConfig{
+			Name: "talos-default",
+			ControlPlane: &machineapi.ControlPlaneConfig{
+				Endpoint: fmt.Sprintf("https://%s:%d", endpoint, constants.DefaultControlPlanePort),
+			},
+			ClusterNetwork: &machineapi.ClusterNetworkConfig{
+				DnsDomain: "cluster.local",
+			},
+		},
+	}
+
+	diskInstallOptions := []interface{}{}
+
+	disks, err := c.Disks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, disk := range disks.Disks {
+		if i == 0 {
+			opts.MachineConfig.InstallConfig.InstallDisk = disk.DeviceName
+		}
+
+		name := fmt.Sprintf("%s  %s  %s", disk.DeviceName, disk.Model, humanize.Bytes(disk.Size))
+		diskInstallOptions = append(diskInstallOptions, name, disk.DeviceName)
+	}
+
+	state := &State{
+		client: c,
+		opts:   opts,
+		pages: []*Page{
+			NewPage("Machine Config",
+				NewItem(
+					"cluster name",
+					v1alpha1.ClusterConfigDoc.Describe("clusterName", true),
+					&opts.ClusterConfig.Name,
+				),
+				NewItem(
+					"machine type",
+					v1alpha1.MachineConfigDoc.Describe("type", true),
+					&opts.MachineConfig.Type,
+					"init", machineapi.MachineConfig_MachineType(machine.TypeInit), // TODO: add more machine types when supported
+					"controlplane", machineapi.MachineConfig_MachineType(machine.TypeControlPlane),
+				),
+				NewItem(
+					"kubernetes version",
+					"Kubernetes version to install.",
+					&opts.MachineConfig.KubernetesVersion,
+				),
+				NewItem(
+					"install disk",
+					v1alpha1.InstallConfigDoc.Describe("disk", true),
+					&opts.MachineConfig.InstallConfig.InstallDisk,
+					diskInstallOptions...,
+				),
+				NewItem(
+					"image",
+					v1alpha1.InstallConfigDoc.Describe("image", true),
+					&opts.MachineConfig.InstallConfig.InstallImage,
+				),
+			),
+			NewPage("Network Config",
+				NewItem(
+					"hostname",
+					v1alpha1.NetworkConfigDoc.Describe("hostname", true),
+					&opts.MachineConfig.NetworkConfig.Hostname,
+				),
+				NewItem(
+					"dns domain",
+					v1alpha1.ClusterNetworkConfigDoc.Describe("dnsDomain", true),
+					&opts.ClusterConfig.ClusterNetwork.DnsDomain,
+				),
+			),
+		},
+	}
+
+	return state, nil
+}
+
+// State installer state.
+type State struct {
+	pages  []*Page
+	opts   *machineapi.GenerateConfigurationRequest
+	client *client.Client
+}
+
+// GenConfig returns current config encoded in yaml.
+func (s *State) GenConfig(ctx context.Context) (*machineapi.GenerateConfigurationResponse, error) {
+	return s.client.GenerateConfiguration(ctx, s.opts)
+}

--- a/pkg/cluster/kubernetes.go
+++ b/pkg/cluster/kubernetes.go
@@ -15,6 +15,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	k8s "github.com/talos-systems/talos/pkg/kubernetes"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 // KubernetesClient provides Kubernetes client built via Talos API Kubeconfig.
@@ -67,7 +68,7 @@ func (k *KubernetesClient) K8sRestConfig(ctx context.Context) (*rest.Config, err
 	config.Timeout = time.Minute
 
 	if k.ForceEndpoint != "" {
-		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, 6443)
+		config.Host = fmt.Sprintf("%s:%d", k.ForceEndpoint, constants.DefaultControlPlanePort)
 	}
 
 	return config, nil

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -31,6 +31,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/api/common"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	networkapi "github.com/talos-systems/talos/pkg/machinery/api/network"
+	storageapi "github.com/talos-systems/talos/pkg/machinery/api/storage"
 	timeapi "github.com/talos-systems/talos/pkg/machinery/api/time"
 	"github.com/talos-systems/talos/pkg/machinery/client/config"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
@@ -52,6 +53,7 @@ type Client struct {
 	TimeClient    timeapi.TimeServiceClient
 	NetworkClient networkapi.NetworkServiceClient
 	ClusterClient clusterapi.ClusterServiceClient
+	StorageClient storageapi.StorageServiceClient
 }
 
 func (c *Client) resolveConfigContext() error {
@@ -142,6 +144,7 @@ func New(ctx context.Context, opts ...OptionFunc) (c *Client, err error) {
 	c.TimeClient = timeapi.NewTimeServiceClient(c.conn)
 	c.NetworkClient = networkapi.NewNetworkServiceClient(c.conn)
 	c.ClusterClient = clusterapi.NewClusterServiceClient(c.conn)
+	c.StorageClient = storageapi.NewStorageServiceClient(c.conn)
 
 	return c, nil
 }
@@ -366,6 +369,11 @@ func (c *Client) ApplyConfiguration(ctx context.Context, req *machineapi.ApplyCo
 // GenerateConfiguration implements proto.MachineServiceClient interface.
 func (c *Client) GenerateConfiguration(ctx context.Context, req *machineapi.GenerateConfigurationRequest, callOptions ...grpc.CallOption) (resp *machineapi.GenerateConfigurationResponse, err error) {
 	return c.MachineClient.GenerateConfiguration(ctx, req, callOptions...)
+}
+
+// Disks returns the list of block devices.
+func (c *Client) Disks(ctx context.Context, callOptions ...grpc.CallOption) (resp *storageapi.DisksResponse, err error) {
+	return c.StorageClient.Disks(ctx, &empty.Empty{}, callOptions...)
 }
 
 // Stats implements the proto.MachineServiceClient interface.

--- a/pkg/machinery/client/config/config.go
+++ b/pkg/machinery/client/config/config.go
@@ -108,11 +108,23 @@ func (c *Config) Bytes() ([]byte, error) {
 	return yaml.Marshal(c)
 }
 
+// Rename describes context rename during merge.
+type Rename struct {
+	From string
+	To   string
+}
+
+// String converts to "from" -> "to".
+func (r *Rename) String() string {
+	return fmt.Sprintf("%q -> %q", r.From, r.To)
+}
+
 // Merge in additional contexts from another Config.
 //
 // Current context is overridden from passed in config.
-func (c *Config) Merge(cfg *Config) {
+func (c *Config) Merge(cfg *Config) []Rename {
 	mappedContexts := map[string]string{}
+	renames := []Rename{}
 
 	for name, ctx := range cfg.Contexts {
 		mergedName := name
@@ -130,7 +142,7 @@ func (c *Config) Merge(cfg *Config) {
 		mappedContexts[name] = mergedName
 
 		if name != mergedName {
-			fmt.Printf("renamed talosconfig context %q -> %q\n", name, mergedName)
+			renames = append(renames, Rename{name, mergedName})
 		}
 
 		c.Contexts[mergedName] = ctx
@@ -139,6 +151,8 @@ func (c *Config) Merge(cfg *Config) {
 	if cfg.Context != "" {
 		c.Context = mappedContexts[cfg.Context]
 	}
+
+	return renames
 }
 
 func ensure(filename string) (err error) {

--- a/pkg/machinery/config/encoder/documentation.go
+++ b/pkg/machinery/config/encoder/documentation.go
@@ -55,6 +55,23 @@ func (d *Doc) AddExample(name string, value interface{}) {
 	})
 }
 
+// Describe returns a field description.
+func (d *Doc) Describe(field string, short bool) string {
+	desc := ""
+
+	for _, f := range d.Fields {
+		if f.Name == field {
+			desc = f.Description
+		}
+	}
+
+	if short {
+		desc = strings.Split(desc, "\n")[0]
+	}
+
+	return desc
+}
+
 // Example represents one example snippet for a type.
 type Example struct {
 	Name  string

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -76,7 +76,9 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 	}
 
 	// Handle generating net-new configs
-	fmt.Println("generating PKI and tokens")
+	if options.Verbose {
+		fmt.Println("generating PKI and tokens")
+	}
 
 	var input *generate.Input
 

--- a/pkg/machinery/config/types/v1alpha1/bundle/options.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/options.go
@@ -20,12 +20,15 @@ type InputOptions struct {
 // Options describes generate parameters.
 type Options struct {
 	ExistingConfigs string // path to existing config files
+	Verbose         bool   // wheither to write any logs during generate
 	InputOptions    *InputOptions
 }
 
 // DefaultOptions returns default options.
 func DefaultOptions() Options {
-	return Options{}
+	return Options{
+		Verbose: true,
+	}
 }
 
 // WithExistingConfigs sets the path to existing config files.
@@ -41,6 +44,15 @@ func WithExistingConfigs(configPath string) Option {
 func WithInputOptions(inputOpts *InputOptions) Option {
 	return func(o *Options) error {
 		o.InputOptions = inputOpts
+
+		return nil
+	}
+}
+
+// WithVerbose allows setting verbose logging.
+func WithVerbose(verbose bool) Option {
+	return func(o *Options) error {
+		o.Verbose = verbose
 
 		return nil
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -231,7 +231,7 @@ func (c *ClusterConfig) Endpoint() *url.URL {
 // LocalAPIServerPort implements the config.Provider interface.
 func (c *ClusterConfig) LocalAPIServerPort() int {
 	if c.ControlPlane.LocalAPIServerPort == 0 {
-		return 6443
+		return constants.DefaultControlPlanePort
 	}
 
 	return c.ControlPlane.LocalAPIServerPort

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -165,6 +165,9 @@ const (
 	// DefaultKubernetesVersion is the default target version of the control plane.
 	DefaultKubernetesVersion = "1.19.4"
 
+	// DefaultControlPlanePort is the default port to use for the control plane.
+	DefaultControlPlanePort = 6443
+
 	// KubeletImage is the enforced kubelet image to use.
 	KubeletImage = "ghcr.io/talos-systems/kubelet"
 

--- a/website/content/docs/v0.7/Reference/cli.md
+++ b/website/content/docs/v0.7/Reference/cli.md
@@ -19,6 +19,7 @@ talosctl apply-config [flags]
   -f, --file string                the filename of the updated configuration
   -h, --help                       help for apply-config
   -i, --insecure                   apply the config using the insecure (encrypted with no auth) maintenance service
+      --interactive                apply the config using text based interactive mode
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/2742

This is initial commit of the installer.
What's done:
- verifying node availability before starting any operations.
- gathering information about disks on the machine.
- allows setting: install disk, hostname, machine type, installer image,
  kubernetes version, dns domain, cluster name.
- can dump/merge talosconfig to a file after applying configuration.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>