### PR TITLE
feat: add example command in maintenance, enforce cert fingerprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3
-	github.com/talos-systems/crypto v0.2.1-0.20201028152949-d0c3eef149ec
+	github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b
 	github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45

--- a/go.sum
+++ b/go.sum
@@ -815,10 +815,9 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3 h1:Lp/MzZ7QzHjkE0uR9FYAGiOrVX55BEfvdukv6MynCZU=
 github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
-github.com/talos-systems/crypto v0.2.0 h1:UwT8uhJ0eDlklY0vYwo1+LGoFgiqkPqjQnae6j8UNYE=
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
-github.com/talos-systems/crypto v0.2.1-0.20201028152949-d0c3eef149ec h1:qO6KZJ1XbXQmkTcaonJYsTduNrKWGFfp9Tykc63raA4=
-github.com/talos-systems/crypto v0.2.1-0.20201028152949-d0c3eef149ec/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
+github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b h1:EctcXxyT5hTXnrUbdKvN8oxZLxc8HOJ9E8paAkv3yRg=
+github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f h1:DiWsa6+uyi9fuxWBs9NpLYDCs3OIg+HwEvSlVjkAm0U=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -433,7 +433,7 @@ func LoadConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 
 				b, e = receiveConfigViaMaintenanceService(ctx, logger, r)
 				if e != nil {
-					return fmt.Errorf("failed to receive config via maintenance service: %w", err)
+					return fmt.Errorf("failed to receive config via maintenance service: %w", e)
 				}
 			}
 
@@ -458,12 +458,12 @@ func LoadConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 		}
 
 		if !cfg.Persist() {
-			logger.Printf("found existing config, but peristence is disabled, downloading config")
+			logger.Printf("found existing config, but persistence is disabled, downloading config")
 
 			return download()
 		}
 
-		logger.Printf("peristence is enabled, using existing config on disk")
+		logger.Printf("persistence is enabled, using existing config on disk")
 
 		b, err := cfg.Bytes()
 		if err != nil {

--- a/website/content/docs/v0.7/Reference/cli.md
+++ b/website/content/docs/v0.7/Reference/cli.md
@@ -15,9 +15,10 @@ talosctl apply-config [flags]
 ### Options
 
 ```
-  -f, --file string   the filename of the updated configuration
-  -h, --help          help for apply-config
-  -i, --insecure      apply the config using the insecure (encrypted with no auth) maintenance service
+      --cert-fingerprint strings   list of server certificate fingeprints to accept (defaults to no check)
+  -f, --file string                the filename of the updated configuration
+  -h, --help                       help for apply-config
+  -i, --insecure                   apply the config using the insecure (encrypted with no auth) maintenance service
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Server in maintenance mode now prints certficate fingerprint and
provides sample talosctl command to upload config to the node.

`talosctl` can optionally enforce server certificate fingerprint.

See also https://github.com/talos-systems/crypto/pull/4

Fixes #2753

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
