### PR TITLE
feat: sync time before installer runs

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -158,6 +158,9 @@ func (*Sequencer) Install(r runtime.Runtime) []runtime.Phase {
 				"containerd",
 				StartContainerd,
 			).Append(
+				"timed",
+				StartTimedAtInstall,
+			).Append(
 				"install",
 				Install,
 			).Append(

--- a/internal/app/machined/pkg/system/services/timed.go
+++ b/internal/app/machined/pkg/system/services/timed.go
@@ -35,7 +35,9 @@ import (
 
 // Timed implements the Service interface. It serves as the concrete type with
 // the required methods.
-type Timed struct{}
+type Timed struct {
+	SkipNetworkd bool
+}
 
 // ID implements the Service interface.
 func (n *Timed) ID(r runtime.Runtime) string {
@@ -59,6 +61,10 @@ func (n *Timed) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (n *Timed) DependsOn(r runtime.Runtime) []string {
+	if n.SkipNetworkd {
+		return []string{"containerd"}
+	}
+
 	return []string{"containerd", "networkd"}
 }
 


### PR DESCRIPTION
Under normal boot, Talos run `timed` before starting almost anything
else, but in the installer phase timed doesn't run. If the RTC is
missing or totally off, it might lead to image pull failure for the
installer.

This is special task to run timed without blocking on time sync, as it
might not be available in some environments.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

