### PR TITLE
fix: use hugetlbfs instead of none

### DIFF
--- a/internal/pkg/mount/pseudo.go
+++ b/internal/pkg/mount/pseudo.go
@@ -26,7 +26,7 @@ func PseudoSubMountPoints() (mountpoints *Points, err error) {
 	pseudo := NewMountPoints()
 	pseudo.Set("devshm", NewMountPoint("tmpfs", "/dev/shm", "tmpfs", unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV|unix.MS_RELATIME, ""))
 	pseudo.Set("devpts", NewMountPoint("devpts", "/dev/pts", "devpts", unix.MS_NOSUID|unix.MS_NOEXEC, "ptmxmode=000,mode=620,gid=5"))
-	pseudo.Set("hugetlb", NewMountPoint("none", "/dev/hugepages", "hugetlbfs", 0, ""))
+	pseudo.Set("hugetlb", NewMountPoint("hugetlbfs", "/dev/hugepages", "hugetlbfs", 0, ""))
 	pseudo.Set("securityfs", NewMountPoint("securityfs", "/sys/kernel/security", "securityfs", unix.MS_NOSUID|unix.MS_NOEXEC|unix.MS_NODEV|unix.MS_RELATIME, ""))
 
 	return pseudo, nil


### PR DESCRIPTION
Specifies the mount source as `hugetlbfs`.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
