### PR TITLE
fix: use the correct console on Banana Pi M64

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64/bananapi_m64.go
@@ -93,7 +93,7 @@ func (b *BananaPiM64) Install(disk string) (err error) {
 // KernelArgs implements the runtime.Board.
 func (b *BananaPiM64) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
-		procfs.NewParameter("console").Append("tty0").Append("ttyS2,115200n8"),
+		procfs.NewParameter("console").Append("tty0").Append("ttyS0,115200"),
 	}
 }
 


### PR DESCRIPTION
This updates the `console` arg for the `bananapi_m64` board to the correct value.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
