### PR TITLE
feat: move to ECDSA keys for all Kubernetes/etcd certs and keys 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
-	github.com/talos-systems/crypto v0.2.1-0.20210125160556-cf75519cab82
+	github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54
 	github.com/talos-systems/go-blockdevice v0.2.0
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20210108152626-8cbc42d3dc24

--- a/go.sum
+++ b/go.sum
@@ -856,8 +856,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0TYG7HtkIgExQo+2RdLuwRft63jn2HWj8=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/talos-systems/crypto v0.2.1-0.20210125160556-cf75519cab82 h1:5TsM3o/yJJF6kakHyPee88D0yWNNDNKZJ2NCX9MFsKk=
-github.com/talos-systems/crypto v0.2.1-0.20210125160556-cf75519cab82/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
+github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54 h1:2IGs3f0qG7f33Fv37XuYzIMxLARl4dcpwahZXLmdT2A=
+github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
 github.com/talos-systems/go-blockdevice v0.2.0 h1:tTu0ak3GfF8iSxNsdsicVhTKebIcyBARQYxhRV86AF0=
 github.com/talos-systems/go-blockdevice v0.2.0/go.mod h1:DGbop5CJa0PYdhQK9cNVF61pPJNedas1m7Gi/qAnrsM=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=

--- a/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
@@ -69,7 +69,7 @@ func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r control
 
 		secrets := secretsRes.(*secrets.Kubernetes).Secrets()
 
-		serviceAccountKey, err := secrets.ServiceAccount.GetRSAKey()
+		serviceAccountKey, err := secrets.ServiceAccount.GetKey()
 		if err != nil {
 			return fmt.Errorf("error parsing service account key: %w", err)
 		}
