### PR TITLE
fix: make default generate image arch dynamic based on arch

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -5,6 +5,8 @@
 package generate
 
 import (
+	"runtime"
+
 	v1alpha1 "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 )
 
@@ -175,6 +177,6 @@ type GenOptions struct {
 func DefaultGenOptions() GenOptions {
 	return GenOptions{
 		Persist:      true,
-		Architecture: "amd64",
+		Architecture: runtime.GOARCH,
 	}
 }


### PR DESCRIPTION
This should fix interactive installer on arm64.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

