### PR TITLE
fix: drop cri dependency on etcd

### DIFF
--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -20,7 +20,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/process"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
 	"github.com/talos-systems/talos/pkg/conditions"
-	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
@@ -50,13 +49,7 @@ func (c *CRI) Condition(r runtime.Runtime) conditions.Condition {
 
 // DependsOn implements the Service interface.
 func (c *CRI) DependsOn(r runtime.Runtime) []string {
-	depends := []string{"networkd"}
-
-	if r.Config().Machine().Type() != machine.TypeJoin {
-		depends = append(depends, "etcd")
-	}
-
-	return depends
+	return []string{"networkd"}
 }
 
 // Runner implements the Service interface.


### PR DESCRIPTION
This allows cri to start before etcd, allowing kubelet to be started
early on so that static pods can be started which might do some network
setup required for etcd to be up.

This fix was first added to 0.8 to help with single-node control plane
clusters.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

