### PR TITLE
fix: remove value (change to empty) for `NoSchedule` taint

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -223,7 +223,6 @@ func (h *Client) LabelNodeAsMaster(name string, taintNoSchedule bool) (err error
 		if !taintFound {
 			n.Spec.Taints = append(n.Spec.Taints, corev1.Taint{
 				Key:    constants.LabelNodeRoleMaster,
-				Value:  "true",
 				Effect: corev1.TaintEffectNoSchedule,
 			})
 		}


### PR DESCRIPTION
This seems to be more preferred way and fixes compatibility with
deployments which don't do `operator: Exists` in tolerations.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

