### PR TITLE
fix: handle case when kubelet serving certificates are issued

### DIFF
--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -198,6 +198,12 @@ func (o *APID) syncKubeletPKI() {
 		}
 	}
 
+	if err := os.MkdirAll(constants.KubeletPKIDir, 0o700); err != nil {
+		log.Printf("failed creating kubelet PKI directory: %s", err)
+
+		return
+	}
+
 	copyAll()
 
 	o.ctx, o.cancel = context.WithCancel(context.Background())


### PR DESCRIPTION
If kubelet is configured to issue certificates from the control plane,
`/var/lib/kubelet/pki/kubelet.crt` file is never created, and cluster CA
canv be used to verify the TLS connection.

Use k8s `RESTClient` instead of a custom client, this also results in
much more descriptive error messages if API call fails.

Fix a problem in apid on worker nodes with issued serving certificates:
`/var/lib/kubelet/pki` doesn't exist by the time `apid` starts.

First write static pods, then try to build kubelet client: for issued
serving kubelet certificates, control plane should be up first.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

