### PR TITLE
docs: add architectural doc on the root file system layout

### DIFF
--- a/website/content/docs/v0.8/Learn More/architecture.md
+++ b/website/content/docs/v0.8/Learn More/architecture.md
@@ -17,3 +17,25 @@ All of the main Talos components communicate with each other by gRPC, through a 
 This imposes a clear separation of concerns and ensures that changes over time which affect the interoperation of components are a part of the public git record.
 The benefit is that each component may be iterated and changed as its needs dictate, so long as the external API is controlled.
 This is a key component in reducing coupling and maintaining modularity.
+
+## The File System
+
+One of the more unique design decisions in Talos is the layout of the root file system.
+There are three "layers" to the Talos root file system.
+At its' core the rootfs is a read-only squashfs.
+The sqaushfs is then mounted as a loop device into memory.
+This provides Talos with an immutable base.
+
+The next layer is a set of `tmpfs` file systems for runtime specific needs.
+Aside from the standard pseudo file systems such as `/dev`, `/proc`, `/run`, `/sys` and `/tmp`, a special `/system` is created for internal needs.
+One reason for this is that we need special files such as `/etc/hosts`, and `/etc/resolv.conf` to be writable (remember that the rootfs is read-only).
+For example, at boot Talos will write `/system/etc/hosts` and the bind mount it over `/etc/hosts`.
+This means that instead of making all of `/etc` writable, Talos only makes very specific files writable under `/etc`.
+
+All files under `/system` are completely reproducable.
+For files and directories that need to persist across boots, Talos creates `overlayfs` file systems.
+The `/etc/kuberentes` is a good example of this.
+Directories like this are `overlayfs` backed by an XFS file system mounted at `/var`.
+
+The `/var` directory is owned by Kubernetes with the exception of the above `overlayfs` file systems.
+This directory is writable and used by `etcd` (in the case of control plane nodes), the kubelet, and the CRI (containerd).


### PR DESCRIPTION
This adds documentation on how the root file system is laid out.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
