### PR TITLE
feat: use multi-arch images for k8s and Flannel CNI

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -211,7 +211,6 @@ func create(ctx context.Context) (err error) {
 			generate.WithInstallImage(nodeInstallImage),
 			generate.WithDebug(configDebug),
 			generate.WithDNSDomain(dnsDomain),
-			generate.WithArchitecture(targetArch),
 		}
 
 		for _, registryMirror := range registryMirrors {

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -28,7 +27,6 @@ import (
 var (
 	additionalSANs    []string
 	configVersion     string
-	architecture      string
 	dnsDomain         string
 	kubernetesVersion string
 	installDisk       string
@@ -141,7 +139,6 @@ func genV1Alpha1Config(args []string) error {
 					generate.WithAdditionalSubjectAltNames(additionalSANs),
 					generate.WithDNSDomain(dnsDomain),
 					generate.WithPersist(persistConfig),
-					generate.WithArchitecture(architecture),
 				),
 			},
 		),
@@ -179,7 +176,6 @@ func init() {
 	genConfigCmd.Flags().StringVar(&installImage, "install-image", helpers.DefaultImage(images.DefaultInstallerImageRepository), "the image used to perform an installation")
 	genConfigCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
 	genConfigCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
-	genConfigCmd.Flags().StringVar(&architecture, "arch", runtime.GOARCH, "the architecture of the cluster")
 	genConfigCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")
 	genConfigCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", "", "desired kubernetes version to run")
 	genConfigCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "destination to output generated files")

--- a/cmd/talosctl/cmd/talos/upgrade-k8s.go
+++ b/cmd/talosctl/cmd/talos/upgrade-k8s.go
@@ -6,7 +6,6 @@ package talos
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/spf13/cobra"
 
@@ -33,7 +32,6 @@ var upgradeOptions k8s.UpgradeOptions
 func init() {
 	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.FromVersion, "from", "", "the Kubernetes control plane version to upgrade from")
 	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.ToVersion, "to", constants.DefaultKubernetesVersion, "the Kubernetes control plane version to upgrade to")
-	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.Architecture, "arch", runtime.GOARCH, "the cluster architecture")
 	upgradeK8sCmd.Flags().StringVar(&upgradeOptions.ControlPlaneEndpoint, "endpoint", "", "the cluster control plane endpoint")
 	cli.Should(upgradeK8sCmd.MarkFlagRequired("from"))
 	cli.Should(upgradeK8sCmd.MarkFlagRequired("to"))

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 
@@ -511,8 +510,6 @@ func (suite *UpgradeSuite) upgradeKubernetes(fromVersion, toVersion string) {
 	suite.Require().NoError(kubernetes.Upgrade(suite.ctx, suite.clusterAccess, kubernetes.UpgradeOptions{
 		FromVersion: fromVersion,
 		ToVersion:   toVersion,
-
-		Architecture: runtime.GOARCH,
 
 		ControlPlaneEndpoint: suite.controlPlaneEndpoint,
 	}))

--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -39,8 +39,6 @@ type UpgradeOptions struct {
 	FromVersion string
 	ToVersion   string
 
-	Architecture string
-
 	ControlPlaneEndpoint string
 
 	extraUpdaters                []daemonsetUpdater
@@ -236,13 +234,13 @@ func hyperkubeUpgradeDs(ctx context.Context, clientset *kubernetes.Clientset, ds
 
 		switch ds {
 		case kubeAPIServer:
-			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesAPIServerImage, options.Architecture, options.ToVersion)
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, options.ToVersion)
 		case kubeControllerManager:
-			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesControllerManagerImage, options.Architecture, options.ToVersion)
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, options.ToVersion)
 		case kubeScheduler:
-			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesSchedulerImage, options.Architecture, options.ToVersion)
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, options.ToVersion)
 		case kubeProxy:
-			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesProxyImage, options.Architecture, options.ToVersion)
+			daemonset.Spec.Template.Spec.Containers[0].Image = fmt.Sprintf("%s:v%s", constants.KubernetesProxyImage, options.ToVersion)
 		default:
 			return fmt.Errorf("failed to build new image spec")
 		}

