### PR TITLE
test: update integration tests to use wrapped client for etcd APIs

### DIFF
--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -42,7 +42,9 @@ var etcdForfeitLeadershipCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
-			return c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
+			_, err := c.EtcdForfeitLeadership(ctx, &machine.EtcdForfeitLeadershipRequest{})
+
+			return err
 		})
 	},
 }

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -68,10 +68,8 @@ func (suite *EtcdSuite) TestEtcdForfeitLeadership() {
 	var leader string
 
 	for _, node := range nodes {
-		resp, err := suite.Client.MachineClient.EtcdForfeitLeadership(client.WithNodes(suite.ctx, node), &machineapi.EtcdForfeitLeadershipRequest{})
+		resp, err := suite.Client.EtcdForfeitLeadership(client.WithNodes(suite.ctx, node), &machineapi.EtcdForfeitLeadershipRequest{})
 		suite.Require().NoError(err)
-
-		suite.Assert().Empty(resp.Messages[0].Metadata.Error, "node: %s", node)
 
 		if resp.Messages[0].GetMember() != "" {
 			leader = resp.Messages[0].GetMember()
@@ -107,18 +105,18 @@ func (suite *EtcdSuite) TestEtcdLeaveCluster() {
 
 	nodeCtx := client.WithNodes(suite.ctx, node)
 
-	_, err := suite.Client.MachineClient.EtcdForfeitLeadership(nodeCtx, &machineapi.EtcdForfeitLeadershipRequest{})
+	_, err := suite.Client.EtcdForfeitLeadership(nodeCtx, &machineapi.EtcdForfeitLeadershipRequest{})
 	suite.Require().NoError(err)
 
-	_, err = suite.Client.MachineClient.EtcdLeaveCluster(nodeCtx, &machineapi.EtcdLeaveClusterRequest{})
+	err = suite.Client.EtcdLeaveCluster(nodeCtx, &machineapi.EtcdLeaveClusterRequest{})
 	suite.Require().NoError(err)
 
-	services, err := suite.Client.MachineClient.ServiceList(nodeCtx, &empty.Empty{})
+	services, err := suite.Client.ServiceInfo(nodeCtx, "etcd")
 	suite.Require().NoError(err)
 
-	for _, service := range services.Messages[0].GetServices() {
-		if service.Id == "etcd" && service.State != "Finished" {
-			suite.Assert().Equal("Finished", service.State)
+	for _, service := range services {
+		if service.Service.Id == "etcd" {
+			suite.Assert().Equal("Finished", service.Service.State)
 		}
 	}
 

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -863,14 +863,14 @@ func (c *Client) EtcdLeaveCluster(ctx context.Context, req *machineapi.EtcdLeave
 }
 
 // EtcdForfeitLeadership makes node forfeit leadership in the etcd cluster.
-func (c *Client) EtcdForfeitLeadership(ctx context.Context, req *machineapi.EtcdForfeitLeadershipRequest, callOptions ...grpc.CallOption) error {
+func (c *Client) EtcdForfeitLeadership(ctx context.Context, req *machineapi.EtcdForfeitLeadershipRequest, callOptions ...grpc.CallOption) (*machineapi.EtcdForfeitLeadershipResponse, error) {
 	resp, err := c.MachineClient.EtcdForfeitLeadership(ctx, req, callOptions...)
 
-	if err == nil {
-		_, err = FilterMessages(resp, err)
-	}
+	var filtered interface{}
+	filtered, err = FilterMessages(resp, err)
+	resp, _ = filtered.(*machineapi.EtcdForfeitLeadershipResponse) //nolint: errcheck
 
-	return err
+	return resp, err
 }
 
 // EtcdMemberList lists etcd members of the cluster.


### PR DESCRIPTION
This continues the fix from #3167.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

