### PR TITLE
feat: implement ephemeral partition encryption

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -338,20 +338,28 @@ local integration_provision_tests_track_1 = Step("provision-tests-track-1", priv
 //         "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
 //         "REGISTRY": local_registry,
 // });
-local integration_cilium = Step("e2e-cilium-1.8.5", target="e2e-qemu", privileged=true, depends_on=[integration_qemu], environment={
+local integration_cilium = Step("e2e-cilium-1.8.5", target="e2e-qemu", privileged=true, depends_on=[integration_provision_tests_track_1], environment={
         "SHORT_INTEGRATION_TEST": "yes",
         "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.8.5/install/kubernetes/quick-install.yaml",
         "REGISTRY": local_registry,
+        "CLUSTER_CIDR": 2,
 });
 local integration_uefi = Step("e2e-uefi", target="e2e-qemu", privileged=true, depends_on=[integration_cilium], environment={
         "SHORT_INTEGRATION_TEST": "yes",
         "WITH_UEFI": "true",
+        "CLUSTER_CIDR": 3,
         "REGISTRY": local_registry,
 });
 local integration_disk_image = Step("e2e-disk-image", target="e2e-qemu", privileged=true, depends_on=[integration_uefi], environment={
         "SHORT_INTEGRATION_TEST": "yes",
         "USE_DISK_IMAGE": "true",
         "REGISTRY": local_registry,
+        "CLUSTER_CIDR": 4,
+});
+local integration_disk_encryption = Step("e2e-encrypted", target="e2e-qemu", privileged=true, depends_on=[integration_disk_image], environment={
+        "WITH_DISK_ENCRYPTION": "true",
+        "REGISTRY": local_registry,
+        "CLUSTER_CIDR": 5,
 });
 local push_edge = {
   name: 'push-edge',
@@ -385,6 +393,7 @@ local integration_steps = default_steps + [
   integration_cilium,
   integration_uefi,
   integration_disk_image,
+  integration_disk_encryption,
   push_edge,
 ];
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM ghcr.io/talos-systems/dosfstools:${PKGS} AS pkg-dosfstools
 FROM ghcr.io/talos-systems/eudev:${PKGS} AS pkg-eudev
 FROM ghcr.io/talos-systems/grub:${PKGS} AS pkg-grub
 FROM ghcr.io/talos-systems/iptables:${PKGS} AS pkg-iptables
+FROM ghcr.io/talos-systems/libjson-c:${PKGS} AS pkg-libjson-c
+FROM ghcr.io/talos-systems/libpopt:${PKGS} AS pkg-libpopt
 FROM ghcr.io/talos-systems/libressl:${PKGS} AS pkg-libressl
 FROM ghcr.io/talos-systems/libseccomp:${PKGS} AS pkg-libseccomp
 FROM ghcr.io/talos-systems/linux-firmware:${PKGS} AS pkg-linux-firmware
@@ -358,6 +360,8 @@ COPY --from=pkg-containerd / /rootfs
 COPY --from=pkg-dosfstools / /rootfs
 COPY --from=pkg-eudev / /rootfs
 COPY --from=pkg-iptables / /rootfs
+COPY --from=pkg-libjson-c / /rootfs
+COPY --from=pkg-libpopt / /rootfs
 COPY --from=pkg-libressl / /rootfs
 COPY --from=pkg-libseccomp / /rootfs
 COPY --from=pkg-linux-firmware /lib/firmware/bnx2 /rootfs/lib/firmware/bnx2

--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/partition/gpt"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util"
@@ -22,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board"
 	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/partition"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
@@ -131,16 +133,12 @@ func NewManifest(label string, sequence runtime.Sequence, bootPartitionFound boo
 
 	stateTarget := StateTarget(opts.Disk, &Target{
 		PreserveContents: bootPartitionFound,
-		ExtraPreserveSources: []PreserveSource{
-			{
-				Label:          constants.LegacyBootPartitionLabel,
-				FileSystemType: FilesystemTypeVFAT,
-				FnmatchFilters: []string{"config.yaml"},
-			},
+		FormatOptions: &partition.FormatOptions{
+			FileSystemType: partition.FilesystemTypeNone,
 		},
 	})
 
-	ephemeralTarget := EphemeralTarget(opts.Disk, nil)
+	ephemeralTarget := EphemeralTarget(opts.Disk, NoFilesystem)
 
 	if opts.Force {
 		ephemeralTarget.Force = true
@@ -417,7 +415,7 @@ func (m *Manifest) preserveContents(device Device, targets []*Target) (err error
 
 		var (
 			sourcePart     *gpt.Partition
-			fileSystemType FileSystemType
+			fileSystemType partition.FileSystemType
 			fnmatchFilters []string
 		)
 
@@ -466,11 +464,11 @@ func (m *Manifest) restoreContents(targets []*Target) error {
 }
 
 // SystemMountpoints returns list of system mountpoints for the manifest.
-func (m *Manifest) SystemMountpoints() (*mount.Points, error) {
+func (m *Manifest) SystemMountpoints(opts ...mount.Option) (*mount.Points, error) {
 	mountpoints := mount.NewMountPoints()
 
 	for dev := range m.Targets {
-		mp, err := mount.SystemMountPointsForDevice(dev)
+		mp, err := mount.SystemMountPointsForDevice(dev, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -511,13 +509,7 @@ func (m *Manifest) zeroDevice(device Device) (err error) {
 // nolint: dupl, gocyclo
 func (t *Target) Partition(pt *gpt.GPT, pos int, bd *blockdevice.BlockDevice) (err error) {
 	if t.Skip {
-		var part *gpt.Partition
-
-		part, err = t.Locate(pt)
-		if err != nil {
-			return err
-		}
-
+		part := pt.Partitions().FindByName(t.Label)
 		if part != nil {
 			log.Printf("skipped %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
 		}
@@ -525,7 +517,7 @@ func (t *Target) Partition(pt *gpt.GPT, pos int, bd *blockdevice.BlockDevice) (e
 		return nil
 	}
 
-	log.Printf("partitioning %s - %s\n", t.Device, t.Label)
+	log.Printf("partitioning %s - %s %q\n", t.Device, t.Label, humanize.Bytes(t.Size))
 
 	opts := []gpt.PartitionOption{
 		gpt.WithPartitionType(t.PartitionType),

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54
-	github.com/talos-systems/go-blockdevice v0.2.0
+	github.com/talos-systems/go-blockdevice v0.2.1-0.20210215235705-1cf7f252c38c
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20210108152626-8cbc42d3dc24
 	github.com/talos-systems/go-retry v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54 h1:2IGs3f0qG7f33Fv37XuYzIMxLARl4dcpwahZXLmdT2A=
 github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
-github.com/talos-systems/go-blockdevice v0.2.0 h1:tTu0ak3GfF8iSxNsdsicVhTKebIcyBARQYxhRV86AF0=
-github.com/talos-systems/go-blockdevice v0.2.0/go.mod h1:DGbop5CJa0PYdhQK9cNVF61pPJNedas1m7Gi/qAnrsM=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210215235705-1cf7f252c38c h1:Phuso/dkIkP+xZBA0WNNea1MR3kzKdLQuPyHOu44S8w=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210215235705-1cf7f252c38c/go.mod h1:DGbop5CJa0PYdhQK9cNVF61pPJNedas1m7Gi/qAnrsM=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
 github.com/talos-systems/go-procfs v0.0.0-20210108152626-8cbc42d3dc24 h1:fN8vYvlB9XBQ5aImb1vLgR0ZaDwvfZfBMptqkpi3aEg=
@@ -1298,7 +1298,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1329,7 +1328,6 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -1342,7 +1340,6 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -498,9 +498,9 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 			case constants.MetaPartitionLabel:
 				target = installer.MetaTarget(bd.Device().Name(), nil)
 			case constants.StatePartitionLabel:
-				target = installer.StateTarget(bd.Device().Name(), nil)
+				target = installer.StateTarget(bd.Device().Name(), installer.NoFilesystem)
 			case constants.EphemeralPartitionLabel:
-				target = installer.EphemeralTarget(bd.Device().Name(), nil)
+				target = installer.EphemeralTarget(bd.Device().Name(), installer.NoFilesystem)
 			default:
 				return nil, fmt.Errorf("label %q is not supported", spec.Label)
 			}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -53,6 +53,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/kernel/kspp"
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/partition"
 	"github.com/talos-systems/talos/pkg/cmd"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/images"
@@ -882,11 +883,13 @@ func partitionAndFormatDisks(logger *log.Logger, r runtime.Runtime) error {
 
 			for _, part := range disk.Partitions() {
 				extraTarget := &installer.Target{
-					Device:         disk.Device(),
-					Size:           part.Size(),
-					Force:          true,
-					PartitionType:  installer.LinuxFilesystemData,
-					FileSystemType: installer.FilesystemTypeXFS,
+					Device: disk.Device(),
+					FormatOptions: &partition.FormatOptions{
+						Size:           part.Size(),
+						Force:          true,
+						PartitionType:  partition.LinuxFilesystemData,
+						FileSystemType: partition.FilesystemTypeXFS,
+					},
 				}
 
 				m.Targets[disk.Device()] = append(m.Targets[disk.Device()], extraTarget)
@@ -1202,10 +1205,10 @@ func UnmountSystemDiskBindMounts(seq runtime.Sequence, data interface{}) (runtim
 				continue
 			}
 
-			device := fields[0]
+			device := strings.ReplaceAll(fields[0], "/dev/mapper", "/dev")
 			mountpoint := fields[1]
 
-			if strings.HasPrefix(device, devname) {
+			if strings.HasPrefix(device, devname) && device != devname {
 				logger.Printf("unmounting %s\n", mountpoint)
 
 				if err = unix.Unmount(mountpoint, 0); err != nil {
@@ -1580,7 +1583,7 @@ func UnmountEFIPartition(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 // MountStatePartition mounts the system partition.
 func MountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mount.SystemPartitionMount(r, constants.StatePartitionLabel, mount.WithSkipIfMounted(true))
+		return mount.SystemPartitionMount(r, constants.StatePartitionLabel, mount.WithFlags(mount.SkipIfMounted))
 	}, "mountStatePartition"
 }
 
@@ -1591,11 +1594,11 @@ func UnmountStatePartition(seq runtime.Sequence, data interface{}) (runtime.Task
 	}, "unmountStatePartition"
 }
 
-// MountEphermeralPartition mounts the ephemeral partition.
-func MountEphermeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
+// MountEphemeralPartition mounts the ephemeral partition.
+func MountEphemeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mount.SystemPartitionMount(r, constants.EphemeralPartitionLabel, mount.WithResize(true))
-	}, "mountEphermeralPartition"
+		return mount.SystemPartitionMount(r, constants.EphemeralPartitionLabel, mount.WithFlags(mount.Resize))
+	}, "mountEphemeralPartition"
 }
 
 // UnmountEphemeralPartition unmounts the ephemeral partition.

--- a/internal/integration/api/apply-config.go
+++ b/internal/integration/api/apply-config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/client"
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
@@ -177,6 +178,129 @@ func (suite *ApplyConfigSuite) TestApplyNoReboot() {
 		Data:     cfgDataOut,
 	})
 	suite.Require().NoError(err, "failed to apply deferred configuration (node %q): %w", node)
+}
+
+// TestApplyConfigRotateEncryptionSecrets verify key rotation by sequential apply config calls.
+func (suite *ApplyConfigSuite) TestApplyConfigRotateEncryptionSecrets() {
+	suite.T().Skip("skip: this test is not stable yet")
+
+	node := suite.RandomDiscoveredNode(machine.TypeJoin)
+	suite.ClearConnectionRefused(suite.ctx, node)
+
+	nodeCtx := client.WithNodes(suite.ctx, node)
+	provider, err := suite.readConfigFromNode(nodeCtx)
+
+	suite.Assert().NoError(err)
+
+	encryption := provider.Machine().SystemDiskEncryption().Get(constants.EphemeralPartitionLabel)
+
+	if encryption == nil {
+		suite.T().Skip("skipped in not encrypted mode")
+	}
+
+	suite.WaitForBootDone(suite.ctx)
+
+	cfg, ok := encryption.(*v1alpha1.EncryptionConfig)
+	suite.Assert().True(ok)
+
+	keySets := [][]*v1alpha1.EncryptionKey{
+		{
+			{
+				KeyNodeID: &v1alpha1.EncryptionKeyNodeID{},
+				KeySlot:   0,
+			},
+			{
+				KeyStatic: &v1alpha1.EncryptionKeyStatic{
+					KeyData: "AlO93jayutOpsDxDS=-",
+				},
+				KeySlot: 1,
+			},
+		},
+		{
+			{
+				KeyStatic: &v1alpha1.EncryptionKeyStatic{
+					KeyData: "AlO93jayutOpsDxDS=-",
+				},
+				KeySlot: 1,
+			},
+		},
+		{
+			{
+				KeyNodeID: &v1alpha1.EncryptionKeyNodeID{},
+				KeySlot:   0,
+			},
+			{
+				KeyStatic: &v1alpha1.EncryptionKeyStatic{
+					KeyData: "AlO93jayutOpsDxDS=-",
+				},
+				KeySlot: 1,
+			},
+		},
+		{
+			{
+				KeyNodeID: &v1alpha1.EncryptionKeyNodeID{},
+				KeySlot:   0,
+			},
+			{
+				KeyStatic: &v1alpha1.EncryptionKeyStatic{
+					KeyData: "1js4nfhvneJJsak=GVN4Inf5gh",
+				},
+				KeySlot: 1,
+			},
+		},
+	}
+
+	for _, keys := range keySets {
+		cfg.EncryptionKeys = keys
+
+		data, err := provider.Bytes()
+		suite.Require().NoError(err)
+
+		suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
+			_, err = suite.Client.ApplyConfiguration(nodeCtx, &machineapi.ApplyConfigurationRequest{
+				Data: data,
+			})
+			if err != nil {
+				// It is expected that the connection will EOF here, so just log the error
+				suite.Assert().Nilf("failed to apply configuration (node %q): %w", node, err)
+			}
+
+			return nil
+		}, assertRebootedRebootTimeout)
+
+		// Verify configuration change
+		var newProvider config.Provider
+
+		suite.Require().Nilf(retry.Constant(time.Minute, retry.WithUnits(time.Second)).Retry(func() error {
+			newProvider, err = suite.readConfigFromNode(nodeCtx)
+			if err != nil {
+				return retry.ExpectedError(err)
+			}
+
+			return nil
+		}), "failed to read updated configuration from node %q: %w", node, err)
+
+		e := newProvider.Machine().SystemDiskEncryption().Get(constants.EphemeralPartitionLabel)
+
+		for i, k := range e.Keys() {
+			if keys[i].KeyStatic == nil {
+				suite.Require().Nil(k.Static())
+			} else {
+				suite.Require().Equal(keys[i].Static().Key(), k.Static().Key())
+			}
+
+			if keys[i].KeyNodeID == nil {
+				suite.Require().Nil(k.NodeID())
+			} else {
+				suite.Require().NotNil(keys[i].NodeID())
+			}
+
+			suite.Require().Equal(keys[i].Slot(), k.Slot())
+			suite.Require().Equal(keys[i].Slot(), k.Slot())
+		}
+
+		suite.WaitForBootDone(suite.ctx)
+	}
 }
 
 func (suite *ApplyConfigSuite) readConfigFromNode(nodeCtx context.Context) (config.Provider, error) {

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -4,7 +4,7 @@
 
 // +build integration
 
-// Package provision provides integration tests which rely on on provisioning cluster per test.
+// Package provision provides integration tests which rely on provisioning cluster per test.
 package provision
 
 import (

--- a/internal/pkg/encryption/encryption.go
+++ b/internal/pkg/encryption/encryption.go
@@ -1,0 +1,254 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package encryption provides modules for the partition encryption handling.
+package encryption
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+
+	"github.com/talos-systems/go-blockdevice/blockdevice"
+	"github.com/talos-systems/go-blockdevice/blockdevice/encryption"
+	"github.com/talos-systems/go-blockdevice/blockdevice/encryption/luks"
+	"github.com/talos-systems/go-blockdevice/blockdevice/partition/gpt"
+
+	"github.com/talos-systems/talos/internal/pkg/encryption/keys"
+	"github.com/talos-systems/talos/pkg/machinery/config"
+)
+
+// NewHandler creates new Handler.
+func NewHandler(device *blockdevice.BlockDevice, partition *gpt.Partition, encryptionConfig config.Encryption) (*Handler, error) {
+	keys, err := getKeys(encryptionConfig, partition)
+	if err != nil {
+		return nil, err
+	}
+
+	var provider encryption.Provider
+
+	switch encryptionConfig.Kind() {
+	case encryption.LUKS2:
+		cipher, err := luks.ParseCipherKind(encryptionConfig.Cipher())
+		if err != nil {
+			return nil, err
+		}
+
+		provider = luks.New(
+			cipher,
+		)
+	default:
+		return nil, fmt.Errorf("unknown encryption kind %s", encryptionConfig.Kind())
+	}
+
+	return &Handler{
+		device:             device,
+		partition:          partition,
+		encryptionConfig:   encryptionConfig,
+		keys:               keys,
+		encryptionProvider: provider,
+	}, nil
+}
+
+// Handler reads encryption config, creates appropriate
+// encryption provider, handles encrypted partition open and close.
+type Handler struct {
+	device             *blockdevice.BlockDevice
+	partition          *gpt.Partition
+	encryptionConfig   config.Encryption
+	keys               []*encryption.Key
+	encryptionProvider encryption.Provider
+	encryptedPath      string
+}
+
+// Open encrypted partition.
+// nolint:gocyclo
+func (h *Handler) Open() (string, error) {
+	partPath, err := h.partition.Path()
+	if err != nil {
+		return "", err
+	}
+
+	sb, err := h.partition.SuperBlock()
+	if err != nil {
+		return "", err
+	}
+
+	var path string
+
+	// encrypt if partition is not encrypted and empty
+	if sb == nil {
+		err = h.formatAndEncrypt(partPath)
+		if err != nil {
+			return "", err
+		}
+	} else if sb.Type() != h.encryptionConfig.Kind() {
+		return "", fmt.Errorf("failed to encrypt the partition %s, because it is not empty", partPath)
+	}
+
+	var k *encryption.Key
+
+	for _, k = range h.keys {
+		path, err = h.encryptionProvider.Open(partPath, k)
+		if err != nil {
+			if err == encryption.ErrEncryptionKeyRejected {
+				continue
+			}
+
+			return "", err
+		}
+
+		break
+	}
+
+	if path == "" {
+		return "", fmt.Errorf("failed to open encrypted device %s, no key matched", partPath)
+	}
+
+	log.Printf("mapped encrypted partition %s -> %s", partPath, path)
+
+	if err = h.syncKeys(k, partPath); err != nil {
+		return "", err
+	}
+
+	h.encryptedPath = path
+
+	return path, nil
+}
+
+// Close encrypted partition.
+func (h *Handler) Close() error {
+	if h.encryptedPath == "" {
+		return nil
+	}
+
+	if err := h.encryptionProvider.Close(h.encryptedPath); err != nil {
+		return err
+	}
+
+	log.Printf("closed encrypted partition %s", h.encryptedPath)
+
+	return nil
+}
+
+func (h *Handler) formatAndEncrypt(path string) error {
+	log.Printf("encrypting the partition %s (%s)", path, h.partition.Name)
+
+	if len(h.keys) == 0 {
+		return fmt.Errorf("no encryption keys found")
+	}
+
+	key := h.keys[0]
+
+	err := h.encryptionProvider.Encrypt(path, key)
+	if err != nil {
+		return err
+	}
+
+	for _, extraKey := range h.keys[1:] {
+		if err = h.encryptionProvider.AddKey(path, key, extraKey); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+//nolint:gocyclo
+func (h *Handler) syncKeys(k *encryption.Key, path string) error {
+	keyslots, err := h.encryptionProvider.ReadKeyslots(path)
+	if err != nil {
+		return err
+	}
+
+	visited := map[string]bool{}
+
+	for _, key := range h.keys {
+		slot := fmt.Sprintf("%d", key.Slot)
+		visited[slot] = true
+		// no need to update the key which we already detected as unchanged
+		if k.Slot == key.Slot {
+			continue
+		}
+
+		// keyslot exists
+		if _, ok := keyslots.Keyslots[slot]; ok {
+			if err = h.updateKey(k, key, path); err != nil {
+				return err
+			}
+
+			log.Printf("updated encryption key at slot %d", key.Slot)
+		} else {
+			// keyslot does not exist so just add the key
+			if err = h.encryptionProvider.AddKey(path, k, key); err != nil {
+				return err
+			}
+
+			log.Printf("added encryption key to slot %d", key.Slot)
+		}
+	}
+
+	// cleanup deleted key slots
+	for slot := range keyslots.Keyslots {
+		if !visited[slot] {
+			s, err := strconv.ParseInt(slot, 10, 64)
+			if err != nil {
+				return err
+			}
+
+			if err = h.encryptionProvider.RemoveKey(path, int(s), k); err != nil {
+				return err
+			}
+
+			log.Printf("removed key at slot %d", k.Slot)
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) updateKey(existingKey, newKey *encryption.Key, path string) error {
+	if valid, err := h.encryptionProvider.CheckKey(path, newKey); err != nil {
+		return err
+	} else if !valid {
+		// re-add the key to the slot
+		err = h.encryptionProvider.RemoveKey(path, newKey.Slot, existingKey)
+		if err != nil {
+			return fmt.Errorf("failed to drop old key during key update %w", err)
+		}
+
+		err = h.encryptionProvider.AddKey(path, existingKey, newKey)
+		if err != nil {
+			return fmt.Errorf("failed to add new key during key update %w", err)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func getKeys(encryptionConfig config.Encryption, partition *gpt.Partition) ([]*encryption.Key, error) {
+	encryptionKeys := make([]*encryption.Key, len(encryptionConfig.Keys()))
+
+	for i, cfg := range encryptionConfig.Keys() {
+		handler, err := keys.NewHandler(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		k, err := handler.GetKey(keys.WithPartitionLabel(partition.Name))
+		if err != nil {
+			return nil, err
+		}
+
+		encryptionKeys[i] = encryption.NewKey(cfg.Slot(), k)
+	}
+
+	//nolint:scopelint
+	sort.Slice(encryptionKeys, func(i, j int) bool { return encryptionKeys[i].Slot < encryptionKeys[j].Slot })
+
+	return encryptionKeys, nil
+}

--- a/internal/pkg/encryption/encryption_test.go
+++ b/internal/pkg/encryption/encryption_test.go
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package encryption_test
+
+import "testing"
+
+func TestEmpty(t *testing.T) {
+	// added for accurate coverage estimation
+	//
+	// please remove it once any unit-test is added
+	// for this package
+}

--- a/internal/pkg/encryption/keys/keys.go
+++ b/internal/pkg/encryption/keys/keys.go
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package keys contains various encryption KeyHandler implementations.
+package keys
+
+import (
+	"fmt"
+
+	"github.com/talos-systems/talos/pkg/machinery/config"
+)
+
+// NewHandler creates a new key handler depending on key handler kind.
+func NewHandler(key config.EncryptionKey) (Handler, error) {
+	switch {
+	case key.Static() != nil:
+		k := key.Static().Key()
+		if k == nil {
+			return nil, fmt.Errorf("static key must have key data defined")
+		}
+
+		return NewStaticKeyHandler(k)
+	case key.NodeID() != nil:
+		return NewNodeIDKeyHandler()
+	}
+
+	return nil, fmt.Errorf("failed to create key handler: malformed config")
+}
+
+// Handler represents an interface for fetching encryption keys.
+type Handler interface {
+	GetKey(options ...KeyOption) ([]byte, error)
+}

--- a/internal/pkg/encryption/keys/nodeid.go
+++ b/internal/pkg/encryption/keys/nodeid.go
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package keys
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/talos-systems/go-smbios/smbios"
+)
+
+// NodeIDKeyHandler generates the key based on current node information
+// and provided template string.
+type NodeIDKeyHandler struct {
+}
+
+// NewNodeIDKeyHandler creates new NodeIDKeyHandler.
+func NewNodeIDKeyHandler() (*NodeIDKeyHandler, error) {
+	return &NodeIDKeyHandler{}, nil
+}
+
+// GetKey implements KeyHandler interface.
+func (h *NodeIDKeyHandler) GetKey(options ...KeyOption) ([]byte, error) {
+	opts, err := NewDefaultOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := smbios.New()
+	if err != nil {
+		return nil, err
+	}
+
+	machineUUID, err := s.SystemInformation().UUID()
+	if err != nil {
+		return nil, err
+	}
+
+	if machineUUID == uuid.Nil {
+		return nil, fmt.Errorf("machine UUID is not populated %s", machineUUID)
+	}
+
+	id := machineUUID.String()
+
+	// primitive entropy check
+	counts := map[rune]int{}
+	for _, s := range id {
+		counts[s]++
+		if counts[s] > len(id)/2 {
+			return nil, fmt.Errorf("machine UUID %s entropy check failed", machineUUID)
+		}
+	}
+
+	return []byte(id + opts.PartitionLabel), nil
+}

--- a/internal/pkg/encryption/keys/options.go
+++ b/internal/pkg/encryption/keys/options.go
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package keys
+
+// KeyOption represents key option callback used in KeyHandler.GetKey func.
+type KeyOption func(o *KeyOptions) error
+
+// KeyOptions set of options to be used in KeyHandler.GetKey func.
+type KeyOptions struct {
+	PartitionLabel string
+}
+
+// WithPartitionLabel passes the partition label in to GetKey function.
+func WithPartitionLabel(label string) KeyOption {
+	return func(o *KeyOptions) error {
+		o.PartitionLabel = label
+
+		return nil
+	}
+}
+
+// NewDefaultOptions creates new KeyOptions.
+func NewDefaultOptions(options []KeyOption) (*KeyOptions, error) {
+	var opts KeyOptions
+
+	for _, o := range options {
+		err := o(&opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &opts, nil
+}

--- a/internal/pkg/encryption/keys/static.go
+++ b/internal/pkg/encryption/keys/static.go
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package keys
+
+// StaticKeyHandler just handles the static key value all the time.
+type StaticKeyHandler struct {
+	key []byte
+}
+
+// NewStaticKeyHandler creates new EphemeralKeyHandler.
+func NewStaticKeyHandler(key []byte) (*StaticKeyHandler, error) {
+	return &StaticKeyHandler{
+		key: key,
+	}, nil
+}
+
+// GetKey implements KeyHandler interface.
+func (h *StaticKeyHandler) GetKey(options ...KeyOption) ([]byte, error) {
+	return h.key, nil
+}

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -4,19 +4,48 @@
 
 package mount
 
+import "github.com/talos-systems/talos/pkg/machinery/config"
+
+const (
+	// ReadOnly is a flag for setting the mount point as readonly.
+	ReadOnly Flags = 1 << iota
+	// Shared is a flag for setting the mount point as shared.
+	Shared
+	// Resize indicates that a the partition for a given mount point should be
+	// resized to the maximum allowed.
+	Resize
+	// Overlay indicates that a the partition for a given mount point should be
+	// mounted using overlayfs.
+	Overlay
+	// SkipIfMounted is a flag for skipping mount if the mountpoint is already mounted.
+	SkipIfMounted
+)
+
+// Flags is the mount flags.
+type Flags uint
+
 // Options is the functional options struct.
 type Options struct {
-	Loopback      string
-	Prefix        string
-	ReadOnly      bool
-	Shared        bool
-	Resize        bool
-	Overlay       bool
-	SkipIfMounted bool
+	Loopback         string
+	Prefix           string
+	MountFlags       Flags
+	PreMountHooks    []Hook
+	PostUnmountHooks []Hook
+	Encryption       config.Encryption
 }
 
 // Option is the functional option func.
 type Option func(*Options)
+
+// Check checks if all provided flags are set.
+func (f Flags) Check(flags Flags) bool {
+	return (f & flags) == flags
+}
+
+// Intersects checks if at least one flag is set.
+func (f Flags) Intersects(flags Flags) bool {
+	return (f & flags) != 0
+}
 
 // WithPrefix is a functional option for setting the mount point prefix.
 func WithPrefix(o string) Option {
@@ -25,52 +54,45 @@ func WithPrefix(o string) Option {
 	}
 }
 
-// WithReadOnly is a functional option for setting the mount point as readonly.
-func WithReadOnly(o bool) Option {
+// WithFlags is a functional option to set up mount flags.
+func WithFlags(flags Flags) Option {
 	return func(args *Options) {
-		args.ReadOnly = o
+		args.MountFlags = flags
 	}
 }
 
-// WithShared is a functional option for setting the mount point as shared.
-func WithShared(o bool) Option {
+// WithPreMountHooks adds functions to be called before mounting the partition.
+func WithPreMountHooks(hooks ...Hook) Option {
 	return func(args *Options) {
-		args.Shared = o
+		args.PreMountHooks = hooks
 	}
 }
 
-// WithSkipIfMounted is a functional option for skipping mount if the mountpoint is already mounted.
-func WithSkipIfMounted(o bool) Option {
+// WithPostUnmountHooks adds functions to be called after unmounting the partition.
+func WithPostUnmountHooks(hooks ...Hook) Option {
 	return func(args *Options) {
-		args.SkipIfMounted = o
+		args.PostUnmountHooks = hooks
 	}
 }
 
-// WithResize indicates that a the partition for a given mount point should be
-// resized to the maximum allowed.
-func WithResize(o bool) Option {
+// WithEncryptionConfig partition encryption configuration.
+func WithEncryptionConfig(cfg config.Encryption) Option {
 	return func(args *Options) {
-		args.Resize = o
+		args.Encryption = cfg
 	}
 }
 
-// WithOverlay indicates that a the partition for a given mount point should be
-// mounted using overlayfs.
-func WithOverlay(o bool) Option {
-	return func(args *Options) {
-		args.Overlay = o
-	}
-}
+// Hook represents pre/post mount hook.
+type Hook func(p *Point) error
 
 // NewDefaultOptions initializes a Options struct with default values.
 func NewDefaultOptions(setters ...Option) *Options {
 	opts := &Options{
-		Loopback: "",
-		Prefix:   "",
-		ReadOnly: false,
-		Shared:   false,
-		Resize:   false,
-		Overlay:  false,
+		Loopback:         "",
+		Prefix:           "",
+		MountFlags:       0,
+		PreMountHooks:    []Hook{},
+		PostUnmountHooks: []Hook{},
 	}
 
 	for _, setter := range setters {

--- a/internal/pkg/mount/overlay.go
+++ b/internal/pkg/mount/overlay.go
@@ -22,7 +22,7 @@ func OverlayMountPoints() (mountpoints *Points, err error) {
 	}
 
 	for _, target := range overlays {
-		mountpoint := NewMountPoint("", target, "", unix.MS_I_VERSION, "", WithOverlay(true))
+		mountpoint := NewMountPoint("", target, "", unix.MS_I_VERSION, "", WithFlags(Overlay))
 		mountpoints.Set(target, mountpoint)
 	}
 

--- a/internal/pkg/mount/squashfs.go
+++ b/internal/pkg/mount/squashfs.go
@@ -21,7 +21,7 @@ func SquashfsMountPoints(prefix string) (mountpoints *Points, err error) {
 	}
 
 	squashfs := NewMountPoints()
-	squashfs.Set("squashfs", NewMountPoint(dev.Path(), "/", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithReadOnly(true), WithShared(true)))
+	squashfs.Set("squashfs", NewMountPoint(dev.Path(), "/", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithFlags(ReadOnly|Shared)))
 
 	return squashfs, nil
 }

--- a/internal/pkg/partition/constants.go
+++ b/internal/pkg/partition/constants.go
@@ -2,18 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package install
+package partition
 
-// PartitionType in partition table.
-type PartitionType = string
+// Type in partition table.
+type Type = string
 
 // GPT partition types.
 //
 // TODO: should be moved into the blockdevice library.
 const (
-	EFISystemPartition  PartitionType = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-	BIOSBootPartition   PartitionType = "21686148-6449-6E6F-744E-656564454649"
-	LinuxFilesystemData PartitionType = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+	EFISystemPartition  Type = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+	BIOSBootPartition   Type = "21686148-6449-6E6F-744E-656564454649"
+	LinuxFilesystemData Type = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
 )
 
 // FileSystemType is used to format partitions.

--- a/internal/pkg/partition/format.go
+++ b/internal/pkg/partition/format.go
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package partition provides common utils for system partition format.
+package partition
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/talos-systems/go-blockdevice/blockdevice"
+
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/makefs"
+)
+
+// FormatOptions contains format parameters.
+type FormatOptions struct {
+	Label          string
+	PartitionType  Type
+	FileSystemType FileSystemType
+	Size           uint64
+	Force          bool
+}
+
+// NewFormatOptions creates a new format options.
+func NewFormatOptions(label string) *FormatOptions {
+	opts, ok := systemPartitions[label]
+	if ok {
+		return &opts
+	}
+
+	return nil
+}
+
+// Format zeroes the device and formats it using filesystem type provided.
+func Format(devname string, t *FormatOptions) error {
+	if t.FileSystemType == FilesystemTypeNone {
+		return zeroPartition(devname, int64(t.Size))
+	}
+
+	opts := []makefs.Option{makefs.WithForce(t.Force), makefs.WithLabel(t.Label)}
+	log.Printf("formatting the partition %q as %q with label %q\n", devname, t.FileSystemType, t.Label)
+
+	switch t.FileSystemType {
+	case FilesystemTypeVFAT:
+		return makefs.VFAT(devname, opts...)
+	case FilesystemTypeXFS:
+		return makefs.XFS(devname, opts...)
+	default:
+		return fmt.Errorf("unsupported filesystem type: %q", t.FileSystemType)
+	}
+}
+
+// zeroPartition fills the partition with zeroes.
+func zeroPartition(devname string, size int64) (err error) {
+	log.Printf("zeroing out %q", devname)
+
+	zeroes, err := os.Open("/dev/zero")
+	if err != nil {
+		return err
+	}
+
+	defer zeroes.Close() //nolint: errcheck
+
+	part, err := os.OpenFile(devname, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+
+	defer part.Close() //nolint: errcheck
+
+	// wipe at least minimal header size
+	if size == 0 {
+		size = blockdevice.FastWipeRange
+	}
+
+	_, err = io.CopyN(part, zeroes, size)
+
+	return err
+}
+
+var systemPartitions = map[string]FormatOptions{
+	constants.EFIPartitionLabel: {
+		Label:          constants.EFIPartitionLabel,
+		PartitionType:  EFISystemPartition,
+		FileSystemType: FilesystemTypeVFAT,
+		Size:           EFISize,
+		Force:          true,
+	},
+	constants.BIOSGrubPartitionLabel: {
+		Label:          constants.BIOSGrubPartitionLabel,
+		PartitionType:  BIOSBootPartition,
+		FileSystemType: FilesystemTypeNone,
+		Size:           BIOSGrubSize,
+		Force:          true,
+	},
+	constants.BootPartitionLabel: {
+		Label:          constants.BootPartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeXFS,
+		Size:           BootSize,
+		Force:          true,
+	},
+	constants.MetaPartitionLabel: {
+		Label:          constants.MetaPartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeNone,
+		Size:           MetaSize,
+		Force:          true,
+	},
+	constants.StatePartitionLabel: {
+		Label:          constants.StatePartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeXFS,
+		Size:           StateSize,
+		Force:          true,
+	},
+	constants.EphemeralPartitionLabel: {
+		Label:          constants.EphemeralPartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeXFS,
+		Size:           0,
+		Force:          true,
+	},
+}

--- a/internal/pkg/partition/partition.go
+++ b/internal/pkg/partition/partition.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package partition provides common utils for system partition format.
+package partition

--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -41,7 +41,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		func(cluster ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
 				return ApidReadyAssertion(ctx, cluster)
-			}, 2*time.Minute, 5*time.Second)
+			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for kubelet to be healthy on all
 		func(cluster ClusterInfo) conditions.Condition {

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -45,6 +45,7 @@ type MachineConfig interface {
 	Kubelet() Kubelet
 	Sysctls() map[string]string
 	Registries() Registries
+	SystemDiskEncryption() SystemDiskEncryption
 }
 
 // Disk represents the options available for partitioning, formatting, and
@@ -341,4 +342,32 @@ type CoreDNS interface {
 // AdminKubeconfig defines settings for admin kubeconfig.
 type AdminKubeconfig interface {
 	CertLifetime() time.Duration
+}
+
+// EncryptionKey defines settings for the partition encryption key handling.
+type EncryptionKey interface {
+	Static() EncryptionKeyStatic
+	NodeID() EncryptionKeyNodeID
+	Slot() int
+}
+
+// EncryptionKeyStatic ephemeral encryption key.
+type EncryptionKeyStatic interface {
+	Key() []byte
+}
+
+// EncryptionKeyNodeID deterministically generated encryption key.
+type EncryptionKeyNodeID interface {
+}
+
+// Encryption defines settings for the partition encryption.
+type Encryption interface {
+	Kind() string
+	Cipher() string
+	Keys() []EncryptionKey
+}
+
+// SystemDiskEncryption accumulates settings for all system partitions encryption.
+type SystemDiskEncryption interface {
+	Get(label string) Encryption
 }

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -19,7 +19,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
-// NewConfigBundle returns a new bundle
+// NewConfigBundle returns a new bundle.
 // nolint: gocyclo
 func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 	options := DefaultOptions()

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -80,9 +80,10 @@ type Input struct {
 	NetworkConfig *v1alpha1.NetworkConfig
 	CNIConfig     *v1alpha1.CNIConfig
 
-	RegistryMirrors map[string]*v1alpha1.RegistryMirrorConfig
-	RegistryConfig  map[string]*v1alpha1.RegistryConfig
-	MachineDisks    []*v1alpha1.MachineDisk
+	RegistryMirrors            map[string]*v1alpha1.RegistryMirrorConfig
+	RegistryConfig             map[string]*v1alpha1.RegistryConfig
+	MachineDisks               []*v1alpha1.MachineDisk
+	SystemDiskEncryptionConfig *v1alpha1.SystemDiskEncryptionConfig
 
 	Debug                    bool
 	Persist                  bool
@@ -454,28 +455,29 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 	}
 
 	input = &Input{
-		Certs:                     secrets.Certs,
-		ControlPlaneEndpoint:      endpoint,
-		PodNet:                    []string{podNet},
-		ServiceNet:                []string{serviceNet},
-		ServiceDomain:             options.DNSDomain,
-		ClusterName:               clustername,
-		KubernetesVersion:         kubernetesVersion,
-		Secrets:                   secrets.Secrets,
-		TrustdInfo:                secrets.TrustdInfo,
-		AdditionalSubjectAltNames: additionalSubjectAltNames,
-		AdditionalMachineCertSANs: additionalMachineCertSANs,
-		InstallDisk:               options.InstallDisk,
-		InstallImage:              options.InstallImage,
-		InstallExtraKernelArgs:    options.InstallExtraKernelArgs,
-		NetworkConfig:             options.NetworkConfig,
-		CNIConfig:                 options.CNIConfig,
-		RegistryMirrors:           options.RegistryMirrors,
-		RegistryConfig:            options.RegistryConfig,
-		Debug:                     options.Debug,
-		Persist:                   options.Persist,
-		AllowSchedulingOnMasters:  options.AllowSchedulingOnMasters,
-		MachineDisks:              options.MachineDisks,
+		Certs:                      secrets.Certs,
+		ControlPlaneEndpoint:       endpoint,
+		PodNet:                     []string{podNet},
+		ServiceNet:                 []string{serviceNet},
+		ServiceDomain:              options.DNSDomain,
+		ClusterName:                clustername,
+		KubernetesVersion:          kubernetesVersion,
+		Secrets:                    secrets.Secrets,
+		TrustdInfo:                 secrets.TrustdInfo,
+		AdditionalSubjectAltNames:  additionalSubjectAltNames,
+		AdditionalMachineCertSANs:  additionalMachineCertSANs,
+		InstallDisk:                options.InstallDisk,
+		InstallImage:               options.InstallImage,
+		InstallExtraKernelArgs:     options.InstallExtraKernelArgs,
+		NetworkConfig:              options.NetworkConfig,
+		CNIConfig:                  options.CNIConfig,
+		RegistryMirrors:            options.RegistryMirrors,
+		RegistryConfig:             options.RegistryConfig,
+		Debug:                      options.Debug,
+		Persist:                    options.Persist,
+		AllowSchedulingOnMasters:   options.AllowSchedulingOnMasters,
+		MachineDisks:               options.MachineDisks,
+		SystemDiskEncryptionConfig: options.SystemDiskEncryptionConfig,
 	}
 
 	return input, nil

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -38,7 +38,8 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			RegistryMirrors: in.RegistryMirrors,
 			RegistryConfig:  in.RegistryConfig,
 		},
-		MachineDisks: in.MachineDisks,
+		MachineDisks:                in.MachineDisks,
+		MachineSystemDiskEncryption: in.SystemDiskEncryptionConfig,
 	}
 
 	certSANs := in.GetAPIServerSANs()

--- a/pkg/machinery/config/types/v1alpha1/generate/join.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/join.go
@@ -39,7 +39,8 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 			RegistryMirrors: in.RegistryMirrors,
 			RegistryConfig:  in.RegistryConfig,
 		},
-		MachineDisks: in.MachineDisks,
+		MachineDisks:                in.MachineDisks,
+		MachineSystemDiskEncryption: in.SystemDiskEncryptionConfig,
 	}
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -163,23 +163,33 @@ func WithVersionContract(versionContract *config.VersionContract) GenOption {
 	}
 }
 
+// WithSystemDiskEncryption specifies encryption settings for the system disk partitions.
+func WithSystemDiskEncryption(cfg *v1alpha1.SystemDiskEncryptionConfig) GenOption {
+	return func(o *GenOptions) error {
+		o.SystemDiskEncryptionConfig = cfg
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
-	EndpointList              []string
-	InstallDisk               string
-	InstallImage              string
-	InstallExtraKernelArgs    []string
-	AdditionalSubjectAltNames []string
-	NetworkConfig             *v1alpha1.NetworkConfig
-	CNIConfig                 *v1alpha1.CNIConfig
-	RegistryMirrors           map[string]*v1alpha1.RegistryMirrorConfig
-	RegistryConfig            map[string]*v1alpha1.RegistryConfig
-	DNSDomain                 string
-	Debug                     bool
-	Persist                   bool
-	AllowSchedulingOnMasters  bool
-	MachineDisks              []*v1alpha1.MachineDisk
-	VersionContract           *config.VersionContract
+	EndpointList               []string
+	InstallDisk                string
+	InstallImage               string
+	InstallExtraKernelArgs     []string
+	AdditionalSubjectAltNames  []string
+	NetworkConfig              *v1alpha1.NetworkConfig
+	CNIConfig                  *v1alpha1.CNIConfig
+	RegistryMirrors            map[string]*v1alpha1.RegistryMirrorConfig
+	RegistryConfig             map[string]*v1alpha1.RegistryConfig
+	DNSDomain                  string
+	Debug                      bool
+	Persist                    bool
+	AllowSchedulingOnMasters   bool
+	MachineDisks               []*v1alpha1.MachineDisk
+	VersionContract            *config.VersionContract
+	SystemDiskEncryptionConfig *v1alpha1.SystemDiskEncryptionConfig
 }
 
 // DefaultGenOptions returns default options.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -233,6 +233,15 @@ func (m *MachineConfig) Registries() config.Registries {
 	return &m.MachineRegistries
 }
 
+// SystemDiskEncryption implements the config.Provider interface.
+func (m *MachineConfig) SystemDiskEncryption() config.SystemDiskEncryption {
+	if m.MachineSystemDiskEncryption == nil {
+		return &SystemDiskEncryptionConfig{}
+	}
+
+	return m.MachineSystemDiskEncryption
+}
+
 // Image implements the config.Provider interface.
 func (k *KubeletConfig) Image() string {
 	image := k.KubeletImage
@@ -1178,4 +1187,66 @@ func (p *DiskPartition) Size() uint64 {
 // MountPoint implements the config.Provider interface.
 func (p *DiskPartition) MountPoint() string {
 	return p.DiskMountPoint
+}
+
+// Kind implements the config.Provider interface.
+func (e *EncryptionConfig) Kind() string {
+	return e.EncryptionProvider
+}
+
+// Cipher implements the config.Provider interface.
+func (e *EncryptionConfig) Cipher() string {
+	return e.EncryptionCipher
+}
+
+// Keys implements the config.Provider interface.
+func (e *EncryptionConfig) Keys() []config.EncryptionKey {
+	keys := make([]config.EncryptionKey, len(e.EncryptionKeys))
+
+	for i, key := range e.EncryptionKeys {
+		keys[i] = key
+	}
+
+	return keys
+}
+
+// Static implements the config.Provider interface.
+func (e *EncryptionKey) Static() config.EncryptionKeyStatic {
+	if e.KeyStatic == nil {
+		return nil
+	}
+
+	return e.KeyStatic
+}
+
+// NodeID implements the config.Provider interface.
+func (e *EncryptionKey) NodeID() config.EncryptionKeyNodeID {
+	if e.KeyNodeID == nil {
+		return nil
+	}
+
+	return e.KeyNodeID
+}
+
+// Slot implements the config.Provider interface.
+func (e *EncryptionKey) Slot() int {
+	return e.KeySlot
+}
+
+// Key implements the config.Provider interface.
+func (e *EncryptionKeyStatic) Key() []byte {
+	return []byte(e.KeyData)
+}
+
+// Get implements the config.Provider interface.
+func (e *SystemDiskEncryptionConfig) Get(label string) config.Encryption {
+	if label == constants.EphemeralPartitionLabel {
+		if e.EphemeralPartition == nil {
+			return nil
+		}
+
+		return e.EphemeralPartition
+	}
+
+	return nil
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -198,6 +198,18 @@ var (
 		"net.ipv4.ip_forward": "0",
 	}
 
+	machineSystemDiskEncryptionExample = &SystemDiskEncryptionConfig{
+		EphemeralPartition: &EncryptionConfig{
+			EncryptionProvider: "luks2",
+			EncryptionKeys: []*EncryptionKey{
+				{
+					KeyNodeID: &EncryptionKeyNodeID{},
+					KeySlot:   0,
+				},
+			},
+		},
+	}
+
 	clusterConfigExample = struct {
 		ControlPlane *ControlPlaneConfig   `yaml:"controlPlane"`
 		ClusterName  string                `yaml:"clusterName"`
@@ -533,6 +545,12 @@ type MachineConfig struct {
 	//   examples:
 	//     - value: machineConfigRegistriesExample
 	MachineRegistries RegistriesConfig `yaml:"registries,omitempty"`
+	//   description: |
+	//     Machine system disk encryption configuration.
+	//     Defines each system partition encryption parameters.
+	//   examples:
+	//     - value: machineSystemDiskEncryptionExample
+	MachineSystemDiskEncryption *SystemDiskEncryptionConfig `yaml:"systemDiskEncryption,omitempty"`
 }
 
 // ClusterConfig represents the cluster-wide config values.
@@ -1051,6 +1069,45 @@ type DiskPartition struct {
 	DiskMountPoint string `yaml:"mountpoint,omitempty"`
 }
 
+// EncryptionConfig represents partition encryption settings.
+type EncryptionConfig struct {
+	//   description: >
+	//     Encryption provider to use for the encryption.
+	//   examples:
+	//     - value: '"luks2"'
+	EncryptionProvider string `yaml:"provider"`
+	//   description: >
+	//     Defines the encryption keys generation and storage method.
+	EncryptionKeys []*EncryptionKey `yaml:"keys"`
+	//   description: >
+	//     Cipher kind to use for the encryption.
+	//     Depends on the encryption provider.
+	EncryptionCipher string `yaml:"cipher,omitempty"`
+}
+
+// EncryptionKey represents configuration for disk encryption key.
+type EncryptionKey struct {
+	//   description: >
+	//     Key which value is stored in the configuration file.
+	KeyStatic *EncryptionKeyStatic `yaml:"static,omitempty"`
+	//   description: >
+	//     Deterministically generated key from the node UUID and PartitionLabel.
+	KeyNodeID *EncryptionKeyNodeID `yaml:"nodeID,omitempty"`
+	//   description: >
+	//     Key slot number for luks2 encryption.
+	KeySlot int `yaml:"slot"`
+}
+
+// EncryptionKeyStatic represents throw away key type.
+type EncryptionKeyStatic struct {
+	//   description: >
+	//     Defines the static passphrase value.
+	KeyData string `yaml:"passphrase,omitempty"`
+}
+
+// EncryptionKeyNodeID represents deterministically generated key from the node UUID and PartitionLabel.
+type EncryptionKeyNodeID struct{}
+
 // Env represents a set of environment variables.
 type Env = map[string]string
 
@@ -1395,4 +1452,11 @@ type RegistryTLSConfig struct {
 	//   description: |
 	//     Skip TLS server certificate verification (not recommended).
 	TLSInsecureSkipVerify bool `yaml:"insecureSkipVerify,omitempty"`
+}
+
+// SystemDiskEncryptionConfig specifies system disk partitions encryption settings.
+type SystemDiskEncryptionConfig struct {
+	//   description: |
+	//     Ephemeral partition encryption.
+	EphemeralPartition *EncryptionConfig `yaml:"ephemeral,omitempty"`
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -11,41 +11,46 @@ import (
 )
 
 var (
-	ConfigDoc                  encoder.Doc
-	MachineConfigDoc           encoder.Doc
-	ClusterConfigDoc           encoder.Doc
-	KubeletConfigDoc           encoder.Doc
-	NetworkConfigDoc           encoder.Doc
-	InstallConfigDoc           encoder.Doc
-	TimeConfigDoc              encoder.Doc
-	RegistriesConfigDoc        encoder.Doc
-	PodCheckpointerDoc         encoder.Doc
-	CoreDNSDoc                 encoder.Doc
-	EndpointDoc                encoder.Doc
-	ControlPlaneConfigDoc      encoder.Doc
-	APIServerConfigDoc         encoder.Doc
-	ControllerManagerConfigDoc encoder.Doc
-	ProxyConfigDoc             encoder.Doc
-	SchedulerConfigDoc         encoder.Doc
-	EtcdConfigDoc              encoder.Doc
-	ClusterNetworkConfigDoc    encoder.Doc
-	CNIConfigDoc               encoder.Doc
-	AdminKubeconfigConfigDoc   encoder.Doc
-	MachineDiskDoc             encoder.Doc
-	DiskPartitionDoc           encoder.Doc
-	MachineFileDoc             encoder.Doc
-	ExtraHostDoc               encoder.Doc
-	DeviceDoc                  encoder.Doc
-	DHCPOptionsDoc             encoder.Doc
-	DeviceWireguardConfigDoc   encoder.Doc
-	DeviceWireguardPeerDoc     encoder.Doc
-	BondDoc                    encoder.Doc
-	VlanDoc                    encoder.Doc
-	RouteDoc                   encoder.Doc
-	RegistryMirrorConfigDoc    encoder.Doc
-	RegistryConfigDoc          encoder.Doc
-	RegistryAuthConfigDoc      encoder.Doc
-	RegistryTLSConfigDoc       encoder.Doc
+	ConfigDoc                     encoder.Doc
+	MachineConfigDoc              encoder.Doc
+	ClusterConfigDoc              encoder.Doc
+	KubeletConfigDoc              encoder.Doc
+	NetworkConfigDoc              encoder.Doc
+	InstallConfigDoc              encoder.Doc
+	TimeConfigDoc                 encoder.Doc
+	RegistriesConfigDoc           encoder.Doc
+	PodCheckpointerDoc            encoder.Doc
+	CoreDNSDoc                    encoder.Doc
+	EndpointDoc                   encoder.Doc
+	ControlPlaneConfigDoc         encoder.Doc
+	APIServerConfigDoc            encoder.Doc
+	ControllerManagerConfigDoc    encoder.Doc
+	ProxyConfigDoc                encoder.Doc
+	SchedulerConfigDoc            encoder.Doc
+	EtcdConfigDoc                 encoder.Doc
+	ClusterNetworkConfigDoc       encoder.Doc
+	CNIConfigDoc                  encoder.Doc
+	AdminKubeconfigConfigDoc      encoder.Doc
+	MachineDiskDoc                encoder.Doc
+	DiskPartitionDoc              encoder.Doc
+	EncryptionConfigDoc           encoder.Doc
+	EncryptionKeyDoc              encoder.Doc
+	EncryptionKeyStaticDoc        encoder.Doc
+	EncryptionKeyNodeIDDoc        encoder.Doc
+	MachineFileDoc                encoder.Doc
+	ExtraHostDoc                  encoder.Doc
+	DeviceDoc                     encoder.Doc
+	DHCPOptionsDoc                encoder.Doc
+	DeviceWireguardConfigDoc      encoder.Doc
+	DeviceWireguardPeerDoc        encoder.Doc
+	BondDoc                       encoder.Doc
+	VlanDoc                       encoder.Doc
+	RouteDoc                      encoder.Doc
+	RegistryMirrorConfigDoc       encoder.Doc
+	RegistryConfigDoc             encoder.Doc
+	RegistryAuthConfigDoc         encoder.Doc
+	RegistryTLSConfigDoc          encoder.Doc
+	SystemDiskEncryptionConfigDoc encoder.Doc
 )
 
 func init() {
@@ -107,7 +112,7 @@ func init() {
 			FieldName: "machine",
 		},
 	}
-	MachineConfigDoc.Fields = make([]encoder.Doc, 13)
+	MachineConfigDoc.Fields = make([]encoder.Doc, 14)
 	MachineConfigDoc.Fields[0].Name = "type"
 	MachineConfigDoc.Fields[0].Type = "string"
 	MachineConfigDoc.Fields[0].Note = ""
@@ -213,6 +218,13 @@ func init() {
 	MachineConfigDoc.Fields[12].Comments[encoder.LineComment] = "Used to configure the machine's container image registry mirrors."
 
 	MachineConfigDoc.Fields[12].AddExample("", machineConfigRegistriesExample)
+	MachineConfigDoc.Fields[13].Name = "systemDiskEncryption"
+	MachineConfigDoc.Fields[13].Type = "SystemDiskEncryptionConfig"
+	MachineConfigDoc.Fields[13].Note = ""
+	MachineConfigDoc.Fields[13].Description = "Machine system disk encryption configuration.\nDefines each system partition encryption parameters."
+	MachineConfigDoc.Fields[13].Comments[encoder.LineComment] = "Machine system disk encryption configuration."
+
+	MachineConfigDoc.Fields[13].AddExample("", machineSystemDiskEncryptionExample)
 
 	ClusterConfigDoc.Type = "ClusterConfig"
 	ClusterConfigDoc.Comments[encoder.LineComment] = "ClusterConfig represents the cluster-wide config values."
@@ -912,6 +924,87 @@ func init() {
 	DiskPartitionDoc.Fields[1].Description = "Where to mount the partition."
 	DiskPartitionDoc.Fields[1].Comments[encoder.LineComment] = "Where to mount the partition."
 
+	EncryptionConfigDoc.Type = "EncryptionConfig"
+	EncryptionConfigDoc.Comments[encoder.LineComment] = "EncryptionConfig represents partition encryption settings."
+	EncryptionConfigDoc.Description = "EncryptionConfig represents partition encryption settings."
+	EncryptionConfigDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "SystemDiskEncryptionConfig",
+			FieldName: "ephemeral",
+		},
+	}
+	EncryptionConfigDoc.Fields = make([]encoder.Doc, 3)
+	EncryptionConfigDoc.Fields[0].Name = "provider"
+	EncryptionConfigDoc.Fields[0].Type = "string"
+	EncryptionConfigDoc.Fields[0].Note = ""
+	EncryptionConfigDoc.Fields[0].Description = "Encryption provider to use for the encryption."
+	EncryptionConfigDoc.Fields[0].Comments[encoder.LineComment] = "Encryption provider to use for the encryption."
+
+	EncryptionConfigDoc.Fields[0].AddExample("", "luks2")
+	EncryptionConfigDoc.Fields[1].Name = "keys"
+	EncryptionConfigDoc.Fields[1].Type = "[]EncryptionKey"
+	EncryptionConfigDoc.Fields[1].Note = ""
+	EncryptionConfigDoc.Fields[1].Description = "Defines the encryption keys generation and storage method."
+	EncryptionConfigDoc.Fields[1].Comments[encoder.LineComment] = "Defines the encryption keys generation and storage method."
+	EncryptionConfigDoc.Fields[2].Name = "cipher"
+	EncryptionConfigDoc.Fields[2].Type = "string"
+	EncryptionConfigDoc.Fields[2].Note = ""
+	EncryptionConfigDoc.Fields[2].Description = "Cipher kind to use for the encryption. Depends on the encryption provider."
+	EncryptionConfigDoc.Fields[2].Comments[encoder.LineComment] = "Cipher kind to use for the encryption. Depends on the encryption provider."
+
+	EncryptionKeyDoc.Type = "EncryptionKey"
+	EncryptionKeyDoc.Comments[encoder.LineComment] = "EncryptionKey represents configuration for disk encryption key."
+	EncryptionKeyDoc.Description = "EncryptionKey represents configuration for disk encryption key."
+	EncryptionKeyDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "EncryptionConfig",
+			FieldName: "keys",
+		},
+	}
+	EncryptionKeyDoc.Fields = make([]encoder.Doc, 3)
+	EncryptionKeyDoc.Fields[0].Name = "static"
+	EncryptionKeyDoc.Fields[0].Type = "EncryptionKeyStatic"
+	EncryptionKeyDoc.Fields[0].Note = ""
+	EncryptionKeyDoc.Fields[0].Description = "Key which value is stored in the configuration file."
+	EncryptionKeyDoc.Fields[0].Comments[encoder.LineComment] = "Key which value is stored in the configuration file."
+	EncryptionKeyDoc.Fields[1].Name = "nodeID"
+	EncryptionKeyDoc.Fields[1].Type = "EncryptionKeyNodeID"
+	EncryptionKeyDoc.Fields[1].Note = ""
+	EncryptionKeyDoc.Fields[1].Description = "Deterministically generated key from the node UUID and PartitionLabel."
+	EncryptionKeyDoc.Fields[1].Comments[encoder.LineComment] = "Deterministically generated key from the node UUID and PartitionLabel."
+	EncryptionKeyDoc.Fields[2].Name = "slot"
+	EncryptionKeyDoc.Fields[2].Type = "int"
+	EncryptionKeyDoc.Fields[2].Note = ""
+	EncryptionKeyDoc.Fields[2].Description = "Key slot number for luks2 encryption."
+	EncryptionKeyDoc.Fields[2].Comments[encoder.LineComment] = "Key slot number for luks2 encryption."
+
+	EncryptionKeyStaticDoc.Type = "EncryptionKeyStatic"
+	EncryptionKeyStaticDoc.Comments[encoder.LineComment] = "EncryptionKeyStatic represents throw away key type."
+	EncryptionKeyStaticDoc.Description = "EncryptionKeyStatic represents throw away key type."
+	EncryptionKeyStaticDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "EncryptionKey",
+			FieldName: "static",
+		},
+	}
+	EncryptionKeyStaticDoc.Fields = make([]encoder.Doc, 1)
+	EncryptionKeyStaticDoc.Fields[0].Name = "passphrase"
+	EncryptionKeyStaticDoc.Fields[0].Type = "string"
+	EncryptionKeyStaticDoc.Fields[0].Note = ""
+	EncryptionKeyStaticDoc.Fields[0].Description = "Defines the static passphrase value."
+	EncryptionKeyStaticDoc.Fields[0].Comments[encoder.LineComment] = "Defines the static passphrase value."
+
+	EncryptionKeyNodeIDDoc.Type = "EncryptionKeyNodeID"
+	EncryptionKeyNodeIDDoc.Comments[encoder.LineComment] = "EncryptionKeyNodeID represents deterministically generated key from the node UUID and PartitionLabel."
+	EncryptionKeyNodeIDDoc.Description = "EncryptionKeyNodeID represents deterministically generated key from the node UUID and PartitionLabel."
+	EncryptionKeyNodeIDDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "EncryptionKey",
+			FieldName: "nodeID",
+		},
+	}
+	EncryptionKeyNodeIDDoc.Fields = make([]encoder.Doc, 0)
+
 	MachineFileDoc.Type = "MachineFile"
 	MachineFileDoc.Comments[encoder.LineComment] = "MachineFile represents a file to write to disk."
 	MachineFileDoc.Description = "MachineFile represents a file to write to disk."
@@ -1473,6 +1566,24 @@ func init() {
 	RegistryTLSConfigDoc.Fields[2].Note = ""
 	RegistryTLSConfigDoc.Fields[2].Description = "Skip TLS server certificate verification (not recommended)."
 	RegistryTLSConfigDoc.Fields[2].Comments[encoder.LineComment] = "Skip TLS server certificate verification (not recommended)."
+
+	SystemDiskEncryptionConfigDoc.Type = "SystemDiskEncryptionConfig"
+	SystemDiskEncryptionConfigDoc.Comments[encoder.LineComment] = "SystemDiskEncryptionConfig specifies system disk partitions encryption settings."
+	SystemDiskEncryptionConfigDoc.Description = "SystemDiskEncryptionConfig specifies system disk partitions encryption settings."
+
+	SystemDiskEncryptionConfigDoc.AddExample("", machineSystemDiskEncryptionExample)
+	SystemDiskEncryptionConfigDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "MachineConfig",
+			FieldName: "systemDiskEncryption",
+		},
+	}
+	SystemDiskEncryptionConfigDoc.Fields = make([]encoder.Doc, 1)
+	SystemDiskEncryptionConfigDoc.Fields[0].Name = "ephemeral"
+	SystemDiskEncryptionConfigDoc.Fields[0].Type = "EncryptionConfig"
+	SystemDiskEncryptionConfigDoc.Fields[0].Note = ""
+	SystemDiskEncryptionConfigDoc.Fields[0].Description = "Ephemeral partition encryption."
+	SystemDiskEncryptionConfigDoc.Fields[0].Comments[encoder.LineComment] = "Ephemeral partition encryption."
 }
 
 func (_ Config) Doc() *encoder.Doc {
@@ -1563,6 +1674,22 @@ func (_ DiskPartition) Doc() *encoder.Doc {
 	return &DiskPartitionDoc
 }
 
+func (_ EncryptionConfig) Doc() *encoder.Doc {
+	return &EncryptionConfigDoc
+}
+
+func (_ EncryptionKey) Doc() *encoder.Doc {
+	return &EncryptionKeyDoc
+}
+
+func (_ EncryptionKeyStatic) Doc() *encoder.Doc {
+	return &EncryptionKeyStaticDoc
+}
+
+func (_ EncryptionKeyNodeID) Doc() *encoder.Doc {
+	return &EncryptionKeyNodeIDDoc
+}
+
 func (_ MachineFile) Doc() *encoder.Doc {
 	return &MachineFileDoc
 }
@@ -1615,6 +1742,10 @@ func (_ RegistryTLSConfig) Doc() *encoder.Doc {
 	return &RegistryTLSConfigDoc
 }
 
+func (_ SystemDiskEncryptionConfig) Doc() *encoder.Doc {
+	return &SystemDiskEncryptionConfigDoc
+}
+
 // GetConfigurationDoc returns documentation for the file ./v1alpha1_types_doc.go.
 func GetConfigurationDoc() *encoder.FileDoc {
 	return &encoder.FileDoc{
@@ -1643,6 +1774,10 @@ func GetConfigurationDoc() *encoder.FileDoc {
 			&AdminKubeconfigConfigDoc,
 			&MachineDiskDoc,
 			&DiskPartitionDoc,
+			&EncryptionConfigDoc,
+			&EncryptionKeyDoc,
+			&EncryptionKeyStaticDoc,
+			&EncryptionKeyNodeIDDoc,
 			&MachineFileDoc,
 			&ExtraHostDoc,
 			&DeviceDoc,
@@ -1656,6 +1791,7 @@ func GetConfigurationDoc() *encoder.FileDoc {
 			&RegistryConfigDoc,
 			&RegistryAuthConfigDoc,
 			&RegistryTLSConfigDoc,
+			&SystemDiskEncryptionConfigDoc,
 		},
 	}
 }

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -88,6 +88,7 @@ talosctl cluster create [flags]
       --disk-image-path string                  disk image to use
       --dns-domain string                       the dns domain to use for cluster (default "cluster.local")
       --docker-host-ip string                   Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
+      --encrypt-ephemeral                       enable ephemeral partition encryption
       --endpoint string                         use endpoint instead of provider defaults
   -p, --exposed-ports string                    Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
   -h, --help                                    help for create

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -658,6 +658,38 @@ registries:
 
 <hr />
 
+<div class="dd">
+
+<code>systemDiskEncryption</code>  <i><a href="#systemdiskencryptionconfig">SystemDiskEncryptionConfig</a></i>
+
+</div>
+<div class="dt">
+
+Machine system disk encryption configuration.
+Defines each system partition encryption parameters.
+
+
+
+Examples:
+
+
+``` yaml
+systemDiskEncryption:
+    # Ephemeral partition encryption.
+    ephemeral:
+        provider: luks2 # Encryption provider to use for the encryption.
+        # Defines the encryption keys generation and storage method.
+        keys:
+            - # Deterministically generated key from the node UUID and PartitionLabel.
+              nodeID: {}
+              slot: 0 # Key slot number for luks2 encryption.
+```
+
+
+</div>
+
+<hr />
+
 
 
 
@@ -2693,6 +2725,167 @@ Where to mount the partition.
 
 
 
+## EncryptionConfig
+EncryptionConfig represents partition encryption settings.
+
+Appears in:
+
+
+- <code><a href="#systemdiskencryptionconfig">SystemDiskEncryptionConfig</a>.ephemeral</code>
+
+
+
+<hr />
+
+<div class="dd">
+
+<code>provider</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Encryption provider to use for the encryption.
+
+
+
+Examples:
+
+
+``` yaml
+provider: luks2
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>keys</code>  <i>[]<a href="#encryptionkey">EncryptionKey</a></i>
+
+</div>
+<div class="dt">
+
+Defines the encryption keys generation and storage method.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>cipher</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Cipher kind to use for the encryption. Depends on the encryption provider.
+
+</div>
+
+<hr />
+
+
+
+
+
+## EncryptionKey
+EncryptionKey represents configuration for disk encryption key.
+
+Appears in:
+
+
+- <code><a href="#encryptionconfig">EncryptionConfig</a>.keys</code>
+
+
+
+<hr />
+
+<div class="dd">
+
+<code>static</code>  <i><a href="#encryptionkeystatic">EncryptionKeyStatic</a></i>
+
+</div>
+<div class="dt">
+
+Key which value is stored in the configuration file.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>nodeID</code>  <i><a href="#encryptionkeynodeid">EncryptionKeyNodeID</a></i>
+
+</div>
+<div class="dt">
+
+Deterministically generated key from the node UUID and PartitionLabel.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>slot</code>  <i>int</i>
+
+</div>
+<div class="dt">
+
+Key slot number for luks2 encryption.
+
+</div>
+
+<hr />
+
+
+
+
+
+## EncryptionKeyStatic
+EncryptionKeyStatic represents throw away key type.
+
+Appears in:
+
+
+- <code><a href="#encryptionkey">EncryptionKey</a>.static</code>
+
+
+
+<hr />
+
+<div class="dd">
+
+<code>passphrase</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Defines the static passphrase value.
+
+</div>
+
+<hr />
+
+
+
+
+
+## EncryptionKeyNodeID
+EncryptionKeyNodeID represents deterministically generated key from the node UUID and PartitionLabel.
+
+Appears in:
+
+
+- <code><a href="#encryptionkey">EncryptionKey</a>.nodeID</code>
+
+
+
+
+
 ## MachineFile
 MachineFile represents a file to write to disk.
 
@@ -4191,6 +4384,45 @@ Certificate should be base64-encoded.
 <div class="dt">
 
 Skip TLS server certificate verification (not recommended).
+
+</div>
+
+<hr />
+
+
+
+
+
+## SystemDiskEncryptionConfig
+SystemDiskEncryptionConfig specifies system disk partitions encryption settings.
+
+Appears in:
+
+
+- <code><a href="#machineconfig">MachineConfig</a>.systemDiskEncryption</code>
+
+
+``` yaml
+# Ephemeral partition encryption.
+ephemeral:
+    provider: luks2 # Encryption provider to use for the encryption.
+    # Defines the encryption keys generation and storage method.
+    keys:
+        - # Deterministically generated key from the node UUID and PartitionLabel.
+          nodeID: {}
+          slot: 0 # Key slot number for luks2 encryption.
+```
+
+<hr />
+
+<div class="dd">
+
+<code>ephemeral</code>  <i><a href="#encryptionconfig">EncryptionConfig</a></i>
+
+</div>
+<div class="dt">
+
+Ephemeral partition encryption.
 
 </div>
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3106

This PR introduces the first part of disk encryption support.
New config section `systemDiskEncryption` was added into MachineConfig.
For now it contains only Ephemeral partition encryption.

Encryption itself supports two kinds of keys for now:
- generated which can be generated from a template.
- static key, which is hardcoded into the config (mainly for test purposes).

Talosctl cluster create can now be told to encrypt ephemeral partition
by using `--encrypt-ephemeral` flag.

Additionally:
- updated pkgs library version.
- changed Dockefile to copy cryptsetup deps from pkgs.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>