### PR TITLE
fix: find master node IPs correctly in health checks

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_cluster.go
@@ -106,11 +106,11 @@ func (cluster *clusterState) resolve(ctx context.Context, k8sProvider *cluster.K
 			return err
 		}
 
-		if cluster.controlPlaneNodes, err = k8sProvider.KubeHelper.MasterIPs(ctx); err != nil {
+		if cluster.controlPlaneNodes, err = k8sProvider.KubeHelper.NodeIPs(ctx, machine.TypeControlPlane); err != nil {
 			return err
 		}
 
-		if cluster.workerNodes, err = k8sProvider.KubeHelper.WorkerIPs(ctx); err != nil {
+		if cluster.workerNodes, err = k8sProvider.KubeHelper.NodeIPs(ctx, machine.TypeJoin); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Health checks verify node list in Kubernetes to match expectations, but
initial set of nodes for server-side health checks was driven by
`MasterIPs` functions which returns list of master endpoints which is
not exactly same as master nodes: endpoints also include some
healthchecks.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

