### PR TITLE
fix: ignore errors on stopping/removing pod sandboxes

### DIFF
--- a/internal/pkg/cri/pods.go
+++ b/internal/pkg/cri/pods.go
@@ -218,7 +218,9 @@ func stopAndRemove(ctx context.Context, stopAction StopAction, client *Client, p
 			return nil
 		}
 
-		return err
+		log.Printf("error stopping pod %s/%s, ignored: %s", pod.Metadata.Namespace, pod.Metadata.Name, err)
+
+		return nil
 	}
 
 	if stopAction == StopAndRemove {
@@ -227,7 +229,9 @@ func stopAndRemove(ctx context.Context, stopAction StopAction, client *Client, p
 				return nil
 			}
 
-			return err
+			log.Printf("error removing pod %s/%s, ignored: %s", pod.Metadata.Namespace, pod.Metadata.Name, err)
+
+			return nil
 		}
 	}
 


### PR DESCRIPTION
Talos stops CRI pods and containers before upgrade to make sure
ephemeral partition is not mounted anymore. At the same time with
different CNIs it's frequent that removing stop sandbox might fail
because of CNI teardown issue (dependency on API server being up, for
example). As upgrade only depends on volume mounts and doesn't require
CNI to be stopped, we can ignore such errors.

Plus installer anyway does mount check across all mount namespaces, so
it will abort if ephemeral partition is still mounted.

Fixes #2974

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

