### PR TITLE
chore: bump K8s to 1.19.4 in e2e scripts with CABPT version

### DIFF
--- a/hack/test/capi/cluster-aws.yaml
+++ b/hack/test/capi/cluster-aws.yaml
@@ -57,7 +57,7 @@ kind: TalosControlPlane
 metadata:
   name: talos-e2e-{{TAG}}-aws-controlplane
 spec:
-  version: v1.19.3
+  version: v1.19.4
   replicas: 3
   infrastructureTemplate:
     kind: AWSMachineTemplate
@@ -111,7 +111,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
         kind: AWSMachineTemplate
         name: talos-e2e-{{TAG}}-aws-workers
-      version: 1.19.3
+      version: 1.19.4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AWSMachineTemplate

--- a/hack/test/capi/cluster-gcp.yaml
+++ b/hack/test/capi/cluster-gcp.yaml
@@ -44,7 +44,7 @@ kind: TalosControlPlane
 metadata:
   name: talos-e2e-{{TAG}}-gcp-controlplane
 spec:
-  version: v1.19.3
+  version: v1.19.4
   replicas: 3
   infrastructureTemplate:
     kind: GCPMachineTemplate
@@ -102,7 +102,7 @@ spec:
         kind: GCPMachineTemplate
         name: talos-e2e-{{TAG}}-gcp-workers
         namespace: default
-      version: 1.19.3
+      version: 1.19.4
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: GCPMachineTemplate

--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 source ./hack/test/e2e.sh
 
-export CABPT_VERSION="0.2.0-alpha.6"
+export CABPT_VERSION="0.2.0-alpha.7"
 export CACPPT_VERSION="0.1.0-alpha.8"
 export CAPA_VERSION="0.5.4"
 


### PR DESCRIPTION
This should fix the problem with the kubelet image.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

