### PR TITLE
release(v0.8.0-alpha.2): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,64 @@
 
+<a name="v0.8.0-alpha.2"></a>
+## [v0.8.0-alpha.2](https://github.com/talos-systems/talos/compare/v0.8.0-alpha.1...v0.8.0-alpha.2) (2020-12-04)
+
+### Chore
+
+* publish Rock64 image
+* enable thrice daily pipeline
+* run integration test thrice daily
+* output SBC images as compressed raw images
+* build SBC images
+* update module dependencies
+* drop support for `docker load`
+* fix metal image name
+* use IMAGE_TAG instead of TAG for :latest pushes
+
+### Docs
+
+* fix typos
+* add openstack docs
+* ensure port for vbox and proxmox docs
+* add console kernel arg to rpi_4 image generation
+* add console kernel arg to libretech_all_h3_cc_h5 image generation
+
+### Feat
+
+* add support for the Pine64 Rock64
+* add TUI for configuring network interfaces settings
+* make GenerateConfiguration accept current time as a parameter
+* introduce configpatcher package in machinery
+* suggest fixed control plane endpoints in talosctl gen config
+* update kubernetes to 1.20.0-rc.0
+* allow boards to set kernel args
+* add support for the Banana Pi M64
+* stop including K8s version by default in `talosctl gen config`
+* add support for the Raspberry Pi 4 Model B
+* implement network interfaces list API
+* bump package for kernel with CIFS support
+* upgrade etcd to 3.4.14
+* update Containerd and Linux
+* add support for installing to SBCs
+* add ability to choose CNI config
+
+### Fix
+
+* make default generate image arch dynamic based on arch
+* stabilize serial console on RPi4, add video console
+* make reset work again
+* node taint doesn't contain value anymore
+* defer resolving config context in client code
+* remove value (change to empty) for `NoSchedule` taint
+* prevent endless loop with DHCP requests in networkd
+* skip `board` argument to the installer if it's not set
+* use the dtb from kernel pkg for libretech_all_h3_cc_h5
+* prevent crash in `talosctl config` commands
+* update generated .ova manifest for raw disk size
+* **security:** update Containerd to v1.4.3
+
+
 <a name="v0.8.0-alpha.1"></a>
-## [v0.8.0-alpha.1](https://github.com/talos-systems/talos/compare/v0.8.0-alpha.0...v0.8.0-alpha.1) (2020-11-25)
+## [v0.8.0-alpha.1](https://github.com/talos-systems/talos/compare/v0.8.0-alpha.0...v0.8.0-alpha.1) (2020-11-26)
 
 ### Chore
 
@@ -59,6 +117,10 @@
 ### Refactor
 
 * drop osd compatibility layer
+
+### Release
+
+* **v0.8.0-alpha.1:** prepare release
 
 ### Test
 

--- a/Makefile
+++ b/Makefile
@@ -160,17 +160,20 @@ talosctl-%:
 talosctl: $(TALOSCTL_DEFAULT_TARGET) ## Builds the talosctl binary for the local machine.
 
 image-%: ## Builds the specified image. Valid options are aws, azure, digital-ocean, gcp, and vmware (e.g. image-aws)
+	@docker pull $(REGISTRY)/$(USERNAME)/installer:$(TAG)
 	@docker run --rm -v /dev:/dev --privileged $(REGISTRY)/$(USERNAME)/installer:$(TAG) image --platform $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
 images: image-aws image-azure image-digital-ocean image-gcp image-metal image-openstack image-vmware ## Builds all known images (AWS, Azure, Digital Ocean, GCP, Metal, Openstack, and VMware).
 
 sbc-%: ## Builds the specified SBC image. Valid options are rpi_4, rock64, bananapi_m64, and libretech_all_h3_cc_h5 (e.g. sbc-rpi_4)
+	@docker pull $(REGISTRY)/$(USERNAME)/installer:$(TAG)
 	@docker run --rm -v /dev:/dev --privileged $(REGISTRY)/$(USERNAME)/installer:$(TAG) image --platform metal --board $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
 sbcs: sbc-rpi_4 sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 ## Builds all known SBC images (Raspberry Pi 4 Model B, Rock64, Banana Pi M64, and Libre Computer Board ALL-H3-CC).
 
 .PHONY: iso
 iso: ## Builds the ISO and outputs it to the artifact directory.
+	@docker pull $(REGISTRY)/$(USERNAME)/installer:$(TAG)
 	@docker run --rm -i $(REGISTRY)/$(USERNAME)/installer:$(TAG) iso --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
 .PHONY: boot

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -77,7 +77,7 @@ talosctl cluster create [flags]
       --arch string                             cluster architecture (default "amd64")
       --cidr string                             CIDR of the cluster network (default "10.5.0.0/24")
       --cni-bin-path strings                    search path for CNI binaries (VM only) (default [/home/user/.talos/cni/bin])
-      --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.8.0-alpha.1/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.8.0-alpha.2/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                    CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                     CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
       --cpus string                             the share of CPUs as fraction (each container/VM) (default "2.0")


### PR DESCRIPTION
This is the official v0.8.0-alpha.2 release.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
