### PR TITLE
fix: checkpoint controller-manager and scheduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
-	github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116
+	github.com/talos-systems/bootkube-plugin v0.0.0-20201223175004-aee474d8d060
 	github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745
 	github.com/talos-systems/go-blockdevice v0.1.1-0.20201218174450-f2728a581972
 	github.com/talos-systems/go-loadbalancer v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -925,8 +925,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116 h1:ly3meWKF9LIVOv0BLI3y74jJAKluivEDymVVXTzAwIA=
-github.com/talos-systems/bootkube-plugin v0.0.0-20201123195241-c59f3fa21116/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
+github.com/talos-systems/bootkube-plugin v0.0.0-20201223175004-aee474d8d060 h1:mPJ7w+edz0xQhhZ9Qp1iF7w5vcj7owK2ExmS8usDsFA=
+github.com/talos-systems/bootkube-plugin v0.0.0-20201223175004-aee474d8d060/go.mod h1:AbdJAgHK5rJNDPUN3msPTfQJSR9b4DKb5xNN07uG8/Y=
 github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745 h1:Smw6ebFiEiwrkaOD2hEYYb+xkIhQTMZNq3WVYKLszB8=
 github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745/go.mod h1:KwqG+jANKU1FNQIapmioHQ5fkovY1DJkAqMenjYBGh0=
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201218174450-f2728a581972 h1:/yEPl6h6+pK9XIfQEiZ989GDuw6dCUBeinzUcCu6dyY=

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -14,7 +14,8 @@ function create_cluster {
     --provisioner "${PROVISIONER}" \
     --name "${CLUSTER_NAME}" \
     --image "${IMAGE}" \
-    --masters=3 \
+    --masters=1 \
+    --workers=1 \
     --mtu 1450 \
     --memory 2048 \
     --cpus 2.0 \

--- a/internal/integration/api/recover.go
+++ b/internal/integration/api/recover.go
@@ -53,6 +53,8 @@ func (suite *RecoverSuite) TearDownTest() {
 
 // TestRecoverControlPlane removes the control plane components and attempts to recover them with the recover API.
 func (suite *RecoverSuite) TestRecoverControlPlane() {
+	suite.T().Skip("with checkpoints enabled for kube-scheduler and kube-controller-manager this test no longer makes sense")
+
 	if !suite.Capabilities().SupportsRecover {
 		suite.T().Skip("cluster doesn't support recovery")
 	}


### PR DESCRIPTION
Default manifests created by bootkube so far were only enabling
pod-checkpointer for kube-apiserver. This seems to have issues with
single-node control plane scenario, when without scheduler and
controller-manager node might fall into `NodeAffinity` state.

See https://github.com/talos-systems/bootkube-plugin/pull/23

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

