### PR TITLE
fix: mount kubelet secrets from system instead of ephemeral

### DIFF
--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -181,8 +181,11 @@ const (
 	// KubeletPort is the kubelet port for secure API.
 	KubeletPort = 10250
 
-	// KubeletPKIDir is the path to the directory where kubelet stores issues certificates and keys.
+	// KubeletPKIDir is the path to the directory where kubelet stores issued certificates and keys.
 	KubeletPKIDir = "/var/lib/kubelet/pki"
+
+	// SystemKubeletPKIDir is the path to the directory where Talos copies kubelet issued certificates and keys.
+	SystemKubeletPKIDir = "/system/secrets/kubelet"
 
 	// DefaultKubernetesVersion is the default target version of the control plane.
 	DefaultKubernetesVersion = "1.20.2"


### PR DESCRIPTION
Launch goroutine that copies kubelet pki folder contents into
`/system/secrets/kubelet` every minute before starting apid container
when running on the worker node.

Mounting kubelet secrets directly from `/var/lib/kubelet/pki` breaks
upgrade flow, because we are not able to unmount ephemeral partition,
which is being used by apid, which is not stopped during the upgrade.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>