### PR TITLE
fix: set proper hostname on docker nodes

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/container/container.go
@@ -5,8 +5,10 @@
 package container
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -44,7 +46,13 @@ func (c *Container) Configuration(context.Context) ([]byte, error) {
 
 // Hostname implements the platform.Platform interface.
 func (c *Container) Hostname(context.Context) (hostname []byte, err error) {
-	return nil, nil
+	hostname, err = ioutil.ReadFile("/etc/hostname")
+
+	if err == nil {
+		hostname = bytes.TrimSpace(hostname)
+	}
+
+	return
 }
 
 // Mode implements the platform.Platform interface.

--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -84,6 +84,12 @@ func (n *Networkd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: filepath.Dir(constants.NetworkSocketPath), Source: filepath.Dir(constants.NetworkSocketPath), Options: []string{"rbind", "rw"}},
 	}
 
+	if r.State().Platform().Mode() == runtime.ModeContainer {
+		mounts = append(mounts,
+			specs.Mount{Type: "bind", Destination: "/etc/hostname", Source: "/etc/hostname", Options: []string{"rbind", "ro"}},
+		)
+	}
+
 	env := []string{}
 	for key, val := range r.Config().Machine().Env() {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))


### PR DESCRIPTION
Before this change, every node had `os.Hostname()` of `talos-127-0-1-1`
which breaks resolving node hostname into the IP address (used in new
controller-runtime to fetch kubelet pod status).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

