### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+---
+
+# See https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+  - package-ecosystem: "gomod"
+    directory: "/pkg/machinery"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+  - package-ecosystem: "gomod"
+    directory: "/hack/cloud-image-uploader"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    commit-message:
+      prefix: "chore:"
+    open-pull-requests-limit: 10
+    rebase-strategy: disabled
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "UTC"
+
+# no website for now


### PR DESCRIPTION
# Pull Request

## What? (description)

https://docs.github.com/en/github/administering-a-repository/about-dependabot-version-updates

After merging, dependabot should be enabled at https://github.com/talos-systems/talos/settings/security_analysis

Manual invocation and logs are here: https://github.com/talos-systems/talos/network/updates

Settings are tweaked for Talos: automatic rebasing is disabled to prevent CI overloading, custom prefix matches existing conventions.

## Why? (reasoning)

To keep dependencies up-to-date and receive notifications about incompatible changes early.
