### PR TITLE
fix(security): update Containerd to v1.4.3

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -32,6 +32,7 @@ policies:
           - routerd
           - talosctl
           - kernel
+          - security
           - ^v0.7
           - '*'
   - type: license

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ARG EXTRAS
 
 FROM ghcr.io/talos-systems/fhs:${PKGS} AS pkg-fhs
 FROM ghcr.io/talos-systems/ca-certificates:${PKGS} AS pkg-ca-certificates
-FROM ghcr.io/talos-systems/containerd:${PKGS} AS pkg-containerd
+# Explicit version for containerd for 1.4.3 security fix.
+FROM ghcr.io/talos-systems/containerd:v0.3.0-45-gcbf412f AS pkg-containerd
 FROM ghcr.io/talos-systems/dosfstools:${PKGS} AS pkg-dosfstools
 FROM ghcr.io/talos-systems/eudev:${PKGS} AS pkg-eudev
 FROM ghcr.io/talos-systems/grub:${PKGS} AS pkg-grub

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -253,7 +253,7 @@ const (
 	TrustdPort = 50001
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.4.1"
+	DefaultContainerdVersion = "1.4.3"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
This brings in the the latest Containerd to address a CVE.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
(cherry picked from commit 98976602f72f512a885add165d8f61f46d648c0e)
Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

