### PR TITLE
feat: stop all pods before unmounting the ephemeral partition

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -58,6 +58,9 @@ func (*Sequencer) ApplyConfiguration(r runtime.Runtime, req *machineapi.ApplyCon
 	).Append(
 		"unmountState",
 		UnmountStatePartition,
+	).Append(
+		"cleanup",
+		StopAllPods,
 	).AppendList(
 		stopAllPhaselist(r),
 	).Append(
@@ -273,7 +276,11 @@ func (*Sequencer) Bootstrap(r runtime.Runtime) []runtime.Phase {
 
 // Reboot is the reboot sequence.
 func (*Sequencer) Reboot(r runtime.Runtime) []runtime.Phase {
-	phases := PhaseList{}.AppendList(stopAllPhaselist(r)).
+	phases := PhaseList{}.Append(
+		"cleanup",
+		StopAllPods,
+	).
+		AppendList(stopAllPhaselist(r)).
 		Append("reboot", Reboot)
 
 	return phases
@@ -334,6 +341,10 @@ func (*Sequencer) Reset(r runtime.Runtime, in runtime.ResetOptions) []runtime.Ph
 // Shutdown is the shutdown sequence.
 func (*Sequencer) Shutdown(r runtime.Runtime) []runtime.Phase {
 	phases := PhaseList{}.
+		Append(
+			"cleanup",
+			StopAllPods,
+		).
 		AppendList(stopAllPhaselist(r)).
 		Append("shutdown", Shutdown)
 
@@ -352,6 +363,9 @@ func (*Sequencer) StageUpgrade(r runtime.Runtime, in *machineapi.UpgradeRequest)
 			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
 			"leave",
 			LeaveEtcd,
+		).Append(
+			"cleanup",
+			StopAllPods,
 		).AppendList(
 			stopAllPhaselist(r),
 		).Append(
@@ -397,12 +411,12 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 			UnmountOverlayFilesystems,
 			UnmountPodMounts,
 		).Append(
+			"unmountBind",
+			UnmountSystemDiskBindMounts,
+		).Append(
 			"unmountSystem",
 			UnmountEphemeralPartition,
 			UnmountStatePartition,
-		).Append(
-			"unmountBind",
-			UnmountSystemDiskBindMounts,
 		).Append(
 			"verifyDisk",
 			VerifyDiskAvailability,
@@ -442,12 +456,12 @@ func stopAllPhaselist(r runtime.Runtime) PhaseList {
 			UnmountOverlayFilesystems,
 			UnmountPodMounts,
 		).Append(
+			"unmountBind",
+			UnmountSystemDiskBindMounts,
+		).Append(
 			"unmountSystem",
 			UnmountEphemeralPartition,
 			UnmountStatePartition,
-		).Append(
-			"unmountBind",
-			UnmountSystemDiskBindMounts,
 		)
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1202,10 +1202,10 @@ func UnmountSystemDiskBindMounts(seq runtime.Sequence, data interface{}) (runtim
 				continue
 			}
 
-			device := fields[0]
+			device := strings.ReplaceAll(fields[0], "/dev/mapper", "/dev")
 			mountpoint := fields[1]
 
-			if strings.HasPrefix(device, devname) {
+			if strings.HasPrefix(device, devname) && device != devname {
 				logger.Printf("unmounting %s\n", mountpoint)
 
 				if err = unix.Unmount(mountpoint, 0); err != nil {


### PR DESCRIPTION
This should address flakiness issues related to partition unmount.
Also changed the order of partitions unmount in the sequencer.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>