### PR TITLE
fix: pass attributes when adding routes

### DIFF
--- a/internal/app/networkd/pkg/nic/nic.go
+++ b/internal/app/networkd/pkg/nic/nic.go
@@ -413,6 +413,8 @@ func (n *NetworkInterface) configureInterface(method address.Addressing, link *n
 		}
 
 		attr := rtnetlink.RouteAttributes{
+			Dst:      r.Destination.IP,
+			OutIface: uint32(method.Link().Index),
 			Priority: r.Metric,
 		}
 


### PR DESCRIPTION
This PR fixes a bug where we removed adding attributes during the
RouteAdd call for rtnetlink. The way that code is implemented means that
if *any* attributes are passed, the defaults are ignored. But we were
expecting defaults to be there. No longer!

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
