### PR TITLE
test: add ISO test

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -224,6 +224,7 @@ local unit_tests = Step("unit-tests", depends_on=[initramfs]);
 local unit_tests_race = Step("unit-tests-race", depends_on=[initramfs]);
 local e2e_docker = Step("e2e-docker-short", depends_on=[talos, talosctl_linux, unit_tests, unit_tests_race], target="e2e-docker", environment={"SHORT_INTEGRATION_TEST": "yes", "REGISTRY": local_registry});
 local e2e_qemu = Step("e2e-qemu-short", privileged=true, target="e2e-qemu", depends_on=[talosctl_linux, initramfs, kernel, installer, unit_tests, unit_tests_race, talosctl_cni_bundle], environment={"REGISTRY": local_registry, "SHORT_INTEGRATION_TEST": "yes"}, when={event: ['pull_request']});
+local e2e_iso = Step("e2e-iso", privileged=true, target="e2e-iso", depends_on=[talosctl_linux, initramfs, iso_amd64, unit_tests, unit_tests_race], when={event: ['pull_request']}, environment={"REGISTRY": local_registry});
 
 local coverage = {
   name: 'coverage',
@@ -306,8 +307,9 @@ local default_steps = [
   unit_tests,
   unit_tests_race,
   coverage,
-  e2e_docker,
+  e2e_iso,
   e2e_qemu,
+  e2e_docker,
   push,
   push_latest,
 ];

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -eoux pipefail
+
+source ./hack/test/e2e.sh
+
+PROVISIONER=qemu
+CLUSTER_NAME=e2e-iso
+
+NODE="172.20.2.2"
+
+function create_cluster {
+  build_registry_mirrors
+
+  "${TALOSCTL}" cluster create \
+    --iso-path=${ARTIFACTS}/talos-amd64.iso \
+    --skip-injecting-config \
+    --wait=false \
+    --with-init-node \
+    --provisioner "${PROVISIONER}" \
+    --name "${CLUSTER_NAME}" \
+    --masters=1 \
+    --workers=0 \
+    --mtu 1500 \
+    --memory 2048 \
+    --cpus 2.0 \
+    --cidr 172.20.2.0/24 \
+    --install-image ${REGISTRY:-ghcr.io}/talos-systems/installer:${TAG} \
+    --cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
+    ${REGISTRY_MIRROR_FLAGS}
+
+  "${TALOSCTL}" config node "${NODE}"
+}
+
+function destroy_cluster() {
+  "${TALOSCTL}" cluster destroy --name "${CLUSTER_NAME}" --provisioner "${PROVISIONER}"
+}
+
+create_cluster
+timeout -v --preserve-status 1m bash -c "until ${TALOSCTL} apply-config -n ${NODE} --insecure -f controlplane.yaml; do sleep 5; done"
+sleep 5
+timeout -v --preserve-status 2m  bash -c "until nc -z ${NODE} 50000; do sleep 5; done"
+${TALOSCTL} bootstrap -n "${NODE}"
+${TALOSCTL} health --wait-timeout=10m0s -n "${NODE}" --control-plane-nodes="${NODE}"
+destroy_cluster

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
@@ -99,20 +99,14 @@ func (cluster *clusterState) NodesByType(t machine.Type) []string {
 }
 
 func (cluster *clusterState) resolve(ctx context.Context, k8sProvider *cluster.KubernetesClient) error {
-	var err error
+	if len(cluster.controlPlaneNodes) == 0 && len(cluster.workerNodes) == 0 {
+		var err error
 
-	if len(cluster.controlPlaneNodes) == 0 {
 		if _, err = k8sProvider.K8sClient(ctx); err != nil {
 			return err
 		}
 
 		if cluster.controlPlaneNodes, err = k8sProvider.KubeHelper.MasterIPs(ctx); err != nil {
-			return err
-		}
-	}
-
-	if len(cluster.workerNodes) == 0 {
-		if _, err = k8sProvider.K8sClient(ctx); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Adds a simple test for the ISO. Boots the ISO, and then uses the `apply-config` command
in `talosctl` to create a cluster.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
