### PR TITLE
fix: don't run LabelNodeAsMaster in two sequences

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -269,7 +269,6 @@ func (*Sequencer) Bootstrap(r runtime.Runtime) []runtime.Phase {
 	).Append(
 		"kubernetes",
 		BootstrapKubernetes,
-		LabelNodeAsMaster,
 	).Append(
 		"initStatus",
 		SetInitStatus,


### PR DESCRIPTION
It was run both as part of `Boot` and `Bootstrap` sequences, remove it
from the `Bootstrap` sequence.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

