### PR TITLE
feat: implement IPv6 DHCP client in networkd

### DIFF
--- a/internal/app/networkd/pkg/address/dhcp6.go
+++ b/internal/app/networkd/pkg/address/dhcp6.go
@@ -1,0 +1,203 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package address
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/insomniacslk/dhcp/dhcpv6"
+	"github.com/insomniacslk/dhcp/dhcpv6/nclient6"
+	"github.com/jsimonetti/rtnetlink"
+	"github.com/talos-systems/go-retry/retry"
+	"golang.org/x/sys/unix"
+)
+
+// DHCP6 implements the Addressing interface.
+type DHCP6 struct {
+	Reply *dhcpv6.Message
+	NetIf *net.Interface
+	Mtu   int
+}
+
+// Name returns back the name of the address method.
+func (d *DHCP6) Name() string {
+	return "dhcp6"
+}
+
+// Link returns the underlying net.Interface that this address
+// method is configured for.
+func (d *DHCP6) Link() *net.Interface {
+	return d.NetIf
+}
+
+// Discover handles the DHCP client exchange stores the DHCP Ack.
+func (d *DHCP6) Discover(ctx context.Context, link *net.Interface) error {
+	d.NetIf = link
+	err := d.discover(ctx)
+
+	return err
+}
+
+// Address returns back the IP address from the received DHCP offer.
+func (d *DHCP6) Address() *net.IPNet {
+	if d.Reply.Options.OneIANA() == nil {
+		return nil
+	}
+
+	return &net.IPNet{
+		IP:   d.Reply.Options.OneIANA().Options.OneAddress().IPv6Addr,
+		Mask: net.CIDRMask(128, 128),
+	}
+}
+
+// Mask returns the netmask from the DHCP offer.
+func (d *DHCP6) Mask() net.IPMask {
+	return net.CIDRMask(128, 128)
+}
+
+// MTU returs the MTU size from the DHCP offer.
+func (d *DHCP6) MTU() uint32 {
+	if d.Mtu > 0 {
+		return uint32(d.Mtu)
+	}
+
+	return uint32(d.NetIf.MTU)
+}
+
+// TTL denotes how long a DHCP offer is valid for.
+func (d *DHCP6) TTL() time.Duration {
+	if d.Reply == nil {
+		return 0
+	}
+
+	return d.Reply.Options.OneIANA().Options.OneAddress().ValidLifetime
+}
+
+// Family qualifies the address as ipv4 or ipv6.
+func (d *DHCP6) Family() int {
+	return unix.AF_INET6
+}
+
+// Scope sets the address scope.
+func (d *DHCP6) Scope() uint8 {
+	return unix.RT_SCOPE_UNIVERSE
+}
+
+// Valid denotes if this address method should be used.
+func (d *DHCP6) Valid() bool {
+	return d.Reply != nil && d.Reply.Options.OneIANA() != nil
+}
+
+// Routes is not supported on IPv6.
+func (d *DHCP6) Routes() (routes []*Route) {
+	return nil
+}
+
+// Resolvers returns the DNS resolvers from the DHCP offer.
+func (d *DHCP6) Resolvers() []net.IP {
+	return d.Reply.Options.DNS()
+}
+
+// Hostname returns the hostname from the DHCP offer.
+func (d *DHCP6) Hostname() (hostname string) {
+	fqdn := d.Reply.Options.FQDN()
+
+	if fqdn != nil && fqdn.DomainName != nil {
+		hostname = strings.Join(fqdn.DomainName.Labels, ".")
+	} else {
+		hostname = fmt.Sprintf("%s-%s", "talos", strings.ReplaceAll(d.Address().IP.String(), ":", ""))
+	}
+
+	return hostname
+}
+
+// discover handles the actual DHCP conversation.
+func (d *DHCP6) discover(ctx context.Context) error {
+	if err := waitIPv6LinkReady(d.NetIf); err != nil {
+		log.Printf("failed waiting for IPv6 readiness: %s", err)
+
+		return err
+	}
+
+	cli, err := nclient6.New(d.NetIf.Name)
+	if err != nil {
+		log.Printf("failed to create dhcp6 client: %s", err)
+
+		return err
+	}
+
+	// nolint: errcheck
+	defer cli.Close()
+
+	reply, err := cli.RapidSolicit(ctx)
+	if err != nil {
+		// TODO: Make this a well defined error so we can make it not fatal
+		log.Printf("failed dhcp6 request for %q: %v", d.NetIf.Name, err)
+
+		return err
+	}
+
+	log.Printf("DHCP6 REPLY on %q: %s", d.NetIf.Name, collapseSummary(reply.Summary()))
+
+	d.Reply = reply
+
+	return nil
+}
+
+func waitIPv6LinkReady(iface *net.Interface) error {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+
+	defer conn.Close() //nolint: errcheck
+
+	return retry.Constant(30*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(func() error {
+		ready, err := isIPv6LinkReady(iface, conn)
+		if err != nil {
+			return retry.UnexpectedError(err)
+		}
+
+		if !ready {
+			return retry.ExpectedError(fmt.Errorf("IPv6 address is still tentative"))
+		}
+
+		return nil
+	})
+}
+
+// isIPv6LinkReady returns true if the interface has a link-local address
+// which is not tentative.
+func isIPv6LinkReady(iface *net.Interface, conn *rtnetlink.Conn) (bool, error) {
+	addrs, err := conn.Address.List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, addr := range addrs {
+		if addr.Index != uint32(iface.Index) {
+			continue
+		}
+
+		if addr.Family != unix.AF_INET6 {
+			continue
+		}
+
+		if addr.Attributes.Address.IsLinkLocalUnicast() && (addr.Flags&unix.IFA_F_TENTATIVE == 0) {
+			if addr.Flags&unix.IFA_F_DADFAILED != 0 {
+				log.Printf("DADFAILED for %v, continuing anyhow", addr.Attributes.Address)
+			}
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/internal/app/networkd/pkg/networkd/netconf.go
+++ b/internal/app/networkd/pkg/networkd/netconf.go
@@ -47,8 +47,15 @@ func buildOptions(device config.Device, hostname string) (name string, opts []ni
 
 		opts = append(opts, nic.WithAddressing(s))
 	case device.DHCP():
-		d := &address.DHCP{DHCPOptions: device.DHCPOptions(), RouteList: device.Routes(), Mtu: device.MTU()}
-		opts = append(opts, nic.WithAddressing(d))
+		if device.DHCPOptions().IPv4() {
+			d := &address.DHCP4{DHCPOptions: device.DHCPOptions(), RouteList: device.Routes(), Mtu: device.MTU()}
+			opts = append(opts, nic.WithAddressing(d))
+		}
+
+		if device.DHCPOptions().IPv6() {
+			d := &address.DHCP6{Mtu: device.MTU()}
+			opts = append(opts, nic.WithAddressing(d))
+		}
 	default:
 		// Allow master interface without any addressing if VLANs exist
 		if len(device.Vlans()) > 0 {

--- a/internal/app/networkd/pkg/networkd/networkd_test.go
+++ b/internal/app/networkd/pkg/networkd/networkd_test.go
@@ -110,7 +110,7 @@ func (suite *NetworkdSuite) TestHostname() {
 	suite.Require().NoError(err)
 
 	nwd.Interfaces["eth0"].AddressMethod = []address.Addressing{
-		&address.DHCP{
+		&address.DHCP4{
 			Ack: &dhcpv4.DHCPv4{
 				YourIPAddr: net.ParseIP("192.168.0.11"),
 				Options: dhcpv4.Options{
@@ -131,7 +131,7 @@ func (suite *NetworkdSuite) TestHostname() {
 	suite.Require().NoError(err)
 
 	nwd.Interfaces["eth0"].AddressMethod = []address.Addressing{
-		&address.DHCP{
+		&address.DHCP4{
 			Ack: &dhcpv4.DHCPv4{
 				YourIPAddr: net.ParseIP("192.168.0.11"),
 				Options: dhcpv4.Options{
@@ -148,7 +148,7 @@ func (suite *NetworkdSuite) TestHostname() {
 
 	// DHCP without OptionHostname and with OptionDomainName
 	nwd.Interfaces["eth0"].AddressMethod = []address.Addressing{
-		&address.DHCP{
+		&address.DHCP4{
 			Ack: &dhcpv4.DHCPv4{
 				YourIPAddr: net.ParseIP("192.168.0.11"),
 				Options: dhcpv4.Options{

--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -80,7 +80,7 @@ func New(setters ...Option) (*NetworkInterface, error) {
 	// If no addressing methods have been configured, default to DHCP.
 	// If VLANs exist do not force DHCP on master device
 	if len(iface.AddressMethod) == 0 && len(iface.Vlans) == 0 {
-		iface.AddressMethod = append(iface.AddressMethod, &address.DHCP{})
+		iface.AddressMethod = append(iface.AddressMethod, &address.DHCP4{}) // TODO: enable DHCPv6 by default?
 	}
 
 	// Handle netlink connection

--- a/internal/app/networkd/pkg/nic/vlan_options.go
+++ b/internal/app/networkd/pkg/nic/vlan_options.go
@@ -49,7 +49,7 @@ func WithVlanDhcp(id uint16) Option {
 	return func(n *NetworkInterface) (err error) {
 		for _, vlan := range n.Vlans {
 			if vlan.ID == id {
-				vlan.AddressMethod = append(vlan.AddressMethod, &address.DHCP{})
+				vlan.AddressMethod = append(vlan.AddressMethod, &address.DHCP4{}) // TODO: should we enable DHCP6 by default?
 
 				return nil
 			}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -122,6 +122,8 @@ type Device interface {
 // DHCPOptions represents a set of DHCP options.
 type DHCPOptions interface {
 	RouteMetric() uint32
+	IPv4() bool
+	IPv6() bool
 }
 
 // WireguardConfig contains settings for configuring Wireguard network interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -821,9 +821,27 @@ func (d *Device) WireguardConfig() config.WireguardConfig {
 	return d.DeviceWireguardConfig
 }
 
-// RouteMetric implements the MachineNetwork interface.
+// RouteMetric implements the DHCPOptions interface.
 func (d *DHCPOptions) RouteMetric() uint32 {
 	return d.DHCPRouteMetric
+}
+
+// IPv4 implements the DHCPOptions interface.
+func (d *DHCPOptions) IPv4() bool {
+	if d.DHCPIPv4 == nil {
+		return true
+	}
+
+	return *d.DHCPIPv4
+}
+
+// IPv6 implements the DHCPOptions interface.
+func (d *DHCPOptions) IPv6() bool {
+	if d.DHCPIPv6 == nil {
+		return false
+	}
+
+	return *d.DHCPIPv6
 }
 
 // PrivateKey implements the MachineNetwork interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1169,6 +1169,10 @@ type Device struct {
 type DHCPOptions struct {
 	//   description: The priority of all routes received via DHCP.
 	DHCPRouteMetric uint32 `yaml:"routeMetric"`
+	//   description: Enables DHCPv4 protocol for the interface (default is enabled).
+	DHCPIPv4 *bool `yaml:"ipv4,omitempty"`
+	//   description: Enables DHCPv6 protocol for the interface (default is disabled).
+	DHCPIPv6 *bool `yaml:"ipv6,omitempty"`
 }
 
 // DeviceWireguardConfig contains settings for configuring Wireguard network interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -1068,12 +1068,22 @@ func init() {
 			FieldName: "dhcpOptions",
 		},
 	}
-	DHCPOptionsDoc.Fields = make([]encoder.Doc, 1)
+	DHCPOptionsDoc.Fields = make([]encoder.Doc, 3)
 	DHCPOptionsDoc.Fields[0].Name = "routeMetric"
 	DHCPOptionsDoc.Fields[0].Type = "uint32"
 	DHCPOptionsDoc.Fields[0].Note = ""
 	DHCPOptionsDoc.Fields[0].Description = "The priority of all routes received via DHCP."
 	DHCPOptionsDoc.Fields[0].Comments[encoder.LineComment] = "The priority of all routes received via DHCP."
+	DHCPOptionsDoc.Fields[1].Name = "ipv4"
+	DHCPOptionsDoc.Fields[1].Type = "bool"
+	DHCPOptionsDoc.Fields[1].Note = ""
+	DHCPOptionsDoc.Fields[1].Description = "Enables DHCPv4 protocol for the interface (default is enabled)."
+	DHCPOptionsDoc.Fields[1].Comments[encoder.LineComment] = "Enables DHCPv4 protocol for the interface (default is enabled)."
+	DHCPOptionsDoc.Fields[2].Name = "ipv6"
+	DHCPOptionsDoc.Fields[2].Type = "bool"
+	DHCPOptionsDoc.Fields[2].Note = ""
+	DHCPOptionsDoc.Fields[2].Description = "Enables DHCPv6 protocol for the interface (default is disabled)."
+	DHCPOptionsDoc.Fields[2].Comments[encoder.LineComment] = "Enables DHCPv6 protocol for the interface (default is disabled)."
 
 	DeviceWireguardConfigDoc.Type = "DeviceWireguardConfig"
 	DeviceWireguardConfigDoc.Comments[encoder.LineComment] = "DeviceWireguardConfig contains settings for configuring Wireguard network interface."

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -3186,6 +3186,32 @@ The priority of all routes received via DHCP.
 
 <hr />
 
+<div class="dd">
+
+<code>ipv4</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Enables DHCPv4 protocol for the interface (default is enabled).
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>ipv6</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Enables DHCPv6 protocol for the interface (default is disabled).
+
+</div>
+
+<hr />
+
 
 
 


### PR DESCRIPTION
This renames existing 'DHCP' implementation to `DHCP4`, new client is
`DHCP6`.

For now, `DHCP6` is disabled by default and should be explicitly enabled
with the config.

QEMU testbed for IPv6 is going to be pushed as separate PR.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

