### PR TITLE
fix: correctly escape extra args in kube-proxy manifest

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -141,7 +141,7 @@ spec:
         - --proxy-mode={{ .ProxyMode }}
         - --conntrack-max-per-core=0
         {{- range $k, $v := .ProxyExtraArgs }}
-        - --{{ $k }}={{ $v }}
+        - {{ printf "--%s=%s" $k $v | json }}
         {{- end }}
         env:
           - name: NODE_NAME

--- a/pkg/resources/k8s/manifest.go
+++ b/pkg/resources/k8s/manifest.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 
 	"github.com/talos-systems/os-runtime/pkg/resource"
 	"github.com/talos-systems/os-runtime/pkg/resource/core"
@@ -121,8 +120,6 @@ func (r *Manifest) SetYAML(yamlBytes []byte) error {
 			// skip YAML docs which contain only comments
 			continue
 		}
-
-		log.Printf("jsonManifest = %v", string(jsonManifest))
 
 		obj := new(unstructured.Unstructured)
 


### PR DESCRIPTION
JSON is a subset of YAML, so we can use JSON to escape whole YAML value
to handle any kind of symbols.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

