### PR TITLE
fix: bring up bonded interfaces correctly on packet

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
@@ -152,9 +152,6 @@ func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 		}
 
 		bondName = iface.Bond
-
-		// nb: currently only one interface is supported, as adding one more interface breaks networking
-		break
 	}
 
 	// create multiple bond devices and add them to device list.
@@ -168,6 +165,10 @@ func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 			DeviceCIDR:      fmt.Sprintf("%s/%d", addr.Address, addr.CIDR),
 			DeviceBond: &v1alpha1.Bond{
 				BondMode:       bondMode.String(),
+				BondDownDelay:  200,
+				BondMIIMon:     100,
+				BondUpDelay:    200,
+				BondHashPolicy: "layer3+4",
 				BondInterfaces: devicesInBond,
 			},
 		}


### PR DESCRIPTION
This probably fixes bonding in general if 2nd link in the bond is down.

For packet, set additional options for the bonded interface. In
networkd, add interfaces filtered out by link status as ignored to make
them available as bond subinterfaces.

Fixes #3007 

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

