### PR TITLE
fix: use grpc load-balancing when connecting to trustd

### DIFF
--- a/internal/app/apid/pkg/provider/tls.go
+++ b/internal/app/apid/pkg/provider/tls.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/talos-systems/talos/pkg/grpc/gen"
 	"github.com/talos-systems/talos/pkg/machinery/config"
-	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 // TLSConfig provides client & server TLS configs for apid.
@@ -46,7 +45,6 @@ func NewTLSConfig(config config.Provider, endpoints []string) (*TLSConfig, error
 	generator, err := gen.NewRemoteGenerator(
 		config.Machine().Security().Token(),
 		endpoints,
-		constants.TrustdPort,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create remote certificate genertor: %w", err)

--- a/pkg/grpc/middleware/auth/basic/basic.go
+++ b/pkg/grpc/middleware/auth/basic/basic.go
@@ -6,9 +6,7 @@ package basic
 
 import (
 	"crypto/tls"
-	"fmt"
 
-	"github.com/talos-systems/net"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -22,7 +20,7 @@ type Credentials interface {
 
 // NewConnection initializes a grpc.ClientConn configured for basic
 // authentication.
-func NewConnection(address string, port int, creds credentials.PerRPCCredentials) (conn *grpc.ClientConn, err error) {
+func NewConnection(address string, creds credentials.PerRPCCredentials) (conn *grpc.ClientConn, err error) {
 	grpcOpts := []grpc.DialOption{}
 
 	grpcOpts = append(
@@ -34,7 +32,7 @@ func NewConnection(address string, port int, creds credentials.PerRPCCredentials
 		grpc.WithPerRPCCredentials(creds),
 	)
 
-	conn, err = grpc.Dial(fmt.Sprintf("%s:%d", net.FormatAddress(address), port), grpcOpts...)
+	conn, err = grpc.Dial(address, grpcOpts...)
 	if err != nil {
 		return
 	}

--- a/pkg/machinery/client/resolver.go
+++ b/pkg/machinery/client/resolver.go
@@ -5,85 +5,12 @@
 package client
 
 import (
-	"fmt"
-	"math/rand"
-	"strings"
-
-	"github.com/talos-systems/net"
-	"google.golang.org/grpc/resolver"
-
+	"github.com/talos-systems/talos/pkg/machinery/client/resolver"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
+var talosListResolverScheme string
+
 func init() {
-	resolver.Register(&talosListResolverBuilder{})
+	talosListResolverScheme = resolver.RegisterRoundRobinResolver(constants.ApidPort)
 }
-
-const talosListResolverScheme = "taloslist"
-
-type talosListResolverBuilder struct{}
-
-// Build implements resolver.Builder.
-func (b *talosListResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
-	r := &talosListResolver{
-		target: target,
-		cc:     cc,
-	}
-
-	if err := r.start(); err != nil {
-		return nil, err
-	}
-
-	return r, nil
-}
-
-// Build implements resolver.Builder.
-func (b *talosListResolverBuilder) Scheme() string {
-	return talosListResolverScheme
-}
-
-type talosListResolver struct {
-	target resolver.Target
-	cc     resolver.ClientConn
-}
-
-func (r *talosListResolver) start() error {
-	var addrs []resolver.Address // nolint: prealloc
-
-	for _, a := range strings.Split(r.target.Endpoint, ",") {
-		addrs = append(addrs, resolver.Address{
-			ServerName: a,
-			Addr:       fmt.Sprintf("%s:%d", net.FormatAddress(a), constants.ApidPort),
-		})
-	}
-
-	// shuffle the list in case client does just one request
-	rand.Shuffle(len(addrs), func(i, j int) {
-		addrs[i], addrs[j] = addrs[j], addrs[i]
-	})
-
-	serviceConfigJSON := `{
-		"loadBalancingConfig": [{
-			"round_robin": {}
-		}]
-	}`
-
-	parsedServiceConfig := r.cc.ParseServiceConfig(serviceConfigJSON)
-
-	if parsedServiceConfig.Err != nil {
-		return parsedServiceConfig.Err
-	}
-
-	r.cc.UpdateState(resolver.State{
-		Addresses:     addrs,
-		ServiceConfig: parsedServiceConfig,
-	})
-
-	return nil
-}
-
-// ResolveNow implements resolver.Resolver.
-func (r *talosListResolver) ResolveNow(o resolver.ResolveNowOptions) {}
-
-// ResolveNow implements resolver.Resolver.
-func (r *talosListResolver) Close() {}

--- a/pkg/machinery/client/resolver/resolver.go
+++ b/pkg/machinery/client/resolver/resolver.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package resolver implements gRPC resolvers.
+package resolver

--- a/pkg/machinery/client/resolver/roundrobin.go
+++ b/pkg/machinery/client/resolver/roundrobin.go
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package resolver
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+
+	"github.com/talos-systems/net"
+	"google.golang.org/grpc/resolver"
+)
+
+// RegisterRoundRobinResolver registers round-robin gRPC resolver for specified port and returns scheme to use in grpc.Dial.
+func RegisterRoundRobinResolver(port int) (scheme string) {
+	scheme = fmt.Sprintf(roundRobinResolverScheme, port)
+
+	resolver.Register(&roundRobinResolverBuilder{
+		port:   port,
+		scheme: scheme,
+	})
+
+	return
+}
+
+const roundRobinResolverScheme = "taloslist-%d"
+
+type roundRobinResolverBuilder struct {
+	port   int
+	scheme string
+}
+
+// Build implements resolver.Builder.
+func (b *roundRobinResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	r := &roundRobinResolver{
+		target: target,
+		cc:     cc,
+		port:   b.port,
+	}
+
+	if err := r.start(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// Build implements resolver.Builder.
+func (b *roundRobinResolverBuilder) Scheme() string {
+	return b.scheme
+}
+
+type roundRobinResolver struct {
+	target resolver.Target
+	cc     resolver.ClientConn
+	port   int
+}
+
+func (r *roundRobinResolver) start() error {
+	var addrs []resolver.Address // nolint: prealloc
+
+	for _, a := range strings.Split(r.target.Endpoint, ",") {
+		addrs = append(addrs, resolver.Address{
+			ServerName: a,
+			Addr:       fmt.Sprintf("%s:%d", net.FormatAddress(a), r.port),
+		})
+	}
+
+	// shuffle the list in case client does just one request
+	rand.Shuffle(len(addrs), func(i, j int) {
+		addrs[i], addrs[j] = addrs[j], addrs[i]
+	})
+
+	serviceConfigJSON := `{
+		"loadBalancingConfig": [{
+			"round_robin": {}
+		}]
+	}`
+
+	parsedServiceConfig := r.cc.ParseServiceConfig(serviceConfigJSON)
+
+	if parsedServiceConfig.Err != nil {
+		return parsedServiceConfig.Err
+	}
+
+	r.cc.UpdateState(resolver.State{
+		Addresses:     addrs,
+		ServiceConfig: parsedServiceConfig,
+	})
+
+	return nil
+}
+
+// ResolveNow implements resolver.Resolver.
+func (r *roundRobinResolver) ResolveNow(o resolver.ResolveNowOptions) {}
+
+// ResolveNow implements resolver.Resolver.
+func (r *roundRobinResolver) Close() {}


### PR DESCRIPTION
Instead of doing our homegrown "try all the endpoints" method,
use gRPC load-balancing across configured endpoints.

Generalize load-balancer via gRPC resolver we had in Talos API client,
use it in remote certificate generator code. Generalized resolver is
still under `machinery/`, as `pkg/grpc` is not in `machinery/`, and we
can't depend on Talos code from `machinery/`.

Related to: #3068

Full fix for #3068 requires dynamic updates to control plane endpoints
while apid is running, this is coming in the next PR.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

