### PR TITLE
refactor: split kubernetes/etcd resource generation into subresources

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
@@ -132,7 +132,7 @@ func (ctrl *KubeletStaticPodController) Run(ctx context.Context, r controller.Ru
 			return err
 		}
 
-		secrets := secretsResources.(*secrets.Kubernetes).Secrets()
+		secrets := secretsResources.(*secrets.Kubernetes).Certs()
 
 		bootstrapStatus, err := r.Get(ctx, v1alpha1.NewBootstrapStatus().Metadata())
 		if err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
@@ -95,7 +95,7 @@ func (ctrl *ManifestApplyController) Run(ctx context.Context, r controller.Runti
 			return err
 		}
 
-		secrets := secretsResources.(*secrets.Kubernetes).Secrets()
+		secrets := secretsResources.(*secrets.Kubernetes).Certs()
 
 		bootstrapStatus, err := r.Get(ctx, v1alpha1.NewBootstrapStatus().Metadata())
 		if err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -15,7 +15,7 @@ resources:
   - aescbc:
       keys:
       - name: key1
-        secret: {{ .AESCBCEncryptionSecret }}
+        secret: {{ .Root.AESCBCEncryptionSecret }}
   - identity: {}
 `)
 

--- a/internal/app/machined/pkg/controllers/secrets/etcd.go
+++ b/internal/app/machined/pkg/controllers/secrets/etcd.go
@@ -1,0 +1,146 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/AlekSi/pointer"
+	"github.com/talos-systems/os-runtime/pkg/controller"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+
+	"github.com/talos-systems/talos/internal/pkg/etcd"
+	"github.com/talos-systems/talos/pkg/resources/secrets"
+	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
+)
+
+// EtcdController manages secrets.Etcd based on configuration.
+type EtcdController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *EtcdController) Name() string {
+	return "secrets.EtcdController"
+}
+
+// ManagedResources implements controller.Controller interface.
+func (ctrl *EtcdController) ManagedResources() (resource.Namespace, resource.Type) {
+	return secrets.NamespaceName, secrets.EtcdType
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint: gocyclo, dupl
+func (ctrl *EtcdController) Run(ctx context.Context, r controller.Runtime, logger *log.Logger) error {
+	if err := r.UpdateDependencies([]controller.Dependency{
+		{
+			Namespace: secrets.NamespaceName,
+			Type:      secrets.RootType,
+			ID:        pointer.ToString(secrets.RootEtcdID),
+			Kind:      controller.DependencyWeak,
+		},
+		{
+			Namespace: v1alpha1.NamespaceName,
+			Type:      v1alpha1.ServiceType,
+			ID:        pointer.ToString("networkd"),
+			Kind:      controller.DependencyWeak,
+		},
+		{
+			Namespace: v1alpha1.NamespaceName,
+			Type:      v1alpha1.TimeSyncType,
+			ID:        pointer.ToString(v1alpha1.TimeSyncID),
+			Kind:      controller.DependencyWeak,
+		},
+	}); err != nil {
+		return fmt.Errorf("error setting up dependencies: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		etcdRootRes, err := r.Get(ctx, resource.NewMetadata(secrets.NamespaceName, secrets.RootType, secrets.RootEtcdID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				if err = ctrl.teardownAll(ctx, r); err != nil {
+					return fmt.Errorf("error destroying resources: %w", err)
+				}
+
+				continue
+			}
+
+			return fmt.Errorf("error getting etcd root secrets: %w", err)
+		}
+
+		etcdRoot := etcdRootRes.(*secrets.Root).EtcdSpec()
+
+		// wait for networkd to be healthy as it might change IPs/hostname
+		networkdResource, err := r.Get(ctx, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.ServiceType, "networkd", resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return err
+		}
+
+		if !networkdResource.(*v1alpha1.Service).Healthy() {
+			continue
+		}
+
+		// wait for time sync as certs depend on current time
+		timeSyncResource, err := r.Get(ctx, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.TimeSyncType, v1alpha1.TimeSyncID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return err
+		}
+
+		if !timeSyncResource.(*v1alpha1.TimeSync).Sync() {
+			continue
+		}
+
+		if err = r.Update(ctx, secrets.NewEtcd(), func(r resource.Resource) error {
+			return ctrl.updateSecrets(etcdRoot, r.(*secrets.Etcd).Certs())
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+func (ctrl *EtcdController) updateSecrets(etcdRoot *secrets.RootEtcdSpec, etcdCerts *secrets.EtcdCertsSpec) error {
+	var err error
+
+	etcdCerts.EtcdPeer, err = etcd.GeneratePeerCert(etcdRoot.EtcdCA)
+	if err != nil {
+		return fmt.Errorf("error generating etcd certs: %w", err)
+	}
+
+	return nil
+}
+
+func (ctrl *EtcdController) teardownAll(ctx context.Context, r controller.Runtime) error {
+	list, err := r.List(ctx, resource.NewMetadata(secrets.NamespaceName, secrets.EtcdType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	// TODO: change this to proper teardown sequence
+
+	for _, res := range list.Items {
+		if err = r.Destroy(ctx, res.Metadata()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -1,0 +1,172 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/AlekSi/pointer"
+	"github.com/talos-systems/os-runtime/pkg/controller"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+
+	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/secrets"
+)
+
+// RootController manages secrets.Root based on configuration.
+type RootController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *RootController) Name() string {
+	return "secrets.RootController"
+}
+
+// ManagedResources implements controller.Controller interface.
+func (ctrl *RootController) ManagedResources() (resource.Namespace, resource.Type) {
+	return secrets.NamespaceName, secrets.RootType
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint: gocyclo
+func (ctrl *RootController) Run(ctx context.Context, r controller.Runtime, logger *log.Logger) error {
+	if err := r.UpdateDependencies([]controller.Dependency{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.V1Alpha1Type,
+			ID:        pointer.ToString(config.V1Alpha1ID),
+			Kind:      controller.DependencyWeak,
+		},
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineTypeType,
+			ID:        pointer.ToString(config.MachineTypeID),
+			Kind:      controller.DependencyWeak,
+		},
+	}); err != nil {
+		return fmt.Errorf("error setting up dependencies: %w", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		cfg, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.V1Alpha1Type, config.V1Alpha1ID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				if err = ctrl.teardownAll(ctx, r); err != nil {
+					return fmt.Errorf("error destroying static pods: %w", err)
+				}
+
+				continue
+			}
+
+			return fmt.Errorf("error getting config: %w", err)
+		}
+
+		cfgProvider := cfg.(*config.V1Alpha1).Config()
+
+		machineTypeRes, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineTypeType, config.MachineTypeID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return fmt.Errorf("error getting machine type: %w", err)
+		}
+
+		machineType := machineTypeRes.(*config.MachineType).MachineType()
+
+		if machineType != machine.TypeControlPlane && machineType != machine.TypeInit {
+			if err = ctrl.teardownAll(ctx, r); err != nil {
+				return fmt.Errorf("error destroying secrets: %w", err)
+			}
+
+			continue
+		}
+
+		if err = r.Update(ctx, secrets.NewRoot(secrets.RootEtcdID), func(r resource.Resource) error {
+			return ctrl.updateEtcdSecrets(cfgProvider, r.(*secrets.Root).EtcdSpec())
+		}); err != nil {
+			return err
+		}
+
+		if err = r.Update(ctx, secrets.NewRoot(secrets.RootKubernetesID), func(r resource.Resource) error {
+			return ctrl.updateK8sSecrets(cfgProvider, r.(*secrets.Root).KubernetesSpec())
+		}); err != nil {
+			return err
+		}
+	}
+}
+
+func (ctrl *RootController) updateEtcdSecrets(cfgProvider talosconfig.Provider, etcdSecrets *secrets.RootEtcdSpec) error {
+	etcdSecrets.EtcdCA = cfgProvider.Cluster().Etcd().CA()
+
+	if etcdSecrets.EtcdCA == nil {
+		return fmt.Errorf("missing cluster.etcdCA secret")
+	}
+
+	return nil
+}
+
+func (ctrl *RootController) updateK8sSecrets(cfgProvider talosconfig.Provider, k8sSecrets *secrets.RootKubernetesSpec) error {
+	k8sSecrets.Name = cfgProvider.Cluster().Name()
+	k8sSecrets.Endpoint = cfgProvider.Cluster().Endpoint()
+	k8sSecrets.CertSANs = cfgProvider.Cluster().CertSANs()
+	k8sSecrets.DNSDomain = cfgProvider.Cluster().Network().DNSDomain()
+
+	var err error
+
+	k8sSecrets.APIServerIPs, err = cfgProvider.Cluster().Network().APIServerIPs()
+	if err != nil {
+		return fmt.Errorf("error building API service IPs: %w", err)
+	}
+
+	k8sSecrets.AggregatorCA = cfgProvider.Cluster().AggregatorCA()
+
+	if k8sSecrets.AggregatorCA == nil {
+		return fmt.Errorf("missing cluster.aggregatorCA secret")
+	}
+
+	k8sSecrets.CA = cfgProvider.Cluster().CA()
+
+	if k8sSecrets.CA == nil {
+		return fmt.Errorf("missing cluster.CA secret")
+	}
+
+	k8sSecrets.ServiceAccount = cfgProvider.Cluster().ServiceAccount()
+
+	k8sSecrets.AESCBCEncryptionSecret = cfgProvider.Cluster().AESCBCEncryptionSecret()
+
+	k8sSecrets.BootstrapTokenID = cfgProvider.Cluster().Token().ID()
+	k8sSecrets.BootstrapTokenSecret = cfgProvider.Cluster().Token().Secret()
+
+	return nil
+}
+
+func (ctrl *RootController) teardownAll(ctx context.Context, r controller.Runtime) error {
+	list, err := r.List(ctx, resource.NewMetadata(secrets.NamespaceName, secrets.RootType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	// TODO: change this to proper teardown sequence
+
+	for _, res := range list.Items {
+		if err = r.Destroy(ctx, res.Metadata()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -62,7 +62,9 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&k8s.ManifestController{},
 		&k8s.ManifestApplyController{},
 		&k8s.RenderSecretsStaticPodController{},
+		&secrets.EtcdController{},
 		&secrets.KubernetesController{},
+		&secrets.RootController{},
 	} {
 		if err := ctrl.controllerRuntime.RegisterController(c); err != nil {
 			return err

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -80,7 +80,9 @@ func NewState() (*State, error) {
 		&k8s.StaticPod{},
 		&k8s.StaticPodStatus{},
 		&k8s.SecretsStatus{},
+		&secrets.Etcd{},
 		&secrets.Kubernetes{},
+		&secrets.Root{},
 	} {
 		if err := s.resourceRegistry.Register(ctx, r); err != nil {
 			return nil, err

--- a/internal/pkg/kubeconfig/admin.go
+++ b/internal/pkg/kubeconfig/admin.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net/url"
 	"text/template"
 	"time"
 
@@ -38,8 +39,18 @@ contexts:
 current-context: admin@{{ .Cluster }}
 `
 
