### PR TITLE
fix: bump blockdevice library for 2nd partitione entries copy fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116
 	github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745
-	github.com/talos-systems/go-blockdevice v0.1.1-0.20201204153756-943b08bc32a2
+	github.com/talos-systems/go-blockdevice v0.1.1-0.20201218153731-2878460b54e8
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559
 	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688

--- a/go.sum
+++ b/go.sum
@@ -929,8 +929,8 @@ github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116 h1:l
 github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745 h1:Smw6ebFiEiwrkaOD2hEYYb+xkIhQTMZNq3WVYKLszB8=
 github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201204153756-943b08bc32a2 h1:tf6luvv01EddVq11uGTYUwli0vWhoDrUseSlu1ndqiM=
-github.com/talos-systems/go-blockdevice v0.1.1-0.20201204153756-943b08bc32a2/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201218153731-2878460b54e8 h1:eRAx7FVAGul4oRJ8vSU3I0muPbsK71nT4GHzytXgVnY=
+github.com/talos-systems/go-blockdevice v0.1.1-0.20201218153731-2878460b54e8/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559 h1:wHuwJhQa20pD0Re+Ucpr0ec+om/b0GgPcpvTwRHSR3o=


### PR DESCRIPTION
See https://github.com/talos-systems/go-blockdevice/pull/23

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

