### PR TITLE
fix: add 3 seconds grub boot timeout

### DIFF
--- a/cmd/installer/cmd/iso.go
+++ b/cmd/installer/cmd/iso.go
@@ -19,7 +19,7 @@ import (
 )
 
 var cfg = []byte(`set default=0
-set timeout=0
+set timeout=3
 
 insmod all_video
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -43,7 +43,7 @@ const grubCfgTpl = `set default="{{ .Default }}"
 {{ with .Fallback -}}
 set fallback="{{ . }}"
 {{- end }}
-set timeout=0
+set timeout=3
 
 insmod all_video
 


### PR DESCRIPTION
This allows to drop into GRUB menu and edit boot configuration.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

