### PR TITLE
feat: support disk image in talosctl cluster create

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -348,6 +348,11 @@ local integration_uefi = Step("e2e-uefi", target="e2e-qemu", privileged=true, de
         "WITH_UEFI": "true",
         "REGISTRY": local_registry,
 });
+local integration_disk_image = Step("e2e-disk-image", target="e2e-qemu", privileged=true, depends_on=[integration_uefi], environment={
+        "SHORT_INTEGRATION_TEST": "yes",
+        "USE_DISK_IMAGE": "true",
+        "REGISTRY": local_registry,
+});
 local push_edge = {
   name: 'push-edge',
   image: 'autonomy/build-container:latest',
@@ -379,6 +384,7 @@ local integration_steps = default_steps + [
   integration_provision_tests_track_1,
   integration_cilium,
   integration_uefi,
+  integration_disk_image,
   push_edge,
 ];
 

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -14,9 +14,6 @@ function create_cluster {
 
   "${TALOSCTL}" cluster create \
     --iso-path=${ARTIFACTS}/talos-amd64.iso \
-    --skip-injecting-config \
-    --wait=false \
-    --with-init-node \
     --provisioner "${PROVISIONER}" \
     --name "${CLUSTER_NAME}" \
     --masters=1 \
@@ -25,6 +22,7 @@ function create_cluster {
     --memory 2048 \
     --cpus 2.0 \
     --cidr 172.20.2.0/24 \
+    --with-apply-config \
     --install-image ${REGISTRY:-ghcr.io}/talos-systems/installer:${TAG} \
     --cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
     ${REGISTRY_MIRROR_FLAGS}
@@ -37,9 +35,5 @@ function destroy_cluster() {
 }
 
 create_cluster
-timeout -v --preserve-status 1m bash -c "until ${TALOSCTL} apply-config -n ${NODE} --insecure -f controlplane.yaml; do sleep 5; done"
 sleep 5
-timeout -v --preserve-status 2m  bash -c "until nc -z ${NODE} 50000; do sleep 5; done"
-${TALOSCTL} bootstrap -n "${NODE}"
-${TALOSCTL} health --wait-timeout=10m0s -n "${NODE}" --control-plane-nodes="${NODE}"
 destroy_cluster

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -35,6 +35,16 @@ case "${WITH_UEFI:-false}" in
     ;;
 esac
 
+case "${USE_DISK_IMAGE:-false}" in
+  false)
+    DISK_IMAGE_FLAG=
+    ;;
+  *)
+    tar -xf _out/metal-amd64.tar.gz -C _out/ --strip-components=1
+    DISK_IMAGE_FLAG="--disk-image-path=_out/disk.raw --with-apply-config"
+    ;;
+esac
+
 function create_cluster {
   build_registry_mirrors
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -131,5 +131,7 @@ func readConfigFromISO() (b []byte, err error) {
 
 // KernelArgs implements the runtime.Platform interface.
 func (m *Metal) KernelArgs() procfs.Parameters {
-	return nil
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("ttyS0").Append("tty0"),
+	}
 }

--- a/pkg/cluster/apply-config.go
+++ b/pkg/cluster/apply-config.go
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"time"
+
+	"github.com/talos-systems/go-retry/retry"
+
+	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
+	"github.com/talos-systems/talos/pkg/machinery/client"
+	"github.com/talos-systems/talos/pkg/provision"
+)
+
+// ApplyConfigClient client to apply config.
+type ApplyConfigClient struct {
+	ClientProvider
+	Info
+}
+
+// ApplyConfig on the node via the API using insecure mode.
+func (s *APIBoostrapper) ApplyConfig(ctx context.Context, nodes []provision.NodeRequest, out io.Writer) error {
+	for _, node := range nodes {
+		n := node
+
+		configureNode := func() error {
+			c, err := client.New(ctx, client.WithTLSConfig(&tls.Config{
+				InsecureSkipVerify: true,
+			}), client.WithEndpoints(n.IP.String()))
+			if err != nil {
+				return retry.UnexpectedError(err)
+			}
+
+			cfgBytes, err := n.Config.Bytes()
+			if err != nil {
+				return retry.UnexpectedError(err)
+			}
+
+			_, err = c.ApplyConfiguration(ctx, &machineapi.ApplyConfigurationRequest{
+				Data: cfgBytes,
+			})
+			if err != nil {
+				return retry.ExpectedError(err)
+			}
+
+			return nil
+		}
+
+		if err := retry.Constant(2*time.Minute, retry.WithUnits(250*time.Millisecond), retry.WithJitter(50*time.Millisecond)).Retry(configureNode); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/provision/access/adapter.go
+++ b/pkg/provision/access/adapter.go
@@ -17,6 +17,7 @@ type Adapter struct {
 	cluster.APICrashDumper
 	cluster.APIBoostrapper
 	cluster.Info
+	cluster.ApplyConfigClient
 }
 
 type infoWrapper struct {

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -24,6 +24,7 @@ type ClusterRequest struct {
 	KernelPath    string
 	InitramfsPath string
 	ISOPath       string
+	DiskImagePath string
 
 	// Path to talosctl executable to re-execute itself as needed.
 	SelfExecutable string

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -85,6 +85,7 @@ talosctl cluster create [flags]
       --crashdump                               print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string                   install custom CNI from the URL (Talos cluster)
       --disk int                                default limit on disk size in MB (each VM) (default 6144)
+      --disk-image-path string                  disk image to use
       --dns-domain string                       the dns domain to use for cluster (default "cluster.local")
       --docker-host-ip string                   Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
       --endpoint string                         use endpoint instead of provider defaults
@@ -109,6 +110,7 @@ talosctl cluster create [flags]
       --vmlinuz-path string                     the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")
       --wait                                    wait for the cluster to be ready before returning (default true)
       --wait-timeout duration                   timeout to wait for the cluster to be ready (default 20m0s)
+      --with-apply-config                       enable apply config when the VM is starting in maintenance mode
       --with-bootloader                         enable bootloader to load kernel and initramfs from disk image after install (default true)
       --with-debug                              enable debug in Talos config to send service logs to the console
       --with-init-node                          create the cluster with an init node


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/2973

Can now supply disk image using `--disk-image-path` flag.
May need to enable `--with-apply-config` if it's necessary to bootstrap
nodes properly.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>
