### PR TITLE
fix: prefix rendered Talos-owned static pod manifests

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -223,6 +223,9 @@ const (
 	// ManifestsDirectory is the directory that contains all static manifests.
 	ManifestsDirectory = "/etc/kubernetes/manifests"
 
+	// TalosManifestPrefix is the prefix for static pod files created in ManifestsDirectory by Talos.
+	TalosManifestPrefix = "talos-"
+
 	// KubeletKubeconfig is the generated kubeconfig for kubelet.
 	KubeletKubeconfig = "/etc/kubernetes/kubeconfig-kubelet"
 


### PR DESCRIPTION
Using prefix `talos-` so that controller can clean up static pod
manifests which should no longer be there. This allows potential smooth
upgrades if we decide not to run some of the static pods, or future
transition from control plane to worker node.

Fixes #3061

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
