### PR TITLE
docs: graduate v0.7 docs

### DIFF
--- a/website/gridsome.config.js
+++ b/website/gridsome.config.js
@@ -24,13 +24,13 @@ module.exports = {
       {
         version: "v0.7",
         url: "/docs/v0.7/",
-        latest: false,
-        prerelease: true,
+        latest: true,
+        prerelease: false,
       },
       {
         version: "v0.6",
         url: "/docs/v0.6/",
-        latest: true,
+        latest: false,
         prerelease: false,
       },
     ],

--- a/website/src/pages/Index.vue
+++ b/website/src/pages/Index.vue
@@ -27,7 +27,7 @@
                 laptop inside Docker.
               </p>
               <div class="flex-1 text-center pb-4 m-0">
-                <a href="/docs/v0.6/introduction/quickstart">
+                <a href="/docs/v0.7/introduction/quickstart">
                   <button class="teal-cta-button">Try it now</button></a
                 >
               </div>

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -2,5 +2,5 @@
 #
 # The Netlify documentation says that the following redirect rules are
 # equivalent, but that is not what is observed in practice.
-/docs/latest /docs/v0.6
-/docs/latest/ /docs/v0.6
+/docs/latest /docs/v0.7
+/docs/latest/ /docs/v0.7


### PR DESCRIPTION
The v0.7 docs are now the default and marked as stable.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
