### PR TITLE
test: bump Talos release version for upgrade test to 0.7.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.19.0
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.6.3 v0.7.0
+RELEASES ?= v0.6.3 v0.7.1
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -66,7 +66,7 @@ type upgradeSpec struct {
 
 const (
 	previousRelease = "v0.6.3"
-	stableRelease   = "v0.7.0"
+	stableRelease   = "v0.7.1"
 
 	previousK8sVersion = "1.19.0"
 	stableK8sVersion   = "1.19.4"


### PR DESCRIPTION
We should always use latest releases.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

