### PR TITLE
fix: use the dtb from kernel pkg for libretech_all_h3_cc_h5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -471,6 +471,7 @@ COPY --from=pkg-grub / /
 COPY --from=unicode-pf2 /usr/share/grub/unicode.pf2 /usr/share/grub/unicode.pf2
 ARG TARGETARCH
 COPY --from=kernel /vmlinuz-${TARGETARCH} /usr/install/vmlinuz
+COPY --from=pkg-kernel /dtb /usr/install/dtb
 COPY --from=initramfs /initramfs-${TARGETARCH}.xz /usr/install/initramfs.xz
 COPY --from=pkg-u-boot / /usr/install/u-boot
 COPY --from=pkg-raspberrypi-firmware / /usr/install/raspberrypi-firmware

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-11-g84c834e
-PKGS ?= v0.3.0-45-gcbf412f
+PKGS ?= v0.3.0-47-ge880204
 EXTRAS ?= v0.1.0-5-gcc2df81
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
@@ -9,16 +9,19 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/copy"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 var (
 	bin       = fmt.Sprintf("/usr/install/u-boot/%s/u-boot-sunxi-with-spl.bin", constants.BoardLibretechAllH3CCH5)
 	off int64 = 1024 * 8
+	dtb       = "/dtb/allwinner/sun50i-h5-libretech-all-h3-cc.dtb"
 )
 
 // LibretechAllH3CCH5 represents the Libre Computer ALL-H3-CC (Tritium).
@@ -63,6 +66,19 @@ func (l *LibretechAllH3CCH5) Install(disk string) (err error) {
 	// to esure that the file is written before the loopback device is
 	// unmounted.
 	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := "/usr/install" + dtb
+	dst := "/boot/EFI" + dtb
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	err = copy.File(src, dst)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds sun50i-h5-libretech-all-h3-cc.dtb to the EFI partition.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
