### PR TITLE
fix: use ghcr.io/talos-systems/kubelet

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -166,7 +166,7 @@ const (
 	DefaultKubernetesVersion = "1.19.3"
 
 	// KubeletImage is the enforced kubelet image to use.
-	KubeletImage = "docker.io/autonomy/kubelet"
+	KubeletImage = "ghcr.io/talos-systems/kubelet"
 
 	// KubeProxyImage is the enforced kube-proxy image to use for the control plane.
 	KubeProxyImage = "k8s.gcr.io/kube-proxy"

--- a/website/content/docs/v0.7/Guides/upgrading-kubernetes.md
+++ b/website/content/docs/v0.7/Guides/upgrading-kubernetes.md
@@ -251,7 +251,7 @@ spec:
 ### Kubelet
 
 The Talos team now maintains an image for the `kubelet` that should be used starting with Kubernetes 1.19.
-The image for this release is `docker.io/autonomy/kubelet:v1.19.0`.
+The image for this release is `ghcr.io/talos-systems/kubelet:v1.19.3`.
 To explicitly set the image, we can use the [official documentation](/v0.7/en/configuration/v1alpha1#kubelet).
 For example:
 
@@ -259,5 +259,5 @@ For example:
 machine:
   ...
   kubelet:
-    image: docker.io/autonomy/kubelet:v1.19.0
+    image: ghcr.io/talos-systems/kubelet:v1.19.3
 ```

--- a/website/content/docs/v0.7/Reference/configuration.md
+++ b/website/content/docs/v0.7/Reference/configuration.md
@@ -262,7 +262,7 @@ Examples:
 
 ``` yaml
 kubelet:
-    image: docker.io/autonomy/kubelet:v1.19.3 # The `image` field is an optional reference to an alternative kubelet image.
+    image: ghcr.io/talos-systems/kubelet:v1.19.3 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
         key: value
@@ -1064,7 +1064,7 @@ Appears in:
 
 
 ``` yaml
-image: docker.io/autonomy/kubelet:v1.19.3 # The `image` field is an optional reference to an alternative kubelet image.
+image: ghcr.io/talos-systems/kubelet:v1.19.3 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
     key: value
@@ -1096,7 +1096,7 @@ Examples:
 
 
 ``` yaml
-image: docker.io/autonomy/kubelet:v1.19.3
+image: ghcr.io/talos-systems/kubelet:v1.19.3
 ```
 
 


### PR DESCRIPTION
Moves us off of docker.io.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
