### PR TITLE
fix: add reboot=k to openstack platform

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -110,5 +110,6 @@ func (a *Openstack) ExternalIPs(ctx context.Context) (addrs []net.IP, err error)
 func (a *Openstack) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty1").Append("ttyS0"),
+		procfs.NewParameter("reboot").Append("k"),
 	}
 }


### PR DESCRIPTION
This resolves an issue with reboots on openstack.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
