### PR TITLE
docs: document omitting DiskPartition size

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -986,8 +986,9 @@ func (ds *DiskSize) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // DiskPartition represents the options for a disk partition.
 type DiskPartition struct {
-	//   description: |
-	//     This size of partition: either bytes or human readable representation.
+	//   description: >
+	//     The size of partition: either bytes or human readable representation. If `size:`
+	//     is omitted, the partition is sized to occupy the full disk.
 	//   examples:
 	//     - name: Human readable representation.
 	//       value: DiskSize(100000000)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -873,8 +873,8 @@ func init() {
 	DiskPartitionDoc.Fields[0].Name = "size"
 	DiskPartitionDoc.Fields[0].Type = "DiskSize"
 	DiskPartitionDoc.Fields[0].Note = ""
-	DiskPartitionDoc.Fields[0].Description = "This size of partition: either bytes or human readable representation."
-	DiskPartitionDoc.Fields[0].Comments[encoder.LineComment] = "This size of partition: either bytes or human readable representation."
+	DiskPartitionDoc.Fields[0].Description = "The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk."
+	DiskPartitionDoc.Fields[0].Comments[encoder.LineComment] = "The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk."
 
 	DiskPartitionDoc.Fields[0].AddExample("Human readable representation.", DiskSize(100000000))
 

--- a/website/content/docs/v0.6/Reference/configuration.md
+++ b/website/content/docs/v0.6/Reference/configuration.md
@@ -1161,7 +1161,7 @@ Type: `array`
 
 #### size
 
-This size of the partition in bytes.
+The size of the partition in bytes. If `size:` is omitted, the partition is sized to occupy the full disk.
 
 Type: `uint`
 

--- a/website/content/docs/v0.7/Reference/configuration.md
+++ b/website/content/docs/v0.7/Reference/configuration.md
@@ -394,7 +394,7 @@ disks:
       partitions:
         - mountpoint: /var/mnt/extra # Where to mount the partition.
 
-          # # This size of partition: either bytes or human readable representation.
+          # # The size of partition: either bytes or human readable representation. Setting this to <code>0</code> will cause the parititon to take up the rest of the disk.
 
           # # Human readable representation.
           # size: 100 MB
@@ -2451,8 +2451,7 @@ Appears in:
 </div>
 <div class="dt">
 
-This size of partition: either bytes or human readable representation.
-
+The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk.
 
 
 Examples:
@@ -3732,7 +3731,3 @@ Skip TLS server certificate verification (not recommended).
 </div>
 
 <hr />
-
-
-
-

--- a/website/content/docs/v0.8/Reference/configuration.md
+++ b/website/content/docs/v0.8/Reference/configuration.md
@@ -398,7 +398,7 @@ disks:
       partitions:
         - mountpoint: /var/mnt/extra # Where to mount the partition.
 
-          # # This size of partition: either bytes or human readable representation.
+          # # The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk.
 
           # # Human readable representation.
           # size: 100 MB
@@ -2446,7 +2446,7 @@ Appears in:
   partitions:
     - mountpoint: /var/mnt/extra # Where to mount the partition.
 
-      # # This size of partition: either bytes or human readable representation.
+      # # The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk.
 
       # # Human readable representation.
       # size: 100 MB
@@ -2505,7 +2505,7 @@ Appears in:
 </div>
 <div class="dt">
 
-This size of partition: either bytes or human readable representation.
+The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk.
 
 
 


### PR DESCRIPTION
# Pull Request

## What? (description)

Documents the effect of omitting the size of a DiskPartition.

Closes talos-systems/talos#3014

## Why? (reasoning)

This was previously undocumented.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