+// GenerateAdminInput is the interface for the GenerateAdmin function.
+//
+// This interface is implemented by config.Cluster().
+type GenerateAdminInput interface {
+	Name() string
+	Endpoint() *url.URL
+	CA() *x509.PEMEncodedCertificateAndKey
+	AdminKubeconfig() config.AdminKubeconfig
+}
+
 // GenerateAdmin generates admin kubeconfig for the cluster.
-func GenerateAdmin(config config.ClusterConfig, out io.Writer) error {
+func GenerateAdmin(config GenerateAdminInput, out io.Writer) error {
 	tpl, err := template.New("kubeconfig").Parse(adminKubeConfigTemplate)
 	if err != nil {
 		return fmt.Errorf("error parsing kubeconfig template: %w", err)

--- a/pkg/resources/secrets/etcd.go
+++ b/pkg/resources/secrets/etcd.go
@@ -1,0 +1,78 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets
+
+import (
+	"fmt"
+
+	"github.com/talos-systems/crypto/x509"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/resource/core"
+)
+
+// EtcdType is type of Etcd resource.
+const EtcdType = resource.Type("secrets/etcd")
+
+// EtcdID is a resource ID of singletone instance.
+const EtcdID = resource.ID("etcd")
+
+// Etcd contains etcd generated secrets.
+type Etcd struct {
+	md   resource.Metadata
+	spec interface{}
+}
+
+// EtcdCertsSpec describes etcd certs secrets.
+type EtcdCertsSpec struct {
+	EtcdPeer *x509.PEMEncodedCertificateAndKey `yaml:"etcdPeer"`
+}
+
+// NewEtcd initializes a Etc resource.
+func NewEtcd() *Etcd {
+	r := &Etcd{
+		md:   resource.NewMetadata(NamespaceName, EtcdType, EtcdID, resource.VersionUndefined),
+		spec: &EtcdCertsSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Etcd) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Etcd) Spec() interface{} {
+	return r.spec
+}
+
+func (r *Etcd) String() string {
+	return fmt.Sprintf("secrets.Etcd(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Etcd) DeepCopy() resource.Resource {
+	return &Etcd{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements core.ResourceDefinitionProvider interface.
+func (r *Etcd) ResourceDefinition() core.ResourceDefinitionSpec {
+	return core.ResourceDefinitionSpec{
+		Type:             EtcdType,
+		Aliases:          []resource.Type{"etcdSecrets", "etcdSecret"},
+		DefaultNamespace: NamespaceName,
+	}
+}
+
+// Certs returns .spec.
+func (r *Etcd) Certs() *EtcdCertsSpec {
+	return r.spec.(*EtcdCertsSpec)
+}

--- a/pkg/resources/secrets/kubernetes.go
+++ b/pkg/resources/secrets/kubernetes.go
@@ -15,40 +15,29 @@ import (
 // KubernetesType is type of Kubernetes resource.
 const KubernetesType = resource.Type("secrets/kubernetes")
 
-// KubernetesID is ID of the singleton instance.
-const KubernetesID = resource.ID("kubernetes")
+// KubernetesID is a resource ID of singleton instance.
+const KubernetesID = resource.ID("k8s-certs")
 
-// Kubernetes contains K8s secrets.
+// Kubernetes contains K8s generated secrets.
 type Kubernetes struct {
 	md   resource.Metadata
-	spec KubernetesSpec
+	spec interface{}
 }
 
-// KubernetesSpec describes Kubernetes resources.
-type KubernetesSpec struct {
-	EtcdCA   *x509.PEMEncodedCertificateAndKey `yaml:"etcdCA"`
-	EtcdPeer *x509.PEMEncodedCertificateAndKey `yaml:"etcdPeer"`
-
-	CA                     *x509.PEMEncodedCertificateAndKey `yaml:"ca"`
+// KubernetesCertsSpec describes generated Kubernetes certificates.
+type KubernetesCertsSpec struct {
 	APIServer              *x509.PEMEncodedCertificateAndKey `yaml:"apiServer"`
 	APIServerKubeletClient *x509.PEMEncodedCertificateAndKey `yaml:"apiServerKubeletClient"`
-	ServiceAccount         *x509.PEMEncodedKey               `yaml:"serviceAccount"`
-	AggregatorCA           *x509.PEMEncodedCertificateAndKey `yaml:"aggregatorCA"`
 	FrontProxy             *x509.PEMEncodedCertificateAndKey `yaml:"frontProxy"`
 
-	AESCBCEncryptionSecret string `yaml:"aesCBCEncryptionSecret"`
-
 	AdminKubeconfig string `yaml:"adminKubeconfig"`
-
-	BootstrapTokenID     string `yaml:"bootstrapTokenID"`
-	BootstrapTokenSecret string `yaml:"bootstrapTokenSecret"`
 }
 
 // NewKubernetes initializes a Kubernetes resource.
 func NewKubernetes() *Kubernetes {
 	r := &Kubernetes{
 		md:   resource.NewMetadata(NamespaceName, KubernetesType, KubernetesID, resource.VersionUndefined),
-		spec: KubernetesSpec{},
+		spec: &KubernetesCertsSpec{},
 	}
 
 	r.md.BumpVersion()
@@ -82,12 +71,12 @@ func (r *Kubernetes) DeepCopy() resource.Resource {
 func (r *Kubernetes) ResourceDefinition() core.ResourceDefinitionSpec {
 	return core.ResourceDefinitionSpec{
 		Type:             KubernetesType,
-		Aliases:          []resource.Type{"secrets", "secret"},
+		Aliases:          []resource.Type{"k8sSecret", "k8sSecrets"},
 		DefaultNamespace: NamespaceName,
 	}
 }
 
-// Secrets returns .spec.
-func (r *Kubernetes) Secrets() *KubernetesSpec {
-	return &r.spec
+// Certs returns .spec.
+func (r *Kubernetes) Certs() *KubernetesCertsSpec {
+	return r.spec.(*KubernetesCertsSpec)
 }

--- a/pkg/resources/secrets/root.go
+++ b/pkg/resources/secrets/root.go
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/talos-systems/crypto/x509"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/resource/core"
+)
+
+// RootType is type of Root secret resource.
+const RootType = resource.Type("secrets/root")
+
+// IDs of various resources of RootType.
+const (
+	RootEtcdID       = resource.ID("etcd-root")
+	RootKubernetesID = resource.ID("k8s-root")
+)
+
+// Root contains root (not generated) secrets.
+type Root struct {
+	md   resource.Metadata
+	spec interface{}
+}
+
+// RootEtcdSpec describes etcd CA secrets.
+type RootEtcdSpec struct {
+	EtcdCA *x509.PEMEncodedCertificateAndKey `yaml:"etcdCA"`
+}
+
+// RootKubernetesSpec describes root Kubernetes secrets.
+type RootKubernetesSpec struct {
+	Name         string   `yaml:"name"`
+	Endpoint     *url.URL `yaml:"endpoint"`
+	CertSANs     []string `yaml:"certSANs"`
+	APIServerIPs []net.IP `yaml:"apiServerIPs"`
+	DNSDomain    string   `yaml:"dnsDomain"`
+
+	CA             *x509.PEMEncodedCertificateAndKey `yaml:"ca"`
+	ServiceAccount *x509.PEMEncodedKey               `yaml:"serviceAccount"`
+	AggregatorCA   *x509.PEMEncodedCertificateAndKey `yaml:"aggregatorCA"`
+
+	AESCBCEncryptionSecret string `yaml:"aesCBCEncryptionSecret"`
+
+	BootstrapTokenID     string `yaml:"bootstrapTokenID"`
+	BootstrapTokenSecret string `yaml:"bootstrapTokenSecret"`
+}
+
+// NewRoot initializes a Root resource.
+func NewRoot(id resource.ID) *Root {
+	r := &Root{
+		md: resource.NewMetadata(NamespaceName, RootType, id, resource.VersionUndefined),
+	}
+
+	switch id {
+	case RootEtcdID:
+		r.spec = &RootEtcdSpec{}
+	case RootKubernetesID:
+		r.spec = &RootKubernetesSpec{}
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Root) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Root) Spec() interface{} {
+	return r.spec
+}
+
+func (r *Root) String() string {
+	return fmt.Sprintf("secrets.Root(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Root) DeepCopy() resource.Resource {
+	return &Root{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements core.ResourceDefinitionProvider interface.
+func (r *Root) ResourceDefinition() core.ResourceDefinitionSpec {
+	return core.ResourceDefinitionSpec{
+		Type:             RootType,
+		Aliases:          []resource.Type{"rootSecret", "rootSecrets"},
+		DefaultNamespace: NamespaceName,
+	}
+}
+
+// EtcdSpec returns .spec.
+func (r *Root) EtcdSpec() *RootEtcdSpec {
+	return r.spec.(*RootEtcdSpec)
+}
+
+// KubernetesSpec returns .spec.
+func (r *Root) KubernetesSpec() *RootKubernetesSpec {
+	return r.spec.(*RootKubernetesSpec)
+}


### PR DESCRIPTION
Fixes #3062

There's no user-visible change in this PR.

It carefully separates generated secrets (e.g. certs) from source
secrets from the config (e.g. CAs), so that certs are generated on
config changes which actually affect cert input.

And same way separates etcd and Kubernetes PKI, so if etcd CA got
changed, only etcd certs will be regenerated.

This should have noticeable impact with RSA-based PKI as it reduces
number of times PKI gets generated.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

