### PR TITLE
docs: add console kernel arg to libretech_all_h3_cc_h5 image generation

### DIFF
--- a/website/content/docs/v0.8/Single Board Computers/libretech_all_h3_cc_h5.md
+++ b/website/content/docs/v0.8/Single Board Computers/libretech_all_h3_cc_h5.md
@@ -11,7 +11,7 @@ docker run \
   --rm \
   -v /dev:/dev \
   --privileged \
-  ghcr.io/talos-systems/installer:latest image --platform metal --board libretech_all_h3_cc_h5 --tar-to-stdout | tar xz
+  ghcr.io/talos-systems/installer:latest image --platform metal --board libretech_all_h3_cc_h5 --extra-kernel-arg="console=ttyS0,115200" --tar-to-stdout | tar xz
 ```
 
 ## Writing the Image


### PR DESCRIPTION
This documents how to generate the libretech_all_h3_cc_h5 board image with the correct
console args.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
