### PR TITLE
fix: prevent endless loop with DHCP requests in networkd

### DIFF
--- a/internal/app/networkd/pkg/nic/netlink.go
+++ b/internal/app/networkd/pkg/nic/netlink.go
@@ -48,6 +48,10 @@ func (n *NetworkInterface) setMTU(idx int, mtu uint32) error {
 		return err
 	}
 
+	if msg.Attributes != nil && msg.Attributes.MTU == mtu {
+		return nil
+	}
+
 	err = n.rtConn.Link.Set(&rtnetlink.LinkMessage{
 		Family: msg.Family,
 		Type:   msg.Type,

--- a/pkg/provision/providers/vm/dhcpd.go
+++ b/pkg/provision/providers/vm/dhcpd.go
@@ -52,7 +52,7 @@ func handler(serverIP net.IP, statePath string) server4.Handler {
 			dhcpv4.WithOption(dhcpv4.OptHostName(match.Hostname)),
 			dhcpv4.WithOption(dhcpv4.OptDNS(match.Nameservers...)),
 			dhcpv4.WithOption(dhcpv4.OptRouter(match.Gateway)),
-			dhcpv4.WithOption(dhcpv4.OptIPAddressLeaseTime(time.Hour)),
+			dhcpv4.WithOption(dhcpv4.OptIPAddressLeaseTime(5*time.Minute)),
 			dhcpv4.WithOption(dhcpv4.OptServerIdentifier(serverIP)),
 		)
 		if err != nil {


### PR DESCRIPTION
There were two problems:

* `configureInterfaces` was always failing if interface is already set
up, as the routes already exist

* `renew` was halving the renew interval each time `configureInterface`
fails, which starts at (LeaseTime/2) and goes effectively to zero

This was leading to high networkd CPU usage, storm of DHCP requests on
the network.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

