### PR TITLE
fix(security): update Containerd to v1.4.3

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -32,6 +32,7 @@ policies:
           - routerd
           - talosctl
           - kernel
+          - security
           - ^v0.7
           - '*'
   - type: license

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-11-g84c834e
-PKGS ?= v0.3.0-41-g58ce509
+PKGS ?= v0.3.0-45-gcbf412f
 EXTRAS ?= v0.1.0-5-gcc2df81
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -275,7 +275,7 @@ const (
 	TrustdPort = 50001
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.4.2"
+	DefaultContainerdVersion = "1.4.3"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
This brings in the the latest Containerd to address a CVE.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
