### PR TITLE
test: stabilize upgrade test by running health check several times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.19.0
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.6.3 v0.7.1
+RELEASES ?= v0.7.1 v0.8.0-alpha.3
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/internal/integration/api/events.go
+++ b/internal/integration/api/events.go
@@ -92,7 +92,7 @@ func (suite *EventsSuite) TestServiceEvents() {
 	}()
 
 	// wait for event watcher to start
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	_, err = suite.Client.ServiceRestart(suite.nodeCtx, service)
 	suite.Assert().NoError(err)

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -15,9 +15,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/talos-systems/talos/internal/integration/base"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
@@ -125,16 +122,7 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 
 		suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
 			// force reboot after reset, as this is the only mode we can test
-			err = suite.Client.Reset(nodeCtx, true, true)
-			if err != nil {
-				if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
-					// ignore errors if reboot happens before response is fully received
-
-					err = nil
-				}
-			}
-
-			return err
+			return base.IgnoreGRPCUnavailable(suite.Client.Reset(nodeCtx, true, true))
 		}, 10*time.Minute)
 
 		postReset, err := suite.hashKubeletCert(suite.ctx, node)
@@ -165,16 +153,7 @@ func (suite *ResetSuite) TestResetNoGraceful() {
 
 	suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
 		// force reboot after reset, as this is the only mode we can test
-		err = suite.Client.Reset(nodeCtx, false, true)
-		if err != nil {
-			if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
-				// ignore errors if reboot happens before response is fully received
-
-				err = nil
-			}
-		}
-
-		return err
+		return base.IgnoreGRPCUnavailable(suite.Client.Reset(nodeCtx, false, true))
 	}, 5*time.Minute)
 
 	postReset, err := suite.hashKubeletCert(suite.ctx, node)
@@ -204,7 +183,7 @@ func (suite *ResetSuite) TestResetWithSpecEphemeral() {
 
 	suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
 		// force reboot after reset, as this is the only mode we can test
-		err = suite.Client.ResetGeneric(nodeCtx, &machineapi.ResetRequest{
+		return base.IgnoreGRPCUnavailable(suite.Client.ResetGeneric(nodeCtx, &machineapi.ResetRequest{
 			Reboot:   true,
 			Graceful: true,
 			SystemPartitionsToWipe: []*machineapi.ResetPartitionSpec{
@@ -213,16 +192,7 @@ func (suite *ResetSuite) TestResetWithSpecEphemeral() {
 					Wipe:  true,
 				},
 			},
-		})
-		if err != nil {
-			if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
-				// ignore errors if reboot happens before response is fully received
-
-				err = nil
-			}
-		}
-
-		return err
+		}))
 	}, 5*time.Minute)
 
 	postReset, err := suite.hashKubeletCert(suite.ctx, node)
@@ -254,7 +224,7 @@ func (suite *ResetSuite) TestResetWithSpecState() {
 
 	suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
 		// force reboot after reset, as this is the only mode we can test
-		err = suite.Client.ResetGeneric(nodeCtx, &machineapi.ResetRequest{
+		return base.IgnoreGRPCUnavailable(suite.Client.ResetGeneric(nodeCtx, &machineapi.ResetRequest{
 			Reboot:   true,
 			Graceful: true,
 			SystemPartitionsToWipe: []*machineapi.ResetPartitionSpec{
@@ -263,16 +233,7 @@ func (suite *ResetSuite) TestResetWithSpecState() {
 					Wipe:  true,
 				},
 			},
-		})
-		if err != nil {
-			if s, ok := status.FromError(err); ok && s.Code() == codes.Unavailable {
-				// ignore errors if reboot happens before response is fully received
-
-				err = nil
-			}
-		}
-
-		return err
+		}))
 	}, 5*time.Minute)
 
 	postReset, err := suite.hashKubeletCert(suite.ctx, node)

--- a/internal/integration/base/errors.go
+++ b/internal/integration/base/errors.go
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build integration
+
+package base
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IgnoreGRPCUnavailable searches through unwrapped errors and ignores the error if it is grpc.Unavailable.
+func IgnoreGRPCUnavailable(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	unwrappedErr := err
+
+	for {
+		if s, ok := status.FromError(unwrappedErr); ok && s.Code() == codes.Unavailable {
+			// ignore errors if reboot happens before response is fully received
+			return nil
+		}
+
+		unwrappedErr = errors.Unwrap(unwrappedErr)
+		if unwrappedErr == nil {
+			break
+		}
+	}
+
+	return err
+}


### PR DESCRIPTION
For single node clusters, control plane is unstable after reboot, run
health check several times to let it settle down to avoid failures in
subsequent checks.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
