### PR TITLE
feat: support version contract for Talos config generation

### DIFF
--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"
 	"github.com/talos-systems/talos/pkg/images"
+	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/bundle"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
@@ -29,6 +30,7 @@ var (
 	configVersion     string
 	dnsDomain         string
 	kubernetesVersion string
+	talosVersion      string
 	installDisk       string
 	installImage      string
 	outputDir         string
@@ -127,6 +129,17 @@ func genV1Alpha1Config(args []string) error {
 		genOptions = append(genOptions, generate.WithRegistryMirror(components[0], components[1]))
 	}
 
+	if talosVersion != "" {
+		var versionContract *config.VersionContract
+
+		versionContract, err = config.ParseContractFromVersion(talosVersion)
+		if err != nil {
+			return fmt.Errorf("invalid talos-version: %w", err)
+		}
+
+		genOptions = append(genOptions, generate.WithVersionContract(versionContract))
+	}
+
 	configBundle, err := bundle.NewConfigBundle(
 		bundle.WithInputOptions(
 			&bundle.InputOptions{
@@ -177,6 +190,7 @@ func init() {
 	genConfigCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
 	genConfigCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	genConfigCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")
+	genConfigCmd.Flags().StringVar(&talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
 	genConfigCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", "", "desired kubernetes version to run")
 	genConfigCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "destination to output generated files")
 	genConfigCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -112,7 +112,7 @@ func Generate(ctx context.Context, in *machine.GenerateConfigurationRequest) (re
 
 		switch {
 		case os.IsNotExist(err):
-			secrets, err = generate.NewSecretsBundle(clock, false)
+			secrets, err = generate.NewSecretsBundle(clock)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+// VersionContract describes Talos version to generate config for.
+//
+// Config generation only supports backwards compatibility (e.g. Talos 0.9 can generate configs for Talos 0.9 and 0.8).
+// Matching version of the machinery package is required to generate configs for the current version of Talos.
+//
+// Nil value of *VersionContract always describes current version of Talos.
+type VersionContract struct {
+	Major int
+	Minor int
+}
+
+// Well-known Talos version contracts.
+var (
+	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion0_9     = &VersionContract{0, 9}
+	TalosVersion0_8     = &VersionContract{0, 8}
+)
+
+var versionRegexp = regexp.MustCompile(`^v(\d+)\.(\d+)($|\.)`)
+
+// ParseContractFromVersion parses Talos version into VersionContract.
+func ParseContractFromVersion(version string) (*VersionContract, error) {
+	matches := versionRegexp.FindStringSubmatch(version)
+	if len(matches) < 3 {
+		return nil, fmt.Errorf("error parsing version %q", version)
+	}
+
+	var contract VersionContract
+
+	contract.Major, _ = strconv.Atoi(matches[1]) //nolint: errcheck
+	contract.Minor, _ = strconv.Atoi(matches[2]) //nolint: errcheck
+
+	return &contract, nil
+}
+
+// Greater compares contract to another contract.
+func (contract *VersionContract) Greater(other *VersionContract) bool {
+	if contract == nil {
+		return other != nil
+	}
+
+	if other == nil {
+		return false
+	}
+
+	return contract.Major > other.Major || (contract.Major == other.Major && contract.Minor > other.Minor)
+}
+
+// SupportsECDSAKeys returns true if version of Talos supports ECDSA keys (vs. RSA keys).
+func (contract *VersionContract) SupportsECDSAKeys() bool {
+	return contract.Greater(TalosVersion0_8)
+}
+
+// SupportsAggregatorCA returns true if version of Talos supports AggregatorCA in the config.
+func (contract *VersionContract) SupportsAggregatorCA() bool {
+	return contract.Greater(TalosVersion0_8)
+}
+
+// SupportsServiceAccount returns true if version of Talos supports ServiceAccount in the config.
+func (contract *VersionContract) SupportsServiceAccount() bool {
+	return contract.Greater(TalosVersion0_8)
+}

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/pkg/machinery/config"
+)
+
+func TestContractGreater(t *testing.T) {
+	assert.True(t, config.TalosVersion0_9.Greater(config.TalosVersion0_8))
+	assert.True(t, config.TalosVersionCurrent.Greater(config.TalosVersion0_8))
+	assert.True(t, config.TalosVersionCurrent.Greater(config.TalosVersion0_9))
+
+	assert.False(t, config.TalosVersion0_8.Greater(config.TalosVersion0_9))
+	assert.False(t, config.TalosVersion0_8.Greater(config.TalosVersion0_8))
+	assert.False(t, config.TalosVersionCurrent.Greater(config.TalosVersionCurrent))
+}
+
+func TestContractParseVersion(t *testing.T) {
+	contract, err := config.ParseContractFromVersion("v0.8")
+	assert.NoError(t, err)
+	assert.Equal(t, config.TalosVersion0_8, contract)
+
+	contract, err = config.ParseContractFromVersion("v0.8.1")
+	assert.NoError(t, err)
+	assert.Equal(t, config.TalosVersion0_8, contract)
+
+	contract, err = config.ParseContractFromVersion("v0.88")
+	assert.NoError(t, err)
+	assert.NotEqual(t, config.TalosVersion0_8, contract)
+
+	contract, err = config.ParseContractFromVersion("v0.8.3-alpha.4")
+	assert.NoError(t, err)
+	assert.Equal(t, config.TalosVersion0_8, contract)
+}
+
+func TestContractCurrent(t *testing.T) {
+	assert.True(t, config.TalosVersionCurrent.SupportsAggregatorCA())
+	assert.True(t, config.TalosVersionCurrent.SupportsECDSAKeys())
+	assert.True(t, config.TalosVersionCurrent.SupportsServiceAccount())
+}
+
+func TestContract0_9(t *testing.T) {
+	assert.True(t, config.TalosVersion0_9.SupportsAggregatorCA())
+	assert.True(t, config.TalosVersion0_9.SupportsECDSAKeys())
+	assert.True(t, config.TalosVersion0_9.SupportsServiceAccount())
+}
+
+func TestContract0_8(t *testing.T) {
+	assert.False(t, config.TalosVersion0_8.SupportsAggregatorCA())
+	assert.False(t, config.TalosVersion0_8.SupportsECDSAKeys())
+	assert.False(t, config.TalosVersion0_8.SupportsServiceAccount())
+}

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -80,7 +80,7 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 		fmt.Println("generating PKI and tokens")
 	}
 
-	secrets, err := generate.NewSecretsBundle(generate.NewClock(), options.InputOptions.UseRSAKeys)
+	secrets, err := generate.NewSecretsBundle(generate.NewClock(), options.InputOptions.GenOptions...)
 	if err != nil {
 		return bundle, err
 	}

--- a/pkg/machinery/config/types/v1alpha1/bundle/options.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/options.go
@@ -15,7 +15,6 @@ type InputOptions struct {
 	Endpoint    string
 	KubeVersion string
 	GenOptions  []generate.GenOption
-	UseRSAKeys  bool
 }
 
 // Options describes generate parameters.

--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -5,6 +5,7 @@
 package generate
 
 import (
+	"github.com/talos-systems/talos/pkg/machinery/config"
 	v1alpha1 "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 )
 
@@ -153,6 +154,15 @@ func WithAllowSchedulingOnMasters(enabled bool) GenOption {
 	}
 }
 
+// WithVersionContract specifies version contract to use when generating.
+func WithVersionContract(versionContract *config.VersionContract) GenOption {
+	return func(o *GenOptions) error {
+		o.VersionContract = versionContract
+
+		return nil
+	}
+}
+
 // GenOptions describes generate parameters.
 type GenOptions struct {
 	EndpointList              []string
@@ -169,6 +179,7 @@ type GenOptions struct {
 	Persist                   bool
 	AllowSchedulingOnMasters  bool
 	MachineDisks              []*v1alpha1.MachineDisk
+	VersionContract           *config.VersionContract
 }
 
 // DefaultGenOptions returns default options.

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -108,6 +108,7 @@ talosctl cluster create [flags]
       --registry-mirror strings                 list of registry mirrors to use in format: <registry host>=<mirror URL>
       --skip-injecting-config                   skip injecting config from embedded metadata server, write config files to current directory
       --skip-kubeconfig                         skip merging kubeconfig from the created cluster
+      --talos-version string                    the desired Talos version to generate config for (if not set, defaults to image version)
       --user-disk strings                       list of disks to create for each VM in format: <mount_point1>:<size1>:<mount_point2>:<size2>
       --vmlinuz-path string                     the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")
       --wait                                    wait for the cluster to be ready before returning (default true)
@@ -854,6 +855,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
   -o, --output-dir string           destination to output generated files
   -p, --persist                     the desired persist value for configs (default true)
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --talos-version string        the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
       --version string              the desired machine config version to generate (default "v1alpha1")
 ```
 


### PR DESCRIPTION
This allows to generating current version Talos configs (by default) or
backwards compatible configuration (e.g. for Talos 0.8).

`talosctl gen config` defaults to current version, but explicit version
can be passed to the command via flags.

`talosctl cluster create` defaults to install/container image version,
but that can be overridden. This makes `talosctl cluster create` now
compatible with 0.8.1 images out of the box.

Upgrade tests use contract based on source version in the test.

When used as a library, `VersionContract` can be omitted (defaults to
current version) or passed explicitly. `VersionContract` can be
convienietly parsed from Talos version string or specified as one of the
constants.

Fixes #3130

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

