### PR TITLE
docs: fix typos

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -121,7 +121,7 @@ var (
 	machineKubeletExample = &KubeletConfig{
 		KubeletImage: (&KubeletConfig{}).Image(),
 		KubeletExtraArgs: map[string]string{
-			"--feature-gates": "ServerSideApply=true",
+			"feature-gates": "ServerSideApply=true",
 		},
 	}
 
@@ -230,8 +230,8 @@ var (
 	clusterAPIServerExample = &APIServerConfig{
 		ContainerImage: (&APIServerConfig{}).Image(),
 		ExtraArgsConfig: map[string]string{
-			"--feature-gates":                    "ServerSideApply=true",
-			"--http2-max-streams-per-connection": "32",
+			"feature-gates":                    "ServerSideApply=true",
+			"http2-max-streams-per-connection": "32",
 		},
 		CertSANs: []string{
 			"1.2.3.4",
@@ -244,7 +244,7 @@ var (
 	clusterControllerManagerExample = &ControllerManagerConfig{
 		ContainerImage: (&ControllerManagerConfig{}).Image(),
 		ExtraArgsConfig: map[string]string{
-			"--feature-gates": "ServerSideApply=true",
+			"feature-gates": "ServerSideApply=true",
 		},
 	}
 
@@ -253,7 +253,7 @@ var (
 	clusterProxyExample = &ProxyConfig{
 		ContainerImage: (&ProxyConfig{}).Image(),
 		ExtraArgsConfig: map[string]string{
-			"--proxy-mode": "iptables",
+			"proxy-mode": "iptables",
 		},
 		ModeConfig: "ipvs",
 	}
@@ -263,7 +263,7 @@ var (
 	clusterSchedulerExample = &SchedulerConfig{
 		ContainerImage: (&SchedulerConfig{}).Image(),
 		ExtraArgsConfig: map[string]string{
-			"--feature-gates": "AllBeta=true",
+			"feature-gates": "AllBeta=true",
 		},
 	}
 
@@ -272,7 +272,7 @@ var (
 	clusterEtcdExample = &EtcdConfig{
 		ContainerImage: (&EtcdConfig{}).Image(),
 		EtcdExtraArgs: map[string]string{
-			"--election-timeout": "5000",
+			"election-timeout": "5000",
 		},
 		RootCA: pemEncodedCertificateExample,
 	}

--- a/website/content/docs/v0.8/Guides/advanced-networking.md
+++ b/website/content/docs/v0.8/Guides/advanced-networking.md
@@ -13,9 +13,6 @@ machine:
     hostname: talos
     nameservers:
       - 10.0.0.1
-    time:
-      servers:
-        - time.cloudflare.com
     interfaces:
       - interface: eth0
         cidr: 10.0.0.201/8
@@ -25,6 +22,9 @@ machine:
             gateway: 10.0.0.1
       - interface: eth1
         ignore: true
+  time:
+    servers:
+      - time.cloudflare.com
 ```
 
 ## Additional Addresses for an Interface

--- a/website/content/docs/v0.8/Reference/configuration.md
+++ b/website/content/docs/v0.8/Reference/configuration.md
@@ -292,7 +292,7 @@ kubelet:
     image: ghcr.io/talos-systems/kubelet:v1.20.1 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
-        --feature-gates: ServerSideApply=true
+        feature-gates: ServerSideApply=true
 
     # # The `extraMounts` field is used to add additional mounts to the kubelet container.
     # extraMounts:
@@ -829,8 +829,8 @@ apiServer:
     image: k8s.gcr.io/kube-apiserver-amd64:v1.20.1 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
-        --feature-gates: ServerSideApply=true
-        --http2-max-streams-per-connection: "32"
+        feature-gates: ServerSideApply=true
+        http2-max-streams-per-connection: "32"
     # Extra certificate subject alternative names for the API server's certificate.
     certSANs:
         - 1.2.3.4
@@ -861,7 +861,7 @@ controllerManager:
     image: k8s.gcr.io/kube-controller-manager-amd64:v1.20.1 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
-        --feature-gates: ServerSideApply=true
+        feature-gates: ServerSideApply=true
 ```
 
 
@@ -889,7 +889,7 @@ proxy:
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
-        --proxy-mode: iptables
+        proxy-mode: iptables
 ```
 
 
@@ -916,7 +916,7 @@ scheduler:
     image: k8s.gcr.io/kube-scheduler-amd64:v1.20.1 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
-        --feature-gates: AllBeta=true
+        feature-gates: AllBeta=true
 ```
 
 
@@ -947,7 +947,7 @@ etcd:
         key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
     # Extra arguments to supply to etcd.
     extraArgs:
-        --election-timeout: "5000"
+        election-timeout: "5000"
 ```
 
 
@@ -1120,7 +1120,7 @@ Appears in:
 image: ghcr.io/talos-systems/kubelet:v1.20.1 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
-    --feature-gates: ServerSideApply=true
+    feature-gates: ServerSideApply=true
 
 # # The `extraMounts` field is used to add additional mounts to the kubelet container.
 # extraMounts:
@@ -1862,8 +1862,8 @@ Appears in:
 image: k8s.gcr.io/kube-apiserver-amd64:v1.20.1 # The container image used in the API server manifest.
 # Extra arguments to supply to the API server.
 extraArgs:
-    --feature-gates: ServerSideApply=true
-    --http2-max-streams-per-connection: "32"
+    feature-gates: ServerSideApply=true
+    http2-max-streams-per-connection: "32"
 # Extra certificate subject alternative names for the API server's certificate.
 certSANs:
     - 1.2.3.4
@@ -1938,7 +1938,7 @@ Appears in:
 image: k8s.gcr.io/kube-controller-manager-amd64:v1.20.1 # The container image used in the controller manager manifest.
 # Extra arguments to supply to the controller manager.
 extraArgs:
-    --feature-gates: ServerSideApply=true
+    feature-gates: ServerSideApply=true
 ```
 
 <hr />
@@ -1997,7 +1997,7 @@ image: k8s.gcr.io/kube-proxy-amd64:v1.20.1 # The container image used in the kub
 mode: ipvs # proxy mode of kube-proxy.
 # Extra arguments to supply to kube-proxy.
 extraArgs:
-    --proxy-mode: iptables
+    proxy-mode: iptables
 ```
 
 <hr />
@@ -2069,7 +2069,7 @@ Appears in:
 image: k8s.gcr.io/kube-scheduler-amd64:v1.20.1 # The container image used in the scheduler manifest.
 # Extra arguments to supply to the scheduler.
 extraArgs:
-    --feature-gates: AllBeta=true
+    feature-gates: AllBeta=true
 ```
 
 <hr />
@@ -2131,7 +2131,7 @@ ca:
     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
 # Extra arguments to supply to etcd.
 extraArgs:
-    --election-timeout: "5000"
+    election-timeout: "5000"
 ```
 
 <hr />

--- a/website/content/docs/v0.9/Guides/advanced-networking.md
+++ b/website/content/docs/v0.9/Guides/advanced-networking.md
@@ -13,9 +13,6 @@ machine:
     hostname: talos
     nameservers:
       - 10.0.0.1
-    time:
-      servers:
-        - time.cloudflare.com
     interfaces:
       - interface: eth0
         cidr: 10.0.0.201/8
@@ -25,6 +22,9 @@ machine:
             gateway: 10.0.0.1
       - interface: eth1
         ignore: true
+  time:
+    servers:
+      - time.cloudflare.com
 ```
 
 ## Additional Addresses for an Interface

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -292,7 +292,7 @@ kubelet:
     image: ghcr.io/talos-systems/kubelet:v1.20.2 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
-        --feature-gates: ServerSideApply=true
+        feature-gates: ServerSideApply=true
 
     # # The `extraMounts` field is used to add additional mounts to the kubelet container.
     # extraMounts:
@@ -905,8 +905,8 @@ apiServer:
     image: k8s.gcr.io/kube-apiserver:v1.20.2 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
-        --feature-gates: ServerSideApply=true
-        --http2-max-streams-per-connection: "32"
+        feature-gates: ServerSideApply=true
+        http2-max-streams-per-connection: "32"
     # Extra certificate subject alternative names for the API server's certificate.
     certSANs:
         - 1.2.3.4
@@ -937,7 +937,7 @@ controllerManager:
     image: k8s.gcr.io/kube-controller-manager:v1.20.2 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
-        --feature-gates: ServerSideApply=true
+        feature-gates: ServerSideApply=true
 ```
 
 
@@ -965,7 +965,7 @@ proxy:
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
-        --proxy-mode: iptables
+        proxy-mode: iptables
 ```
 
 
@@ -992,7 +992,7 @@ scheduler:
     image: k8s.gcr.io/kube-scheduler:v1.20.2 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
-        --feature-gates: AllBeta=true
+        feature-gates: AllBeta=true
 ```
 
 
@@ -1023,7 +1023,7 @@ etcd:
         key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
     # Extra arguments to supply to etcd.
     extraArgs:
-        --election-timeout: "5000"
+        election-timeout: "5000"
 ```
 
 
@@ -1196,7 +1196,7 @@ Appears in:
 image: ghcr.io/talos-systems/kubelet:v1.20.2 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
-    --feature-gates: ServerSideApply=true
+    feature-gates: ServerSideApply=true
 
 # # The `extraMounts` field is used to add additional mounts to the kubelet container.
 # extraMounts:
@@ -2013,8 +2013,8 @@ Appears in:
 image: k8s.gcr.io/kube-apiserver:v1.20.2 # The container image used in the API server manifest.
 # Extra arguments to supply to the API server.
 extraArgs:
-    --feature-gates: ServerSideApply=true
-    --http2-max-streams-per-connection: "32"
+    feature-gates: ServerSideApply=true
+    http2-max-streams-per-connection: "32"
 # Extra certificate subject alternative names for the API server's certificate.
 certSANs:
     - 1.2.3.4
@@ -2089,7 +2089,7 @@ Appears in:
 image: k8s.gcr.io/kube-controller-manager:v1.20.2 # The container image used in the controller manager manifest.
 # Extra arguments to supply to the controller manager.
 extraArgs:
-    --feature-gates: ServerSideApply=true
+    feature-gates: ServerSideApply=true
 ```
 
 <hr />
@@ -2148,7 +2148,7 @@ image: k8s.gcr.io/kube-proxy:v1.20.2 # The container image used in the kube-prox
 mode: ipvs # proxy mode of kube-proxy.
 # Extra arguments to supply to kube-proxy.
 extraArgs:
-    --proxy-mode: iptables
+    proxy-mode: iptables
 ```
 
 <hr />
@@ -2220,7 +2220,7 @@ Appears in:
 image: k8s.gcr.io/kube-scheduler:v1.20.2 # The container image used in the scheduler manifest.
 # Extra arguments to supply to the scheduler.
 extraArgs:
-    --feature-gates: AllBeta=true
+    feature-gates: AllBeta=true
 ```
 
 <hr />
@@ -2282,7 +2282,7 @@ ca:
     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
 # Extra arguments to supply to etcd.
 extraArgs:
-    --election-timeout: "5000"
+    election-timeout: "5000"
 ```
 
 <hr />


### PR DESCRIPTION
Fixes a few typos in our docs.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
