### PR TITLE
feat: bump Linux kernel to 5.10.1, add CONFIG_USB_ACM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-13-g05b7372
-PKGS ?= v0.3.0-55-g649edb3
+PKGS ?= v0.3.0-57-ga7f6270
 EXTRAS ?= v0.1.0-6-gdc32cc8
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.9.13-talos"
+	DefaultKernelVersion = "5.10.1-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This pulls in following PRs:

* https://github.com/talos-systems/pkgs/pull/219
* https://github.com/talos-systems/pkgs/pull/220

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
