### PR TITLE
fix: move versions to annotations in control plane static pods

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -189,10 +189,13 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kube-apiserver",
 				Namespace: "kube-system",
+				Annotations: map[string]string{
+					constants.AnnotationStaticPodSecretsVersion: secretsVersion,
+					constants.AnnotationStaticPodConfigVersion:  configResource.Metadata().Version().String(),
+				},
 				Labels: map[string]string{
-					"tier":            "control-plane",
-					"k8s-app":         "kube-apiserver",
-					"secrets-version": secretsVersion,
+					"tier":    "control-plane",
+					"k8s-app": "kube-apiserver",
 				},
 			},
 			Spec: v1.PodSpec{
@@ -277,10 +280,13 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kube-controller-manager",
 				Namespace: "kube-system",
+				Annotations: map[string]string{
+					constants.AnnotationStaticPodSecretsVersion: secretsVersion,
+					constants.AnnotationStaticPodConfigVersion:  configResource.Metadata().Version().String(),
+				},
 				Labels: map[string]string{
-					"tier":            "control-plane",
-					"k8s-app":         "kube-controller-manager",
-					"secrets-version": secretsVersion,
+					"tier":    "control-plane",
+					"k8s-app": "kube-controller-manager",
 				},
 			},
 			Spec: v1.PodSpec{
@@ -356,10 +362,13 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kube-scheduler",
 				Namespace: "kube-system",
+				Annotations: map[string]string{
+					constants.AnnotationStaticPodSecretsVersion: secretsVersion,
+					constants.AnnotationStaticPodConfigVersion:  configResource.Metadata().Version().String(),
+				},
 				Labels: map[string]string{
-					"tier":            "control-plane",
-					"k8s-app":         "kube-scheduler",
-					"secrets-version": secretsVersion,
+					"tier":    "control-plane",
+					"k8s-app": "kube-scheduler",
 				},
 			},
 			Spec: v1.PodSpec{

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -387,6 +387,18 @@ const (
 	// NodeReadyTimeout is the timeout to wait for the node to be ready (CNI to be running).
 	// For bootstrap API, this includes time to run bootstrap.
 	NodeReadyTimeout = BootTimeout
+
+	// AnnotationCordonedKey is the annotation key for the nodes cordoned by Talos.
+	AnnotationCordonedKey = "talos.dev/cordoned"
+
+	// AnnotationCordonedValue is the annotation key for the nodes cordoned by Talos.
+	AnnotationCordonedValue = "true"
+
+	// AnnotationStaticPodSecretsVersion is the annotation key for the static pod secret version.
+	AnnotationStaticPodSecretsVersion = "talos.dev/secrets-version"
+
+	// AnnotationStaticPodConfigVersion is the annotation key for the static pod config version.
+	AnnotationStaticPodConfigVersion = "talos.dev/config-version"
 )
 
 // See https://linux.die.net/man/3/klogctl


### PR DESCRIPTION
Labels shouldn't be used, as this is not supposed to be used for
filtering pods. Use proper annotation prefix private for Talos.
Add config-version annotation to track how static pod propagates up to
API server (it will be used in control plane upgrade).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

