### PR TITLE
feat: add an option to disable kube-proxy manifest

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -187,6 +187,7 @@ func (ctrl *K8sControlPlaneController) manageManifestsConfig(ctx context.Context
 			PodCIDRs:     cfgProvider.Cluster().Network().PodCIDR(),
 			FirstPodCIDR: strings.Split(cfgProvider.Cluster().Network().PodCIDR(), ",")[0],
 
+			ProxyEnabled:   cfgProvider.Cluster().Proxy().Enabled(),
 			ProxyImage:     cfgProvider.Cluster().Proxy().Image(),
 			ProxyMode:      cfgProvider.Cluster().Proxy().Mode(),
 			ProxyExtraArgs: cfgProvider.Cluster().Proxy().ExtraArgs(),

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -159,7 +159,6 @@ func (ctrl *ManifestController) render(cfg config.K8sManifestsSpec, scrt *secret
 		{"01-csr-renewal-role-binding", csrRenewalRoleBindingTemplate},
 		{"02-kube-system-sa-role-binding", kubeSystemSARoleBindingTemplate},
 		{"03-default-pod-security-policy", podSecurityPolicy},
-		{"10-kube-proxy", kubeProxyTemplate},
 		{"11-kube-config-in-cluster", kubeConfigInClusterTemplate},
 		{"11-core-dns", coreDNSTemplate},
 		{"11-core-dns-svc", coreDNSSvcTemplate},
@@ -177,6 +176,14 @@ func (ctrl *ManifestController) render(cfg config.K8sManifestsSpec, scrt *secret
 		defaultManifests = append(defaultManifests,
 			[]manifestDesc{
 				{"05-flannel", flannelTemplate},
+			}...,
+		)
+	}
+
+	if cfg.ProxyEnabled {
+		defaultManifests = append(defaultManifests,
+			[]manifestDesc{
+				{"10-kube-proxy", kubeProxyTemplate},
 			}...,
 		)
 	}

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -1,0 +1,177 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
+
+	k8sctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/secrets"
+)
+
+type ManifestSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *ManifestSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	logger := log.New(log.Writer(), "controller-runtime: ", log.Flags())
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.ManifestController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *ManifestSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *ManifestSuite) assertManifests(manifests []string) error {
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.ManifestType, "", resource.VersionUndefined))
+	if err != nil {
+		return retry.UnexpectedError(err)
+	}
+
+	ids := make([]string, 0, len(resources.Items))
+
+	for _, res := range resources.Items {
+		ids = append(ids, res.Metadata().ID())
+	}
+
+	if !reflect.DeepEqual(manifests, ids) {
+		return retry.ExpectedError(fmt.Errorf("expected %q, got %q", manifests, ids))
+	}
+
+	return nil
+}
+
+var defaultManifestSpec = config.K8sManifestsSpec{
+	Server:        "127.0.0.1",
+	ClusterDomain: "cluster.",
+
+	PodCIDRs:     constants.DefaultIPv4PodNet,
+	FirstPodCIDR: constants.DefaultIPv4PodNet,
+
+	ProxyEnabled: true,
+	ProxyImage:   "foo/bar",
+
+	CoreDNSImage: "foo/bar",
+
+	DNSServiceIP: "192.168.0.1",
+
+	FlannelEnabled:  true,
+	FlannelImage:    "foo/bar",
+	FlannelCNIImage: "foo/bar",
+}
+
+func (suite *ManifestSuite) TestReconcileDefaults() {
+	rootSecrets := secrets.NewRoot(secrets.RootKubernetesID)
+	manifestConfig := config.NewK8sManifests()
+	manifestConfig.SetManifests(defaultManifestSpec)
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, rootSecrets))
+	suite.Require().NoError(suite.state.Create(suite.ctx, manifestConfig))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertManifests(
+				[]string{
+					"00-kubelet-bootstrapping-token",
+					"01-csr-approver-role-binding",
+					"01-csr-node-bootstrap",
+					"01-csr-renewal-role-binding",
+					"02-kube-system-sa-role-binding", "03-default-pod-security-policy", "05-flannel",
+					"10-kube-proxy",
+					"11-core-dns",
+					"11-core-dns-svc",
+					"11-kube-config-in-cluster",
+				},
+			)
+		},
+	))
+}
+
+func (suite *ManifestSuite) TestReconcileDisableKubeProxy() {
+	rootSecrets := secrets.NewRoot(secrets.RootKubernetesID)
+	manifestConfig := config.NewK8sManifests()
+	spec := defaultManifestSpec
+	spec.ProxyEnabled = false
+	manifestConfig.SetManifests(spec)
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, rootSecrets))
+	suite.Require().NoError(suite.state.Create(suite.ctx, manifestConfig))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertManifests(
+				[]string{
+					"00-kubelet-bootstrapping-token",
+					"01-csr-approver-role-binding",
+					"01-csr-node-bootstrap",
+					"01-csr-renewal-role-binding",
+					"02-kube-system-sa-role-binding", "03-default-pod-security-policy", "05-flannel",
+					"11-core-dns",
+					"11-core-dns-svc",
+					"11-kube-config-in-cluster",
+				},
+			)
+		},
+	))
+}
+
+func (suite *ManifestSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	suite.Assert().NoError(suite.state.Create(context.Background(), secrets.NewRoot(secrets.RootEtcdID)))
+	suite.Assert().NoError(suite.state.Create(context.Background(), config.NewK8sControlPlaneAPIServer()))
+}
+
+func TestManifestSuite(t *testing.T) {
+	suite.Run(t, new(ManifestSuite))
+}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -302,6 +302,8 @@ type ControllerManager interface {
 // Proxy defines the requirements for a config that pertains to the kube-proxy
 // options.
 type Proxy interface {
+	Enabled() bool
+
 	Image() string
 
 	// Mode indicates the proxy mode for kube-proxy.  By default, this is `iptables`.  Other options include `ipvs`.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -384,6 +384,11 @@ func (c *ClusterConfig) Proxy() config.Proxy {
 	return c.ProxyConfig
 }
 
+// Enabled implements the config.Provider interface.
+func (p *ProxyConfig) Enabled() bool {
+	return !p.Disabled
+}
+
 // Image implements the config.Provider interface.
 func (p *ProxyConfig) Image() string {
 	image := p.ContainerImage

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -894,6 +894,11 @@ type ControllerManagerConfig struct {
 // ProxyConfig represents the kube proxy configuration options.
 type ProxyConfig struct {
 	//   description: |
+	//     Disable kube-proxy deployment on cluster bootstrap.
+	//   examples:
+	//     - value: false
+	Disabled bool `yaml:"disabled,omitempty"`
+	//   description: |
 	//     The container image used in the kube-proxy manifest.
 	//   examples:
 	//     - value: clusterProxyImageExample

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -718,24 +718,31 @@ func init() {
 			FieldName: "proxy",
 		},
 	}
-	ProxyConfigDoc.Fields = make([]encoder.Doc, 3)
-	ProxyConfigDoc.Fields[0].Name = "image"
-	ProxyConfigDoc.Fields[0].Type = "string"
+	ProxyConfigDoc.Fields = make([]encoder.Doc, 4)
+	ProxyConfigDoc.Fields[0].Name = "disabled"
+	ProxyConfigDoc.Fields[0].Type = "bool"
 	ProxyConfigDoc.Fields[0].Note = ""
-	ProxyConfigDoc.Fields[0].Description = "The container image used in the kube-proxy manifest."
-	ProxyConfigDoc.Fields[0].Comments[encoder.LineComment] = "The container image used in the kube-proxy manifest."
+	ProxyConfigDoc.Fields[0].Description = "Disable kube-proxy deployment on cluster bootstrap."
+	ProxyConfigDoc.Fields[0].Comments[encoder.LineComment] = "Disable kube-proxy deployment on cluster bootstrap."
 
-	ProxyConfigDoc.Fields[0].AddExample("", clusterProxyImageExample)
-	ProxyConfigDoc.Fields[1].Name = "mode"
+	ProxyConfigDoc.Fields[0].AddExample("", false)
+	ProxyConfigDoc.Fields[1].Name = "image"
 	ProxyConfigDoc.Fields[1].Type = "string"
 	ProxyConfigDoc.Fields[1].Note = ""
-	ProxyConfigDoc.Fields[1].Description = "proxy mode of kube-proxy.\nThe default is 'iptables'."
-	ProxyConfigDoc.Fields[1].Comments[encoder.LineComment] = "proxy mode of kube-proxy."
-	ProxyConfigDoc.Fields[2].Name = "extraArgs"
-	ProxyConfigDoc.Fields[2].Type = "map[string]string"
+	ProxyConfigDoc.Fields[1].Description = "The container image used in the kube-proxy manifest."
+	ProxyConfigDoc.Fields[1].Comments[encoder.LineComment] = "The container image used in the kube-proxy manifest."
+
+	ProxyConfigDoc.Fields[1].AddExample("", clusterProxyImageExample)
+	ProxyConfigDoc.Fields[2].Name = "mode"
+	ProxyConfigDoc.Fields[2].Type = "string"
 	ProxyConfigDoc.Fields[2].Note = ""
-	ProxyConfigDoc.Fields[2].Description = "Extra arguments to supply to kube-proxy."
-	ProxyConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra arguments to supply to kube-proxy."
+	ProxyConfigDoc.Fields[2].Description = "proxy mode of kube-proxy.\nThe default is 'iptables'."
+	ProxyConfigDoc.Fields[2].Comments[encoder.LineComment] = "proxy mode of kube-proxy."
+	ProxyConfigDoc.Fields[3].Name = "extraArgs"
+	ProxyConfigDoc.Fields[3].Type = "map[string]string"
+	ProxyConfigDoc.Fields[3].Note = ""
+	ProxyConfigDoc.Fields[3].Description = "Extra arguments to supply to kube-proxy."
+	ProxyConfigDoc.Fields[3].Comments[encoder.LineComment] = "Extra arguments to supply to kube-proxy."
 
 	SchedulerConfigDoc.Type = "SchedulerConfig"
 	SchedulerConfigDoc.Comments[encoder.LineComment] = "SchedulerConfig represents the kube scheduler configuration options."

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -63,6 +63,8 @@ type K8sControlPlaneSchedulerSpec struct {
 }
 
 // K8sManifestsSpec is configuration for manifests.
+//
+//nolint: malign
 type K8sManifestsSpec struct {
 	Server        string `yaml:"string"`
 	ClusterDomain string `yaml:"clusterDomain"`
@@ -70,6 +72,7 @@ type K8sManifestsSpec struct {
 	PodCIDRs     string `yaml:"podCIDRs"`
 	FirstPodCIDR string `yaml:"firstPodCIDR"`
 
+	ProxyEnabled   bool              `yaml:"proxyEnabled"`
 	ProxyImage     string            `yaml:"proxyImage"`
 	ProxyMode      string            `yaml:"proxyMode"`
 	ProxyExtraArgs map[string]string `yaml:"proxyExtraArgs"`

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -2187,6 +2187,29 @@ extraArgs:
 
 <div class="dd">
 
+<code>disabled</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Disable kube-proxy deployment on cluster bootstrap.
+
+
+
+Examples:
+
+
+``` yaml
+disabled: false
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
 <code>image</code>  <i>string</i>
 
 </div>


### PR DESCRIPTION
This options drops kube-proxy manifest from the list of bootstrap
manifests. It might be used with CNIs which don't need `kube-proxy`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

