### PR TITLE
docs: add modes to validate command

### DIFF
--- a/cmd/talosctl/cmd/mgmt/validate.go
+++ b/cmd/talosctl/cmd/mgmt/validate.go
@@ -47,7 +47,13 @@ var validateCmd = &cobra.Command{
 
 func init() {
 	validateCmd.Flags().StringVarP(&validateConfigArg, "config", "c", "", "the path of the config file")
-	validateCmd.Flags().StringVarP(&validateModeArg, "mode", "m", "", "the mode to validate the config for")
+	validateCmd.Flags().StringVarP(
+		&validateModeArg,
+		"mode",
+		"m",
+		"",
+		fmt.Sprintf("the mode to validate the config for (valid values are %s, %s, and %s)", runtime.ModeMetal.String(), runtime.ModeCloud.String(), runtime.ModeContainer.String()),
+	)
 	cli.Should(validateCmd.MarkFlagRequired("mode"))
 	addCommand(validateCmd)
 }

--- a/website/content/docs/v0.8/Reference/cli.md
+++ b/website/content/docs/v0.8/Reference/cli.md
@@ -1709,7 +1709,7 @@ talosctl validate [flags]
 ```
   -c, --config string   the path of the config file
   -h, --help            help for validate
-  -m, --mode string     the mode to validate the config for
+  -m, --mode string     the mode to validate the config for (valid values are metal, cloud, and container)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Adds valid modes in the help menu for `validate`.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
