### PR TITLE
test: clear connection refused errors after reset

### DIFF
--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -136,6 +136,8 @@ func (suite *ApplyConfigSuite) TestApplyNoReboot() {
 	suite.WaitForBootDone(suite.ctx)
 
 	node := suite.RandomDiscoveredNode()
+	suite.ClearConnectionRefused(suite.ctx, node)
+
 	nodeCtx := client.WithNodes(suite.ctx, node)
 
 	provider, err := suite.readConfigFromNode(nodeCtx)

--- a/internal/integration/api/reset.go
+++ b/internal/integration/api/reset.go
@@ -125,6 +125,8 @@ func (suite *ResetSuite) TestResetNodeByNode() {
 			return base.IgnoreGRPCUnavailable(suite.Client.Reset(nodeCtx, true, true))
 		}, 10*time.Minute)
 
+		suite.ClearConnectionRefused(suite.ctx, node)
+
 		postReset, err := suite.hashKubeletCert(suite.ctx, node)
 		suite.Require().NoError(err)
 
@@ -155,6 +157,8 @@ func (suite *ResetSuite) TestResetNoGraceful() {
 		// force reboot after reset, as this is the only mode we can test
 		return base.IgnoreGRPCUnavailable(suite.Client.Reset(nodeCtx, false, true))
 	}, 5*time.Minute)
+
+	suite.ClearConnectionRefused(suite.ctx, node)
 
 	postReset, err := suite.hashKubeletCert(suite.ctx, node)
 	suite.Require().NoError(err)
@@ -194,6 +198,8 @@ func (suite *ResetSuite) TestResetWithSpecEphemeral() {
 			},
 		}))
 	}, 5*time.Minute)
+
+	suite.ClearConnectionRefused(suite.ctx, node)
 
 	postReset, err := suite.hashKubeletCert(suite.ctx, node)
 	suite.Require().NoError(err)
@@ -235,6 +241,8 @@ func (suite *ResetSuite) TestResetWithSpecState() {
 			},
 		}))
 	}, 5*time.Minute)
+
+	suite.ClearConnectionRefused(suite.ctx, node)
 
 	postReset, err := suite.hashKubeletCert(suite.ctx, node)
 	suite.Require().NoError(err)


### PR DESCRIPTION
After node reboot (and gRPC API unavailability), gRPC stack might cache
connection refused errors for up to backoff timeout. Explicitly clear
such errors in reset tests before trying to read data from the node to
verify reset success.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

