### PR TITLE
fix: correctly unwrap responses for etcd commands

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -202,7 +202,7 @@ local sbcs_arm64 = Step("sbcs-arm64", target="sbcs", depends_on=[images_amd64, i
 local unit_tests = Step("unit-tests", target="unit-tests unit-tests-race", depends_on=[build, lint]);
 local e2e_docker = Step("e2e-docker-short", depends_on=[build, unit_tests], target="e2e-docker", environment={"SHORT_INTEGRATION_TEST": "yes", "REGISTRY": local_registry});
 local e2e_qemu = Step("e2e-qemu-short", privileged=true, target="e2e-qemu", depends_on=[build, unit_tests, talosctl_cni_bundle], environment={"REGISTRY": local_registry, "SHORT_INTEGRATION_TEST": "yes"}, when={event: ['pull_request']});
-local e2e_iso = Step("e2e-iso", privileged=true, target="e2e-iso", depends_on=[build, unit_tests, iso_amd64], when={event: ['pull_request']}, environment={"REGISTRY": local_registry});
+local e2e_iso = Step("e2e-iso", privileged=true, target="e2e-iso", depends_on=[build, unit_tests, iso_amd64, talosctl_cni_bundle], when={event: ['pull_request']}, environment={"REGISTRY": local_registry});
 
 local coverage = {
   name: 'coverage',

--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/talos-systems/talos/pkg/cli"
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
@@ -30,9 +31,7 @@ var etcdLeaveCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
-			_, err := c.MachineClient.EtcdLeaveCluster(ctx, &machine.EtcdLeaveClusterRequest{})
-
-			return err
+			return c.EtcdLeaveCluster(ctx, &machine.EtcdLeaveClusterRequest{})
 		})
 	},
 }
@@ -43,9 +42,7 @@ var etcdForfeitLeadershipCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
-			_, err := c.MachineClient.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
-
-			return err
+			return c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
 		})
 	},
 }
@@ -56,11 +53,14 @@ var etcdMemberListCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
-			response, err := c.MachineClient.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
+			response, err := c.EtcdMemberList(ctx, &machine.EtcdMemberListRequest{
 				QueryLocal: true,
 			})
 			if err != nil {
-				return fmt.Errorf("error getting members: %w", err)
+				if response == nil {
+					return fmt.Errorf("error getting members: %w", err)
+				}
+				cli.Warning("%s", err)
 			}
 
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)

--- a/internal/integration/cli/etcd.go
+++ b/internal/integration/cli/etcd.go
@@ -28,6 +28,12 @@ func (suite *EtcdSuite) TestMembers() {
 
 // TestForfeitLeadership etcd forfeit-leadership check.
 func (suite *EtcdSuite) TestForfeitLeadership() {
+	nodes := suite.DiscoverNodes().NodesByType(machine.TypeControlPlane)
+
+	if len(nodes) < 3 {
+		suite.T().Skip("test only can be run on HA etcd clusters")
+	}
+
 	suite.RunCLI([]string{"etcd", "forfeit-leadership", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane)},
 		base.StdoutEmpty(),
 	)

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -851,6 +851,39 @@ func (c *Client) ClusterHealthCheck(ctx context.Context, waitTimeout time.Durati
 	})
 }
 
+// EtcdLeaveCluster makes node leave etcd cluster.
+func (c *Client) EtcdLeaveCluster(ctx context.Context, req *machineapi.EtcdLeaveClusterRequest, callOptions ...grpc.CallOption) error {
+	resp, err := c.MachineClient.EtcdLeaveCluster(ctx, req, callOptions...)
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
+	return err
+}
+
+// EtcdForfeitLeadership makes node forfeit leadership in the etcd cluster.
+func (c *Client) EtcdForfeitLeadership(ctx context.Context, req *machineapi.EtcdForfeitLeadershipRequest, callOptions ...grpc.CallOption) error {
+	resp, err := c.MachineClient.EtcdForfeitLeadership(ctx, req, callOptions...)
+
+	if err == nil {
+		_, err = FilterMessages(resp, err)
+	}
+
+	return err
+}
+
+// EtcdMemberList lists etcd members of the cluster.
+func (c *Client) EtcdMemberList(ctx context.Context, req *machineapi.EtcdMemberListRequest, callOptions ...grpc.CallOption) (*machineapi.EtcdMemberListResponse, error) {
+	resp, err := c.MachineClient.EtcdMemberList(ctx, req, callOptions...)
+
+	var filtered interface{}
+	filtered, err = FilterMessages(resp, err)
+	resp, _ = filtered.(*machineapi.EtcdMemberListResponse) //nolint: errcheck
+
+	return resp, err
+}
+
 // MachineStream is a common interface for streams returned by streaming APIs.
 type MachineStream interface {
 	Recv() (*common.Data, error)


### PR DESCRIPTION
This uses wrappers which helps to unwrap errors from proxied apid
responses.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

