### PR TITLE
feat: add talosctl config contexts

### DIFF
--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// TalosconfigSuite verifies dmesg command.
+type TalosconfigSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *TalosconfigSuite) SuiteName() string {
+	return "cli.TalosconfigSuite"
+}
+
+// TestList checks how talosctl config merge.
+func (suite *TalosconfigSuite) TestList() {
+	suite.RunCLI([]string{"config", "contexts"},
+		base.StdoutShouldMatch(regexp.MustCompile(`CURRENT`)))
+}
+
+func init() {
+	allSuites = append(allSuites, new(TalosconfigSuite))
+}

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -342,6 +342,33 @@ talosctl config context <context> [flags]
 
 * [talosctl config](#talosctl-config)	 - Manage the client configuration
 
+## talosctl config contexts
+
+List contexts defined in Talos config
+
+```
+talosctl config contexts [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for contexts
+```
+
+### Options inherited from parent commands
+
+```
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
+```
+
+### SEE ALSO
+
+* [talosctl config](#talosctl-config)	 - Manage the client configuration
+
 ## talosctl config endpoint
 
 Set the endpoint(s) for the current context
@@ -420,6 +447,7 @@ Manage the client configuration
 * [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl config add](#talosctl-config-add)	 - Add a new context
 * [talosctl config context](#talosctl-config-context)	 - Set the current context
+* [talosctl config contexts](#talosctl-config-contexts)	 - List contexts defined in Talos config
 * [talosctl config endpoint](#talosctl-config-endpoint)	 - Set the endpoint(s) for the current context
 * [talosctl config node](#talosctl-config-node)	 - Set the node(s) for the current context
 


### PR DESCRIPTION
Bonus to `talosctl config merge`.
Got that idea after using talosctl for a weekend.
I feel that can be a good addition to have a command that can list existing
contexts in a table view, which is similar to what `kubectl config get-contexts`
does. To avoid going through the file which has all the certs and such.

Called it just `contexts` to align with whatever we have now (to switch
    context you need to use `talosctl config context`).

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>