### PR TITLE
fix: don't use filename from URL when downloading manifest

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/extra_manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/extra_manifest.go
@@ -141,8 +141,6 @@ func (ctrl *ExtraManifestController) download(ctx context.Context, r controller.
 
 	defer os.RemoveAll(tmpDir) //nolint: errcheck
 
-	fileName := filepath.Base(manifest.URL)
-
 	// I wish we never used go-getter package, as it doesn't allow downloading into memory.
 	// But there's not much we can do about it right now, as it supports lots of magic
 	// users might rely upon now.
@@ -166,7 +164,7 @@ func (ctrl *ExtraManifestController) download(ctx context.Context, r controller.
 	client := &getter.Client{
 		Ctx:     ctx,
 		Src:     manifest.URL,
-		Dst:     filepath.Join(tmpDir, fileName),
+		Dst:     filepath.Join(tmpDir, "manifest.yaml"),
 		Pwd:     tmpDir,
 		Mode:    getter.ClientModeFile,
 		Options: []getter.ClientOption{},


### PR DESCRIPTION
Manifest URL might be anything, including any GET parameters which might
get into filename which might lead to 'filename too long' error. As each
URL is downloaded to a separate temporary directory, there's no reason
to use filename based on the URL.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

