### PR TITLE
fix: add more dependencies for bootstrap services

### DIFF
--- a/internal/app/machined/pkg/system/services/bootkube.go
+++ b/internal/app/machined/pkg/system/services/bootkube.go
@@ -137,7 +137,7 @@ func (b *Bootkube) PostFunc(r runtime.Runtime, state events.ServiceState) (err e
 
 // DependsOn implements the Service interface.
 func (b *Bootkube) DependsOn(r runtime.Runtime) []string {
-	return []string{"etcd"}
+	return []string{"etcd", "kubelet"}
 }
 
 // Condition implements the Service interface.

--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -20,6 +20,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
@@ -49,7 +50,13 @@ func (c *CRI) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (c *CRI) DependsOn(r runtime.Runtime) []string {
-	return []string{"networkd"}
+	depends := []string{"networkd"}
+
+	if r.Config().Machine().Type() != machine.TypeJoin {
+		depends = append(depends, "etcd")
+	}
+
+	return depends
 }
 
 // Runner implements the Service interface.


### PR DESCRIPTION
CRI now waits for etcd to be up on control plane nodes, this makes sure
that if CRI is going to start kube-apiserver, API server will be able to
connect to local etcd.

Bootkube waits for kubelet to be healthy, as bootkube relies on kubelet
to start its operations.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

