### PR TITLE
feat: skip filesystem for state and ephemeral partitions in the installer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54
-	github.com/talos-systems/go-blockdevice v0.2.0
+	github.com/talos-systems/go-blockdevice v0.2.1-0.20210216182145-8f976c203110
 	github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0
 	github.com/talos-systems/go-loadbalancer v0.1.0
 	github.com/talos-systems/go-procfs v0.0.0-20210108152626-8cbc42d3dc24

--- a/go.sum
+++ b/go.sum
@@ -868,9 +868,9 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54 h1:2IGs3f0qG7f33Fv37XuYzIMxLARl4dcpwahZXLmdT2A=
 github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
-github.com/talos-systems/go-blockdevice v0.2.0 h1:tTu0ak3GfF8iSxNsdsicVhTKebIcyBARQYxhRV86AF0=
-github.com/talos-systems/go-blockdevice v0.2.0/go.mod h1:DGbop5CJa0PYdhQK9cNVF61pPJNedas1m7Gi/qAnrsM=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0 h1:DI+BjK+fcrLBc70Fi50dZocQcaHosqsuWHrGHKp2NzE=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210216182145-8f976c203110 h1:qyJ+0mNpddRvt2KRGOGU3KFIFFVWuP7KjYgnn3aVbqk=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210216182145-8f976c203110/go.mod h1:Wt0/JMsa+WysYRDlNo6fu9rdn/re73uRnktFWyVUqjs=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -498,9 +498,9 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 			case constants.MetaPartitionLabel:
 				target = installer.MetaTarget(bd.Device().Name(), nil)
 			case constants.StatePartitionLabel:
-				target = installer.StateTarget(bd.Device().Name(), nil)
+				target = installer.StateTarget(bd.Device().Name(), installer.NoFilesystem)
 			case constants.EphemeralPartitionLabel:
-				target = installer.EphemeralTarget(bd.Device().Name(), nil)
+				target = installer.EphemeralTarget(bd.Device().Name(), installer.NoFilesystem)
 			default:
 				return nil, fmt.Errorf("label %q is not supported", spec.Label)
 			}

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -213,7 +213,7 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
 		"ephemeral",
-		MountEphermeralPartition,
+		MountEphemeralPartition,
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
 		"verifyInstall",

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -54,6 +54,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/kernel/kspp"
 	"github.com/talos-systems/talos/internal/pkg/kmsg"
 	"github.com/talos-systems/talos/internal/pkg/mount"
+	"github.com/talos-systems/talos/internal/pkg/partition"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/images"
 	"github.com/talos-systems/talos/pkg/kubernetes"
@@ -882,11 +883,13 @@ func partitionAndFormatDisks(logger *log.Logger, r runtime.Runtime) error {
 
 			for _, part := range disk.Partitions() {
 				extraTarget := &installer.Target{
-					Device:         disk.Device(),
-					Size:           part.Size(),
-					Force:          true,
-					PartitionType:  installer.LinuxFilesystemData,
-					FileSystemType: installer.FilesystemTypeXFS,
+					Device: disk.Device(),
+					FormatOptions: &partition.FormatOptions{
+						Size:           part.Size(),
+						Force:          true,
+						PartitionType:  partition.LinuxFilesystemData,
+						FileSystemType: partition.FilesystemTypeXFS,
+					},
 				}
 
 				m.Targets[disk.Device()] = append(m.Targets[disk.Device()], extraTarget)
@@ -1580,7 +1583,7 @@ func UnmountEFIPartition(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 // MountStatePartition mounts the system partition.
 func MountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return mount.SystemPartitionMount(r, constants.StatePartitionLabel, mount.WithSkipIfMounted(true))
+		return mount.SystemPartitionMount(r, constants.StatePartitionLabel, mount.WithFlags(mount.SkipIfMounted))
 	}, "mountStatePartition"
 }
 
@@ -1591,11 +1594,11 @@ func UnmountStatePartition(seq runtime.Sequence, data interface{}) (runtime.Task
 	}, "unmountStatePartition"
 }
 
