### PR TITLE
feat: support openstack platform

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -495,6 +495,8 @@ local release = {
       '_out/gcp-arm64.tar.gz',
       '_out/initramfs-amd64.xz',
       '_out/initramfs-arm64.xz',
+      '_out/openstack-amd64.tar.gz',
+      '_out/openstack-arm64.tar.gz',
       '_out/talos-amd64.iso',
       '_out/talos-arm64.iso',
       '_out/talosctl-cni-bundle-amd64.tar.gz',

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ talosctl: $(TALOSCTL_DEFAULT_TARGET) ## Builds the talosctl binary for the local
 image-%: ## Builds the specified image. Valid options are aws, azure, digital-ocean, gcp, and vmware (e.g. image-aws)
 	@docker run --rm -v /dev:/dev --privileged $(REGISTRY)/$(USERNAME)/installer:$(TAG) image --platform $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
-images: image-aws image-azure image-digital-ocean image-gcp image-vmware ## Builds all known images (AWS, Azure, Digital Ocean, GCP, and VMware).
+images: image-aws image-azure image-digital-ocean image-gcp image-openstack image-vmware ## Builds all known images (AWS, Azure, Digital Ocean, GCP, Openstack, and VMware).
 
 .PHONY: iso
 iso: ## Builds the ISO and outputs it to the artifact directory.

--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -140,6 +140,10 @@ func finalize(platform runtime.Platform, img string) (err error) {
 		if err = tar(fmt.Sprintf("gcp-%s.tar.gz", stdruntime.GOARCH), file, dir); err != nil {
 			return err
 		}
+	case "openstack":
+		if err = tar(fmt.Sprintf("openstack-%s.tar.gz", stdruntime.GOARCH), file, dir); err != nil {
+			return err
+		}
 	case "vmware":
 		if err = ova.CreateOVAFromRAW(name, img, outputArg); err != nil {
 			return err

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -1,0 +1,114 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/talos-systems/go-procfs/procfs"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
+	"github.com/talos-systems/talos/pkg/download"
+)
+
+const (
+	// OpenstackExternalIPEndpoint is the local EC2 endpoint for the external IP.
+	OpenstackExternalIPEndpoint = "http://169.254.169.254/latest/meta-data/public-ipv4"
+
+	// OpenstackHostnameEndpoint is the local EC2 endpoint for the hostname.
+	OpenstackHostnameEndpoint = "http://169.254.169.254/latest/meta-data/hostname"
+
+	// OpenstackUserDataEndpoint is the local EC2 endpoint for the config.
+	OpenstackUserDataEndpoint = "http://169.254.169.254/latest/user-data"
+)
+
+// Openstack is the concrete type that implements the runtime.Platform interface.
+type Openstack struct{}
+
+// Name implements the runtime.Platform interface.
+func (a *Openstack) Name() string {
+	return "openstack"
+}
+
+// Configuration implements the runtime.Platform interface.
+func (a *Openstack) Configuration(ctx context.Context) ([]byte, error) {
+	log.Printf("fetching machine config from: %q", OpenstackUserDataEndpoint)
+
+	return download.Download(ctx, OpenstackUserDataEndpoint,
+		download.WithErrorOnNotFound(errors.ErrNoConfigSource),
+		download.WithErrorOnEmptyResponse(errors.ErrNoConfigSource))
+}
+
+// Mode implements the runtime.Platform interface.
+func (a *Openstack) Mode() runtime.Mode {
+	return runtime.ModeCloud
+}
+
+// Hostname implements the runtime.Platform interface.
+func (a *Openstack) Hostname(ctx context.Context) (hostname []byte, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, OpenstackHostnameEndpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	// nolint: errcheck
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return hostname, fmt.Errorf("failed to fetch hostname from metadata service: %d", resp.StatusCode)
+	}
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+// ExternalIPs implements the runtime.Platform interface.
+func (a *Openstack) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
+	var (
+		body []byte
+		req  *http.Request
+		resp *http.Response
+	)
+
+	if req, err = http.NewRequestWithContext(ctx, "GET", OpenstackExternalIPEndpoint, nil); err != nil {
+		return
+	}
+
+	client := &http.Client{}
+	if resp, err = client.Do(req); err != nil {
+		return
+	}
+
+	// nolint: errcheck
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return addrs, fmt.Errorf("failed to retrieve external addresses for instance")
+	}
+
+	if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		return
+	}
+
+	addrs = append(addrs, net.ParseIP(string(body)))
+
+	return addrs, err
+}
+
+// KernelArgs implements the runtime.Platform interface.
+func (a *Openstack) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
+	}
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package openstack_test
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	// added for accurate coverage estimation
+	//
+	// please remove it once any unit-test is added
+	// for this package
+}

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/platform.go
@@ -18,6 +18,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/digitalocean"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/metal"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/packet"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
@@ -49,20 +50,23 @@ func NewPlatform(platform string) (p runtime.Platform, err error) {
 	return newPlatform(platform)
 }
 
+// nolint: gocyclo
 func newPlatform(platform string) (p runtime.Platform, err error) {
 	switch platform {
 	case "aws":
 		p = &aws.AWS{}
 	case "azure":
 		p = &azure.Azure{}
-	case "digital-ocean":
-		p = &digitalocean.DigitalOcean{}
-	case "metal":
-		p = &metal.Metal{}
 	case "container":
 		p = &container.Container{}
+	case "digital-ocean":
+		p = &digitalocean.DigitalOcean{}
 	case "gcp":
 		p = &gcp.GCP{}
+	case "metal":
+		p = &metal.Metal{}
+	case "openstack":
+		p = &openstack.Openstack{}
 	case "packet":
 		p = &packet.Packet{}
 	case "vmware":


### PR DESCRIPTION
This PR adds the ability for us to deploy Talos in openstack. Tested in
local devstack with a supplied userdata file. It also adds support to
the Makefile for building the openstack image so it'll be published with
next release.