@@ -121,8 +121,8 @@ func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r control
 					{
 						getter: func() *x509.PEMEncodedCertificateAndKey {
 							return &x509.PEMEncodedCertificateAndKey{
-								Crt: serviceAccountKey.PublicKeyPEM,
-								Key: serviceAccountKey.KeyPEM,
+								Crt: serviceAccountKey.GetPublicKeyPEM(),
+								Key: serviceAccountKey.GetPrivateKeyPEM(),
 							}
 						},
 						certFilename: "service-account.pub",
@@ -161,8 +161,8 @@ func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r control
 					{
 						getter: func() *x509.PEMEncodedCertificateAndKey {
 							return &x509.PEMEncodedCertificateAndKey{
-								Crt: serviceAccountKey.PublicKeyPEM,
-								Key: serviceAccountKey.KeyPEM,
+								Crt: serviceAccountKey.GetPublicKeyPEM(),
+								Key: serviceAccountKey.GetPrivateKeyPEM(),
 							}
 						},
 						keyFilename: "service-account.key",

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -180,13 +180,12 @@ func (ctrl *KubernetesController) updateSecrets(cfgProvider talosconfig.Provider
 		"kubernetes.default.svc."+cfgProvider.Cluster().Network().DNSDomain(),
 	)
 
-	ca, err := x509.NewCertificateAuthorityFromCertificateAndKey(k8sSecrets.Secrets().CA, x509.RSA(true))
+	ca, err := x509.NewCertificateAuthorityFromCertificateAndKey(k8sSecrets.Secrets().CA)
 	if err != nil {
 		return fmt.Errorf("failed to parse CA certificate: %w", err)
 	}
 
 	apiServer, err := x509.NewKeyPair(ca,
-		x509.RSA(true),
 		x509.IPAddresses(altNames.IPs),
 		x509.DNSNames(altNames.DNSNames),
 		x509.CommonName("kube-apiserver"),
@@ -200,7 +199,6 @@ func (ctrl *KubernetesController) updateSecrets(cfgProvider talosconfig.Provider
 	k8sSecrets.Secrets().APIServer = x509.NewCertificateAndKeyFromKeyPair(apiServer)
 
 	apiServerKubeletClient, err := x509.NewKeyPair(ca,
-		x509.RSA(true),
 		x509.CommonName(constants.KubernetesAdminCertCommonName),
 		x509.Organization(constants.KubernetesAdminCertOrganization),
 		x509.NotAfter(time.Now().Add(constants.KubernetesDefaultCertificateValidityDuration)),
@@ -213,13 +211,12 @@ func (ctrl *KubernetesController) updateSecrets(cfgProvider talosconfig.Provider
 
 	k8sSecrets.Secrets().ServiceAccount = cfgProvider.Cluster().ServiceAccount()
 
-	aggregatorCA, err := x509.NewCertificateAuthorityFromCertificateAndKey(k8sSecrets.Secrets().AggregatorCA, x509.RSA(true))
+	aggregatorCA, err := x509.NewCertificateAuthorityFromCertificateAndKey(k8sSecrets.Secrets().AggregatorCA)
 	if err != nil {
 		return fmt.Errorf("failed to parse aggregator CA: %w", err)
 	}
 
 	frontProxy, err := x509.NewKeyPair(aggregatorCA,
-		x509.RSA(true),
 		x509.CommonName("front-proxy-client"),
 		x509.NotAfter(time.Now().Add(constants.KubernetesDefaultCertificateValidityDuration)),
 	)

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -62,6 +62,7 @@ type upgradeSpec struct {
 
 	UpgradePreserve bool
 	UpgradeStage    bool
+	UseRSAKeys      bool
 }
 
 const (
@@ -105,6 +106,7 @@ func upgradeBetweenTwoLastReleases() upgradeSpec {
 
 		MasterNodes: DefaultSettings.MasterNodes,
 		WorkerNodes: DefaultSettings.WorkerNodes,
+		UseRSAKeys:  true, // ECDSA is supported with Talos >= 0.9
 	}
 }
 
@@ -125,6 +127,7 @@ func upgradeStableReleaseToCurrent() upgradeSpec {
 
 		MasterNodes: DefaultSettings.MasterNodes,
 		WorkerNodes: DefaultSettings.WorkerNodes,
+		UseRSAKeys:  true, // ECDSA is supported with Talos >= 0.9
 	}
 }
 
@@ -146,6 +149,7 @@ func upgradeSingeNodePreserve() upgradeSpec {
 		MasterNodes:     1,
 		WorkerNodes:     0,
 		UpgradePreserve: true,
+		UseRSAKeys:      true, // ECDSA is supported with Talos >= 0.9
 	}
 }
 
@@ -168,6 +172,7 @@ func upgradeSingeNodeStage() upgradeSpec {
 		WorkerNodes:     0,
 		UpgradePreserve: true,
 		UpgradeStage:    true,
+		UseRSAKeys:      true, // ECDSA is supported with Talos >= 0.9
 	}
 }
 
@@ -319,6 +324,7 @@ func (suite *UpgradeSuite) setupCluster() {
 			ClusterName: clusterName,
 			Endpoint:    suite.controlPlaneEndpoint,
 			KubeVersion: "", // keep empty so that default version is used per Talos version
+			UseRSAKeys:  suite.spec.UseRSAKeys,
 			GenOptions: append(
 				genOptions,
 				generate.WithEndpointList(masterEndpoints),

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -112,7 +112,7 @@ func Generate(ctx context.Context, in *machine.GenerateConfigurationRequest) (re
 
 		switch {
 		case os.IsNotExist(err):
-			secrets, err = generate.NewSecretsBundle(clock)
+			secrets, err = generate.NewSecretsBundle(clock, false)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/pkg/etcd/certs.go
+++ b/internal/pkg/etcd/certs.go
@@ -41,7 +41,6 @@ func GeneratePeerCert(etcdCA *x509.PEMEncodedCertificateAndKey) (*x509.PEMEncode
 	opts := []x509.Option{
 		x509.CommonName(hostname),
 		x509.DNSNames(dnsNames),
-		x509.RSA(true),
 		x509.IPAddresses(ips),
 		x509.NotAfter(time.Now().Add(87600 * time.Hour)),
 	}

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -80,7 +80,7 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 		fmt.Println("generating PKI and tokens")
 	}
 
-	secrets, err := generate.NewSecretsBundle(generate.NewClock())
+	secrets, err := generate.NewSecretsBundle(generate.NewClock(), options.InputOptions.UseRSAKeys)
 	if err != nil {
 		return bundle, err
 	}

--- a/pkg/machinery/config/types/v1alpha1/bundle/options.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/options.go
@@ -15,6 +15,7 @@ type InputOptions struct {
 	Endpoint    string
 	KubeVersion string
 	GenOptions  []generate.GenOption
+	UseRSAKeys  bool
 }
 
 // Options describes generate parameters.

--- a/pkg/machinery/config/types/v1alpha1/generate/generate_test.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate_test.go
@@ -26,7 +26,7 @@ func TestGenerateSuite(t *testing.T) {
 
 func (suite *GenerateSuite) SetupSuite() {
 	var err error
-	secrets, err := genv1alpha1.NewSecretsBundle(genv1alpha1.NewClock())
+	secrets, err := genv1alpha1.NewSecretsBundle(genv1alpha1.NewClock(), false)
 	suite.Require().NoError(err)
 	suite.input, err = genv1alpha1.NewInput("test", "10.0.1.5", constants.DefaultKubernetesVersion, secrets)
 	suite.Require().NoError(err)

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/talos-systems/crypto v0.2.1-0.20210125160556-cf75519cab82
+	github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54
 	github.com/talos-systems/net v0.2.1-0.20210121122956-005a94f8b36b
 	github.com/talos-systems/os-runtime v0.0.0-20210126185717-734f1e1cee9e
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -93,8 +93,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/talos-systems/crypto v0.2.1-0.20210125160556-cf75519cab82 h1:5TsM3o/yJJF6kakHyPee88D0yWNNDNKZJ2NCX9MFsKk=
-github.com/talos-systems/crypto v0.2.1-0.20210125160556-cf75519cab82/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
+github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54 h1:2IGs3f0qG7f33Fv37XuYzIMxLARl4dcpwahZXLmdT2A=
+github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
 github.com/talos-systems/go-retry v0.2.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/net v0.2.1-0.20210121122956-005a94f8b36b h1:y3mBkTJdW7cUn+ff53TZN0yyWCpjS6XrVmlx+vx9pwA=
 github.com/talos-systems/net v0.2.1-0.20210121122956-005a94f8b36b/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=


### PR DESCRIPTION
ECDSA keys are smaller which decreases Talos config size, they are more
efficient in terms of key generation, signing, etc., so it makes boot
performance better (and config generation as well).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

