### PR TITLE
fix: pass disk image flags to e2e-qemu cluster create command

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -40,7 +40,7 @@ case "${USE_DISK_IMAGE:-false}" in
     DISK_IMAGE_FLAG=
     ;;
   *)
-    tar -xf _out/metal-amd64.tar.gz -C _out/ --strip-components=1
+    tar -xf _out/metal-amd64.tar.gz -C _out/
     DISK_IMAGE_FLAG="--disk-image-path=_out/disk.raw --with-apply-config"
     ;;
 esac
@@ -62,6 +62,7 @@ function create_cluster {
     --with-init-node=false \
     --cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
     --crashdump \
+    ${DISK_IMAGE_FLAG} \
     ${REGISTRY_MIRROR_FLAGS} \
     ${QEMU_FLAGS} \
     ${CUSTOM_CNI_FLAG}


### PR DESCRIPTION
Forgot to add it in the original PR.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>