### PR TITLE
fix: bump blockdevice library for `mmcblk` part name fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3
 	github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201118151932-8076344a9502
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201120123651-2a1baadffdf8
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/talos-systems/bootkube-plugin v0.0.0-20200915135634-229d57e818f3/go.m
 github.com/talos-systems/crypto v0.2.0/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b h1:EctcXxyT5hTXnrUbdKvN8oxZLxc8HOJ9E8paAkv3yRg=
 github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201118151932-8076344a9502 h1:6LpnCu7wEF2LGmxavbdtiM+YZX2vMPVKtZCaZynQqwM=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201118151932-8076344a9502/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201120123651-2a1baadffdf8 h1:D4NLy7uXLIWvhFaOAf1Olml5U76sNmaY03dNt2pHnOg=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201120123651-2a1baadffdf8/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=


### PR DESCRIPTION
See https://github.com/talos-systems/go-blockdevice/pull/17

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

