### PR TITLE
fix: skip empty manifest YAML sub-documents

### DIFF
--- a/pkg/resources/k8s/manifest.go
+++ b/pkg/resources/k8s/manifest.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 
 	"github.com/talos-systems/os-runtime/pkg/resource"
 	"github.com/talos-systems/os-runtime/pkg/resource/core"
@@ -115,6 +116,13 @@ func (r *Manifest) SetYAML(yamlBytes []byte) error {
 		if err != nil {
 			return fmt.Errorf("error converting manifest to JSON: %w", err)
 		}
+
+		if bytes.Equal(jsonManifest, []byte("null")) || bytes.Equal(jsonManifest, []byte("{}")) {
+			// skip YAML docs which contain only comments
+			continue
+		}
+
+		log.Printf("jsonManifest = %v", string(jsonManifest))
 
 		obj := new(unstructured.Unstructured)
 

--- a/pkg/resources/k8s/manifest_test.go
+++ b/pkg/resources/k8s/manifest_test.go
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+)
+
+func TestManifestSetYAML(t *testing.T) {
+	manifest := k8s.NewManifest(k8s.ControlPlaneNamespaceName, "test")
+
+	require.NoError(t, manifest.SetYAML([]byte(strings.TrimSpace(`
+---
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata
+---
+`))))
+
+	assert.Len(t, manifest.Objects(), 1)
+	assert.Equal(t, manifest.Objects()[0].GetKind(), "Policy")
+}
+
+func TestManifestSetYAMLEmptyComments(t *testing.T) {
+	manifest := k8s.NewManifest(k8s.ControlPlaneNamespaceName, "test")
+
+	require.NoError(t, manifest.SetYAML([]byte(strings.TrimSpace(`
+---
+apiVersion: audit.k8s.io/v1beta1
+kind: Policy
+rules:
+- level: Metadata
+---
+# Left empty
+---
+`))))
+
+	assert.Len(t, manifest.Objects(), 1)
+	assert.Equal(t, manifest.Objects()[0].GetKind(), "Policy")
+}


### PR DESCRIPTION
If sub-doc contains a comment, it's not empty, but when
loaded into JSON it yields `nil` which should be skipped, as
`Unstructured` can't load from such object.

E.g.:

```
---
 # Some comment
---
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

