### PR TITLE
feat: bump pkgs for kernel with HZ=250 on amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-13-g05b7372
-PKGS ?= v0.3.0-57-ga7f6270
+PKGS ?= v0.3.0-59-g3f7a335
 EXTRAS ?= v0.1.0-6-gdc32cc8
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6


### PR DESCRIPTION
This pulls in:

* https://github.com/talos-systems/pkgs/pull/222
* https://github.com/talos-systems/pkgs/pull/226

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

