### PR TITLE
fix: prefer configured nameservers, fix DHCP6 in container

### DIFF
--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -115,6 +115,7 @@ func (n *Networkd) Runner(r runtime.Runtime) (runner.Runner, error) {
 				strings.ToUpper("CAP_" + capability.CAP_NET_ADMIN.String()),
 				strings.ToUpper("CAP_" + capability.CAP_SYS_ADMIN.String()),
 				strings.ToUpper("CAP_" + capability.CAP_NET_RAW.String()),
+				strings.ToUpper("CAP_" + capability.CAP_NET_BIND_SERVICE.String()),
 			}),
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),


### PR DESCRIPTION
Always prefer explicitly configured nameservers,
networkd was missing capability to bind address for DHCP6.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

