### PR TITLE
fix: pick first interface valid hostname (vs. last one)

### DIFF
--- a/internal/app/networkd/pkg/networkd/networkd.go
+++ b/internal/app/networkd/pkg/networkd/networkd.go
@@ -310,6 +310,7 @@ func (n *Networkd) decideHostname() (hostname, domainname string, address net.IP
 
 	// Loop through address responses and use the first hostname
 	// and address response.
+outer:
 	for _, intName := range interfaceNames {
 		iface := n.Interfaces[intName]
 
@@ -329,7 +330,7 @@ func (n *Networkd) decideHostname() (hostname, domainname string, address net.IP
 
 				address = method.Address().IP
 
-				break
+				break outer
 			}
 		}
 	}

--- a/internal/app/networkd/pkg/networkd/networkd_test.go
+++ b/internal/app/networkd/pkg/networkd/networkd_test.go
@@ -199,6 +199,11 @@ func dhcpConfigFile() config.Provider {
 					{
 						DeviceInterface: "eth0",
 					},
+					{
+						DeviceInterface: "eth1",
+						DeviceCIDR:      "192.168.0.10/24",
+						DeviceMTU:       9100,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Looks like the code before change in #1578 returned the first hostname
found while interating over interfaces and addressing methods, but #1578
supposedly inadvertently flipped that to iterate over all interfaces (so
last interface wins).

Problem is that both `DHCP` and `Static` addressing methods provide
hostnames, while DHCP hostname comes from DHCP server, while `Static`
defines hostname as `talos-10-5-0-2` (by IP).

If we were to fix it for real, we should build a list of hostname with
priorities coming from different sources and pick a hostname with the
highest priority, so this fix is more of a bandaid rather than a real
fix.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

