### PR TITLE
refactor: define default kernel flags in machinery instead of procfs

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -20,6 +20,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub"
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/kernel"
 	"github.com/talos-systems/talos/pkg/version"
 )
 
@@ -48,7 +49,9 @@ func Install(p runtime.Platform, seq runtime.Sequence, opts *Options) (err error
 	cmdline.SetAll(p.KernelArgs().Strings())
 
 	// first defaults, then extra kernel args to allow extra kernel args to override defaults
-	cmdline.AppendDefaults()
+	if err = cmdline.AppendAll(kernel.DefaultArgs); err != nil {
+		return err
+	}
 
 	if err = cmdline.AppendAll(opts.ExtraKernelArgs); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/talos-systems/crypto v0.2.1-0.20201203131813-e0dd56ac4745
 	github.com/talos-systems/go-blockdevice v0.1.1-0.20201218174450-f2728a581972
 	github.com/talos-systems/go-loadbalancer v0.1.0
-	github.com/talos-systems/go-procfs v0.0.0-20201223150035-a82654edcec1
+	github.com/talos-systems/go-procfs v0.0.0-20201224133103-24d06a955782
 	github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688
 	github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e
 	github.com/talos-systems/grpc-proxy v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -933,10 +933,8 @@ github.com/talos-systems/go-blockdevice v0.1.1-0.20201218174450-f2728a581972 h1:
 github.com/talos-systems/go-blockdevice v0.1.1-0.20201218174450-f2728a581972/go.mod h1:efEE9wjtgxiovqsZAV39xlOd/AOI/0sLuZqb5jEgeqo=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
-github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559 h1:wHuwJhQa20pD0Re+Ucpr0ec+om/b0GgPcpvTwRHSR3o=
-github.com/talos-systems/go-procfs v0.0.0-20201210152942-5a9a4a75d559/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
-github.com/talos-systems/go-procfs v0.0.0-20201223150035-a82654edcec1 h1:n6q6VlyJp5yyCAzUyds+CFDLW6iDvTDSDXoI3NoXpcs=
-github.com/talos-systems/go-procfs v0.0.0-20201223150035-a82654edcec1/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
+github.com/talos-systems/go-procfs v0.0.0-20201224133103-24d06a955782 h1:q9g1aGWfmbUtOcON2BIJUP9JfsW58gWdMlhuZ+fVQ+8=
+github.com/talos-systems/go-procfs v0.0.0-20201224133103-24d06a955782/go.mod h1:ATyUGFQIW8OnbnmvqefZWVPgL9g+CAmXHfkgny21xX8=
 github.com/talos-systems/go-retry v0.1.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688 h1:U5wFGj5LXt/r+qfy1nGftQxJvEbg/lVJuasHKtk3K7s=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=

--- a/pkg/machinery/kernel/kernel.go
+++ b/pkg/machinery/kernel/kernel.go
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kernel
+
+// DefaultArgs returns the Talos default kernel commandline options.
+var DefaultArgs = []string{
+	"init_on_alloc=1",
+	"init_on_free=1",
+	"slab_nomerge=",
+	"pti=on",
+	"consoleblank=0",
+	// AWS recommends setting the nvme_core.io_timeout to the highest value possible.
+	// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html.
+	"nvme_core.io_timeout=4294967295",
+	"random.trust_cpu=on",
+	// Disable rate limited printk
+	"printk.devkmsg=on",
+	"ima_template=ima-ng",
+	"ima_appraise=fix",
+	"ima_hash=sha512",
+}

--- a/pkg/provision/providers/firecracker/node.go
+++ b/pkg/provision/providers/firecracker/node.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/kernel"
 	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers/vm"
 )
@@ -75,7 +76,9 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		return provision.NodeInfo{}, err
 	}
 
-	cmdline := procfs.NewDefaultCmdline()
+	cmdline := procfs.NewCmdline("")
+
+	cmdline.SetAll(kernel.DefaultArgs)
 
 	// required to get kernel console
 	cmdline.Append("console", "ttyS0")

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/kernel"
 	"github.com/talos-systems/talos/pkg/provision"
 	"github.com/talos-systems/talos/pkg/provision/providers/vm"
 )
@@ -66,7 +67,9 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	defer logFile.Close() //nolint: errcheck
 
-	cmdline := procfs.NewDefaultCmdline()
+	cmdline := procfs.NewCmdline("")
+
+	cmdline.SetAll(kernel.DefaultArgs)
 
 	// backwards compatibility to boot initrd from Talos < 0.8
 	// we can remove it once we stop testing upgrades from versions < 0.8


### PR DESCRIPTION
That change should make Talos updates more straightforward in any
projects that depend on Talos.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>