### PR TITLE
chore: add drone pipeline to upload cloud images

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -478,6 +478,25 @@ local nightly_trigger = {
 
 local nightly_pipeline = Pipeline('nightly', conformance_steps) + nightly_trigger;
 
+// Cloud images pipeline.
+
+local cloud_images = Step("cloud-images", depends_on=[images_amd64, images_arm64], environment=creds_env_vars);
+
+local upload_images_steps = default_steps + [
+  cloud_images,
+];
+
+
+local upload_images_trigger = {
+  trigger: {
+    target: {
+      include: ['upload-images'],
+    },
+  },
+};
+
+local upload_images_pipeline = Pipeline('upload-images', upload_images_steps) + upload_images_trigger;
+
 // Release pipeline.
 
 local boot = Step('boot', depends_on=[e2e_docker, e2e_qemu]);
@@ -585,7 +604,7 @@ local notify_trigger = {
   },
 };
 
-local notify_pipeline = Pipeline('notify', notify_steps, [default_pipeline, e2e_pipeline, integration_pipeline, integration_thrice_daily_pipeline, integration_nightly_pipeline, conformance_pipeline, nightly_pipeline, release_pipeline], false, true) + notify_trigger;
+local notify_pipeline = Pipeline('notify', notify_steps, [default_pipeline, e2e_pipeline, integration_pipeline, integration_thrice_daily_pipeline, integration_nightly_pipeline, conformance_pipeline, upload_images_pipeline, nightly_pipeline, release_pipeline], false, true) + notify_trigger;
 
 // Final configuration file definition.
 
@@ -596,6 +615,7 @@ local notify_pipeline = Pipeline('notify', notify_steps, [default_pipeline, e2e_
   integration_nightly_pipeline,
   e2e_pipeline,
   conformance_pipeline,
+  upload_images_pipeline,
   nightly_pipeline,
   release_pipeline,
   notify_pipeline,

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,15 @@ talosctl-cni-bundle: ## Creates a compressed tarball that includes CNI bundle fo
 	done
 	@rm -rf $(ARTIFACTS)/talosctl-cni-bundle-*/
 
+.PHONY: cloud-images
+cloud-images: ## Uploads cloud images (AMIs, etc.) to the cloud registry.
+	@docker run --rm -v $(PWD):/src -w /src \
+		-e TAG=$(TAG) -e ARTIFACTS=$(ARTIFACTS) \
+		-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SVC_ACCT \
+		-e AZURE_SVC_ACCT -e GCE_SVC_ACCT -e PACKET_AUTH_TOKEN \
+		golang:$(GO_VERSION) \
+		./hack/cloud-image-uploader.sh
+
 # Code Quality
 
 .PHONY: fmt
@@ -254,7 +263,6 @@ e2e-%: $(ARTIFACTS)/$(INTEGRATION_TEST_DEFAULT_TARGET)-amd64 $(ARTIFACTS)/sonobu
 		KUBECTL=$(PWD)/$(ARTIFACTS)/kubectl \
 		SONOBUOY=$(PWD)/$(ARTIFACTS)/sonobuoy \
 		CLUSTERCTL=$(PWD)/$(ARTIFACTS)/clusterctl
-
 
 provision-tests-prepare: release-artifacts $(ARTIFACTS)/$(INTEGRATION_TEST_PROVISION_DEFAULT_TARGET)-amd64
 

--- a/hack/cloud-image-uploader.sh
+++ b/hack/cloud-image-uploader.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cd hack/cloud-image-uploader
+
+go run . --artifacts-path="../../${ARTIFACTS}" --tag="${TAG}"


### PR DESCRIPTION
At the moment only AMIs for AWS, and upload results should be pushed
back to the docs as separate PR.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

