### PR TITLE
docs: add console kernel arg to rpi_4 image generation

### DIFF
--- a/website/content/docs/v0.8/Single Board Computers/rpi_4.md
+++ b/website/content/docs/v0.8/Single Board Computers/rpi_4.md
@@ -29,7 +29,7 @@ docker run \
   --rm \
   -v /dev:/dev \
   --privileged \
-  ghcr.io/talos-systems/installer:latest image --platform metal --board rpi_4 --tar-to-stdout | tar xz
+  ghcr.io/talos-systems/installer:latest image --platform metal --board rpi_4 --extra-kernel-arg="console=ttyS0,115200" --tar-to-stdout | tar xz
 ```
 
 ## Writing the Image


### PR DESCRIPTION
This documents how to generate the rpi_4 board image with the correct console args.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
