### PR TITLE
chore: build arm64 images in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,13 +171,13 @@ talosctl-%:
 talosctl: $(TALOSCTL_DEFAULT_TARGET) ## Builds the talosctl binary for the local machine.
 
 image-%: ## Builds the specified image. Valid options are aws, azure, digital-ocean, gcp, and vmware (e.g. image-aws)
-	@docker run --rm -v /dev:/dev -v $(PWD)/$(ARTIFACTS):/out --privileged $(REGISTRY)/$(USERNAME)/installer:$(TAG) image --platform $*
+	@docker run --rm -v /dev:/dev --privileged $(REGISTRY)/$(USERNAME)/installer:$(TAG) image --platform $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
 images: image-aws image-azure image-digital-ocean image-gcp image-vmware ## Builds all known images (AWS, Azure, Digital Ocean, GCP, and VMware).
 
 .PHONY: iso
 iso: ## Builds the ISO and outputs it to the artifact directory.
-	@docker run --rm -i -v $(PWD)/$(ARTIFACTS):/out $(REGISTRY)/$(USERNAME)/installer:$(TAG) iso
+	@docker run --rm -i $(REGISTRY)/$(USERNAME)/installer:$(TAG) iso --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
 .PHONY: boot
 boot: ## Creates a compressed tarball that includes vmlinuz-{amd64,arm64} and initramfs-{amd64,arm64}.xz. Note that these files must already be present in the artifacts directory.

