### PR TITLE
docs: add storage doc

### DIFF
--- a/website/content/docs/v0.8/Guides/storage.md
+++ b/website/content/docs/v0.8/Guides/storage.md
@@ -1,0 +1,15 @@
+---
+title: "Storage"
+description: ""
+---
+
+Talos is known to work with Rook and NFS.
+
+## Rook
+
+We recommend at least Rook v1.5.
+
+## NFS
+
+The NFS client is part of the [`kubelet` image](https://github.com/talos-systems/kubelet) maintained by the Talos team.
+This means that the version installed in your running `kubelet` is the version of NFS supported by Talos.


### PR DESCRIPTION
Adds a basic guide on storage.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
