### PR TITLE
chore(ci): fix schedules in Drone pipelines

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -337,7 +337,7 @@ local default_pipeline = Pipeline('default', default_steps) + default_trigger;
 local cron_trigger(schedules) = {
   trigger: {
     cron: {
-      include: ['thrice-daily', 'nightly'],
+      include: schedules,
     },
   },
 };


### PR DESCRIPTION
That removes actually e2e-* from the `thrice-daily`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

