### PR TITLE
fix: leave etcd for staged upgrades

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -385,7 +385,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 				defer mu.Unlock(ctx) // nolint: errcheck
 			}
 
-			if err := s.Controller.Run(runtime.SequenceReboot, in); err != nil {
+			if err := s.Controller.Run(runtime.SequenceStageUpgrade, in); err != nil {
 				log.Println("reboot for staged upgrade failed:", err)
 
 				if err != runtime.ErrLocked {

--- a/internal/app/machined/pkg/runtime/sequencer.go
+++ b/internal/app/machined/pkg/runtime/sequencer.go
@@ -28,6 +28,8 @@ const (
 	SequenceShutdown
 	// SequenceUpgrade is the upgrade sequence.
 	SequenceUpgrade
+	// SequenceStageUpgrade is the stage upgrade sequence.
+	SequenceStageUpgrade
 	// SequenceReset is the reset sequence.
 	SequenceReset
 	// SequenceReboot is the reboot sequence.
@@ -46,6 +48,7 @@ const (
 	install            = "install"
 	shutdown           = "shutdown"
 	upgrade            = "upgrade"
+	stageUpgrade       = "stageUpgrade"
 	reset              = "reset"
 	reboot             = "reboot"
 	recover            = "recover"
@@ -54,7 +57,7 @@ const (
 
 // String returns the string representation of a `Sequence`.
 func (s Sequence) String() string {
-	return [...]string{applyConfiguration, boot, bootstrap, initialize, install, shutdown, upgrade, reset, reboot, recover, noop}[s]
+	return [...]string{applyConfiguration, boot, bootstrap, initialize, install, shutdown, upgrade, stageUpgrade, reset, reboot, recover, noop}[s]
 }
 
 // ParseSequence returns a `Sequence` that matches the specified string.
@@ -76,6 +79,8 @@ func ParseSequence(s string) (seq Sequence, err error) {
 		seq = SequenceShutdown
 	case upgrade:
 		seq = SequenceUpgrade
+	case stageUpgrade:
+		seq = SequenceStageUpgrade
 	case reset:
 		seq = SequenceReset
 	case reboot:
@@ -116,6 +121,7 @@ type Sequencer interface {
 	Recover(Runtime, *machine.RecoverRequest) []Phase
 	Reset(Runtime, ResetOptions) []Phase
 	Shutdown(Runtime) []Phase
+	StageUpgrade(Runtime, *machine.UpgradeRequest) []Phase
 	Upgrade(Runtime, *machine.UpgradeRequest) []Phase
 }
 

--- a/internal/app/machined/pkg/runtime/sequencer_test.go
+++ b/internal/app/machined/pkg/runtime/sequencer_test.go
@@ -38,6 +38,11 @@ func TestSequence_String(t *testing.T) {
 			want: "upgrade",
 		},
 		{
+			name: "stageUpgrade",
+			s:    runtime.SequenceStageUpgrade,
+			want: "stageUpgrade",
+		},
+		{
 			name: "reboot",
 			s:    runtime.SequenceReboot,
 			want: "reboot",
@@ -96,6 +101,12 @@ func TestParseSequence(t *testing.T) {
 			name:    "upgrade",
 			args:    args{"upgrade"},
 			wantSeq: runtime.SequenceUpgrade,
+			wantErr: false,
+		},
+		{
+			name:    "stageUpgrade",
+			args:    args{"stageUpgrade"},
+			wantSeq: runtime.SequenceStageUpgrade,
 			wantErr: false,
 		},
 		{

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -383,6 +383,17 @@ func (c *Controller) phases(seq runtime.Sequence, data interface{}) ([]runtime.P
 		}
 
 		phases = c.s.Upgrade(c.r, in)
+	case runtime.SequenceStageUpgrade:
+		var (
+			in *machine.UpgradeRequest
+			ok bool
+		)
+
+		if in, ok = data.(*machine.UpgradeRequest); !ok {
+			return nil, runtime.ErrInvalidSequenceData
+		}
+
+		phases = c.s.StageUpgrade(c.r, in)
 	case runtime.SequenceReset:
 		var (
 			in runtime.ResetOptions

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -355,6 +355,29 @@ func (*Sequencer) Shutdown(r runtime.Runtime) []runtime.Phase {
 	return phases
 }
 
+// StageUpgrade is the stage upgrade sequence.
+func (*Sequencer) StageUpgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []runtime.Phase {
+	phases := PhaseList{}
+
+	switch r.State().Platform().Mode() { //nolint: exhaustive
+	case runtime.ModeContainer:
+		return nil
+	default:
+		phases = phases.AppendWhen(
+			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
+			"leave",
+			LeaveEtcd,
+		).AppendList(
+			stopAllPhaselist(r),
+		).Append(
+			"reboot",
+			Reboot,
+		)
+	}
+
+	return phases
+}
+
 // Upgrade is the upgrade sequence.
 func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []runtime.Phase {
 	phases := PhaseList{}


### PR DESCRIPTION
Upgrade itself is going to happen after the reboot, but we need to leave
etcd if the disks are to be wiped (!preserve) upgrade.

We're not doing integration test right now, as we need source version
for the upgrade to contain a fix. We can add a test once we release new
version with this fix (dropped a note to look into that later).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

