### PR TITLE
feat: suggest fixed control plane endpoints in talosctl gen config

### DIFF
--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -9,6 +9,7 @@ package cli
 import (
 	"io/ioutil"
 	"os"
+	"regexp"
 
 	"github.com/talos-systems/talos/internal/integration/base"
 )
@@ -102,6 +103,33 @@ func (suite *GenSuite) TestKeypair() {
 
 	suite.Assert().FileExists("Foo.crt")
 	suite.Assert().FileExists("Foo.key")
+}
+
+// TestGenConfigURLValidation ...
+func (suite *GenSuite) TestGenConfigURLValidation() {
+	suite.RunCLI([]string{"gen", "config", "foo", "192.168.0.1"},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(regexp.QuoteMeta(`try: "https://192.168.0.1:6443"`))))
+
+	suite.RunCLI([]string{"gen", "config", "foo", "192.168.0.1:6443"},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(regexp.QuoteMeta(`try: "https://192.168.0.1:6443"`))))
+
+	suite.RunCLI([]string{"gen", "config", "foo", "192.168.0.1:2000"},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(regexp.QuoteMeta(`try: "https://192.168.0.1:2000"`))))
+
+	suite.RunCLI([]string{"gen", "config", "foo", "http://192.168.0.1:2000"},
+		base.ShouldFail(),
+		base.StdoutEmpty(),
+		base.StderrNotEmpty(),
+		base.StderrShouldMatch(regexp.MustCompile(regexp.QuoteMeta(`try: "https://192.168.0.1:2000"`))))
 }
 
 func init() {


### PR DESCRIPTION
Ex.:

```
$ talosctl gen config foo 192.168.0.1
no scheme and port specified for the cluster endpoint URL
try: "https://192.168.0.1:6443"
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>


