### PR TITLE
fix: bump timeout for config downloading on bare metal

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -82,7 +82,7 @@ func Download(ctx context.Context, endpoint string, opts ...Option) (b []byte, e
 		req.Header.Set(k, v)
 	}
 
-	err = retry.Exponential(60*time.Second, retry.WithUnits(time.Second), retry.WithJitter(time.Second)).Retry(func() error {
+	err = retry.Exponential(180*time.Second, retry.WithUnits(time.Second), retry.WithJitter(time.Second), retry.WithErrorLogging(true)).Retry(func() error {
 		select {
 		case <-ctx.Done():
 			return retry.UnexpectedError(context.Canceled)


### PR DESCRIPTION
Depending on the nature of the error, each attempt might take much
longer than 1 second, so bump the overall timeout, but print the error
encountered so that longer timeout doesn't mean less feedback for the
user.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

