### PR TITLE
feat: upgrade CoreDNS to 1.8.0

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -209,10 +209,10 @@ const (
 	KubernetesSchedulerImage = "k8s.gcr.io/kube-scheduler"
 
 	// CoreDNSImage is the enforced CoreDNS image to use.
-	CoreDNSImage = "k8s.gcr.io/coredns"
+	CoreDNSImage = "docker.io/coredns/coredns"
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
-	DefaultCoreDNSVersion = "1.7.0"
+	DefaultCoreDNSVersion = "1.8.0"
 
 	// LabelNodeRoleMaster is the node label required by a control plane node.
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -1071,7 +1071,7 @@ Examples:
 
 ``` yaml
 coreDNS:
-    image: k8s.gcr.io/coredns:1.7.0 # The `image` field is an override to the default coredns image.
+    image: docker.io/coredns/coredns:1.8.0 # The `image` field is an override to the default coredns image.
 ```
 
 
@@ -1897,7 +1897,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/coredns:1.7.0 # The `image` field is an override to the default coredns image.
+image: docker.io/coredns/coredns:1.8.0 # The `image` field is an override to the default coredns image.
 ```
 
 <hr />


### PR DESCRIPTION
Brings in v1.8.0 of CoreDNS.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
