### PR TITLE
fix: set hdmi_safe=1 on Raspberry Pi for maximum HDMI compatibility

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
@@ -6,6 +6,7 @@ package rpi4
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/talos-systems/go-procfs/procfs"
 
@@ -14,11 +15,16 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
-var configTxt = []byte(`arm_64bit=1
+// https://www.raspberrypi.org/documentation/configuration/config-txt/
+var configTxt = []byte(strings.TrimSpace(`
+
+arm_64bit=1
 enable_uart=1
 kernel=u-boot.bin
 dtoverlay=disable-bt
-`)
+hdmi_safe=1
+
+` + "\n"))
 
 // RPi4 represents the Raspberry Pi 4 Model B.
 //


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

fix: set hdmi_safe=1 on Raspberry Pi for maximum HDMI compatibility

Setting hdmi_safe to 1 will lead to "safe mode" settings being used to try to boot with
maximum HDMI compatibility.
See https://www.raspberrypi.org/documentation/configuration/config-txt/video.md

## Why? (reasoning)

My Raspberry Pi 4 8GB does boot without it.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
