### PR TITLE
chore: publish Rock64 image

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -507,6 +507,7 @@ local release = {
       '_out/metal-amd64.tar.gz',
       '_out/metal-arm64.tar.gz',
       '_out/metal-rpi_4-arm64.img.xz',
+      '_out/metal-rock64-arm64.img.xz',
       '_out/metal-bananapi_m64-arm64.img.xz',
       '_out/metal-libretech_all_h3_cc_h5-arm64.img.xz',
       '_out/openstack-amd64.tar.gz',

--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,10 @@ image-%: ## Builds the specified image. Valid options are aws, azure, digital-oc
 
 images: image-aws image-azure image-digital-ocean image-gcp image-metal image-openstack image-vmware ## Builds all known images (AWS, Azure, Digital Ocean, GCP, Metal, Openstack, and VMware).
 
-sbc-%: ## Builds the specified SBC image. Valid options are rpi_4, bananapi_m64, and libretech_all_h3_cc_h5 (e.g. sbc-rpi_4)
+sbc-%: ## Builds the specified SBC image. Valid options are rpi_4, rock64, bananapi_m64, and libretech_all_h3_cc_h5 (e.g. sbc-rpi_4)
 	@docker run --rm -v /dev:/dev --privileged $(REGISTRY)/$(USERNAME)/installer:$(TAG) image --platform metal --board $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
-sbcs: sbc-rpi_4 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 ## Builds all known SBC images (Raspberry Pi 4 Model B, Banana Pi M64, and Libre Computer Board ALL-H3-CC).
+sbcs: sbc-rpi_4 sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 ## Builds all known SBC images (Raspberry Pi 4 Model B, Rock64, Banana Pi M64, and Libre Computer Board ALL-H3-CC).
 
 .PHONY: iso
 iso: ## Builds the ISO and outputs it to the artifact directory.


### PR DESCRIPTION
This publishes the Pine64 Rock64 image.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
