### PR TITLE
fix: stabilize serial console on RPi4, add video console

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
@@ -93,7 +93,7 @@ func (b *BananaPiM64) Install(disk string) (err error) {
 // KernelArgs implements the runtime.Board.
 func (b *BananaPiM64) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS2,115200n8"),
+		procfs.NewParameter("console").Append("tty0").Append("ttyS2,115200n8"),
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5/libretech_all_h3_cc_h5.go
@@ -90,7 +90,7 @@ func (l *LibretechAllH3CCH5) Install(disk string) (err error) {
 // KernelArgs implements the runtime.Board.
 func (l *LibretechAllH3CCH5) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS0,115200"),
+		procfs.NewParameter("console").Append("tty0").Append("ttyS0,115200"),
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rock64/rock64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rock64/rock64.go
@@ -90,7 +90,7 @@ func (r *Rock64) Install(disk string) (err error) {
 // KernelArgs implements the runtime.Board.
 func (r *Rock64) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS2,115200n8"),
+		procfs.NewParameter("console").Append("tty0").Append("ttyS2,115200n8"),
 	}
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
@@ -17,6 +17,7 @@ import (
 var configTxt = []byte(`arm_64bit=1
 enable_uart=1
 kernel=u-boot.bin
+dtoverlay=disable-bt
 `)
 
 // RPi4 represents the Raspberry Pi 4 Model B.
@@ -47,7 +48,7 @@ func (r *RPi4) Install(disk string) (err error) {
 // KernelArgs implements the runtime.Board.
 func (r *RPi4) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("ttyS0,115200"),
+		procfs.NewParameter("console").Append("tty0").Append("ttyAMA0,115200"),
 	}
 }
 


### PR DESCRIPTION
This adds `tty0` for all the boards in case HDMI output actually works.

For RPi4, disable BT to enable PL011 instead of mini-UART for serial
console, as PL011 is much more stable (fixes garbage on serial output).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

