### PR TITLE
feat: update Containerd and Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-11-g84c834e
-PKGS ?= v0.3.0-35-g6b7be81
+PKGS ?= v0.3.0-37-gd1a9827
 EXTRAS ?= v0.1.0-5-gcc2df81
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.9.3-talos"
+	DefaultKernelVersion = "5.9.11-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.
@@ -272,7 +272,7 @@ const (
 	TrustdPort = 50001
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.4.1"
+	DefaultContainerdVersion = "1.4.2"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
This brings in Containerd v1.4.2 and Linux v5.9.11

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
