### PR TITLE
fix: lower memory usage a bit by disabling memory profiling

### DIFF
--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"log"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/talos-systems/grpc-proxy/proxy"
@@ -28,6 +29,9 @@ import (
 var endpoints *string
 
 func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	runtime.MemProfileRate = 0
+
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	endpoints = flag.String("endpoints", "", "the IPs of the control plane nodes")

--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -22,6 +23,11 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/version"
 )
+
+func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	runtime.MemProfileRate = 0
+}
 
 func run() (err error) {
 	// Mount the pseudo devices.

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	goruntime "runtime"
 	"syscall"
 	"time"
 
@@ -36,6 +37,9 @@ import (
 )
 
 func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	goruntime.MemProfileRate = 0
+
 	// Explicitly set the default http client transport to work around proxy.Do
 	// once. This is the http.DefaultTransport with the Proxy func overridden so
 	// that the environment variables with be reread/initialized each time the

--- a/internal/app/networkd/main.go
+++ b/internal/app/networkd/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"log"
+	"runtime"
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/networkd"
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/reg"
@@ -16,6 +17,9 @@ import (
 )
 
 func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	runtime.MemProfileRate = 0
+
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	flag.Parse()

--- a/internal/app/routerd/main.go
+++ b/internal/app/routerd/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"log"
+	"runtime"
 
 	"github.com/talos-systems/grpc-proxy/proxy"
 	"google.golang.org/grpc"
@@ -16,6 +17,11 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/startup"
 )
+
+func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	runtime.MemProfileRate = 0
+}
 
 func main() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)

--- a/internal/app/timed/main.go
+++ b/internal/app/timed/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"flag"
 	"log"
+	"runtime"
 
 	"github.com/talos-systems/talos/internal/app/timed/pkg/ntp"
 	"github.com/talos-systems/talos/internal/app/timed/pkg/reg"
@@ -26,6 +27,9 @@ const (
 )
 
 func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	runtime.MemProfileRate = 0
+
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	flag.Parse()

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"log"
 	stdlibnet "net"
+	"runtime"
 
 	"github.com/talos-systems/crypto/tls"
 	"github.com/talos-systems/net"
@@ -24,6 +25,9 @@ import (
 )
 
 func init() {
+	// Explicitly disable memory profiling to save around 1.4MiB of memory.
+	runtime.MemProfileRate = 0
+
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	flag.Parse()


### PR DESCRIPTION
As of now, we're not using Go profiling, so it's safe to disable it to
save some memory and CPU costs. Once we start using it, we can re-enable
it conditionally.

Each process allocates around 1.4MiB on amd64 for memory profiling
buckets.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

