### PR TITLE
test: add support for mounting ISO in talosctl cluster create

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -50,6 +50,7 @@ var (
 	kubernetesVersion       string
 	nodeVmlinuzPath         string
 	nodeInitramfsPath       string
+	nodeISOPath             string
 	bootloaderEnabled       bool
 	uefiEnabled             bool
 	configDebug             bool
@@ -171,6 +172,7 @@ func create(ctx context.Context) (err error) {
 		Image:         nodeImage,
 		KernelPath:    nodeVmlinuzPath,
 		InitramfsPath: nodeInitramfsPath,
+		ISOPath:       nodeISOPath,
 
 		SelfExecutable: os.Args[0],
 		StateDirectory: stateDir,
@@ -559,6 +561,7 @@ func init() {
 	createCmd.Flags().StringVar(&nodeImage, "image", helpers.DefaultImage(images.DefaultTalosImageRepository), "the image to use")
 	createCmd.Flags().StringVar(&nodeInstallImage, "install-image", helpers.DefaultImage(images.DefaultInstallerImageRepository), "the installer image to use")
 	createCmd.Flags().StringVar(&nodeVmlinuzPath, "vmlinuz-path", helpers.ArtifactPath(constants.KernelAssetWithArch), "the compressed kernel image to use")
+	createCmd.Flags().StringVar(&nodeISOPath, "iso-path", "", "the ISO path to use for the initial boot (VM only)")
 	createCmd.Flags().StringVar(&nodeInitramfsPath, "initrd-path", helpers.ArtifactPath(constants.InitramfsAssetWithArch), "the uncompressed kernel image to use")
 	createCmd.Flags().BoolVar(&bootloaderEnabled, "with-bootloader", true, "enable bootloader to load kernel and initramfs from disk image after install")
 	createCmd.Flags().BoolVar(&uefiEnabled, "with-uefi", false, "enable UEFI on x86_64 architecture (always enabled for arm64)")

--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -38,6 +38,7 @@ type LaunchConfig struct {
 	QemuExecutable    string
 	KernelImagePath   string
 	InitrdPath        string
+	ISOPath           string
 	PFlashImages      []string
 	KernelArgs        string
 	MachineType       string
@@ -235,12 +236,18 @@ func launchVM(config *LaunchConfig) error {
 		return err
 	}
 
-	if (!diskBootable || !config.BootloaderEnabled) && config.KernelImagePath != "" {
-		args = append(args,
-			"-kernel", config.KernelImagePath,
-			"-initrd", config.InitrdPath,
-			"-append", config.KernelArgs,
-		)
+	if !diskBootable || !config.BootloaderEnabled {
+		if config.ISOPath != "" {
+			args = append(args,
+				"-cdrom", config.ISOPath,
+			)
+		} else if config.KernelImagePath != "" {
+			args = append(args,
+				"-kernel", config.KernelImagePath,
+				"-initrd", config.InitrdPath,
+				"-append", config.KernelArgs,
+			)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "starting qemu with args:\n%s\n", strings.Join(args, " "))

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -120,6 +120,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	if !nodeReq.PXEBooted {
 		launchConfig.KernelImagePath = strings.ReplaceAll(clusterReq.KernelPath, constants.ArchVariable, opts.TargetArch)
 		launchConfig.InitrdPath = strings.ReplaceAll(clusterReq.InitramfsPath, constants.ArchVariable, opts.TargetArch)
+		launchConfig.ISOPath = strings.ReplaceAll(clusterReq.ISOPath, constants.ArchVariable, opts.TargetArch)
 	}
 
 	launchConfig.StatePath, err = state.StatePath()

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -23,6 +23,7 @@ type ClusterRequest struct {
 	Image         string
 	KernelPath    string
 	InitramfsPath string
+	ISOPath       string
 
 	// Path to talosctl executable to re-execute itself as needed.
 	SelfExecutable string

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -94,6 +94,7 @@ talosctl cluster create [flags]
       --initrd-path string                      the uncompressed kernel image to use (default "_out/initramfs-${ARCH}.xz")
   -i, --input-dir string                        location of pre-generated config files
       --install-image string                    the installer image to use (default "ghcr.io/talos-systems/installer:latest")
+      --iso-path string                         the ISO path to use for the initial boot (VM only)
       --kubernetes-version string               desired kubernetes version to run (default "1.20.0")
       --masters int                             the number of masters to create (default 1)
       --memory int                              the limit on memory usage in MB (each container/VM) (default 2048)


### PR DESCRIPTION
If disk is empty and ISO path is given, QEMU provisioner mounts ISO on
the first boot.

To drop into maintenance mode:

```
talosctl cluster create --provisioner=qemu --iso-path=./_out/talos-amd64.iso --skip-injecting-config --wait=false
```

Then inject the config, bootstrap the node, wait for it to come up (via
`talosctl cluster health`).

See #2881

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

