### PR TITLE
docs: improve configuration reference documentation

### DIFF
--- a/pkg/machinery/config/encoder/encoder.go
+++ b/pkg/machinery/config/encoder/encoder.go
@@ -225,7 +225,7 @@ func toYamlNode(in interface{}) (*yaml.Node, error) {
 			element := v.MapIndex(k)
 			value := element.Interface()
 
-			if err := addToMap(node, getDoc(value), k.Interface(), value, 0); err != nil {
+			if err := addToMap(node, nil, k.Interface(), value, 0); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/machinery/config/encoder/encoder_test.go
+++ b/pkg/machinery/config/encoder/encoder_test.go
@@ -80,13 +80,13 @@ var (
 )
 
 func init() {
-	configDoc.Comments[encoder.HeadComment] = "test configuration"
+	configDoc.Comments[encoder.LineComment] = "test configuration"
 	configDoc.Fields = make([]encoder.Doc, 8)
 	configDoc.Fields[1].Comments[encoder.LineComment] = "<<<"
 	configDoc.Fields[2].Comments[encoder.HeadComment] = "complex slice"
 	configDoc.Fields[3].Comments[encoder.FootComment] = "some text example for map"
 
-	endpointDoc.Comments[encoder.HeadComment] = "endpoint settings"
+	endpointDoc.Comments[encoder.LineComment] = "endpoint settings"
 	endpointDoc.Fields = make([]encoder.Doc, 2)
 	endpointDoc.Fields[0].Comments[encoder.LineComment] = "endpoint host"
 	endpointDoc.Fields[1].Comments[encoder.LineComment] = "custom port"
@@ -169,8 +169,7 @@ func (suite *EncoderSuite) TestRun() {
 		{
 			name:  "default struct",
 			value: &Config{},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
@@ -186,8 +185,7 @@ map: {}
 					value: "abcd",
 				},
 			},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
@@ -205,8 +203,7 @@ custommarshaller:
 			value: &Config{
 				Bytes: []byte("..."),
 			},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
@@ -225,14 +222,12 @@ bytes: [46, 46, 46]
 				},
 				unexported: -1,
 			},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
 complex_slice: []
 map:
-    # endpoint settings
     endpoint:
         host: "" # endpoint host
 # some text example for map
@@ -245,14 +240,12 @@ map:
 					"endpoint": nil,
 				},
 			},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
 complex_slice: []
 map:
-    # endpoint settings
     endpoint: null
 # some text example for map
 `,
@@ -265,8 +258,7 @@ map:
 				},
 				ComplexSlice: []*Endpoint{e},
 			},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
@@ -274,7 +266,6 @@ complex_slice:
     - host: "" # endpoint host
       port: 8080 # custom port
 map:
-    # endpoint settings
     endpoint:
         host: "" # endpoint host
 # some text example for map
@@ -287,8 +278,7 @@ map:
 					MixedIn: "a",
 				},
 			},
-			expectedYAML: `# test configuration
-integer: 0
+			expectedYAML: `integer: 0
 # <<<
 slice: []
 # complex slice
@@ -332,7 +322,7 @@ mixed_in: a # was inlined
 			},
 			expectedYAML: `machine:
     state: 1000
-    
+    ` + `
     # config:
     #     # this is some version
     #     version: 0.0.2

--- a/pkg/machinery/config/encoder/markdown.go
+++ b/pkg/machinery/config/encoder/markdown.go
@@ -32,7 +32,7 @@ Examples:
 ## {{ $struct.Type }}
 {{ if $struct.Description -}}
 {{ $struct.Description }}
