### PR TITLE
feat: make GenerateConfiguration API reuse current node auth

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -80,12 +80,18 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 		fmt.Println("generating PKI and tokens")
 	}
 
+	secrets, err := generate.NewSecretsBundle()
+	if err != nil {
+		return bundle, err
+	}
+
 	var input *generate.Input
 
-	input, err := generate.NewInput(
+	input, err = generate.NewInput(
 		options.InputOptions.ClusterName,
 		options.InputOptions.Endpoint,
 		options.InputOptions.KubeVersion,
+		secrets,
 		options.InputOptions.GenOptions...,
 	)
 	if err != nil {

--- a/pkg/machinery/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate_test.go
@@ -26,7 +26,9 @@ func TestGenerateSuite(t *testing.T) {
 
 func (suite *GenerateSuite) SetupSuite() {
 	var err error
-	suite.input, err = genv1alpha1.NewInput("test", "10.0.1.5", constants.DefaultKubernetesVersion)
+	secrets, err := genv1alpha1.NewSecretsBundle()
+	suite.Require().NoError(err)
+	suite.input, err = genv1alpha1.NewInput("test", "10.0.1.5", constants.DefaultKubernetesVersion, secrets)
 	suite.Require().NoError(err)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/2819

Only if requested config type is not `TypeInit`.
This functionality will help implementing TUI installer cluster
extension workflow.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>