-// MountEphermeralPartition mounts the ephemeral partition.
-func MountEphermeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
+// MountEphemeralPartition mounts the ephemeral partition.
+func MountEphemeralPartition(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
-		return mount.SystemPartitionMount(r, constants.EphemeralPartitionLabel, mount.WithResize(true))
-	}, "mountEphermeralPartition"
+		return mount.SystemPartitionMount(r, constants.EphemeralPartitionLabel, mount.WithFlags(mount.Resize))
+	}, "mountEphemeralPartition"
 }
 
 // UnmountEphemeralPartition unmounts the ephemeral partition.

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -4,7 +4,7 @@
 
 // +build integration
 
-// Package provision provides integration tests which rely on on provisioning cluster per test.
+// Package provision provides integration tests which rely on provisioning cluster per test.
 package provision
 
 import (

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -403,7 +403,7 @@ func (suite *UpgradeSuite) waitForClusterHealth() {
 			time.Sleep(15 * time.Second)
 		}
 
-		checkCtx, checkCtxCancel := context.WithTimeout(suite.ctx, 10*time.Minute)
+		checkCtx, checkCtxCancel := context.WithTimeout(suite.ctx, 15*time.Minute)
 		defer checkCtxCancel()
 
 		suite.Require().NoError(check.Wait(checkCtx, suite.clusterAccess, check.DefaultClusterChecks(), check.StderrReporter()))

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -4,19 +4,45 @@
 
 package mount
 
+const (
+	// ReadOnly is a flag for setting the mount point as readonly.
+	ReadOnly Flags = 1 << iota
+	// Shared is a flag for setting the mount point as shared.
+	Shared
+	// Resize indicates that a the partition for a given mount point should be
+	// resized to the maximum allowed.
+	Resize
+	// Overlay indicates that a the partition for a given mount point should be
+	// mounted using overlayfs.
+	Overlay
+	// SkipIfMounted is a flag for skipping mount if the mountpoint is already mounted.
+	SkipIfMounted
+)
+
+// Flags is the mount flags.
+type Flags uint
+
 // Options is the functional options struct.
 type Options struct {
-	Loopback      string
-	Prefix        string
-	ReadOnly      bool
-	Shared        bool
-	Resize        bool
-	Overlay       bool
-	SkipIfMounted bool
+	Loopback         string
+	Prefix           string
+	MountFlags       Flags
+	PreMountHooks    []Hook
+	PostUnmountHooks []Hook
 }
 
 // Option is the functional option func.
 type Option func(*Options)
+
+// Check checks if all provided flags are set.
+func (f Flags) Check(flags Flags) bool {
+	return (f & flags) == flags
+}
+
+// Intersects checks if at least one flag is set.
+func (f Flags) Intersects(flags Flags) bool {
+	return (f & flags) != 0
+}
 
 // WithPrefix is a functional option for setting the mount point prefix.
 func WithPrefix(o string) Option {
@@ -25,52 +51,38 @@ func WithPrefix(o string) Option {
 	}
 }
 
-// WithReadOnly is a functional option for setting the mount point as readonly.
-func WithReadOnly(o bool) Option {
+// WithFlags is a functional option to set up mount flags.
+func WithFlags(flags Flags) Option {
 	return func(args *Options) {
-		args.ReadOnly = o
+		args.MountFlags = flags
 	}
 }
 
-// WithShared is a functional option for setting the mount point as shared.
-func WithShared(o bool) Option {
+// WithPreMountHooks adds functions to be called before mounting the partition.
+func WithPreMountHooks(hooks ...Hook) Option {
 	return func(args *Options) {
-		args.Shared = o
+		args.PreMountHooks = hooks
 	}
 }
 
-// WithSkipIfMounted is a functional option for skipping mount if the mountpoint is already mounted.
-func WithSkipIfMounted(o bool) Option {
+// WithPostUnmountHooks adds functions to be called after unmounting the partition.
+func WithPostUnmountHooks(hooks ...Hook) Option {
 	return func(args *Options) {
-		args.SkipIfMounted = o
+		args.PostUnmountHooks = hooks
 	}
 }
 
-// WithResize indicates that a the partition for a given mount point should be
-// resized to the maximum allowed.
-func WithResize(o bool) Option {
-	return func(args *Options) {
-		args.Resize = o
-	}
-}
-
-// WithOverlay indicates that a the partition for a given mount point should be
-// mounted using overlayfs.
-func WithOverlay(o bool) Option {
-	return func(args *Options) {
-		args.Overlay = o
-	}
-}
+// Hook represents pre/post mount hook.
+type Hook func(p *Point) error
 
 // NewDefaultOptions initializes a Options struct with default values.
 func NewDefaultOptions(setters ...Option) *Options {
 	opts := &Options{
-		Loopback: "",
-		Prefix:   "",
-		ReadOnly: false,
-		Shared:   false,
-		Resize:   false,
-		Overlay:  false,
+		Loopback:         "",
+		Prefix:           "",
+		MountFlags:       0,
+		PreMountHooks:    []Hook{},
+		PostUnmountHooks: []Hook{},
 	}
 
 	for _, setter := range setters {

--- a/internal/pkg/mount/overlay.go
+++ b/internal/pkg/mount/overlay.go
@@ -22,7 +22,7 @@ func OverlayMountPoints() (mountpoints *Points, err error) {
 	}
 
 	for _, target := range overlays {
-		mountpoint := NewMountPoint("", target, "", unix.MS_I_VERSION, "", WithOverlay(true))
+		mountpoint := NewMountPoint("", target, "", unix.MS_I_VERSION, "", WithFlags(Overlay))
 		mountpoints.Set(target, mountpoint)
 	}
 

--- a/internal/pkg/mount/squashfs.go
+++ b/internal/pkg/mount/squashfs.go
@@ -21,7 +21,7 @@ func SquashfsMountPoints(prefix string) (mountpoints *Points, err error) {
 	}
 
 	squashfs := NewMountPoints()
-	squashfs.Set("squashfs", NewMountPoint(dev.Path(), "/", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithReadOnly(true), WithShared(true)))
+	squashfs.Set("squashfs", NewMountPoint(dev.Path(), "/", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithFlags(ReadOnly|Shared)))
 
 	return squashfs, nil
 }

--- a/internal/pkg/mount/system.go
+++ b/internal/pkg/mount/system.go
@@ -9,12 +9,16 @@ import (
 	"os"
 
 	"github.com/talos-systems/go-blockdevice/blockdevice"
+	"github.com/talos-systems/go-blockdevice/blockdevice/filesystem"
 	"golang.org/x/sys/unix"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/disk"
+	"github.com/talos-systems/talos/internal/pkg/partition"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
+
+var mountpoints = map[string]*Point{}
 
 // SystemMountPointsForDevice returns the mountpoints required to boot the system.
 // This function is called exclusively during installations ( both image
@@ -61,12 +65,12 @@ func SystemMountPointForLabel(device *blockdevice.BlockDevice, label string, opt
 		return nil, fmt.Errorf("unknown label: %q", label)
 	}
 
-	partition, err := device.GetPartition(label)
+	part, err := device.GetPartition(label)
 	if err != nil && err != os.ErrNotExist {
 		return nil, err
 	}
 
-	if partition == nil {
+	if part == nil {
 		// A boot partitition is not required.
 		if label == constants.BootPartitionLabel {
 			return nil, nil
@@ -75,15 +79,46 @@ func SystemMountPointForLabel(device *blockdevice.BlockDevice, label string, opt
 		return nil, fmt.Errorf("failed to find device with label %s: %w", label, err)
 	}
 
-	fsType, err := partition.Filesystem()
+	fsType, err := part.Filesystem()
 	if err != nil {
 		return nil, err
 	}
 
-	partPath, err := partition.Path()
+	partPath, err := part.Path()
 	if err != nil {
 		return nil, err
 	}
+
+	preMountHooks := []Hook{}
+
+	// Format the partition if it does not have any filesystem
+	preMountHooks = append(preMountHooks, func(p *Point) error {
+		sb, err := filesystem.Probe(p.source)
+		if err != nil {
+			return err
+		}
+
+		p.fstype = ""
+
+		// skip formatting the partition if filesystem is detected
+		// and assign proper fs type to the mountpoint
+		if sb != nil && sb.Type() != filesystem.Unknown {
+			p.fstype = sb.Type()
+
+			return nil
+		}
+
+		opts := partition.NewFormatOptions(part.Name)
+		if opts == nil {
+			return fmt.Errorf("failed to determine format options for partition label %s", part.Name)
+		}
+
+		p.fstype = opts.FileSystemType
+
+		return partition.Format(p.source, opts)
+	})
+
+	opts = append(opts, WithPreMountHooks(preMountHooks...))
 
 	mountpoint = NewMountPoint(partPath, target, fsType, unix.MS_NOATIME, "", opts...)
 
@@ -97,8 +132,6 @@ func SystemPartitionMount(r runtime.Runtime, label string, opts ...Option) (err 
 		return fmt.Errorf("failed to find device with partition labeled %s", label)
 	}
 
-	mountpoints := NewMountPoints()
-
 	mountpoint, err := SystemMountPointForLabel(device.BlockDevice, label, opts...)
 	if err != nil {
 		return err
@@ -108,37 +141,24 @@ func SystemPartitionMount(r runtime.Runtime, label string, opts ...Option) (err 
 		return fmt.Errorf("no mountpoints for label %q", label)
 	}
 
-	mountpoints.Set(label, mountpoint)
-
-	if err = Mount(mountpoints); err != nil {
+	if err = mountMountpoint(mountpoint); err != nil {
 		return err
 	}
+
+	mountpoints[label] = mountpoint
 
 	return nil
 }
 
 // SystemPartitionUnmount unmounts a system partition by the label.
 func SystemPartitionUnmount(r runtime.Runtime, label string) (err error) {
-	device := r.State().Machine().Disk(disk.WithPartitionLabel(label))
-	if device == nil {
-		return fmt.Errorf("failed to find device with partition labeled %s", label)
-	}
+	if mountpoint, ok := mountpoints[label]; ok {
+		err = mountpoint.Unmount()
+		if err != nil {
+			return err
+		}
 
-	mountpoints := NewMountPoints()
-
-	mountpoint, err := SystemMountPointForLabel(device.BlockDevice, label)
-	if err != nil {
-		return err
-	}
-
-	if mountpoint == nil {
-		return fmt.Errorf("no mountpoints for label %q", label)
-	}
-
-	mountpoints.Set(label, mountpoint)
-
-	if err = Unmount(mountpoints); err != nil {
-		return err
+		delete(mountpoints, label)
 	}
 
 	return nil

--- a/internal/pkg/partition/constants.go
+++ b/internal/pkg/partition/constants.go
@@ -2,18 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package install
+package partition
 
-// PartitionType in partition table.
-type PartitionType = string
+// Type in partition table.
+type Type = string
 
 // GPT partition types.
 //
 // TODO: should be moved into the blockdevice library.
 const (
-	EFISystemPartition  PartitionType = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-	BIOSBootPartition   PartitionType = "21686148-6449-6E6F-744E-656564454649"
-	LinuxFilesystemData PartitionType = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+	EFISystemPartition  Type = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+	BIOSBootPartition   Type = "21686148-6449-6E6F-744E-656564454649"
+	LinuxFilesystemData Type = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
 )
 
 // FileSystemType is used to format partitions.

--- a/internal/pkg/partition/format.go
+++ b/internal/pkg/partition/format.go
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package partition provides common utils for system partition format.
+package partition
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/talos-systems/go-blockdevice/blockdevice"
+
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/makefs"
+)
+
+// FormatOptions contains format parameters.
+type FormatOptions struct {
+	Label          string
+	PartitionType  Type
+	FileSystemType FileSystemType
+	Size           uint64
+	Force          bool
+}
+
+// NewFormatOptions creates a new format options.
+func NewFormatOptions(label string) *FormatOptions {
+	opts, ok := systemPartitions[label]
+	if ok {
+		return &opts
+	}
+
+	return nil
+}
+
+// Format zeroes the device and formats it using filesystem type provided.
+func Format(devname string, t *FormatOptions) error {
+	if t.FileSystemType == FilesystemTypeNone {
+		return zeroPartition(devname, int64(t.Size))
+	}
+
+	opts := []makefs.Option{makefs.WithForce(t.Force), makefs.WithLabel(t.Label)}
+	log.Printf("formatting the partition %q as %q with label %q\n", devname, t.FileSystemType, t.Label)
+
+	switch t.FileSystemType {
+	case FilesystemTypeVFAT:
+		return makefs.VFAT(devname, opts...)
+	case FilesystemTypeXFS:
+		return makefs.XFS(devname, opts...)
+	default:
+		return fmt.Errorf("unsupported filesystem type: %q", t.FileSystemType)
+	}
+}
+
+// zeroPartition fills the partition with zeroes.
+func zeroPartition(devname string, size int64) (err error) {
+	log.Printf("zeroing out %q", devname)
+
+	zeroes, err := os.Open("/dev/zero")
+	if err != nil {
+		return err
+	}
+
+	defer zeroes.Close() //nolint: errcheck
+
+	part, err := os.OpenFile(devname, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+
+	defer part.Close() //nolint: errcheck
+
+	// wipe at least minimal header size
+	if size == 0 {
+		size = blockdevice.FastWipeRange
+	}
+
+	_, err = io.CopyN(part, zeroes, size)
+
+	return err
+}
+
+var systemPartitions = map[string]FormatOptions{
+	constants.EFIPartitionLabel: {
+		Label:          constants.EFIPartitionLabel,
+		PartitionType:  EFISystemPartition,
+		FileSystemType: FilesystemTypeVFAT,
+		Size:           EFISize,
+		Force:          true,
+	},
+	constants.BIOSGrubPartitionLabel: {
+		Label:          constants.BIOSGrubPartitionLabel,
+		PartitionType:  BIOSBootPartition,
+		FileSystemType: FilesystemTypeNone,
+		Size:           BIOSGrubSize,
+		Force:          true,
+	},
+	constants.BootPartitionLabel: {
+		Label:          constants.BootPartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeXFS,
+		Size:           BootSize,
+		Force:          true,
+	},
+	constants.MetaPartitionLabel: {
+		Label:          constants.MetaPartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeNone,
+		Size:           MetaSize,
+		Force:          true,
+	},
+	constants.StatePartitionLabel: {
+		Label:          constants.StatePartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeXFS,
+		Size:           StateSize,
+		Force:          true,
+	},
+	constants.EphemeralPartitionLabel: {
+		Label:          constants.EphemeralPartitionLabel,
+		PartitionType:  LinuxFilesystemData,
+		FileSystemType: FilesystemTypeXFS,
+		Size:           0,
+		Force:          true,
+	},
+}

--- a/internal/pkg/partition/partition.go
+++ b/internal/pkg/partition/partition.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package partition provides common utils for system partition format.
+package partition

--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -41,7 +41,7 @@ func DefaultClusterChecks() []ClusterCheck {
 		func(cluster ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("apid to be ready", func(ctx context.Context) error {
 				return ApidReadyAssertion(ctx, cluster)
-			}, 2*time.Minute, 5*time.Second)
+			}, 5*time.Minute, 5*time.Second)
 		},
 		// wait for kubelet to be healthy on all
 		func(cluster ClusterInfo) conditions.Condition {


### PR DESCRIPTION
Filesystem creation step is moved on the later stage: when Talos mounts
the partition for the first time.
Now it checks if the partition doesn't have any filesystem and formats
it right before mounting.

Additionally refactored mount options a bit:
- replaced separate options with a set of binary flags.
- implemented pre-mount and post-unmount hooks.

And fixed typos in couple of places and increased timeout for `apid ready`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>