### PR TITLE
test: remove provision tests with Cilium CNI

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -334,10 +334,10 @@ local integration_qemu = Step("e2e-qemu", privileged=true, depends_on=[initramfs
 local integration_provision_tests_prepare = Step("provision-tests-prepare", privileged=true, depends_on=[initramfs, talosctl_linux, kernel, installer, unit_tests, unit_tests_race, e2e_qemu, e2e_docker]);
 local integration_provision_tests_track_0 = Step("provision-tests-track-0", privileged=true, depends_on=[integration_provision_tests_prepare], environment={"REGISTRY": local_registry});
 local integration_provision_tests_track_1 = Step("provision-tests-track-1", privileged=true, depends_on=[integration_provision_tests_prepare], environment={"REGISTRY": local_registry});
-local integration_provision_tests_track_0_cilium = Step("provision-tests-track-0-cilium", target="provision-tests-track-0", privileged=true, depends_on=[integration_provision_tests_track_0], environment={
-        "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
-        "REGISTRY": local_registry,
-});
+// local integration_provision_tests_track_0_cilium = Step("provision-tests-track-0-cilium", target="provision-tests-track-0", privileged=true, depends_on=[integration_provision_tests_track_0], environment={
+//         "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
+//         "REGISTRY": local_registry,
+// });
 local integration_cilium = Step("e2e-cilium-1.8.5", target="e2e-qemu", privileged=true, depends_on=[integration_qemu], environment={
         "SHORT_INTEGRATION_TEST": "yes",
         "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
@@ -365,9 +365,9 @@ local push_edge = {
   },
   depends_on: [
      // we skip track_0 dependency since it's a dependency for the cilium test below.
+    integration_provision_tests_track_0.name,
     integration_provision_tests_track_1.name,
     integration_uefi.name,
-    integration_provision_tests_track_0_cilium.name,
   ],
 };
 
@@ -377,7 +377,6 @@ local integration_steps = default_steps + [
   integration_provision_tests_prepare,
   integration_provision_tests_track_0,
   integration_provision_tests_track_1,
-  integration_provision_tests_track_0_cilium,
   integration_cilium,
   integration_uefi,
   push_edge,


### PR DESCRIPTION
Self-hosted control plane upgrade with Cilium looks to be really flaky,
and it often fails the test run. We still have e2e-test with Cilium for
the test coverage.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

