### PR TITLE
fix: use SetAll instead of AppendAll when building kernel args

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -45,9 +45,7 @@ func Install(p runtime.Platform, seq runtime.Sequence, opts *Options) (err error
 		cmdline.Append(constants.KernelParamConfig, opts.ConfigSource)
 	}
 
-	if err = cmdline.AppendAll(p.KernelArgs().Strings()); err != nil {
-		return err
-	}
+	cmdline.SetAll(p.KernelArgs().Strings())
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
 	cmdline.AppendDefaults()
@@ -169,10 +167,7 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 
 		i.cmdline.Append(constants.KernelParamBoard, b.Name())
 
-		err = i.cmdline.AppendAll(b.KernelArgs().Strings())
-		if err != nil {
-			return err
-		}
+		i.cmdline.SetAll(b.KernelArgs().Strings())
 	}
 
 	if err = i.manifest.Execute(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745
 	github.com/talos-systems/go-blockdevice v0.1.1-0.20201218174450-f2728a581972
 	github.com/talos-systems/go-loadbalancer v0.1.0
-	github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559
+	github.com/talos-systems/go-procfs v0.0.0-20201223150035-a82654edcec1
 	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688
 	github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e
 	github.com/talos-systems/grpc-proxy v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -935,6 +935,8 @@ github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559 h1:wHuwJhQa20pD0Re+Ucpr0ec+om/b0GgPcpvTwRHSR3o=
 github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
+github.com/talos-systems/go-procfs v0.0.0-20201223150035-a82654edcec1 h1:n6q6VlyJp5yyCAzUyds+CFDLW6iDvTDSDXoI3NoXpcs=
+github.com/talos-systems/go-procfs v0.0.0-20201223150035-a82654edcec1/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
 github.com/talos-systems/go-retry v0.1.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688 h1:U5wFGj5LXt/r+qfy1nGftQxJvEbg/lVJuasHKtk3K7s=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=


### PR DESCRIPTION
SBC should always overwrite default kernel params.
Otherwise we will always get duplicate values for some of them.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>