### PR TITLE
feat: stop including K8s version by default in `talosctl gen config`

### DIFF
--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/bundle"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
-	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 var (
@@ -144,7 +143,7 @@ func init() {
 	genConfigCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	genConfigCmd.Flags().StringVar(&architecture, "arch", runtime.GOARCH, "the architecture of the cluster")
 	genConfigCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")
-	genConfigCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
+	genConfigCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", "", "desired kubernetes version to run")
 	genConfigCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "destination to output generated files")
 	genConfigCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
 	genConfigCmd.Flags().BoolVarP(&persistConfig, "persist", "p", true, "the desired persist value for configs")

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116
 	github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201126002059-98754ec2bb20
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201130193002-5b4ee44cfd43
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45
 	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688

--- a/go.sum
+++ b/go.sum
@@ -870,6 +870,8 @@ github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b h1:EctcXxyT
 github.com/talos-systems/crypto v0.2.1-0.20201112141136-12a489768a6b/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201126002059-98754ec2bb20 h1:4RQ6fsV8rZ684Up6fep2hu/J/I2i2yQeb7MX+unrmso=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201126002059-98754ec2bb20/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201130193002-5b4ee44cfd43 h1:2rl2XCXeVQYmFmoRsWgntJbReBk3rfoGqEjj+zOUHqA=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201130193002-5b4ee44cfd43/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20200219015357-57c7311fdd45 h1:FND/LgzFHTBdJBOeZVzdO6B47kxQZvSIzb9AMIXYotg=

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -235,12 +235,16 @@ var (
 		},
 	}
 
+	clusterAPIServerImageExample = (&APIServerConfig{}).Image()
+
 	clusterControllerManagerExample = &ControllerManagerConfig{
 		ContainerImage: (&ControllerManagerConfig{}).Image(),
 		ExtraArgsConfig: map[string]string{
 			"--feature-gates": "ServerSideApply=true",
 		},
 	}
