### PR TITLE
feat: allow boards to set kernel args

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -166,6 +166,11 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 		}
 
 		i.cmdline.Append(constants.KernelParamBoard, b.Name())
+
+		err = i.cmdline.AppendAll(b.KernelArgs().Strings())
+		if err != nil {
+			return err
+		}
 	}
 
 	if err = i.manifest.Execute(); err != nil {

--- a/internal/app/machined/pkg/runtime/board.go
+++ b/internal/app/machined/pkg/runtime/board.go
@@ -4,6 +4,8 @@
 
 package runtime
 
+import "github.com/talos-systems/go-procfs/procfs"
+
 // PartitionOptions are the board specific options for customizing the
 // partition table.
 type PartitionOptions struct {
@@ -14,5 +16,6 @@ type PartitionOptions struct {
 type Board interface {
 	Name() string
 	Install(string) error
+	KernelArgs() procfs.Parameters
 	PartitionOptions() *PartitionOptions
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/talos-systems/go-procfs/procfs"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -33,12 +34,12 @@ var (
 type BananaPiM64 struct{}
 
 // Name implements the runtime.Board.
-func (l *BananaPiM64) Name() string {
+func (b *BananaPiM64) Name() string {
 	return constants.BoardBananaPiM64
 }
 
 // Install implements the runtime.Board.
-func (l *BananaPiM64) Install(disk string) (err error) {
+func (b *BananaPiM64) Install(disk string) (err error) {
 	var f *os.File
 
 	if f, err = os.OpenFile(disk, os.O_RDWR|unix.O_CLOEXEC, 0o666); err != nil {
@@ -89,7 +90,14 @@ func (l *BananaPiM64) Install(disk string) (err error) {
 	return nil
 }
 
+// KernelArgs implements the runtime.Board.
+func (b *BananaPiM64) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("ttyS2,115200n8"),
+	}
+}
+
 // PartitionOptions implements the runtime.Board.
-func (l *BananaPiM64) PartitionOptions() *runtime.PartitionOptions {
+func (b *BananaPiM64) PartitionOptions() *runtime.PartitionOptions {
 	return &runtime.PartitionOptions{PartitionsOffset: 2048}
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/talos-systems/go-procfs/procfs"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -84,6 +85,13 @@ func (l *LibretechAllH3CCH5) Install(disk string) (err error) {
 	}
 
 	return nil
+}
+
+// KernelArgs implements the runtime.Board.
+func (l *LibretechAllH3CCH5) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("ttyS0,115200"),
+	}
 }
 
 // PartitionOptions implements the runtime.Board.

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
@@ -7,6 +7,8 @@ package rpi4
 import (
 	"io/ioutil"
 
+	"github.com/talos-systems/go-procfs/procfs"
+
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/copy"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
@@ -23,12 +25,12 @@ kernel=u-boot.bin
 type RPi4 struct{}
 
 // Name implements the runtime.Board.
-func (l *RPi4) Name() string {
+func (r *RPi4) Name() string {
 	return constants.BoardRPi4
 }
 
 // Install implements the runtime.Board.
-func (l *RPi4) Install(disk string) (err error) {
+func (r *RPi4) Install(disk string) (err error) {
 	err = copy.Dir("/usr/install/raspberrypi-firmware/boot", "/boot/EFI")
 	if err != nil {
 		return err
@@ -42,7 +44,14 @@ func (l *RPi4) Install(disk string) (err error) {
 	return ioutil.WriteFile("/boot/EFI/config.txt", configTxt, 0o600)
 }
 
+// KernelArgs implements the runtime.Board.
+func (r *RPi4) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("ttyS0,115200"),
+	}
+}
+
 // PartitionOptions implements the runtime.Board.
-func (l *RPi4) PartitionOptions() *runtime.PartitionOptions {
+func (r *RPi4) PartitionOptions() *runtime.PartitionOptions {
 	return nil
 }

--- a/website/content/docs/v0.8/Single Board Computers/bananapi_m64.md
+++ b/website/content/docs/v0.8/Single Board Computers/bananapi_m64.md
@@ -11,7 +11,7 @@ docker run \
   --rm \
   -v /dev:/dev \
   --privileged \
-  ghcr.io/talos-systems/installer:latest image --platform metal --board bananapi_m64 --extra-kernel-arg="console=ttyS2,115200n8" --tar-to-stdout | tar xz
+  ghcr.io/talos-systems/installer:latest image --platform metal --board bananapi_m64 --tar-to-stdout | tar xz
 ```
 
 > Note: This step MUST be executed on an aarch64 machine.

--- a/website/content/docs/v0.8/Single Board Computers/libretech_all_h3_cc_h5.md
+++ b/website/content/docs/v0.8/Single Board Computers/libretech_all_h3_cc_h5.md
@@ -11,7 +11,7 @@ docker run \
   --rm \
   -v /dev:/dev \
   --privileged \
-  ghcr.io/talos-systems/installer:latest image --platform metal --board libretech_all_h3_cc_h5 --extra-kernel-arg="console=ttyS0,115200" --tar-to-stdout | tar xz
+  ghcr.io/talos-systems/installer:latest image --platform metal --board libretech_all_h3_cc_h5 --tar-to-stdout | tar xz
 ```
 
 > Note: This step MUST be executed on an aarch64 machine.

--- a/website/content/docs/v0.8/Single Board Computers/rpi_4.md
+++ b/website/content/docs/v0.8/Single Board Computers/rpi_4.md
@@ -29,7 +29,7 @@ docker run \
   --rm \
   -v /dev:/dev \
   --privileged \
-  ghcr.io/talos-systems/installer:latest image --platform metal --board rpi_4 --extra-kernel-arg="console=ttyS0,115200" --tar-to-stdout | tar xz
+  ghcr.io/talos-systems/installer:latest image --platform metal --board rpi_4 --tar-to-stdout | tar xz
 ```
 
 ## Writing the Image


### PR DESCRIPTION
This allows boards to provide kernel args at install time. We need this so that
we can set the console.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