-{{ end -}}
+{{ end }}
 {{ if $struct.AppearsIn -}}
 Appears in:
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -48,8 +48,10 @@ var (
 
 func init() {
 	ConfigDoc.Type = "Config"
-	ConfigDoc.Comments[encoder.HeadComment] = ""
-	ConfigDoc.Description = ""
+	ConfigDoc.Comments[encoder.LineComment] = "Config defines the v1alpha1 configuration file."
+	ConfigDoc.Description = "Config defines the v1alpha1 configuration file."
+
+	ConfigDoc.AddExample("", configExample)
 	ConfigDoc.Fields = make([]encoder.Doc, 5)
 	ConfigDoc.Fields[0].Name = "version"
 	ConfigDoc.Fields[0].Type = "string"
@@ -93,8 +95,10 @@ func init() {
 	ConfigDoc.Fields[4].Comments[encoder.LineComment] = "Provides cluster specific configuration options."
 
 	MachineConfigDoc.Type = "MachineConfig"
-	MachineConfigDoc.Comments[encoder.HeadComment] = ""
-	MachineConfigDoc.Description = ""
+	MachineConfigDoc.Comments[encoder.LineComment] = "MachineConfig represents the machine-specific config values."
+	MachineConfigDoc.Description = "MachineConfig represents the machine-specific config values."
+
+	MachineConfigDoc.AddExample("", machineConfigExample)
 	MachineConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "Config",
@@ -209,8 +213,10 @@ func init() {
 	MachineConfigDoc.Fields[12].AddExample("", machineConfigRegistriesExample)
 
 	ClusterConfigDoc.Type = "ClusterConfig"
-	ClusterConfigDoc.Comments[encoder.HeadComment] = ""
-	ClusterConfigDoc.Description = ""
+	ClusterConfigDoc.Comments[encoder.LineComment] = "ClusterConfig represents the cluster-wide config values."
+	ClusterConfigDoc.Description = "ClusterConfig represents the cluster-wide config values."
+
+	ClusterConfigDoc.AddExample("", clusterConfigExample)
 	ClusterConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "Config",
@@ -347,8 +353,8 @@ func init() {
 	}
 
 	KubeletConfigDoc.Type = "KubeletConfig"
-	KubeletConfigDoc.Comments[encoder.HeadComment] = ""
-	KubeletConfigDoc.Description = ""
+	KubeletConfigDoc.Comments[encoder.LineComment] = "KubeletConfig represents the kubelet config values."
+	KubeletConfigDoc.Description = "KubeletConfig represents the kubelet config values."
 
 	KubeletConfigDoc.AddExample("Kubelet definition example.", machineKubeletExample)
 	KubeletConfigDoc.AppearsIn = []encoder.Appearance{
@@ -383,8 +389,8 @@ func init() {
 	KubeletConfigDoc.Fields[2].AddExample("", kubeletExtraMountsExample)
 
 	NetworkConfigDoc.Type = "NetworkConfig"
-	NetworkConfigDoc.Comments[encoder.HeadComment] = ""
-	NetworkConfigDoc.Description = ""
+	NetworkConfigDoc.Comments[encoder.LineComment] = "NetworkConfig represents the machine's networking config values."
+	NetworkConfigDoc.Description = "NetworkConfig represents the machine's networking config values."
 
 	NetworkConfigDoc.AddExample("Network definition example.", machineNetworkConfigExample)
 	NetworkConfigDoc.AppearsIn = []encoder.Appearance{
@@ -422,8 +428,8 @@ func init() {
 	NetworkConfigDoc.Fields[3].AddExample("", networkConfigExtraHostsExample)
 
 	InstallConfigDoc.Type = "InstallConfig"
-	InstallConfigDoc.Comments[encoder.HeadComment] = ""
-	InstallConfigDoc.Description = ""
+	InstallConfigDoc.Comments[encoder.LineComment] = "InstallConfig represents the installation options for preparing a node."
+	InstallConfigDoc.Description = "InstallConfig represents the installation options for preparing a node."
 
 	InstallConfigDoc.AddExample("MachineInstall config usage example.", machineInstallExample)
 	InstallConfigDoc.AppearsIn = []encoder.Appearance{
@@ -448,14 +454,14 @@ func init() {
 	InstallConfigDoc.Fields[1].Description = "Allows for supplying extra kernel args via the bootloader."
 	InstallConfigDoc.Fields[1].Comments[encoder.LineComment] = "Allows for supplying extra kernel args via the bootloader."
 
-	InstallConfigDoc.Fields[1].AddExample("", []string{"a=b"})
+	InstallConfigDoc.Fields[1].AddExample("", []string{"talos.platform=metal", "reboot=k"})
 	InstallConfigDoc.Fields[2].Name = "image"
 	InstallConfigDoc.Fields[2].Type = "string"
 	InstallConfigDoc.Fields[2].Note = ""
-	InstallConfigDoc.Fields[2].Description = "Allows for supplying the image used to perform the installation."
+	InstallConfigDoc.Fields[2].Description = "Allows for supplying the image used to perform the installation.\nImage reference for each Talos release can be found on\n[GitHub releases page](https://github.com/talos-systems/talos/releases)."
 	InstallConfigDoc.Fields[2].Comments[encoder.LineComment] = "Allows for supplying the image used to perform the installation."
 
-	InstallConfigDoc.Fields[2].AddExample("", "docker.io/<org>/<image>:<tag>")
+	InstallConfigDoc.Fields[2].AddExample("", "ghcr.io/talos-systems/installer:latest")
 	InstallConfigDoc.Fields[3].Name = "bootloader"
 	InstallConfigDoc.Fields[3].Type = "bool"
 	InstallConfigDoc.Fields[3].Note = ""
@@ -480,8 +486,8 @@ func init() {
 	}
 
 	TimeConfigDoc.Type = "TimeConfig"
-	TimeConfigDoc.Comments[encoder.HeadComment] = ""
-	TimeConfigDoc.Description = ""
+	TimeConfigDoc.Comments[encoder.LineComment] = "TimeConfig represents the options for configuring time on a machine."
+	TimeConfigDoc.Description = "TimeConfig represents the options for configuring time on a machine."
 
 	TimeConfigDoc.AddExample("Example configuration for cloudflare ntp server.", machineTimeExample)
 	TimeConfigDoc.AppearsIn = []encoder.Appearance{
@@ -503,8 +509,8 @@ func init() {
 	TimeConfigDoc.Fields[1].Comments[encoder.LineComment] = "Specifies time (NTP) servers to use for setting the system time."
 
 	RegistriesConfigDoc.Type = "RegistriesConfig"
-	RegistriesConfigDoc.Comments[encoder.HeadComment] = ""
-	RegistriesConfigDoc.Description = ""
+	RegistriesConfigDoc.Comments[encoder.LineComment] = "RegistriesConfig represents the image pull options."
+	RegistriesConfigDoc.Description = "RegistriesConfig represents the image pull options."
 
 	RegistriesConfigDoc.AddExample("", machineConfigRegistriesExample)
 	RegistriesConfigDoc.AppearsIn = []encoder.Appearance{
@@ -530,8 +536,8 @@ func init() {
 	RegistriesConfigDoc.Fields[1].AddExample("", machineConfigRegistryConfigExample)
 
 	PodCheckpointerDoc.Type = "PodCheckpointer"
-	PodCheckpointerDoc.Comments[encoder.HeadComment] = ""
-	PodCheckpointerDoc.Description = ""
+	PodCheckpointerDoc.Comments[encoder.LineComment] = "PodCheckpointer represents the pod-checkpointer config values."
+	PodCheckpointerDoc.Description = "PodCheckpointer represents the pod-checkpointer config values."
 
 	PodCheckpointerDoc.AddExample("", clusterPodCheckpointerExample)
 	PodCheckpointerDoc.AppearsIn = []encoder.Appearance{
@@ -548,8 +554,8 @@ func init() {
 	PodCheckpointerDoc.Fields[0].Comments[encoder.LineComment] = "The `image` field is an override to the default pod-checkpointer image."
 
 	CoreDNSDoc.Type = "CoreDNS"
-	CoreDNSDoc.Comments[encoder.HeadComment] = ""
-	CoreDNSDoc.Description = ""
+	CoreDNSDoc.Comments[encoder.LineComment] = "CoreDNS represents the CoreDNS config values."
+	CoreDNSDoc.Description = "CoreDNS represents the CoreDNS config values."
 
 	CoreDNSDoc.AddExample("", clusterCoreDNSExample)
 	CoreDNSDoc.AppearsIn = []encoder.Appearance{
@@ -566,10 +572,12 @@ func init() {
 	CoreDNSDoc.Fields[0].Comments[encoder.LineComment] = "The `image` field is an override to the default coredns image."
 
 	EndpointDoc.Type = "Endpoint"
-	EndpointDoc.Comments[encoder.HeadComment] = ""
-	EndpointDoc.Description = ""
+	EndpointDoc.Comments[encoder.LineComment] = "Endpoint represents the endpoint URL parsed out of the machine config."
+	EndpointDoc.Description = "Endpoint represents the endpoint URL parsed out of the machine config."
 
-	EndpointDoc.AddExample("", "https://1.2.3.4:443")
+	EndpointDoc.AddExample("", "https://1.2.3.4:6443")
+
+	EndpointDoc.AddExample("", "https://cluster1.internal:6443")
 	EndpointDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "ControlPlaneConfig",
@@ -579,8 +587,8 @@ func init() {
 	EndpointDoc.Fields = make([]encoder.Doc, 0)
 
 	ControlPlaneConfigDoc.Type = "ControlPlaneConfig"
-	ControlPlaneConfigDoc.Comments[encoder.HeadComment] = ""
-	ControlPlaneConfigDoc.Description = ""
+	ControlPlaneConfigDoc.Comments[encoder.LineComment] = "ControlPlaneConfig represents the control plane configuration options."
+	ControlPlaneConfigDoc.Description = "ControlPlaneConfig represents the control plane configuration options."
 
 	ControlPlaneConfigDoc.AddExample("Setting controlplane endpoint address to 1.2.3.4 and port to 443 example.", clusterControlPlaneExample)
 	ControlPlaneConfigDoc.AppearsIn = []encoder.Appearance{
@@ -596,7 +604,9 @@ func init() {
 	ControlPlaneConfigDoc.Fields[0].Description = "Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.\nIt is single-valued, and may optionally include a port number."
 	ControlPlaneConfigDoc.Fields[0].Comments[encoder.LineComment] = "Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname."
 
-	ControlPlaneConfigDoc.Fields[0].AddExample("", "https://1.2.3.4:443")
+	ControlPlaneConfigDoc.Fields[0].AddExample("", "https://1.2.3.4:6443")
+
+	ControlPlaneConfigDoc.Fields[0].AddExample("", "https://cluster1.internal:6443")
 	ControlPlaneConfigDoc.Fields[1].Name = "localAPIServerPort"
 	ControlPlaneConfigDoc.Fields[1].Type = "int"
 	ControlPlaneConfigDoc.Fields[1].Note = ""
@@ -604,8 +614,8 @@ func init() {
 	ControlPlaneConfigDoc.Fields[1].Comments[encoder.LineComment] = "The port that the API server listens on internally."
 
 	APIServerConfigDoc.Type = "APIServerConfig"
-	APIServerConfigDoc.Comments[encoder.HeadComment] = ""
-	APIServerConfigDoc.Description = ""
+	APIServerConfigDoc.Comments[encoder.LineComment] = "APIServerConfig represents the kube apiserver configuration options."
+	APIServerConfigDoc.Description = "APIServerConfig represents the kube apiserver configuration options."
 
 	APIServerConfigDoc.AddExample("", clusterAPIServerExample)
 	APIServerConfigDoc.AppearsIn = []encoder.Appearance{
@@ -632,8 +642,8 @@ func init() {
 	APIServerConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra certificate subject alternative names for the API server's certificate."
 
 	ControllerManagerConfigDoc.Type = "ControllerManagerConfig"
-	ControllerManagerConfigDoc.Comments[encoder.HeadComment] = ""
-	ControllerManagerConfigDoc.Description = ""
+	ControllerManagerConfigDoc.Comments[encoder.LineComment] = "ControllerManagerConfig represents the kube controller manager configuration options."
+	ControllerManagerConfigDoc.Description = "ControllerManagerConfig represents the kube controller manager configuration options."
 
 	ControllerManagerConfigDoc.AddExample("", clusterControllerManagerExample)
 	ControllerManagerConfigDoc.AppearsIn = []encoder.Appearance{
@@ -655,8 +665,8 @@ func init() {
 	ControllerManagerConfigDoc.Fields[1].Comments[encoder.LineComment] = "Extra arguments to supply to the controller manager."
 
 	ProxyConfigDoc.Type = "ProxyConfig"
-	ProxyConfigDoc.Comments[encoder.HeadComment] = ""
-	ProxyConfigDoc.Description = ""
+	ProxyConfigDoc.Comments[encoder.LineComment] = "ProxyConfig represents the kube proxy configuration options."
+	ProxyConfigDoc.Description = "ProxyConfig represents the kube proxy configuration options."
 
 	ProxyConfigDoc.AddExample("", clusterProxyExample)
 	ProxyConfigDoc.AppearsIn = []encoder.Appearance{
@@ -683,8 +693,8 @@ func init() {
 	ProxyConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra arguments to supply to kube-proxy."
 
 	SchedulerConfigDoc.Type = "SchedulerConfig"
-	SchedulerConfigDoc.Comments[encoder.HeadComment] = ""
-	SchedulerConfigDoc.Description = ""
+	SchedulerConfigDoc.Comments[encoder.LineComment] = "SchedulerConfig represents the kube scheduler configuration options."
+	SchedulerConfigDoc.Description = "SchedulerConfig represents the kube scheduler configuration options."
 
 	SchedulerConfigDoc.AddExample("", clusterSchedulerConfig)
 	SchedulerConfigDoc.AppearsIn = []encoder.Appearance{
@@ -706,8 +716,8 @@ func init() {
 	SchedulerConfigDoc.Fields[1].Comments[encoder.LineComment] = "Extra arguments to supply to the scheduler."
 
 	EtcdConfigDoc.Type = "EtcdConfig"
-	EtcdConfigDoc.Comments[encoder.HeadComment] = ""
-	EtcdConfigDoc.Description = ""
+	EtcdConfigDoc.Comments[encoder.LineComment] = "EtcdConfig represents the etcd configuration options."
+	EtcdConfigDoc.Description = "EtcdConfig represents the etcd configuration options."
 
 	EtcdConfigDoc.AddExample("", clusterEtcdConfig)
 	EtcdConfigDoc.AppearsIn = []encoder.Appearance{
@@ -736,8 +746,8 @@ func init() {
 	EtcdConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra arguments to supply to etcd."
 
 	ClusterNetworkConfigDoc.Type = "ClusterNetworkConfig"
-	ClusterNetworkConfigDoc.Comments[encoder.HeadComment] = ""
-	ClusterNetworkConfigDoc.Description = ""
+	ClusterNetworkConfigDoc.Comments[encoder.LineComment] = "ClusterNetworkConfig represents kube networking configuration options."
+	ClusterNetworkConfigDoc.Description = "ClusterNetworkConfig represents kube networking configuration options."
 
 	ClusterNetworkConfigDoc.AddExample("Configuring with flannel CNI and setting up subnets.", clusterNetworkExample)
 	ClusterNetworkConfigDoc.AppearsIn = []encoder.Appearance{
@@ -777,8 +787,8 @@ func init() {
 	ClusterNetworkConfigDoc.Fields[3].AddExample("", []string{"10.96.0.0/12"})
 
 	CNIConfigDoc.Type = "CNIConfig"
-	CNIConfigDoc.Comments[encoder.HeadComment] = ""
-	CNIConfigDoc.Description = ""
+	CNIConfigDoc.Comments[encoder.LineComment] = "CNIConfig represents the CNI configuration options."
+	CNIConfigDoc.Description = "CNIConfig represents the CNI configuration options."
 
 	CNIConfigDoc.AddExample("", clusterCustomCNIExample)
 	CNIConfigDoc.AppearsIn = []encoder.Appearance{
@@ -800,8 +810,8 @@ func init() {
 	CNIConfigDoc.Fields[1].Comments[encoder.LineComment] = "URLs containing manifests to apply for the CNI."
 
 	AdminKubeconfigConfigDoc.Type = "AdminKubeconfigConfig"
-	AdminKubeconfigConfigDoc.Comments[encoder.HeadComment] = ""
-	AdminKubeconfigConfigDoc.Description = ""
+	AdminKubeconfigConfigDoc.Comments[encoder.LineComment] = "AdminKubeconfigConfig contains admin kubeconfig settings."
+	AdminKubeconfigConfigDoc.Description = "AdminKubeconfigConfig contains admin kubeconfig settings."
 
 	AdminKubeconfigConfigDoc.AddExample("", clusterAdminKubeconfigExample)
 	AdminKubeconfigConfigDoc.AppearsIn = []encoder.Appearance{
@@ -818,8 +828,8 @@ func init() {
 	AdminKubeconfigConfigDoc.Fields[0].Comments[encoder.LineComment] = "Admin kubeconfig certificate lifetime (default is 1 year)."
 
 	MachineDiskDoc.Type = "MachineDisk"
-	MachineDiskDoc.Comments[encoder.HeadComment] = ""
-	MachineDiskDoc.Description = ""
+	MachineDiskDoc.Comments[encoder.LineComment] = "MachineDisk represents the options available for partitioning, formatting, and"
+	MachineDiskDoc.Description = "MachineDisk represents the options available for partitioning, formatting, and\nmounting extra disks.\n"
 
 	MachineDiskDoc.AddExample("MachineDisks list example.", machineDisksExample)
 	MachineDiskDoc.AppearsIn = []encoder.Appearance{
@@ -841,8 +851,8 @@ func init() {
 	MachineDiskDoc.Fields[1].Comments[encoder.LineComment] = "A list of partitions to create on the disk."
 
 	DiskPartitionDoc.Type = "DiskPartition"
-	DiskPartitionDoc.Comments[encoder.HeadComment] = ""
-	DiskPartitionDoc.Description = ""
+	DiskPartitionDoc.Comments[encoder.LineComment] = "DiskPartition represents the options for a disk partition."
+	DiskPartitionDoc.Description = "DiskPartition represents the options for a disk partition."
 	DiskPartitionDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "MachineDisk",
@@ -866,8 +876,8 @@ func init() {
 	DiskPartitionDoc.Fields[1].Comments[encoder.LineComment] = "Where to mount the partition."
 
 	MachineFileDoc.Type = "MachineFile"
-	MachineFileDoc.Comments[encoder.HeadComment] = ""
-	MachineFileDoc.Description = ""
+	MachineFileDoc.Comments[encoder.LineComment] = "MachineFile represents a file to write to disk."
+	MachineFileDoc.Description = "MachineFile represents a file to write to disk."
 
 	MachineFileDoc.AddExample("MachineFiles usage example.", machineFilesExample)
 	MachineFileDoc.AppearsIn = []encoder.Appearance{
@@ -904,8 +914,8 @@ func init() {
 	}
 
 	ExtraHostDoc.Type = "ExtraHost"
-	ExtraHostDoc.Comments[encoder.HeadComment] = ""
-	ExtraHostDoc.Description = ""
+	ExtraHostDoc.Comments[encoder.LineComment] = "ExtraHost represents a host entry in /etc/hosts."
+	ExtraHostDoc.Description = "ExtraHost represents a host entry in /etc/hosts."
 
 	ExtraHostDoc.AddExample("", networkConfigExtraHostsExample)
 	ExtraHostDoc.AppearsIn = []encoder.Appearance{
@@ -927,8 +937,8 @@ func init() {
 	ExtraHostDoc.Fields[1].Comments[encoder.LineComment] = "The host alias."
 
 	DeviceDoc.Type = "Device"
-	DeviceDoc.Comments[encoder.HeadComment] = ""
-	DeviceDoc.Description = ""
+	DeviceDoc.Comments[encoder.LineComment] = "Device represents a network interface."
+	DeviceDoc.Description = "Device represents a network interface."
 
 	DeviceDoc.AddExample("", machineNetworkConfigExample.NetworkInterfaces)
 	DeviceDoc.AppearsIn = []encoder.Appearance{
@@ -1002,8 +1012,8 @@ func init() {
 	DeviceDoc.Fields[9].AddExample("", networkConfigDHCPOptionsExample)
 
 	DHCPOptionsDoc.Type = "DHCPOptions"
-	DHCPOptionsDoc.Comments[encoder.HeadComment] = ""
-	DHCPOptionsDoc.Description = ""
+	DHCPOptionsDoc.Comments[encoder.LineComment] = "DHCPOptions contains options for configuring the DHCP settings for a given interface."
+	DHCPOptionsDoc.Description = "DHCPOptions contains options for configuring the DHCP settings for a given interface."
 
 	DHCPOptionsDoc.AddExample("", networkConfigDHCPOptionsExample)
 	DHCPOptionsDoc.AppearsIn = []encoder.Appearance{
@@ -1020,8 +1030,8 @@ func init() {
 	DHCPOptionsDoc.Fields[0].Comments[encoder.LineComment] = "The priority of all routes received via DHCP."
 
 	BondDoc.Type = "Bond"
-	BondDoc.Comments[encoder.HeadComment] = ""
-	BondDoc.Description = ""
+	BondDoc.Comments[encoder.LineComment] = "Bond contains the various options for configuring a bonded interface."
+	BondDoc.Description = "Bond contains the various options for configuring a bonded interface."
 
 	BondDoc.AddExample("", networkConfigBondExample)
 	BondDoc.AppearsIn = []encoder.Appearance{
@@ -1168,8 +1178,8 @@ func init() {
 	BondDoc.Fields[26].Comments[encoder.LineComment] = "A bond option."
 
 	VlanDoc.Type = "Vlan"
-	VlanDoc.Comments[encoder.HeadComment] = ""
-	VlanDoc.Description = ""
+	VlanDoc.Comments[encoder.LineComment] = "Vlan represents vlan settings for a device."
+	VlanDoc.Description = "Vlan represents vlan settings for a device."
 	VlanDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "Device",
@@ -1199,8 +1209,8 @@ func init() {
 	VlanDoc.Fields[3].Comments[encoder.LineComment] = "The VLAN's ID."
 
 	RouteDoc.Type = "Route"
-	RouteDoc.Comments[encoder.HeadComment] = ""
-	RouteDoc.Description = ""
+	RouteDoc.Comments[encoder.LineComment] = "Route represents a network route."
+	RouteDoc.Description = "Route represents a network route."
 
 	RouteDoc.AddExample("", networkConfigRoutesExample)
 	RouteDoc.AppearsIn = []encoder.Appearance{
@@ -1226,8 +1236,8 @@ func init() {
 	RouteDoc.Fields[1].Comments[encoder.LineComment] = "The route's gateway."
 
 	RegistryMirrorConfigDoc.Type = "RegistryMirrorConfig"
-	RegistryMirrorConfigDoc.Comments[encoder.HeadComment] = ""
-	RegistryMirrorConfigDoc.Description = ""
+	RegistryMirrorConfigDoc.Comments[encoder.LineComment] = "RegistryMirrorConfig represents mirror configuration for a registry."
+	RegistryMirrorConfigDoc.Description = "RegistryMirrorConfig represents mirror configuration for a registry."
 
 	RegistryMirrorConfigDoc.AddExample("", machineConfigRegistryMirrorsExample)
 	RegistryMirrorConfigDoc.AppearsIn = []encoder.Appearance{
@@ -1244,8 +1254,8 @@ func init() {
 	RegistryMirrorConfigDoc.Fields[0].Comments[encoder.LineComment] = "List of endpoints (URLs) for registry mirrors to use."
 
 	RegistryConfigDoc.Type = "RegistryConfig"
-	RegistryConfigDoc.Comments[encoder.HeadComment] = ""
-	RegistryConfigDoc.Description = ""
+	RegistryConfigDoc.Comments[encoder.LineComment] = "RegistryConfig specifies auth & TLS config per registry."
+	RegistryConfigDoc.Description = "RegistryConfig specifies auth & TLS config per registry."
 
 	RegistryConfigDoc.AddExample("", machineConfigRegistryConfigExample)
 	RegistryConfigDoc.AppearsIn = []encoder.Appearance{
@@ -1273,8 +1283,8 @@ func init() {
 	RegistryConfigDoc.Fields[1].AddExample("", machineConfigRegistryAuthConfigExample)
 
 	RegistryAuthConfigDoc.Type = "RegistryAuthConfig"
-	RegistryAuthConfigDoc.Comments[encoder.HeadComment] = ""
-	RegistryAuthConfigDoc.Description = ""
+	RegistryAuthConfigDoc.Comments[encoder.LineComment] = "RegistryAuthConfig specifies authentication configuration for a registry."
+	RegistryAuthConfigDoc.Description = "RegistryAuthConfig specifies authentication configuration for a registry."
 
 	RegistryAuthConfigDoc.AddExample("", machineConfigRegistryAuthConfigExample)
 	RegistryAuthConfigDoc.AppearsIn = []encoder.Appearance{
@@ -1306,8 +1316,8 @@ func init() {
 	RegistryAuthConfigDoc.Fields[3].Comments[encoder.LineComment] = "Optional registry authentication."
 
 	RegistryTLSConfigDoc.Type = "RegistryTLSConfig"
-	RegistryTLSConfigDoc.Comments[encoder.HeadComment] = ""
-	RegistryTLSConfigDoc.Description = ""
+	RegistryTLSConfigDoc.Comments[encoder.LineComment] = "RegistryTLSConfig specifies TLS config for HTTPS registries."
+	RegistryTLSConfigDoc.Description = "RegistryTLSConfig specifies TLS config for HTTPS registries."
 
 	RegistryTLSConfigDoc.AddExample("", machineConfigRegistryTLSConfigExample1)
 

--- a/website/content/docs/v0.7/Reference/configuration.md
+++ b/website/content/docs/v0.7/Reference/configuration.md
@@ -17,8 +17,16 @@ talosctl gen config --version v1alpha1 <cluster name> <cluster endpoint>
 This will generate a machine config for each node type, and a talosconfig for the CLI.
 
 ## Config
+Config defines the v1alpha1 configuration file.
 
 
+
+``` yaml
+version: v1alpha1
+persist: true
+machine: # ...
+cluster: # ...
+```
 
 <hr />
 
@@ -119,12 +127,27 @@ Provides cluster specific configuration options.
 
 
 ## MachineConfig
+MachineConfig represents the machine-specific config values.
+
 Appears in:
 
 
 - <code><a href="#config">Config</a>.machine</code>
 
 
+``` yaml
+type: controlplane
+# InstallConfig represents the installation options for preparing a node.
+install:
+    disk: /dev/sda # The disk used for installations.
+    # Allows for supplying extra kernel args via the bootloader.
+    extraKernelArgs:
+        - console=ttyS1
+        - panic=10
+    image: ghcr.io/talos-systems/installer:latest # Allows for supplying the image used to perform the installation.
+    bootloader: true # Indicates if a bootloader should be installed.
+    wipe: false # Indicates if the installation disk should be wiped at installation time.
+```
 
 <hr />
 
@@ -265,7 +288,7 @@ kubelet:
     image: ghcr.io/talos-systems/kubelet:v1.19.4 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
-        key: value
+        --feature-gates: ServerSideApply=true
 
     # # The `extraMounts` field is used to add additional mounts to the kubelet container.
     # extraMounts:
@@ -402,7 +425,8 @@ install:
     disk: /dev/sda # The disk used for installations.
     # Allows for supplying extra kernel args via the bootloader.
     extraKernelArgs:
-        - option=value
+        - console=ttyS1
+        - panic=10
     image: ghcr.io/talos-systems/installer:latest # Allows for supplying the image used to perform the installation.
     bootloader: true # Indicates if a bootloader should be installed.
     wipe: false # Indicates if the installation disk should be wiped at installation time.
@@ -609,12 +633,33 @@ registries:
 
 
 ## ClusterConfig
+ClusterConfig represents the cluster-wide config values.
+
 Appears in:
 
 
 - <code><a href="#config">Config</a>.cluster</code>
 
 
+``` yaml
+# ControlPlaneConfig represents the control plane configuration options.
+controlPlane:
+    endpoint: https://1.2.3.4 # Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
+    localAPIServerPort: 443 # The port that the API server listens on internally.
+clusterName: talos.local
+# ClusterNetworkConfig represents kube networking configuration options.
+network:
+    # The CNI used.
+    cni:
+        name: flannel # Name of CNI to use.
+    dnsDomain: cluster.local # The domain used by Kubernetes DNS.
+    # The pod subnet CIDR.
+    podSubnets:
+        - 10.244.0.0/16
+    # The service subnet CIDR.
+    serviceSubnets:
+        - 10.96.0.0/12
+```
 
 <hr />
 
@@ -779,7 +824,8 @@ apiServer:
     image: k8s.gcr.io/kube-apiserver-amd64:v1.19.4 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
-        key: value
+        --feature-gates: ServerSideApply=true
+        --http2-max-streams-per-connection: "32"
     # Extra certificate subject alternative names for the API server's certificate.
     certSANs:
         - 1.2.3.4
@@ -810,7 +856,7 @@ controllerManager:
     image: k8s.gcr.io/kube-controller-manager-amd64:v1.19.4 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
-        key: value
+        --feature-gates: ServerSideApply=true
 ```
 
 
@@ -838,7 +884,7 @@ proxy:
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
-        key: value
+        --proxy-mode: iptables
 ```
 
 
@@ -865,7 +911,7 @@ scheduler:
     image: k8s.gcr.io/kube-scheduler-amd64:v1.19.4 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
-        key: value
+        --feature-gates: AllBeta=true
 ```
 
 
@@ -896,7 +942,7 @@ etcd:
         key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
     # Extra arguments to supply to etcd.
     extraArgs:
-        key: value
+        --election-timeout: "5000"
 ```
 
 
@@ -1057,6 +1103,8 @@ Valid values:
 
 
 ## KubeletConfig
+KubeletConfig represents the kubelet config values.
+
 Appears in:
 
 
@@ -1067,7 +1115,7 @@ Appears in:
 image: ghcr.io/talos-systems/kubelet:v1.19.4 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
-    key: value
+    --feature-gates: ServerSideApply=true
 
 # # The `extraMounts` field is used to add additional mounts to the kubelet container.
 # extraMounts:
@@ -1162,6 +1210,8 @@ extraMounts:
 
 
 ## NetworkConfig
+NetworkConfig represents the machine's networking config values.
+
 Appears in:
 
 
@@ -1331,6 +1381,8 @@ extraHostEntries:
 
 
 ## InstallConfig
+InstallConfig represents the installation options for preparing a node.
+
 Appears in:
 
 
@@ -1341,7 +1393,8 @@ Appears in:
 disk: /dev/sda # The disk used for installations.
 # Allows for supplying extra kernel args via the bootloader.
 extraKernelArgs:
-    - option=value
+    - console=ttyS1
+    - panic=10
 image: ghcr.io/talos-systems/installer:latest # Allows for supplying the image used to perform the installation.
 bootloader: true # Indicates if a bootloader should be installed.
 wipe: false # Indicates if the installation disk should be wiped at installation time.
@@ -1392,7 +1445,8 @@ Examples:
 
 ``` yaml
 extraKernelArgs:
-    - a=b
+    - talos.platform=metal
+    - reboot=k
 ```
 
 
@@ -1408,6 +1462,8 @@ extraKernelArgs:
 <div class="dt">
 
 Allows for supplying the image used to perform the installation.
+Image reference for each Talos release can be found on
+[GitHub releases page](https://github.com/talos-systems/talos/releases).
 
 
 
@@ -1415,7 +1471,7 @@ Examples:
 
 
 ``` yaml
-image: docker.io/<org>/<image>:<tag>
+image: ghcr.io/talos-systems/installer:latest
 ```
 
 
@@ -1477,6 +1533,8 @@ Valid values:
 
 
 ## TimeConfig
+TimeConfig represents the options for configuring time on a machine.
+
 Appears in:
 
 
@@ -1528,6 +1586,8 @@ Defaults to `pool.ntp.org`
 
 
 ## RegistriesConfig
+RegistriesConfig represents the image pull options.
+
 Appears in:
 
 
@@ -1638,6 +1698,8 @@ config:
 
 
 ## PodCheckpointer
+PodCheckpointer represents the pod-checkpointer config values.
+
 Appears in:
 
 
@@ -1668,6 +1730,8 @@ The `image` field is an override to the default pod-checkpointer image.
 
 
 ## CoreDNS
+CoreDNS represents the CoreDNS config values.
+
 Appears in:
 
 
@@ -1698,6 +1762,8 @@ The `image` field is an override to the default coredns image.
 
 
 ## Endpoint
+Endpoint represents the endpoint URL parsed out of the machine config.
+
 Appears in:
 
 
@@ -1705,12 +1771,17 @@ Appears in:
 
 
 ``` yaml
-https://1.2.3.4:443
+https://1.2.3.4:6443
+```
+``` yaml
+https://cluster1.internal:6443
 ```
 
 
 
 ## ControlPlaneConfig
+ControlPlaneConfig represents the control plane configuration options.
+
 Appears in:
 
 
@@ -1740,7 +1811,11 @@ Examples:
 
 
 ``` yaml
-endpoint: https://1.2.3.4:443
+endpoint: https://1.2.3.4:6443
+```
+
+``` yaml
+endpoint: https://cluster1.internal:6443
 ```
 
 
@@ -1768,6 +1843,8 @@ The default is `6443`.
 
 
 ## APIServerConfig
+APIServerConfig represents the kube apiserver configuration options.
+
 Appears in:
 
 
@@ -1778,7 +1855,8 @@ Appears in:
 image: k8s.gcr.io/kube-apiserver-amd64:v1.19.4 # The container image used in the API server manifest.
 # Extra arguments to supply to the API server.
 extraArgs:
-    key: value
+    --feature-gates: ServerSideApply=true
+    --http2-max-streams-per-connection: "32"
 # Extra certificate subject alternative names for the API server's certificate.
 certSANs:
     - 1.2.3.4
@@ -1831,6 +1909,8 @@ Extra certificate subject alternative names for the API server's certificate.
 
 
 ## ControllerManagerConfig
+ControllerManagerConfig represents the kube controller manager configuration options.
+
 Appears in:
 
 
@@ -1841,7 +1921,7 @@ Appears in:
 image: k8s.gcr.io/kube-controller-manager-amd64:v1.19.4 # The container image used in the controller manager manifest.
 # Extra arguments to supply to the controller manager.
 extraArgs:
-    key: value
+    --feature-gates: ServerSideApply=true
 ```
 
 <hr />
@@ -1877,6 +1957,8 @@ Extra arguments to supply to the controller manager.
 
 
 ## ProxyConfig
+ProxyConfig represents the kube proxy configuration options.
+
 Appears in:
 
 
@@ -1888,7 +1970,7 @@ image: k8s.gcr.io/kube-proxy-amd64:v1.19.4 # The container image used in the kub
 mode: ipvs # proxy mode of kube-proxy.
 # Extra arguments to supply to kube-proxy.
 extraArgs:
-    key: value
+    --proxy-mode: iptables
 ```
 
 <hr />
@@ -1938,6 +2020,8 @@ Extra arguments to supply to kube-proxy.
 
 
 ## SchedulerConfig
+SchedulerConfig represents the kube scheduler configuration options.
+
 Appears in:
 
 
@@ -1948,7 +2032,7 @@ Appears in:
 image: k8s.gcr.io/kube-scheduler-amd64:v1.19.4 # The container image used in the scheduler manifest.
 # Extra arguments to supply to the scheduler.
 extraArgs:
-    key: value
+    --feature-gates: AllBeta=true
 ```
 
 <hr />
@@ -1984,6 +2068,8 @@ Extra arguments to supply to the scheduler.
 
 
 ## EtcdConfig
+EtcdConfig represents the etcd configuration options.
+
 Appears in:
 
 
@@ -1998,7 +2084,7 @@ ca:
     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
 # Extra arguments to supply to etcd.
 extraArgs:
-    key: value
+    --election-timeout: "5000"
 ```
 
 <hr />
@@ -2074,6 +2160,8 @@ Note that the following args are not allowed:
 
 
 ## ClusterNetworkConfig
+ClusterNetworkConfig represents kube networking configuration options.
+
 Appears in:
 
 
@@ -2204,6 +2292,8 @@ serviceSubnets:
 
 
 ## CNIConfig
+CNIConfig represents the CNI configuration options.
+
 Appears in:
 
 
@@ -2250,6 +2340,8 @@ URLs containing manifests to apply for the CNI.
 
 
 ## AdminKubeconfigConfig
+AdminKubeconfigConfig contains admin kubeconfig settings.
+
 Appears in:
 
 
@@ -2281,6 +2373,10 @@ Field format accepts any Go time.Duration format ('1h' for one hour, '10m' for t
 
 
 ## MachineDisk
+MachineDisk represents the options available for partitioning, formatting, and
+mounting extra disks.
+
+
 Appears in:
 
 
@@ -2334,6 +2430,8 @@ A list of partitions to create on the disk.
 
 
 ## DiskPartition
+DiskPartition represents the options for a disk partition.
+
 Appears in:
 
 
@@ -2388,6 +2486,8 @@ Where to mount the partition.
 
 
 ## MachineFile
+MachineFile represents a file to write to disk.
+
 Appears in:
 
 
@@ -2469,6 +2569,8 @@ Valid values:
 
 
 ## ExtraHost
+ExtraHost represents a host entry in /etc/hosts.
+
 Appears in:
 
 
@@ -2516,6 +2618,8 @@ The host alias.
 
 
 ## Device
+Device represents a network interface.
+
 Appears in:
 
 
@@ -2775,6 +2879,8 @@ dhcpOptions:
 
 
 ## DHCPOptions
+DHCPOptions contains options for configuring the DHCP settings for a given interface.
+
 Appears in:
 
 
@@ -2805,6 +2911,8 @@ The priority of all routes received via DHCP.
 
 
 ## Bond
+Bond contains the various options for configuring a bonded interface.
+
 Appears in:
 
 
@@ -3204,6 +3312,8 @@ Please see the official kernel documentation.
 
 
 ## Vlan
+Vlan represents vlan settings for a device.
+
 Appears in:
 
 
@@ -3270,6 +3380,8 @@ The VLAN's ID.
 
 
 ## Route
+Route represents a network route.
+
 Appears in:
 
 
@@ -3318,6 +3430,8 @@ The route's gateway.
 
 
 ## RegistryMirrorConfig
+RegistryMirrorConfig represents mirror configuration for a registry.
+
 Appears in:
 
 
@@ -3354,6 +3468,8 @@ port and path (if path is not set, it defaults to `/v2`).
 
 
 ## RegistryConfig
+RegistryConfig specifies auth & TLS config per registry.
+
 Appears in:
 
 
@@ -3446,6 +3562,8 @@ auth:
 
 
 ## RegistryAuthConfig
+RegistryAuthConfig specifies authentication configuration for a registry.
+
 Appears in:
 
 
@@ -3520,6 +3638,8 @@ The meaning of each field is the same with the corresponding field in .docker/co
 
 
 ## RegistryTLSConfig
+RegistryTLSConfig specifies TLS config for HTTPS registries.
+
 Appears in:
 
 


### PR DESCRIPTION
`docgen` now correctly extracts documentation for the structure itself,
and supports mix of Go-style and yaml-style docblocks, so that we can
keep linter happy while embedding examples.

Fixes for encoder to keep things marshalled same way even with the
presence of the struct docs.

Add real examples replacing fake ones.

Add top-level hacked examples for `Config`, `MachineConfig` and
`ClusterConfig` to show the overall structure without pulling in all the
deep structure of those types.

Fixes #2768 

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

