### PR TITLE
docs: ensure port for vbox and proxmox docs

### DIFF
--- a/website/content/docs/v0.7/Local Platforms/virtualbox.md
+++ b/website/content/docs/v0.7/Local Platforms/virtualbox.md
@@ -108,7 +108,7 @@ With the IP address above, you can now generate the machine configurations to us
 Issue the following command, updating the output directory, cluster name, and control plane IP as you see fit:
 
 ```bash
-talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP --output-dir _out
+talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out
 ```
 
 This will create several files in the _out directory: init.yaml, controlplane.yaml, join.yaml, and talosconfig.

--- a/website/content/docs/v0.7/Virtualized Platforms/proxmox.md
+++ b/website/content/docs/v0.7/Virtualized Platforms/proxmox.md
@@ -114,7 +114,7 @@ With the IP address above, you can now generate the machine configurations to us
 Issue the following command, updating the output directory, cluster name, and control plane IP as you see fit:
 
 ```bash
-talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP --output-dir _out
+talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out
 ```
 
 This will create several files in the _out directory: init.yaml, controlplane.yaml, join.yaml, and talosconfig.

--- a/website/content/docs/v0.8/Local Platforms/virtualbox.md
+++ b/website/content/docs/v0.8/Local Platforms/virtualbox.md
@@ -108,7 +108,7 @@ With the IP address above, you can now generate the machine configurations to us
 Issue the following command, updating the output directory, cluster name, and control plane IP as you see fit:
 
 ```bash
-talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP --output-dir _out
+talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out
 ```
 
 This will create several files in the _out directory: init.yaml, controlplane.yaml, join.yaml, and talosconfig.

--- a/website/content/docs/v0.8/Virtualized Platforms/proxmox.md
+++ b/website/content/docs/v0.8/Virtualized Platforms/proxmox.md
@@ -114,7 +114,7 @@ With the IP address above, you can now generate the machine configurations to us
 Issue the following command, updating the output directory, cluster name, and control plane IP as you see fit:
 
 ```bash
-talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP --output-dir _out
+talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out
 ```
 
 This will create several files in the _out directory: init.yaml, controlplane.yaml, join.yaml, and talosconfig.


### PR DESCRIPTION
This PR adds the default port to these docs so it's clear that port is
required.