### PR TITLE
feat: add state encryption support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -118,7 +118,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/briandowns/spinner v1.6.1 h1:LBxHu5WLyVuVEtTD72xegiC7QJGx598LBpo3ywKTapA=
@@ -180,11 +179,9 @@ github.com/containerd/ttrpc v1.0.2/go.mod h1:UAxOpgT9ziI0gJrmKvgcZivgxOp8iFPSk8h
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containerd/typeurl v1.0.1 h1:PvuK4E3D5S5q6IqsPDCy928FhP0LUIGcmZ/Yhgp5Djw=
 github.com/containerd/typeurl v1.0.1/go.mod h1:TB1hUtrpaiO88KEK56ijojHS1+NeF0izUACaJW2mdXg=
-github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/containernetworking/plugins v0.8.7 h1:bU7QieuAp+sACI2vCzESJ3FoT860urYP+lThyZkb/2M=
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
 github.com/containernetworking/plugins v0.9.0 h1:c+1gegKhR7+d0Caum9pEHugZlyhXPOG6v3V6xJgIGCI=
 github.com/containernetworking/plugins v0.9.0/go.mod h1:dbWv4dI0QrBGuVgj+TuVQ6wJRZVOhrCQj91YyC92sxg=
@@ -292,7 +289,6 @@ github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo
 github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591 h1:0WWUDZ1oxq7NxVyGo8M3KI5jbkiwNAdZFFzAdC68up4=
 github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gizak/termui/v3 v3.1.0 h1:ZZmVDgwHl7gR7elfKf1xc4IudXZ5qqfDh4wExk4Iajc=
 github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmyFlkYTrY=
@@ -421,7 +417,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -550,7 +545,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
@@ -697,14 +691,12 @@ github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.7.1 h1:K0jcRCwNQM3vFGh1ppMtDh/+7ApJrjldlX8fA0jDTLQ=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
@@ -728,12 +720,10 @@ github.com/opencontainers/selinux v1.6.0 h1:+bIAS/Za3q5FTwWym4fTB0vObnfCf3G/NC7K
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfSeg=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
-github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pin/tftp v2.1.0+incompatible h1:Yng4J7jv6lOc6IF4XoB5mnd3P7ZrF60XQq+my3FAMus=
 github.com/pin/tftp v2.1.0+incompatible/go.mod h1:xVpZOMCXTy+A5QMjEVN0Glwa1sUvaJhFXbr/aAxuxGY=
@@ -857,7 +847,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.0/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -868,9 +857,9 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54 h1:2IGs3f0qG7f33Fv37XuYzIMxLARl4dcpwahZXLmdT2A=
 github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
-github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0 h1:DI+BjK+fcrLBc70Fi50dZocQcaHosqsuWHrGHKp2NzE=
 github.com/talos-systems/go-blockdevice v0.2.1-0.20210216182145-8f976c203110 h1:qyJ+0mNpddRvt2KRGOGU3KFIFFVWuP7KjYgnn3aVbqk=
 github.com/talos-systems/go-blockdevice v0.2.1-0.20210216182145-8f976c203110/go.mod h1:Wt0/JMsa+WysYRDlNo6fu9rdn/re73uRnktFWyVUqjs=
+github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0 h1:DI+BjK+fcrLBc70Fi50dZocQcaHosqsuWHrGHKp2NzE=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-loadbalancer v0.1.0 h1:MQFONvSjoleU8RrKq1O1Z8CyTCJGd4SLqdAHDlR6o9s=
 github.com/talos-systems/go-loadbalancer v0.1.0/go.mod h1:D5Qjfz+29WVjONWECZvOkmaLsBb3f5YeWME0u/5HmIc=
@@ -908,7 +897,6 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d h1:Z8Bp/K+wf1+IUvu5Vk2Ml/mMI7fmZTT7rQjkLC8pAmQ=
 github.com/viniciuschiele/tarx v0.0.0-20151205142357-6e3da540444d/go.mod h1:8uo3DXfN526YN7JjAp4JkOMm4foTW4vPzPHaAzb4xiY=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
