### PR TITLE
feat: read config from extra guestinfo key (vmware)

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -58,7 +58,14 @@ func (v *VMware) Configuration(context.Context) ([]byte, error) {
 		}
 
 		if val == "" {
-			return nil, fmt.Errorf("config is required, no value found for guestinfo: %q", constants.VMwareGuestInfoConfigKey)
+			val, err = config.String(constants.VMwareGuestInfoFallbackKey, "")
+			if err != nil {
+				return nil, fmt.Errorf("failed to get guestinfo.%s: %w", constants.VMwareGuestInfoFallbackKey, err)
+			}
+		}
+
+		if val == "" {
+			return nil, fmt.Errorf("config is required, no value found for guestinfo: %q, %q", constants.VMwareGuestInfoConfigKey, constants.VMwareGuestInfoFallbackKey)
 		}
 
 		b, err := base64.StdEncoding.DecodeString(val)

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -234,6 +234,9 @@ const (
 	// VMwareGuestInfoConfigKey is the guestinfo key used to provide a config file.
 	VMwareGuestInfoConfigKey = "talos.config"
 
+	// VMwareGuestInfoFallbackKey is the fallback guestinfo key used to provide a config file.
+	VMwareGuestInfoFallbackKey = "userdata"
+
 	// AuditPolicyPath is the path to the audit-policy.yaml relative to initramfs.
 	AuditPolicyPath = "/etc/kubernetes/audit-policy.yaml"
 


### PR DESCRIPTION
This provides compatibility with VMWare CAPI provider which stores the
bootstrap secret in `guestinfo.userdata`.

Fixes #2798 

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit 39e644c924bde4171790ce8df435b8cba08ae31f)

