### PR TITLE
feat: drop to maintenance mode in cloud platforms if userdata is missing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/talos-systems/go-blockdevice v0.1.1-0.20201111103554-874213371a3f
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
-	github.com/talos-systems/go-retry v0.1.1-0.20200922131245-752f081252cf
+	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688
 	github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e
 	github.com/talos-systems/grpc-proxy v0.2.0
 	github.com/talos-systems/net v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -824,10 +824,9 @@ github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
-github.com/talos-systems/go-retry v0.1.0 h1:O+OeZR54CQ1+ch99p/81Pqi5GqJH6LIu1MTN/N0vd78=
 github.com/talos-systems/go-retry v0.1.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
-github.com/talos-systems/go-retry v0.1.1-0.20200922131245-752f081252cf h1:JzyT28FxRDndO59tFKA1IyGb9uWpJX429PPAfjc0dVQ=
-github.com/talos-systems/go-retry v0.1.1-0.20200922131245-752f081252cf/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
+github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688 h1:U5wFGj5LXt/r+qfy1nGftQxJvEbg/lVJuasHKtk3K7s=
+github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e h1:uCp8BfH4Ky2R1XkOKA5pSZpeMMyt0AbH29PIrkoBlaM=
 github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e/go.mod h1:HxhrzAoTZ7ed5Z5VvtCvnCIrOxyXDS7V2B5hCetAMW8=
 github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1LNzuMEs9Pw=

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -19,6 +19,7 @@ import (
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/download"
 )
 
@@ -142,7 +143,9 @@ func (a *AWS) Name() string {
 func (a *AWS) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", AWSUserDataEndpoint)
 
-	return download.Download(ctx, AWSUserDataEndpoint)
+	return download.Download(ctx, AWSUserDataEndpoint,
+		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
+		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
 }
 
 // Mode implements the runtime.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -57,6 +57,8 @@ func (a *Azure) Name() string {
 
 // Configuration implements the platform.Platform interface.
 func (a *Azure) Configuration(ctx context.Context) ([]byte, error) {
+	// TODO: support ErrNoConfigSource, requires handling of both CD-ROM & user-data sources
+	//       requires splitting `linuxAgent` into separate platform task which is called when node is up (or close to that)
 	// attempt to download from metadata endpoint
 	// disabled by default
 	log.Printf("fetching machine config from: %q", AzureUserDataEndpoint)

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean/digitalocean.go
@@ -15,6 +15,7 @@ import (
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/download"
 )
 
@@ -39,7 +40,9 @@ func (d *DigitalOcean) Name() string {
 func (d *DigitalOcean) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", DigitalOceanUserDataEndpoint)
 
-	return download.Download(ctx, DigitalOceanUserDataEndpoint)
+	return download.Download(ctx, DigitalOceanUserDataEndpoint,
+		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
+		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
 }
 
 // Mode implements the platform.Platform interface.
@@ -104,6 +107,6 @@ func (d *DigitalOcean) ExternalIPs(ctx context.Context) (addrs []net.IP, err err
 // KernelArgs implements the runtime.Platform interface.
 func (d *DigitalOcean) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS0"),
+		procfs.NewParameter("console").Append("ttyS0").Append("tty0").Append("tty1"),
 	}
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/download"
 )
 
@@ -40,7 +41,10 @@ func (g *GCP) Name() string {
 func (g *GCP) Configuration(ctx context.Context) ([]byte, error) {
 	log.Printf("fetching machine config from: %q", GCUserDataEndpoint)
 
-	return download.Download(ctx, GCUserDataEndpoint, download.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}))
+	return download.Download(ctx, GCUserDataEndpoint,
+		download.WithHeaders(map[string]string{"Metadata-Flavor": "Google"}),
+		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
+		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
 }
 
 // Hostname implements the platform.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/nic"
 	"github.com/talos-systems/talos/pkg/download"
 	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
@@ -78,7 +79,9 @@ func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 	// metadata about the instance from packet's metadata server
 	log.Printf("fetching machine config from: %q", PacketUserDataEndpoint)
 
-	machineConfigDl, err := download.Download(ctx, PacketUserDataEndpoint)
+	machineConfigDl, err := download.Download(ctx, PacketUserDataEndpoint,
+		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
+		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/vmw-guestinfo/vmcheck"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	platformerrors "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
@@ -64,7 +65,9 @@ func (v *VMware) Configuration(context.Context) ([]byte, error) {
 		}
 
 		if val == "" {
-			return nil, fmt.Errorf("config is required, no value found for guestinfo: %q, %q", constants.VMwareGuestInfoConfigKey, constants.VMwareGuestInfoFallbackKey)
+			log.Printf("config is required, no value found for guestinfo: %q, %q", constants.VMwareGuestInfoConfigKey, constants.VMwareGuestInfoFallbackKey)
+
+			return nil, platformerrors.ErrNoConfigSource
 		}
 
 		b, err := base64.StdEncoding.DecodeString(val)

--- a/website/content/docs/v0.7/Cloud Platforms/digitalocean.md
+++ b/website/content/docs/v0.7/Cloud Platforms/digitalocean.md
@@ -10,7 +10,8 @@ If you need more information on Digital Ocean specifics, please see the [officia
 
 ### Create the Image
 
-First, download the Digital Ocean image from a Talos release.
+First, download the Digital Ocean image from a Talos release. Extract the archive to get the `disk.raw` file, compress it using
+`gzip` to `disk.raw.gz`.
 
 Using an upload method of your choice (`doctl` does not have Spaces support), upload the image to a space.
 Now, create an image using the URL of the uploaded image:
@@ -18,8 +19,8 @@ Now, create an image using the URL of the uploaded image:
 ```bash
 doctl compute image create \
     --region $REGION \
-    --image-name talos-digital-ocean-tutorial \
-    --image-url https://talos-tutorial.$REGION.digitaloceanspaces.com/digital-ocean.raw.gz \
+    --image-description talos-digital-ocean-tutorial \
+    --image-url https://talos-tutorial.$REGION.digitaloceanspaces.com/disk.raw.gz \
     Talos
 ```
 


### PR DESCRIPTION
On first boot of Talos, if userdata is missing, Talos is going to drop
into maintenance mode which allows to upload config to the server via
`talosctl apply-config` command.

See also: https://github.com/talos-systems/go-retry/pull/4

Fixes #2780

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