-github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 h1:cPXZWzzG0NllBLdjWoD1nDfaqu98YMv+OneaKc8sPOA=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
@@ -1300,7 +1288,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1309,7 +1296,6 @@ gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qS
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124 h1:aPcd9iBdqpFyYkoGRQbQd+asp162GIRDvAVB0FhLxhc=
 gopkg.in/freddierice/go-losetup.v1 v1.0.0-20170407175016-fc9adea44124/go.mod h1:6LXpUYtVsrx91XiupFRJ8jVKOqLZf5PrbEVSGHta/84=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
@@ -1331,7 +1317,6 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -1344,7 +1329,6 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
-honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.6 h1:W18jzjh8mfPez+AwGLxmOImucz/IFjpNlrKVnaj2YVc=
 honnef.co/go/tools v0.0.1-2020.1.6/go.mod h1:pyyisuGw24ruLjrr1ddx39WE0y9OooInRzEYLhQB2YY=

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -8,7 +8,6 @@ source ./hack/test/e2e.sh
 
 PROVISIONER=qemu
 CLUSTER_NAME=e2e-${PROVISIONER}
-CLUSTER_CIDR=${CLUSTER_CIDR:-1}
 
 case "${CI:-false}" in
   true)
@@ -51,7 +50,7 @@ case "${WITH_DISK_ENCRYPTION:-false}" in
     DISK_ENCRYPTION_FLAG=""
     ;;
   *)
-    DISK_ENCRYPTION_FLAG="--encrypt-ephemeral"
+    DISK_ENCRYPTION_FLAG="--encrypt-ephemeral --encrypt-state"
     ;;
 esac
 