--- a/cmd/installer/cmd/iso.go
+++ b/cmd/installer/cmd/iso.go
@@ -46,11 +46,17 @@ var isoCmd = &cobra.Command{
 }
 
 func init() {
+	isoCmd.Flags().StringVar(&outputArg, "output", "/out", "The output path")
+	isoCmd.Flags().BoolVar(&tarToStdout, "tar-to-stdout", false, "Tar output and send to stdout")
 	rootCmd.AddCommand(isoCmd)
 }
 
 // nolint: gocyclo
 func runISOCmd() error {
+	if err := os.MkdirAll(outputArg, 0o777); err != nil {
+		return err
+	}
+
 	files := map[string]string{
 		"/usr/install/vmlinuz":      "/mnt/boot/vmlinuz",
 		"/usr/install/initramfs.xz": "/mnt/boot/initramfs.xz",
@@ -120,6 +126,12 @@ func runISOCmd() error {
 	_, err = io.Copy(to, from)
 	if err != nil {
 		return err
+	}
+
+	if tarToStdout {
+		if err := tarOutput(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/installer/pkg/ova/ova.go
+++ b/cmd/installer/pkg/ova/ova.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -184,7 +185,7 @@ func CreateOVAFromRAW(name, src, out string) (err error) {
 		return err
 	}
 
-	if _, err = cmd.Run("tar", "-cvf", filepath.Join(out, "vmware.ova"), "-C", dir, name+".ovf", name+".mf", name+".vmdk"); err != nil {
+	if _, err = cmd.Run("tar", "-cvf", filepath.Join(out, fmt.Sprintf("vmware-%s.ova", runtime.GOARCH)), "-C", dir, name+".ovf", name+".mf", name+".vmdk"); err != nil {
 		return err
 	}
 

--- a/hack/test/capi/cluster-aws.yaml
+++ b/hack/test/capi/cluster-aws.yaml
@@ -57,7 +57,7 @@ kind: TalosControlPlane
 metadata:
   name: talos-e2e-{{TAG}}-aws-controlplane
 spec:
-  version: v1.19.4
+  version: v1.19.3
   replicas: 3
   infrastructureTemplate:
     kind: AWSMachineTemplate
@@ -111,7 +111,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: talos-e2e-{{TAG}}-aws-workers
-      version: 1.19.4
+      version: 1.19.3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate

--- a/hack/test/capi/cluster-gcp.yaml
+++ b/hack/test/capi/cluster-gcp.yaml
@@ -44,7 +44,7 @@ kind: TalosControlPlane
 metadata:
   name: talos-e2e-{{TAG}}-gcp-controlplane
 spec:
-  version: v1.19.4
+  version: v1.19.3
   replicas: 3
   infrastructureTemplate:
     kind: GCPMachineTemplate
@@ -102,7 +102,7 @@ spec:
         kind: GCPMachineTemplate
         name: talos-e2e-{{TAG}}-gcp-workers
         namespace: default
-      version: 1.19.4
+      version: 1.19.3
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: GCPMachineTemplate

--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -12,7 +12,7 @@ function setup {
   mkdir -p ${TMP}
 
   # Untar image
-  tar -C ${TMP} -xf ${ARTIFACTS}/aws.tar.gz
+  tar -C ${TMP} -xf ${ARTIFACTS}/aws-amd64.tar.gz
 
   # Upload Image
   echo "uploading image to s3"

--- a/hack/test/e2e-azure.sh
+++ b/hack/test/e2e-azure.sh
@@ -19,9 +19,9 @@ function setup {
   # Login to azure
   az login --service-principal --username ${AZURE_CLIENT_ID} --password ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} > /dev/null
   set -x
-  
+
   # Untar image
-  tar -C ${TMP} -xf ${ARTIFACTS}/azure.tar.gz
+  tar -C ${TMP} -xf ${ARTIFACTS}/azure-amd64.tar.gz
 
   # Get connection string
   AZURE_STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -n ${AZURE_STORAGE_ACCOUNT} -g ${AZURE_GROUP} -o tsv)

--- a/hack/test/e2e-gcp.sh
+++ b/hack/test/e2e-gcp.sh
@@ -9,8 +9,8 @@ function setup {
   echo ${GCE_SVC_ACCT} | base64 -d > ${TMP}/svc-acct.json
   gcloud auth activate-service-account --key-file ${TMP}/svc-acct.json
   set -x
-  
-  gsutil cp ${ARTIFACTS}/gcp.tar.gz gs://talos-e2e/gcp-${SHA}.tar.gz
+
+  gsutil cp ${ARTIFACTS}/gcp-amd64.tar.gz gs://talos-e2e/gcp-${SHA}.tar.gz
   gcloud --quiet --project talos-testbed compute images delete talos-e2e-${SHA} || true
   gcloud --quiet --project talos-testbed compute images create talos-e2e-${SHA} --source-uri gs://talos-e2e/gcp-${SHA}.tar.gz
   sed -e "s/{{TAG}}/${SHA}/" ${PWD}/hack/test/capi/cluster-gcp.yaml > ${TMP}/cluster.yaml

--- a/website/content/docs/v0.6/Cloud Platforms/digitalocean.md
+++ b/website/content/docs/v0.6/Cloud Platforms/digitalocean.md
@@ -134,7 +134,7 @@ doctl compute droplet create \
 
 ### Retrieve the `kubeconfig`
 
-To configure `talosctl` we will need the first controla plane node's IP:
+To configure `talosctl` we will need the first control plane node's IP:
 
 ```bash
 doctl compute droplet get --format PublicIPv4 <droplet ID>

--- a/website/content/docs/v0.7/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.7/Cloud Platforms/aws.md
@@ -41,7 +41,7 @@ Note that the role should be associated with the S3 bucket we created above.
 First, download the AWS image from a Talos release:
 
 ```bash
-curl -LO https://github.com/talos-systems/talos/releases/latest/download/aws.tar.gz | tar -xv
+curl -LO https://github.com/talos-systems/talos/releases/latest/download/aws-amd64.tar.gz | tar -xv
 ```
 
 Copy the RAW disk to S3 and import it as a snapshot:

--- a/website/content/docs/v0.7/Cloud Platforms/azure.md
+++ b/website/content/docs/v0.7/Cloud Platforms/azure.md
@@ -36,7 +36,7 @@ export CONNECTION=$(az storage account show-connection-string \
 ### Create the Image
 
 First, download the Azure image from a [Talos release](https://github.com/talos-systems/talos/releases).
-Once downloaded, untar with `tar -xvf /path/to/azure.tar.gz`
+Once downloaded, untar with `tar -xvf /path/to/azure-amd64.tar.gz`
 
 #### Upload the VHD
 

--- a/website/content/docs/v0.7/Cloud Platforms/digitalocean.md
+++ b/website/content/docs/v0.7/Cloud Platforms/digitalocean.md
@@ -134,7 +134,7 @@ doctl compute droplet create \
 
 ### Retrieve the `kubeconfig`
 
-To configure `talosctl` we will need the first controla plane node's IP:
+To configure `talosctl` we will need the first control plane node's IP:
 
 ```bash
 doctl compute droplet get --format PublicIPv4 <droplet ID>

--- a/website/content/docs/v0.7/Cloud Platforms/gcp.md
+++ b/website/content/docs/v0.7/Cloud Platforms/gcp.md
@@ -23,14 +23,14 @@ export REGION="us-central1"
 ### Create the Image
 
 First, download the Google Cloud image from a Talos [release](https://github.com/talos-systems/talos/releases).
-These images are called `gcp.tar.gz`.
+These images are called `gcp-$ARCH.tar.gz`.
 
 #### Upload the Image
 
 Once you have downloaded the image, you can upload it to your storage bucket with:
 
 ```bash
-gsutil cp /path/to/gcp.tar.gz gs://$STORAGE_BUCKET
+gsutil cp /path/to/gcp-amd64.tar.gz gs://$STORAGE_BUCKET
 ```
 
 #### Register the image
@@ -39,7 +39,7 @@ Now that the image is present in our bucket, we'll register it.
 
 ```bash
 gcloud compute images create talos \
- --source-uri=gs://$STORAGE_BUCKET/gcp.tar.gz \
+ --source-uri=gs://$STORAGE_BUCKET/gcp-amd64.tar.gz \
  --guest-os-features=VIRTIO_SCSI_MULTIQUEUE
 ```
 


### PR DESCRIPTION
This changes installer image/iso output to be tar via stdout
(optionally), so that we can copy back artifacts back from remote docker
daemon.

Fixes #2776

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

