### PR TITLE
docs: ensure we configure nodes in guides

### DIFF
--- a/website/content/docs/v0.6/Bare Metal Platforms/digital-rebar.md
+++ b/website/content/docs/v0.6/Bare Metal Platforms/digital-rebar.md
@@ -154,5 +154,6 @@ Once everything is running we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.6/Bare Metal Platforms/equinix-metal.md
+++ b/website/content/docs/v0.6/Bare Metal Platforms/equinix-metal.md
@@ -2,4 +2,4 @@
 title: "Equinix Metal"
 ---
 
-Talos is known to work on KVM; however, it is currently undocumented.
+Talos is known to work on Equinix Metal; however, it is currently undocumented.

--- a/website/content/docs/v0.6/Bare Metal Platforms/matchbox.md
+++ b/website/content/docs/v0.6/Bare Metal Platforms/matchbox.md
@@ -184,5 +184,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.6/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.6/Cloud Platforms/aws.md
@@ -243,5 +243,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.6/Cloud Platforms/azure.md
+++ b/website/content/docs/v0.6/Cloud Platforms/azure.md
@@ -275,6 +275,7 @@ CONTROL_PLANE_0_IP=$(az network public-ip show \
                     --query [ipAddress] \
                     --output tsv)
 talosctl --talosconfig ./talosconfig config endpoint $CONTROL_PLANE_0_IP
+talosctl --talosconfig ./talosconfig config node $CONTROL_PLANE_0_IP
 talosctl --talosconfig ./talosconfig kubeconfig .
 kubectl --kubeconfig ./kubeconfig get nodes
 ```

--- a/website/content/docs/v0.6/Cloud Platforms/digitalocean.md
+++ b/website/content/docs/v0.6/Cloud Platforms/digitalocean.md
@@ -144,5 +144,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.6/Virtualized Platforms/vmware.md
+++ b/website/content/docs/v0.6/Virtualized Platforms/vmware.md
@@ -211,5 +211,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.7/Bare Metal Platforms/digital-rebar.md
+++ b/website/content/docs/v0.7/Bare Metal Platforms/digital-rebar.md
@@ -154,5 +154,6 @@ Once everything is running we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.7/Bare Metal Platforms/equinix-metal.md
+++ b/website/content/docs/v0.7/Bare Metal Platforms/equinix-metal.md
@@ -2,4 +2,4 @@
 title: "Equinix Metal"
 ---
 
-Talos is known to work on KVM; however, it is currently undocumented.
+Talos is known to work on Equinix Metal; however, it is currently undocumented.

--- a/website/content/docs/v0.7/Bare Metal Platforms/matchbox.md
+++ b/website/content/docs/v0.7/Bare Metal Platforms/matchbox.md
@@ -184,5 +184,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.7/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.7/Cloud Platforms/aws.md
@@ -243,5 +243,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.7/Cloud Platforms/azure.md
+++ b/website/content/docs/v0.7/Cloud Platforms/azure.md
@@ -275,6 +275,7 @@ CONTROL_PLANE_0_IP=$(az network public-ip show \
                     --query [ipAddress] \
                     --output tsv)
 talosctl --talosconfig ./talosconfig config endpoint $CONTROL_PLANE_0_IP
+talosctl --talosconfig ./talosconfig config node $CONTROL_PLANE_0_IP
 talosctl --talosconfig ./talosconfig kubeconfig .
 kubectl --kubeconfig ./kubeconfig get nodes
 ```

--- a/website/content/docs/v0.7/Cloud Platforms/digitalocean.md
+++ b/website/content/docs/v0.7/Cloud Platforms/digitalocean.md
@@ -145,5 +145,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.7/Virtualized Platforms/vmware.md
+++ b/website/content/docs/v0.7/Virtualized Platforms/vmware.md
@@ -211,5 +211,6 @@ At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```


### PR DESCRIPTION
This PR makes sure we go through the step of running `talosctl
config nodes` for each of our environment guides.

Will close #2609