--- a/pkg/images/list.go
+++ b/pkg/images/list.go
@@ -6,7 +6,6 @@ package images
 
 import (
 	"fmt"
-	"runtime"
 
 	criconfig "github.com/containerd/cri/pkg/config"
 
@@ -38,7 +37,7 @@ func List(config config.Provider) Versions {
 
 	images.Etcd = config.Cluster().Etcd().Image()
 	images.CoreDNS = config.Cluster().CoreDNS().Image()
-	images.Flannel = fmt.Sprintf("quay.io/coreos/flannel:v0.12.0-%s", runtime.GOARCH)
+	images.Flannel = "quay.io/coreos/flannel:v0.13.0"
 	images.FlannelCNI = fmt.Sprintf("ghcr.io/talos-systems/install-cni:%s", version.ExtrasVersion)
 	images.Kubelet = config.Machine().Kubelet().Image()
 	images.KubeAPIServer = config.Cluster().APIServer().Image()

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -66,7 +66,6 @@ type Input struct {
 	AdditionalMachineCertSANs []string
 
 	ClusterName       string
-	Architecture      string
 	ServiceDomain     string
 	PodNet            []string
 	ServiceNet        []string
@@ -443,7 +442,6 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		ServiceNet:                []string{serviceNet},
 		ServiceDomain:             options.DNSDomain,
 		ClusterName:               clustername,
-		Architecture:              options.Architecture,
 		KubernetesVersion:         kubernetesVersion,
 		Secrets:                   secrets.Secrets,
 		TrustdInfo:                secrets.TrustdInfo,

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -55,16 +55,16 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		},
 		APIServerConfig: &v1alpha1.APIServerConfig{
 			CertSANs:       certSANs,
-			ContainerImage: emptyIf(fmt.Sprintf("%s-%s:v%s", constants.KubernetesAPIServerImage, in.Architecture, in.KubernetesVersion), in.KubernetesVersion),
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, in.KubernetesVersion), in.KubernetesVersion),
 		},
 		ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{
-			ContainerImage: emptyIf(fmt.Sprintf("%s-%s:v%s", constants.KubernetesControllerManagerImage, in.Architecture, in.KubernetesVersion), in.KubernetesVersion),
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, in.KubernetesVersion), in.KubernetesVersion),
 		},
 		ProxyConfig: &v1alpha1.ProxyConfig{
-			ContainerImage: emptyIf(fmt.Sprintf("%s-%s:v%s", constants.KubeProxyImage, in.Architecture, in.KubernetesVersion), in.KubernetesVersion),
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubeProxyImage, in.KubernetesVersion), in.KubernetesVersion),
 		},
 		SchedulerConfig: &v1alpha1.SchedulerConfig{
-			ContainerImage: emptyIf(fmt.Sprintf("%s-%s:v%s", constants.KubernetesSchedulerImage, in.Architecture, in.KubernetesVersion), in.KubernetesVersion),
+			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, in.KubernetesVersion), in.KubernetesVersion),
 		},
 		EtcdConfig: &v1alpha1.EtcdConfig{
 			RootCA: in.Certs.Etcd,

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -5,8 +5,6 @@
 package generate
 
 import (
-	"runtime"
-
 	v1alpha1 "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 )
 
@@ -137,15 +135,6 @@ func WithClusterCNIConfig(config *v1alpha1.CNIConfig) GenOption {
 	}
 }
 
-// WithArchitecture specifies architecture of the Talos cluster.
-func WithArchitecture(arch string) GenOption {
-	return func(o *GenOptions) error {
-		o.Architecture = arch
-
-		return nil
-	}
-}
-
 // WithUserDisks generates user partitions config.
 func WithUserDisks(disks []*v1alpha1.MachineDisk) GenOption {
 	return func(o *GenOptions) error {
@@ -176,7 +165,6 @@ type GenOptions struct {
 	RegistryMirrors           map[string]*v1alpha1.RegistryMirrorConfig
 	RegistryConfig            map[string]*v1alpha1.RegistryConfig
 	DNSDomain                 string
-	Architecture              string
 	Debug                     bool
 	Persist                   bool
 	AllowSchedulingOnMasters  bool
@@ -186,7 +174,6 @@ type GenOptions struct {
 // DefaultGenOptions returns default options.
 func DefaultGenOptions() GenOptions {
 	return GenOptions{
-		Persist:      true,
-		Architecture: runtime.GOARCH,
+		Persist: true,
 	}
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -325,7 +325,7 @@ func (a *APIServerConfig) Image() string {
 	image := a.ContainerImage
 
 	if image == "" {
-		image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesAPIServerImage, goruntime.GOARCH, constants.DefaultKubernetesVersion)
+		image = fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, constants.DefaultKubernetesVersion)
 	}
 
 	return image
@@ -350,7 +350,7 @@ func (c *ControllerManagerConfig) Image() string {
 	image := c.ContainerImage
 
 	if image == "" {
-		image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesControllerManagerImage, goruntime.GOARCH, constants.DefaultKubernetesVersion)
+		image = fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, constants.DefaultKubernetesVersion)
 	}
 
 	return image
@@ -375,7 +375,7 @@ func (p *ProxyConfig) Image() string {
 	image := p.ContainerImage
 
 	if image == "" {
-		image = fmt.Sprintf("%s-%s:v%s", constants.KubeProxyImage, goruntime.GOARCH, constants.DefaultKubernetesVersion)
+		image = fmt.Sprintf("%s:v%s", constants.KubeProxyImage, constants.DefaultKubernetesVersion)
 	}
 
 	return image
@@ -419,7 +419,7 @@ func (s *SchedulerConfig) Image() string {
 	image := s.ContainerImage
 
 	if image == "" {
-		image = fmt.Sprintf("%s-%s:v%s", constants.KubernetesSchedulerImage, goruntime.GOARCH, constants.DefaultKubernetesVersion)
+		image = fmt.Sprintf("%s:v%s", constants.KubernetesSchedulerImage, constants.DefaultKubernetesVersion)
 	}
 
 	return image

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -844,7 +844,6 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
 
 ```
       --additional-sans strings     additional Subject-Alt-Names for the APIServer certificate
-      --arch string                 the architecture of the cluster (default "amd64")
       --dns-domain string           the dns domain to use for cluster (default "cluster.local")
   -h, --help                        help for config
       --install-disk string         the disk to install to (default "/dev/sda")
@@ -1737,7 +1736,6 @@ talosctl upgrade-k8s [flags]
 ### Options
 
 ```
-      --arch string       the cluster architecture (default "amd64")
       --endpoint string   the cluster control plane endpoint
       --from string       the Kubernetes control plane version to upgrade from
   -h, --help              help for upgrade-k8s

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -902,7 +902,7 @@ Examples:
 
 ``` yaml
 apiServer:
-    image: k8s.gcr.io/kube-apiserver-amd64:v1.20.2 # The container image used in the API server manifest.
+    image: k8s.gcr.io/kube-apiserver:v1.20.2 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
         --feature-gates: ServerSideApply=true
@@ -934,7 +934,7 @@ Examples:
 
 ``` yaml
 controllerManager:
-    image: k8s.gcr.io/kube-controller-manager-amd64:v1.20.2 # The container image used in the controller manager manifest.
+    image: k8s.gcr.io/kube-controller-manager:v1.20.2 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
         --feature-gates: ServerSideApply=true
@@ -961,7 +961,7 @@ Examples:
 
 ``` yaml
 proxy:
-    image: k8s.gcr.io/kube-proxy-amd64:v1.20.2 # The container image used in the kube-proxy manifest.
+    image: k8s.gcr.io/kube-proxy:v1.20.2 # The container image used in the kube-proxy manifest.
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
@@ -989,7 +989,7 @@ Examples:
 
 ``` yaml
 scheduler:
-    image: k8s.gcr.io/kube-scheduler-amd64:v1.20.2 # The container image used in the scheduler manifest.
+    image: k8s.gcr.io/kube-scheduler:v1.20.2 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
         --feature-gates: AllBeta=true
@@ -1985,7 +1985,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-apiserver-amd64:v1.20.2 # The container image used in the API server manifest.
+image: k8s.gcr.io/kube-apiserver:v1.20.2 # The container image used in the API server manifest.
 # Extra arguments to supply to the API server.
 extraArgs:
     --feature-gates: ServerSideApply=true
@@ -2013,7 +2013,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-apiserver-amd64:v1.20.2
+image: k8s.gcr.io/kube-apiserver:v1.20.2
 ```
 
 
@@ -2061,7 +2061,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-controller-manager-amd64:v1.20.2 # The container image used in the controller manager manifest.
+image: k8s.gcr.io/kube-controller-manager:v1.20.2 # The container image used in the controller manager manifest.
 # Extra arguments to supply to the controller manager.
 extraArgs:
     --feature-gates: ServerSideApply=true
@@ -2084,7 +2084,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-controller-manager-amd64:v1.20.2
+image: k8s.gcr.io/kube-controller-manager:v1.20.2
 ```
 
 
@@ -2119,7 +2119,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-proxy-amd64:v1.20.2 # The container image used in the kube-proxy manifest.
+image: k8s.gcr.io/kube-proxy:v1.20.2 # The container image used in the kube-proxy manifest.
 mode: ipvs # proxy mode of kube-proxy.
 # Extra arguments to supply to kube-proxy.
 extraArgs:
@@ -2143,7 +2143,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-proxy-amd64:v1.20.2
+image: k8s.gcr.io/kube-proxy:v1.20.2
 ```
 
 
@@ -2192,7 +2192,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-scheduler-amd64:v1.20.2 # The container image used in the scheduler manifest.
+image: k8s.gcr.io/kube-scheduler:v1.20.2 # The container image used in the scheduler manifest.
 # Extra arguments to supply to the scheduler.
 extraArgs:
     --feature-gates: AllBeta=true
@@ -2215,7 +2215,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-scheduler-amd64:v1.20.2
+image: k8s.gcr.io/kube-scheduler:v1.20.2
 ```
 
 


### PR DESCRIPTION
Flannel got updated to 0.13 version which has multi-arch image.

Kubernetes images are multi-arch.

Fixes #3049

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
