### PR TITLE
fix: sync RTC in timed, sync time before fetching packet metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/talos-systems/grpc-proxy v0.2.0
 	github.com/talos-systems/net v0.2.0
 	github.com/talos-systems/talos/pkg/machinery v0.0.0-20200818212414-6a7cc0264819
+	github.com/u-root/u-root v7.0.0+incompatible
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
 	github.com/vmware-tanzu/sonobuoy v0.19.0
 	github.com/vmware/vmw-guestinfo v0.0.0-20200218095840-687661b8bd8e

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -112,8 +112,6 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 		).Append(
 			"discoverNetwork",
 			SetupDiscoveryNetwork,
-			// We MUST mount the boot partition so that this task can attempt to read
-			// the config on disk.
 		).AppendWhen(
 			r.State().Machine().Installed(),
 			"mountSystem",
@@ -121,9 +119,6 @@ func (*Sequencer) Initialize(r runtime.Runtime) []runtime.Phase {
 		).Append(
 			"config",
 			LoadConfig,
-			// We unmount the boot partition here to simplify subsequent sequences.
-			// If we leave it mounted, it becomes tricky trying to figure out if we
-			// need to mount the boot partition.
 		).AppendWhen(
 			r.State().Machine().Installed(),
 			"unmountSystem",

--- a/internal/app/machined/pkg/system/services/timed.go
+++ b/internal/app/machined/pkg/system/services/timed.go
@@ -82,6 +82,7 @@ func (n *Timed) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	mounts := []specs.Mount{
+		{Type: "bind", Destination: "/dev", Source: "/dev", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: filepath.Dir(constants.TimeSocketPath), Source: filepath.Dir(constants.TimeSocketPath), Options: []string{"rbind", "rw"}},
 	}
 
@@ -112,6 +113,7 @@ func (n *Timed) Runner(r runtime.Runtime) (runner.Runner, error) {
 			}),
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
+			oci.WithAllDevicesAllowed,
 		),
 	),
 		restart.WithType(restart.Forever),

--- a/internal/app/timed/pkg/ntp/ntp_test.go
+++ b/internal/app/timed/pkg/ntp/ntp_test.go
@@ -5,6 +5,7 @@
 package ntp_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -28,7 +29,7 @@ func (suite *NtpSuite) TestQuery() {
 	n, err := ntp.NewNTPClient(ntp.WithServer(testServer))
 	suite.Assert().NoError(err)
 
-	_, err = n.Query()
+	_, err = n.Query(context.Background())
 	suite.Assert().NoError(err)
 }
 

--- a/internal/app/timed/pkg/reg/reg.go
+++ b/internal/app/timed/pkg/reg/reg.go
@@ -41,7 +41,7 @@ func (r *Registrator) Register(s *grpc.Server) {
 func (r *Registrator) Time(ctx context.Context, in *empty.Empty) (reply *timeapi.TimeResponse, err error) {
 	reply = &timeapi.TimeResponse{}
 
-	rt, err := r.Timed.Query()
+	rt, err := r.Timed.Query(ctx)
 	if err != nil {
 		return reply, err
 	}
@@ -58,7 +58,7 @@ func (r *Registrator) TimeCheck(ctx context.Context, in *timeapi.TimeRequest) (r
 		return reply, err
 	}
 
-	rt, err := tc.Query()
+	rt, err := tc.Query(ctx)
 	if err != nil {
 		return reply, err
 	}


### PR DESCRIPTION
1. When time is set by timed, also sync RTC with system time, otherwise
time might be off after a reboot.

2. Before fetching Packet (Equinix Metal) metadata over `https://`, do
one-time time sync in the background, as if the clock skew is big
enough, TLS certificate will be considered invalid and boot fails.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

