### PR TITLE
fix: prevent crash in machined on apid service stop

### DIFF
--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -57,7 +57,10 @@ func (o *APID) PreFunc(ctx context.Context, r runtime.Runtime) error {
 
 // PostFunc implements the Service interface.
 func (o *APID) PostFunc(r runtime.Runtime, state events.ServiceState) (err error) {
-	o.cancel()
+	if o.cancel != nil {
+		o.cancel()
+	}
+
 	o.wg.Wait()
 
 	return nil


### PR DESCRIPTION
On reboots, when `apid` is stopped, `PostFunc()` is called, but
`o.cancel` is only initialized for worker nodes, so it leads to `init`
panic on master nodes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

