### PR TITLE
feat: update Linux to 5.10.7, musl-libc to 1.2.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-16-g0fe682e
-PKGS ?= v0.3.0-61-g8e68598
+TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-17-g24a6dac
+PKGS ?= v0.3.0-64-g0386ef5
 EXTRAS ?= v0.1.0-6-gdc32cc8
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.1-talos"
+	DefaultKernelVersion = "5.10.7-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Musl update fixes CVE-2020-28928.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

