### PR TITLE
feat: correctly merge talosconfig (don't ever overwrite)

### DIFF
--- a/pkg/machinery/client/config/config_test.go
+++ b/pkg/machinery/client/config/config_test.go
@@ -4,11 +4,94 @@
 
 package config_test
 
-import "testing"
+import (
+	"testing"
 
-func TestEmpty(t *testing.T) {
-	// added for accurate coverage estimation
-	//
-	// please remove it once any unit-test is added
-	// for this package
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/pkg/machinery/client/config"
+)
+
+func TestConfigMerge(t *testing.T) {
+	context1 := &config.Context{}
+	context2 := &config.Context{}
+
+	for _, tt := range []struct {
+		name          string
+		config        *config.Config
+		configToMerge *config.Config
+
+		expectedContext  string
+		expectedContexts map[string]*config.Context
+	}{
+		{
+			name: "IntoEmpty",
+			config: &config.Config{
+				Contexts: map[string]*config.Context{},
+			},
+			configToMerge: &config.Config{
+				Context: "foo",
+				Contexts: map[string]*config.Context{
+					"foo": context1,
+				},
+			},
+
+			expectedContext: "foo",
+			expectedContexts: map[string]*config.Context{
+				"foo": context1,
+			},
+		},
+		{
+			name: "NoConflict",
+			config: &config.Config{
+				Context: "bar",
+				Contexts: map[string]*config.Context{
+					"bar": context2,
+				},
+			},
+			configToMerge: &config.Config{
+				Context: "",
+				Contexts: map[string]*config.Context{
+					"foo": context1,
+				},
+			},
+
+			expectedContext: "bar",
+			expectedContexts: map[string]*config.Context{
+				"foo": context1,
+				"bar": context2,
+			},
+		},
+		{
+			name: "WithRename",
+			config: &config.Config{
+				Context: "bar",
+				Contexts: map[string]*config.Context{
+					"bar": context2,
+				},
+			},
+			configToMerge: &config.Config{
+				Context: "bar",
+				Contexts: map[string]*config.Context{
+					"bar": context1,
+				},
+			},
+
+			expectedContext: "bar-1",
+			expectedContexts: map[string]*config.Context{
+				"bar-1": context1,
+				"bar":   context2,
+			},
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.config
+			c.Merge(tt.configToMerge)
+
+			assert.Equal(t, tt.expectedContext, c.Context)
+			assert.Equal(t, tt.expectedContexts, c.Contexts)
+		})
+	}
 }


### PR DESCRIPTION
Implement merging of Talos client config without overwrites - numeric
value is appended to context name to avoid ever overwriting config.

Fixes #2799

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

