### PR TITLE
fix: synchronize bootkube timeouts and various boot timeouts

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -732,7 +732,7 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 			all = append(all, cond)
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, constants.BootkubeRunTimeout)
 
 		defer cancel()
 
@@ -1456,7 +1456,7 @@ func LabelNodeAsMaster(seq runtime.Sequence, data interface{}) (runtime.TaskExec
 			return err
 		}
 
-		err = retry.Constant(10*time.Minute, retry.WithUnits(3*time.Second)).Retry(func() error {
+		err = retry.Constant(constants.NodeReadyTimeout, retry.WithUnits(3*time.Second), retry.WithErrorLogging(true)).Retry(func() error {
 			if err = h.LabelNodeAsMaster(hostname, !r.Config().Cluster().ScheduleOnMasters()); err != nil {
 				return retry.ExpectedError(err)
 			}
@@ -1778,7 +1778,7 @@ func BootstrapKubernetes(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 
 		system.Services(r).LoadAndStart(svc)
 
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		ctx, cancel := context.WithTimeout(ctx, constants.BootkubeRunTimeout)
 		defer cancel()
 
 		return system.WaitForService(system.StateEventFinished, svc.ID(r)).Wait(ctx)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -251,7 +251,7 @@ func (h *Client) LabelNodeAsMaster(name string, taintNoSchedule bool) (err error
 
 // WaitUntilReady waits for a node to be ready.
 func (h *Client) WaitUntilReady(name string) error {
-	return retry.Exponential(3*time.Minute, retry.WithUnits(250*time.Millisecond), retry.WithJitter(50*time.Millisecond)).Retry(func() error {
+	return retry.Exponential(10*time.Minute, retry.WithUnits(250*time.Millisecond), retry.WithJitter(50*time.Millisecond), retry.WithErrorLogging(true)).Retry(func() error {
 		attemptCtx, attemptCtxCancel := context.WithTimeout(context.TODO(), 30*time.Second)
 		defer attemptCtxCancel()
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -377,6 +377,16 @@ const (
 	// InitializedKey is the key used to indicate if the cluster has been
 	// initialized.
 	InitializedKey = "initialized"
+
+	// BootkubeAssetTimeout is the constant in bootkube implementation.
+	BootkubeAssetTimeout = 20 * time.Minute
+
+	// BootkubeRunTimeout is the timeout to run bootkube.
+	BootkubeRunTimeout = BootkubeAssetTimeout + 5*time.Minute
+
+	// NodeReadyTimeout is the timeout to wait for the node to be ready (CNI to be running).
+	// For bootstrap API, this includes time to run bootkube.
+	NodeReadyTimeout = BootkubeRunTimeout
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
When bootkube service fails, it can clean up manifests after itself, but
it only happens if we give it a chance to shut down cleanly. If boot
sequence times out, `machined` does emergency reboot and it doesn't let
`bootkube` do the cleanup.

So this fix has two paths:

* synchronize boot/bootstrap sequence timeouts with bootkube asset
timeout;

* cleanup bootkube-generated manfiests and bootkube service startup.

Also logs errors on initial phases like `labelNodeAsMaster` to provide
some feedback on why boot is stuck.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

