### PR TITLE
refactor: remove setup goroutine in etcd service

### DIFF
--- a/internal/pkg/containers/image/image.go
+++ b/internal/pkg/containers/image/image.go
@@ -41,7 +41,7 @@ func Pull(ctx context.Context, reg config.Registries, client *containerd.Client,
 		if img, err = client.Pull(ctx, ref, containerd.WithPullUnpack, containerd.WithResolver(resolver)); err != nil {
 			err = fmt.Errorf("failed to pull image %q: %w", ref, err)
 
-			if errdefs.IsNotFound(err) {
+			if errdefs.IsNotFound(err) || errdefs.IsCanceled(err) {
 				return retry.UnexpectedError(err)
 			}
 


### PR DESCRIPTION
Instead of running `PreFunc` in goroutine which might leak behind the
lifetime of the service `PreFunc`, add more clauses to correctly abort
sequence on context canceled.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