@@ -65,7 +64,7 @@ function create_cluster {
     --mtu 1450 \
     --memory 2048 \
     --cpus 2.0 \
-    --cidr 172.20.${CLUSTER_CIDR}.0/24 \
+    --cidr 172.20.1.0/24 \
     --user-disk /var/lib/extra:100MB \
     --user-disk /var/lib/p1:100MB:/var/lib/p2:100MB \
     --install-image ${REGISTRY:-ghcr.io}/talos-systems/installer:${INSTALLER_TAG} \
@@ -78,7 +77,7 @@ function create_cluster {
     ${QEMU_FLAGS} \
     ${CUSTOM_CNI_FLAG}
 
-  "${TALOSCTL}" config node 172.20.${CLUSTER_CIDR}.2
+  "${TALOSCTL}" config node 172.20.1.2
 }
 
 function destroy_cluster() {

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/adv/adv.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/adv/adv.go
@@ -8,7 +8,9 @@ package adv
 // ADV describes implementation which stores tag-value data.
 type ADV interface {
 	ReadTag(t uint8) (val string, ok bool)
+	ReadTagBytes(t uint8) (val []byte, ok bool)
 	SetTag(t uint8, val string) (ok bool)
+	SetTagBytes(t uint8, val []byte) (ok bool)
 	DeleteTag(t uint8) (ok bool)
 	Bytes() ([]byte, error)
 }
@@ -32,4 +34,6 @@ const (
 	StagedUpgradeImageRef
 	// StagedUpgradeInstallOptions stores JSON-serialized install.Options.
 	StagedUpgradeInstallOptions
+	// StateEncryptionConfig stores JSON-serialized v1alpha1.Encryption.
+	StateEncryptionConfig
 )

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/adv/syslinux/syslinux.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/adv/syslinux/syslinux.go
@@ -49,6 +49,16 @@ func NewADV(r io.ReadSeeker) (adv ADV, err error) {
 
 // ReadTag reads a tag in the ADV.
 func (a ADV) ReadTag(t uint8) (val string, ok bool) {
+	var b []byte
+
+	b, ok = a.ReadTagBytes(t)
+	val = string(b)
+
+	return
+}
+
+// ReadTagBytes reads a tag in the ADV.
+func (a ADV) ReadTagBytes(t uint8) (val []byte, ok bool) {
 	// Header is in first 8 bytes.
 	i := 8
 
@@ -70,7 +80,7 @@ func (a ADV) ReadTag(t uint8) (val string, ok bool) {
 
 		len := int(a[i+1]) + i
 
-		val = string(a[i+2 : len+2])
+		val = a[i+2 : len+2]
 
 		ok = true
 
@@ -81,10 +91,13 @@ func (a ADV) ReadTag(t uint8) (val string, ok bool) {
 }
 
 // SetTag sets a tag in the ADV.
-func (a ADV) SetTag(t uint8, val string) (ok bool) {
-	b := []byte(val)
+func (a ADV) SetTag(t uint8, val string) bool {
+	return a.SetTagBytes(t, []byte(val))
+}
 
-	if len(b) > 255 {
+// SetTagBytes sets a tag in the ADV.
+func (a ADV) SetTagBytes(t uint8, val []byte) (ok bool) {
+	if len(val) > 255 {
 		return false
 	}
 
@@ -103,13 +116,13 @@ func (a ADV) SetTag(t uint8, val string) (ok bool) {
 			continue
 		}
 
-		length := uint8(len(b))
+		length := uint8(len(val))
 
 		a[i] = t
 
 		a[i+1] = length
 
-		copy(a[i+2:uint8(i+2)+length], b)
+		copy(a[i+2:uint8(i+2)+length], val)
 
 		ok = true
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/adv/talos/talos.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/adv/talos/talos.go
@@ -166,16 +166,27 @@ func (a *ADV) Bytes() ([]byte, error) {
 
 // ReadTag to get tag value.
 func (a *ADV) ReadTag(t uint8) (val string, ok bool) {
-	var b []byte
+	b, ok := a.ReadTagBytes(t)
 
-	b, ok = a.Tags[Tag(t)]
 	val = string(b)
+
+	return
+}
+
+// ReadTagBytes to get tag value.
+func (a *ADV) ReadTagBytes(t uint8) (val []byte, ok bool) {
+	val, ok = a.Tags[Tag(t)]
 
 	return
 }
 
 // SetTag to set tag value.
 func (a *ADV) SetTag(t uint8, val string) (ok bool) {
+	return a.SetTagBytes(t, []byte(val))
+}
+
+// SetTagBytes to set tag value.
+func (a *ADV) SetTagBytes(t uint8, val []byte) (ok bool) {
 	size := 20 // magic + checksum
 
 	for _, v := range a.Tags {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -50,6 +50,9 @@ func (*Sequencer) ApplyConfiguration(r runtime.Runtime, req *machineapi.ApplyCon
 	phases := PhaseList{}
 
 	phases = phases.Append(
+		"saveStateEncryptionConfig",
+		SaveStateEncryptionConfig,
+	).Append(
 		"mountState",
 		MountStatePartition,
 	).Append(
@@ -162,6 +165,9 @@ func (*Sequencer) Install(r runtime.Runtime) []runtime.Phase {
 			).Append(
 				"install",
 				Install,
+			).Append(
+				"saveStateEncryptionConfig",
+				SaveStateEncryptionConfig,
 			).Append(
 				"mountState",
 				MountStatePartition,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1240,7 +1240,14 @@ func (e *EncryptionKeyStatic) Key() []byte {
 
 // Get implements the config.Provider interface.
 func (e *SystemDiskEncryptionConfig) Get(label string) config.Encryption {
-	if label == constants.EphemeralPartitionLabel {
+	switch label {
+	case constants.StatePartitionLabel:
+		if e.StatePartition == nil {
+			return nil
+		}
+
+		return e.StatePartition
+	case constants.EphemeralPartitionLabel:
 		if e.EphemeralPartition == nil {
 			return nil
 		}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1457,6 +1457,9 @@ type RegistryTLSConfig struct {
 // SystemDiskEncryptionConfig specifies system disk partitions encryption settings.
 type SystemDiskEncryptionConfig struct {
 	//   description: |
+	//     State partition encryption.
+	StatePartition *EncryptionConfig `yaml:"state,omitempty"`
+	//   description: |
 	//     Ephemeral partition encryption.
 	EphemeralPartition *EncryptionConfig `yaml:"ephemeral,omitempty"`
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -930,6 +930,10 @@ func init() {
 	EncryptionConfigDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "SystemDiskEncryptionConfig",
+			FieldName: "state",
+		},
+		{
+			TypeName:  "SystemDiskEncryptionConfig",
 			FieldName: "ephemeral",
 		},
 	}
@@ -1578,12 +1582,17 @@ func init() {
 			FieldName: "systemDiskEncryption",
 		},
 	}
-	SystemDiskEncryptionConfigDoc.Fields = make([]encoder.Doc, 1)
-	SystemDiskEncryptionConfigDoc.Fields[0].Name = "ephemeral"
+	SystemDiskEncryptionConfigDoc.Fields = make([]encoder.Doc, 2)
+	SystemDiskEncryptionConfigDoc.Fields[0].Name = "state"
 	SystemDiskEncryptionConfigDoc.Fields[0].Type = "EncryptionConfig"
 	SystemDiskEncryptionConfigDoc.Fields[0].Note = ""
-	SystemDiskEncryptionConfigDoc.Fields[0].Description = "Ephemeral partition encryption."
-	SystemDiskEncryptionConfigDoc.Fields[0].Comments[encoder.LineComment] = "Ephemeral partition encryption."
+	SystemDiskEncryptionConfigDoc.Fields[0].Description = "State partition encryption."
+	SystemDiskEncryptionConfigDoc.Fields[0].Comments[encoder.LineComment] = "State partition encryption."
+	SystemDiskEncryptionConfigDoc.Fields[1].Name = "ephemeral"
+	SystemDiskEncryptionConfigDoc.Fields[1].Type = "EncryptionConfig"
+	SystemDiskEncryptionConfigDoc.Fields[1].Note = ""
+	SystemDiskEncryptionConfigDoc.Fields[1].Description = "Ephemeral partition encryption."
+	SystemDiskEncryptionConfigDoc.Fields[1].Comments[encoder.LineComment] = "Ephemeral partition encryption."
 }
 
 func (_ Config) Doc() *encoder.Doc {

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -90,6 +90,7 @@ talosctl cluster create [flags]
       --dns-domain string                       the dns domain to use for cluster (default "cluster.local")
       --docker-host-ip string                   Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
       --encrypt-ephemeral                       enable ephemeral partition encryption
+      --encrypt-state                           enable state partition encryption
       --endpoint string                         use endpoint instead of provider defaults
   -p, --exposed-ports string                    Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
   -h, --help                                    help for create

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -2731,6 +2731,8 @@ EncryptionConfig represents partition encryption settings.
 Appears in:
 
 
+- <code><a href="#systemdiskencryptionconfig">SystemDiskEncryptionConfig</a>.state</code>
+
 - <code><a href="#systemdiskencryptionconfig">SystemDiskEncryptionConfig</a>.ephemeral</code>
 
 
@@ -4412,6 +4414,19 @@ ephemeral:
           nodeID: {}
           slot: 0 # Key slot number for luks2 encryption.
 ```
+
+<hr />
+
+<div class="dd">
+
+<code>state</code>  <i><a href="#encryptionconfig">EncryptionConfig</a></i>
+
+</div>
+<div class="dt">
+
+State partition encryption.
+
+</div>
 
 <hr />
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3109

State partition encryption support adds a new section to the machine config.
And a new step to the sequencer flow which saves encryption
configuration object as json serialized value in the META partition.

Everything else is the same as is for the ephemeral partition.
Additionally enabled state partition encryption in the disk encryption
integration tests.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>