### PR TITLE
chore: enable virtio-balloon and monitor in QEMU provisioner

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -42,6 +42,7 @@ type LaunchConfig struct {
 	PFlashImages      []string
 	KernelArgs        string
 	MachineType       string
+	MonitorPath       string
 	EnableKVM         bool
 	BootloaderEnabled bool
 	NodeUUID          uuid.UUID
@@ -205,6 +206,8 @@ func launchVM(config *LaunchConfig) error {
 		// TODO: uncomment the following line to get another eth interface not connected to anything
 		// "-nic", "tap,model=virtio-net-pci",
 		"-device", "virtio-rng-pci",
+		"-device", "virtio-balloon,deflate-on-oom=on",
+		"-monitor", fmt.Sprintf("unix:%s,server,nowait", config.MonitorPath),
 		"-no-reboot",
 		"-boot", fmt.Sprintf("order=%s,reboot-timeout=5000", bootOrder),
 		"-smbios", fmt.Sprintf("type=1,uuid=%s", config.NodeUUID),

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -113,6 +113,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		KernelArgs:        cmdline.String(),
 		MachineType:       arch.QemuMachine(),
 		PFlashImages:      pflashImages,
+		MonitorPath:       state.GetRelativePath(fmt.Sprintf("%s.monitor", nodeReq.Name)),
 		EnableKVM:         opts.TargetArch == runtime.GOARCH,
 		BootloaderEnabled: opts.BootloaderEnabled,
 		NodeUUID:          nodeUUID,


### PR DESCRIPTION
Ballooning is not automatic, but it can be verified via QEMU monitor by
inflating/deflating the balloon inside the VM.

Monitor can be used like that:

```
$ sudo socat - unix-connect:/home/smira/.talos/clusters/talos-default/talos-default-master-1.monitor
QEMU 5.0.0 monitor - type 'help' for more information
(qemu) info status
info status
VM status: running
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

