### PR TITLE
fix: node taint doesn't contain value anymore

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -213,7 +213,7 @@ func (h *Client) LabelNodeAsMaster(name string, taintNoSchedule bool) (err error
 		// TODO: with K8s 1.21, add new taint LabelNodeRoleControlPlane
 
 		for _, taint := range n.Spec.Taints {
-			if taint.Key == constants.LabelNodeRoleMaster && taint.Value == "true" {
+			if taint.Key == constants.LabelNodeRoleMaster {
 				taintFound = true
 
 				break


### PR DESCRIPTION
As code was looking for existing taint with `value == true`, it failed
to find existing taint and tried to add another one which never
succeeds.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

