### PR TITLE
feat: add talosctl merge config command

### DIFF
--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -7,9 +7,13 @@
 package cli
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/talos-systems/talos/internal/integration/base"
+	clientconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
 )
 
 // TalosconfigSuite verifies dmesg command.
@@ -26,6 +30,40 @@ func (suite *TalosconfigSuite) SuiteName() string {
 func (suite *TalosconfigSuite) TestList() {
 	suite.RunCLI([]string{"config", "contexts"},
 		base.StdoutShouldMatch(regexp.MustCompile(`CURRENT`)))
+}
+
+// TestMerge checks how talosctl config merge.
+func (suite *TalosconfigSuite) TestMerge() {
+	tempDir, err := ioutil.TempDir("", "talos")
+	defer os.RemoveAll(tempDir) //nolint: errcheck
+
+	suite.Require().NoError(err)
+
+	suite.RunCLI([]string{"gen", "config", "-o", tempDir, "foo", "https://192.168.0.1:6443"})
+
+	talosconfigPath := filepath.Join(tempDir, "talosconfig")
+
+	suite.Assert().FileExists(talosconfigPath)
+
+	path := filepath.Join(tempDir, "merged")
+
+	suite.RunCLI([]string{"config", "merge", "--talosconfig", path, talosconfigPath},
+		base.StdoutEmpty())
+
+	suite.Require().FileExists(path)
+
+	c, err := clientconfig.Open(path)
+	suite.Require().NoError(err)
+
+	suite.Require().NotNil(c.Contexts["foo"])
+
+	suite.RunCLI([]string{"config", "merge", "--talosconfig", path, talosconfigPath},
+		base.StdoutShouldMatch(regexp.MustCompile(`renamed`)))
+
+	c, err = clientconfig.Open(path)
+	suite.Require().NoError(err)
+
+	suite.Require().NotNil(c.Contexts["foo-1"])
 }
 
 func init() {

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -396,6 +396,37 @@ talosctl config endpoint <endpoint>... [flags]
 
 * [talosctl config](#talosctl-config)	 - Manage the client configuration
 
+## talosctl config merge
+
+Merge additional contexts from another Talos config into the default config
+
+### Synopsis
+
+Contexts with the same name are renamed while merging configs.
+
+```
+talosctl config merge <from> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for merge
+```
+
+### Options inherited from parent commands
+
+```
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
+```
+
+### SEE ALSO
+
+* [talosctl config](#talosctl-config)	 - Manage the client configuration
+
 ## talosctl config node
 
 Set the node(s) for the current context
@@ -449,6 +480,7 @@ Manage the client configuration
 * [talosctl config context](#talosctl-config-context)	 - Set the current context
 * [talosctl config contexts](#talosctl-config-contexts)	 - List contexts defined in Talos config
 * [talosctl config endpoint](#talosctl-config-endpoint)	 - Set the endpoint(s) for the current context
+* [talosctl config merge](#talosctl-config-merge)	 - Merge additional contexts from another Talos config into the default config
 * [talosctl config node](#talosctl-config-node)	 - Set the node(s) for the current context
 
 ## talosctl containers


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/2875
Allows merging two Talos configs into one. Merges the config in whatever
is set by `TALOSCONFIG` or into `~/.talos/config`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>