### PR TITLE
fix: allow loading of empty config files

### DIFF
--- a/pkg/machinery/client/config/config.go
+++ b/pkg/machinery/client/config/config.go
@@ -123,6 +123,10 @@ func (r *Rename) String() string {
 //
 // Current context is overridden from passed in config.
 func (c *Config) Merge(cfg *Config) []Rename {
+	if c.Contexts == nil {
+		c.Contexts = map[string]*Context{}
+	}
+
 	mappedContexts := map[string]string{}
 	renames := []Rename{}
 

--- a/pkg/machinery/client/config/config_test.go
+++ b/pkg/machinery/client/config/config_test.go
@@ -25,10 +25,8 @@ func TestConfigMerge(t *testing.T) {
 		expectedContexts map[string]*config.Context
 	}{
 		{
-			name: "IntoEmpty",
-			config: &config.Config{
-				Contexts: map[string]*config.Context{},
-			},
+			name:   "IntoEmpty",
+			config: &config.Config{},
 			configToMerge: &config.Config{
 				Context: "foo",
 				Contexts: map[string]*config.Context{


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

fix: allow loading of empty config files

## Why? (reasoning)

Fixes #3113.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
