### PR TITLE
chore: run integration test thrice daily

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -314,13 +314,11 @@ local default_steps = [
 
 local default_trigger = {
   trigger: {
-    cron: {
-      exclude: ['nightly'],
-    },
     event: {
       exclude: [
         'tag',
         'promote',
+        'cron',
       ],
     },
   },
@@ -387,6 +385,14 @@ local integration_trigger = {
   trigger: {
     target: {
       include: ['integration'],
+    },
+  },
+};
+
+local integration_thrice_daily_trigger = {
+  trigger: {
+    cron: {
+      include: ['thrice-daily'],
     },
   },
 };


### PR DESCRIPTION
This PR makes sure that we run integration more often. I did this in
UTC, with Eastern time zones in mind. In Eastern, it'll do 6AM, noon,
and 6PM. That should give us pretty good coverage across all of our
timezones so we can all have a chance to tackle new issues.

The cron that I added to drone (in UTC) is:

```
drone cron add "talos-systems/talos" "thrice-daily" "0 0 11,17,22 * * *"
```

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>