+
+	clusterControllerManagerImageExample = (&ControllerManagerConfig{}).Image()
 
 	clusterProxyExample = &ProxyConfig{
 		ContainerImage: (&ProxyConfig{}).Image(),
@@ -250,20 +254,26 @@ var (
 		ModeConfig: "ipvs",
 	}
 
-	clusterSchedulerConfig = &SchedulerConfig{
+	clusterProxyImageExample = (&ProxyConfig{}).Image()
+
+	clusterSchedulerExample = &SchedulerConfig{
 		ContainerImage: (&SchedulerConfig{}).Image(),
 		ExtraArgsConfig: map[string]string{
 			"--feature-gates": "AllBeta=true",
 		},
 	}
 
-	clusterEtcdConfig = &EtcdConfig{
+	clusterSchedulerImageExample = (&SchedulerConfig{}).Image()
+
+	clusterEtcdExample = &EtcdConfig{
 		ContainerImage: (&EtcdConfig{}).Image(),
 		EtcdExtraArgs: map[string]string{
 			"--election-timeout": "5000",
 		},
 		RootCA: pemEncodedCertificateExample,
 	}
+
+	clusterEtcdImageExample = (&EtcdConfig{}).Image()
 
 	clusterPodCheckpointerExample = &PodCheckpointer{
 		PodCheckpointerImage: "...",
@@ -550,12 +560,12 @@ type ClusterConfig struct {
 	//   description: |
 	//     Scheduler server specific configuration options.
 	//   examples:
-	//     - value: clusterSchedulerConfig
+	//     - value: clusterSchedulerExample
 	SchedulerConfig *SchedulerConfig `yaml:"scheduler,omitempty"`
 	//   description: |
 	//     Etcd specific configuration options.
 	//   examples:
-	//     - value: clusterEtcdConfig
+	//     - value: clusterEtcdExample
 	EtcdConfig *EtcdConfig `yaml:"etcd,omitempty"`
 	//   description: |
 	//     Pod Checkpointer specific configuration options.
@@ -786,6 +796,8 @@ type ControlPlaneConfig struct {
 type APIServerConfig struct {
 	//   description: |
 	//     The container image used in the API server manifest.
+	//   examples:
+	//     - value: clusterAPIServerImageExample
 	ContainerImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     Extra arguments to supply to the API server.
@@ -799,6 +811,8 @@ type APIServerConfig struct {
 type ControllerManagerConfig struct {
 	//   description: |
 	//     The container image used in the controller manager manifest.
+	//   examples:
+	//     - value: clusterControllerManagerImageExample
 	ContainerImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     Extra arguments to supply to the controller manager.
@@ -809,6 +823,8 @@ type ControllerManagerConfig struct {
 type ProxyConfig struct {
 	//   description: |
 	//     The container image used in the kube-proxy manifest.
+	//   examples:
+	//     - value: clusterProxyImageExample
 	ContainerImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     proxy mode of kube-proxy.
@@ -823,6 +839,8 @@ type ProxyConfig struct {
 type SchedulerConfig struct {
 	//   description: |
 	//     The container image used in the scheduler manifest.
+	//   examples:
+	//     - value: clusterSchedulerImageExample
 	ContainerImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     Extra arguments to supply to the scheduler.
@@ -833,6 +851,8 @@ type SchedulerConfig struct {
 type EtcdConfig struct {
 	//   description: |
 	//     The container image used to create the etcd service.
+	//   examples:
+	//     - value: clusterEtcdImageExample
 	ContainerImage string `yaml:"image,omitempty"`
 	//   description: |
 	//     The `ca` is the root certificate authority of the PKI.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -291,14 +291,14 @@ func init() {
 	ClusterConfigDoc.Fields[9].Description = "Scheduler server specific configuration options."
 	ClusterConfigDoc.Fields[9].Comments[encoder.LineComment] = "Scheduler server specific configuration options."
 
-	ClusterConfigDoc.Fields[9].AddExample("", clusterSchedulerConfig)
+	ClusterConfigDoc.Fields[9].AddExample("", clusterSchedulerExample)
 	ClusterConfigDoc.Fields[10].Name = "etcd"
 	ClusterConfigDoc.Fields[10].Type = "EtcdConfig"
 	ClusterConfigDoc.Fields[10].Note = ""
 	ClusterConfigDoc.Fields[10].Description = "Etcd specific configuration options."
 	ClusterConfigDoc.Fields[10].Comments[encoder.LineComment] = "Etcd specific configuration options."
 
-	ClusterConfigDoc.Fields[10].AddExample("", clusterEtcdConfig)
+	ClusterConfigDoc.Fields[10].AddExample("", clusterEtcdExample)
 	ClusterConfigDoc.Fields[11].Name = "podCheckpointer"
 	ClusterConfigDoc.Fields[11].Type = "PodCheckpointer"
 	ClusterConfigDoc.Fields[11].Note = ""
@@ -630,6 +630,8 @@ func init() {
 	APIServerConfigDoc.Fields[0].Note = ""
 	APIServerConfigDoc.Fields[0].Description = "The container image used in the API server manifest."
 	APIServerConfigDoc.Fields[0].Comments[encoder.LineComment] = "The container image used in the API server manifest."
+
+	APIServerConfigDoc.Fields[0].AddExample("", clusterAPIServerImageExample)
 	APIServerConfigDoc.Fields[1].Name = "extraArgs"
 	APIServerConfigDoc.Fields[1].Type = "map[string]string"
 	APIServerConfigDoc.Fields[1].Note = ""
@@ -658,6 +660,8 @@ func init() {
 	ControllerManagerConfigDoc.Fields[0].Note = ""
 	ControllerManagerConfigDoc.Fields[0].Description = "The container image used in the controller manager manifest."
 	ControllerManagerConfigDoc.Fields[0].Comments[encoder.LineComment] = "The container image used in the controller manager manifest."
+
+	ControllerManagerConfigDoc.Fields[0].AddExample("", clusterControllerManagerImageExample)
 	ControllerManagerConfigDoc.Fields[1].Name = "extraArgs"
 	ControllerManagerConfigDoc.Fields[1].Type = "map[string]string"
 	ControllerManagerConfigDoc.Fields[1].Note = ""
@@ -681,6 +685,8 @@ func init() {
 	ProxyConfigDoc.Fields[0].Note = ""
 	ProxyConfigDoc.Fields[0].Description = "The container image used in the kube-proxy manifest."
 	ProxyConfigDoc.Fields[0].Comments[encoder.LineComment] = "The container image used in the kube-proxy manifest."
+
+	ProxyConfigDoc.Fields[0].AddExample("", clusterProxyImageExample)
 	ProxyConfigDoc.Fields[1].Name = "mode"
 	ProxyConfigDoc.Fields[1].Type = "string"
 	ProxyConfigDoc.Fields[1].Note = ""
@@ -696,7 +702,7 @@ func init() {
 	SchedulerConfigDoc.Comments[encoder.LineComment] = "SchedulerConfig represents the kube scheduler configuration options."
 	SchedulerConfigDoc.Description = "SchedulerConfig represents the kube scheduler configuration options."
 
-	SchedulerConfigDoc.AddExample("", clusterSchedulerConfig)
+	SchedulerConfigDoc.AddExample("", clusterSchedulerExample)
 	SchedulerConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "ClusterConfig",
@@ -709,6 +715,8 @@ func init() {
 	SchedulerConfigDoc.Fields[0].Note = ""
 	SchedulerConfigDoc.Fields[0].Description = "The container image used in the scheduler manifest."
 	SchedulerConfigDoc.Fields[0].Comments[encoder.LineComment] = "The container image used in the scheduler manifest."
+
+	SchedulerConfigDoc.Fields[0].AddExample("", clusterSchedulerImageExample)
 	SchedulerConfigDoc.Fields[1].Name = "extraArgs"
 	SchedulerConfigDoc.Fields[1].Type = "map[string]string"
 	SchedulerConfigDoc.Fields[1].Note = ""
@@ -719,7 +727,7 @@ func init() {
 	EtcdConfigDoc.Comments[encoder.LineComment] = "EtcdConfig represents the etcd configuration options."
 	EtcdConfigDoc.Description = "EtcdConfig represents the etcd configuration options."
 
-	EtcdConfigDoc.AddExample("", clusterEtcdConfig)
+	EtcdConfigDoc.AddExample("", clusterEtcdExample)
 	EtcdConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "ClusterConfig",
@@ -732,6 +740,8 @@ func init() {
 	EtcdConfigDoc.Fields[0].Note = ""
 	EtcdConfigDoc.Fields[0].Description = "The container image used to create the etcd service."
 	EtcdConfigDoc.Fields[0].Comments[encoder.LineComment] = "The container image used to create the etcd service."
+
+	EtcdConfigDoc.Fields[0].AddExample("", clusterEtcdImageExample)
 	EtcdConfigDoc.Fields[1].Name = "ca"
 	EtcdConfigDoc.Fields[1].Type = "PEMEncodedCertificateAndKey"
 	EtcdConfigDoc.Fields[1].Note = ""

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -677,7 +677,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
   -h, --help                        help for config
       --install-disk string         the disk to install to (default "/dev/sda")
       --install-image string        the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
-      --kubernetes-version string   desired kubernetes version to run (default "1.20.0-beta.2")
+      --kubernetes-version string   desired kubernetes version to run
   -o, --output-dir string           destination to output generated files
   -p, --persist                     the desired persist value for configs (default true)
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>

--- a/website/content/docs/v0.8/Reference/configuration.md
+++ b/website/content/docs/v0.8/Reference/configuration.md
@@ -1877,6 +1877,16 @@ certSANs:
 
 The container image used in the API server manifest.
 
+
+
+Examples:
+
+
+``` yaml
+image: k8s.gcr.io/kube-apiserver-amd64:v1.20.0-beta.2
+```
+
+
 </div>
 
 <hr />
@@ -1938,6 +1948,16 @@ extraArgs:
 
 The container image used in the controller manager manifest.
 
+
+
+Examples:
+
+
+``` yaml
+image: k8s.gcr.io/kube-controller-manager-amd64:v1.20.0-beta.2
+```
+
+
 </div>
 
 <hr />
@@ -1986,6 +2006,16 @@ extraArgs:
 <div class="dt">
 
 The container image used in the kube-proxy manifest.
+
+
+
+Examples:
+
+
+``` yaml
+image: k8s.gcr.io/kube-proxy-amd64:v1.20.0-beta.2
+```
+
 
 </div>
 
@@ -2049,6 +2079,16 @@ extraArgs:
 
 The container image used in the scheduler manifest.
 
+
+
+Examples:
+
+
+``` yaml
+image: k8s.gcr.io/kube-scheduler-amd64:v1.20.0-beta.2
+```
+
+
 </div>
 
 <hr />
@@ -2100,6 +2140,16 @@ extraArgs:
 <div class="dt">
 
 The container image used to create the etcd service.
+
+
+
+Examples:
+
+
+``` yaml
+image: gcr.io/etcd-development/etcd:v3.4.14
+```
+
 
 </div>
 


### PR DESCRIPTION
Default image versions are kept as commented out examples.

This allows better experience for generating config on amd64 for arm64
servers. (e.g. for RPi).

Without embedded values in the config, Talos is going to use the
defaults which work better.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
