### PR TITLE
feat: support ipv6 routes

### DIFF
--- a/internal/app/networkd/pkg/address/address.go
+++ b/internal/app/networkd/pkg/address/address.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"net"
 	"time"
-
-	"github.com/insomniacslk/dhcp/dhcpv4"
 )
 
 // Addressing provides an interface for abstracting the underlying network
@@ -32,4 +30,19 @@ type Addressing interface {
 }
 
 // Route is a representation of a network route.
-type Route = dhcpv4.Route
+type Route struct {
+	// Destination is the destination network this route provides.
+	Destination *net.IPNet
+
+	// Gateway is the router through which the destination may be reached.
+	// This option is exclusive of Interface
+	Gateway net.IP
+
+	// Interface indicates the route is an interface route, and traffic destinted for the Gateway should be sent through the given network interface.
+	// This option is exclusive of Gateway.
+	Interface string
+
+	// Metric indicates the "distance" to the destination through this route.
+	// This is an integer which allows the control of priority in the case of multiple routes to the same destination.
+	Metric uint32
+}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -166,6 +166,7 @@ type Vlan interface {
 type Route interface {
 	Network() string
 	Gateway() string
+	Metric() uint32
 }
 
 // Time defines the requirements for a config that pertains to time related

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -771,6 +771,11 @@ func (r *Route) Gateway() string {
 	return r.RouteGateway
 }
 
+// Metric implements the MachineNetwork interface.
+func (r *Route) Metric() uint32 {
+	return r.RouteMetric
+}
+
 // Interfaces implements the MachineNetwork interface.
 func (b *Bond) Interfaces() []string {
 	if b == nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -134,6 +134,7 @@ var (
 					{
 						RouteNetwork: "0.0.0.0/0",
 						RouteGateway: "192.168.2.1",
+						RouteMetric:  1024,
 					},
 				},
 			},
@@ -1214,6 +1215,8 @@ type Route struct {
 	RouteNetwork string `yaml:"network"`
 	//   description: The route's gateway.
 	RouteGateway string `yaml:"gateway"`
+	//   description: The optional metric for the route.
+	RouteMetric uint32 `yaml:"metric,omitempty"`
 }
 
 // RegistryMirrorConfig represents mirror configuration for a registry.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1223,7 +1223,7 @@ func init() {
 			FieldName: "routes",
 		},
 	}
-	RouteDoc.Fields = make([]encoder.Doc, 2)
+	RouteDoc.Fields = make([]encoder.Doc, 3)
 	RouteDoc.Fields[0].Name = "network"
 	RouteDoc.Fields[0].Type = "string"
 	RouteDoc.Fields[0].Note = ""
@@ -1234,6 +1234,11 @@ func init() {
 	RouteDoc.Fields[1].Note = ""
 	RouteDoc.Fields[1].Description = "The route's gateway."
 	RouteDoc.Fields[1].Comments[encoder.LineComment] = "The route's gateway."
+	RouteDoc.Fields[2].Name = "metric"
+	RouteDoc.Fields[2].Type = "uint32"
+	RouteDoc.Fields[2].Note = ""
+	RouteDoc.Fields[2].Description = "The optional metric for the route."
+	RouteDoc.Fields[2].Comments[encoder.LineComment] = "The optional metric for the route."
 
 	RegistryMirrorConfigDoc.Type = "RegistryMirrorConfig"
 	RegistryMirrorConfigDoc.Comments[encoder.LineComment] = "RegistryMirrorConfig represents mirror configuration for a registry."

--- a/website/content/docs/v0.7/Reference/configuration.md
+++ b/website/content/docs/v0.7/Reference/configuration.md
@@ -330,6 +330,7 @@ network:
           routes:
             - network: 0.0.0.0/0 # The route's network.
               gateway: 192.168.2.1 # The route's gateway.
+              metric: 1024 # The optional metric for the route.
           mtu: 1500 # The interface's MTU.
 
           # # Bond specific options.
@@ -1228,6 +1229,7 @@ interfaces:
       routes:
         - network: 0.0.0.0/0 # The route's network.
           gateway: 192.168.2.1 # The route's gateway.
+          metric: 1024 # The optional metric for the route.
       mtu: 1500 # The interface's MTU.
 
       # # Bond specific options.
@@ -1298,6 +1300,7 @@ interfaces:
       routes:
         - network: 0.0.0.0/0 # The route's network.
           gateway: 192.168.2.1 # The route's gateway.
+          metric: 1024 # The optional metric for the route.
       mtu: 1500 # The interface's MTU.
 
       # # Bond specific options.
@@ -2633,6 +2636,7 @@ Appears in:
   routes:
     - network: 0.0.0.0/0 # The route's network.
       gateway: 192.168.2.1 # The route's gateway.
+      metric: 1024 # The optional metric for the route.
   mtu: 1500 # The interface's MTU.
 
   # # Bond specific options.
@@ -3420,6 +3424,19 @@ The route's network.
 <div class="dt">
 
 The route's gateway.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>metric</code>  <i>uint32</i>
+
+</div>
+<div class="dt">
+
+The optional metric for the route.
 
 </div>
 


### PR DESCRIPTION
While IPv6 were mostly supported already, there was a single segment in
the interface setup which forced everything into an IPv4 route.
This limitation has been removed.

In so doing, route metrics have been cleaned up a small amount.
This change allows the specification of the route metric from the
config.

Fixes #2772

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
