### PR TITLE
feat: add support for extra volume mounts for control plane pods

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
@@ -1,0 +1,200 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
+
+	configctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+)
+
+type K8sControlPlaneSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *K8sControlPlaneSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	logger := log.New(log.Writer(), "controller-runtime: ", log.Flags())
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&configctrl.K8sControlPlaneController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *K8sControlPlaneSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *K8sControlPlaneSuite) assertK8sControlPlanes(manifests []string) error {
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(config.NamespaceName, config.K8sControlPlaneType, "", resource.VersionUndefined))
+	if err != nil {
+		return retry.UnexpectedError(err)
+	}
+
+	ids := make([]string, 0, len(resources.Items))
+
+	for _, res := range resources.Items {
+		ids = append(ids, res.Metadata().ID())
+	}
+
+	if !reflect.DeepEqual(manifests, ids) {
+		return retry.ExpectedError(fmt.Errorf("expected %q, got %q", manifests, ids))
+	}
+
+	return nil
+}
+
+func (suite *K8sControlPlaneSuite) TestReconcileDefaults() {
+	machineType := config.NewMachineType()
+	machineType.SetMachineType(machine.TypeControlPlane)
+
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+		},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineType))
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertK8sControlPlanes(
+				[]string{
+					config.K8sExtraManifestsID,
+					config.K8sControlPlaneAPIServerID,
+					config.K8sControlPlaneControllerManagerID,
+					config.K8sControlPlaneSchedulerID,
+					config.K8sManifestsID,
+				},
+			)
+		},
+	))
+}
+
+func (suite *K8sControlPlaneSuite) TestReconcileExtraVolumes() {
+	machineType := config.NewMachineType()
+	machineType.SetMachineType(machine.TypeControlPlane)
+
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewV1Alpha1(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+			APIServerConfig: &v1alpha1.APIServerConfig{
+				ExtraVolumesConfig: []v1alpha1.VolumeMountConfig{
+					{
+						VolumeHostPath:  "/var/lib",
+						VolumeMountPath: "/var/foo",
+					},
+				},
+			},
+		},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineType))
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertK8sControlPlanes(
+				[]string{
+					config.K8sExtraManifestsID,
+					config.K8sControlPlaneAPIServerID,
+					config.K8sControlPlaneControllerManagerID,
+					config.K8sControlPlaneSchedulerID,
+					config.K8sManifestsID,
+				},
+			)
+		},
+	))
+
+	r, err := suite.state.Get(suite.ctx, config.NewK8sControlPlaneAPIServer().Metadata())
+	suite.Require().NoError(err)
+
+	apiServerCfg := r.(*config.K8sControlPlane).APIServer()
+
+	suite.Assert().Equal([]config.K8sExtraVolume{
+		{
+			Name:      "-var-foo",
+			HostPath:  "/var/lib",
+			MountPath: "/var/foo",
+			ReadOnly:  false,
+		},
+	}, apiServerCfg.ExtraVolumes)
+}
+
+func (suite *K8sControlPlaneSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	suite.Assert().NoError(suite.state.Create(context.Background(), k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, "-")))
+	suite.Assert().NoError(suite.state.Destroy(context.Background(), config.NewK8sControlPlaneAPIServer().Metadata()))
+}
+
+func TestK8sControlPlaneSuite(t *testing.T) {
+	suite.Run(t, new(K8sControlPlaneSuite))
+}

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
+	v1 "k8s.io/api/core/v1"
+
+	k8sctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+)
+
+type ControlPlaneStaticPodSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *ControlPlaneStaticPodSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	logger := log.New(log.Writer(), "controller-runtime: ", log.Flags())
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.ControlPlaneStaticPodController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *ControlPlaneStaticPodSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+//nolint: dupl
+func (suite *ControlPlaneStaticPodSuite) assertControlPlaneStaticPods(manifests []string) error {
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.StaticPodType, "", resource.VersionUndefined))
+	if err != nil {
+		return retry.UnexpectedError(err)
+	}
+
+	ids := make([]string, 0, len(resources.Items))
+
+	for _, res := range resources.Items {
+		ids = append(ids, res.Metadata().ID())
+	}
+
+	if !reflect.DeepEqual(manifests, ids) {
+		return retry.ExpectedError(fmt.Errorf("expected %q, got %q", manifests, ids))
+	}
+
+	return nil
+}
+
+func (suite *ControlPlaneStaticPodSuite) TestReconcileDefaults() {
+	secretStatus := k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, k8s.StaticPodSecretsStaticPodID)
+	configAPIServer := config.NewK8sControlPlaneAPIServer()
+	configControllerManager := config.NewK8sControlPlaneControllerManager()
+	configScheduler := config.NewK8sControlPlaneScheduler()
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, secretStatus))
+	suite.Require().NoError(suite.state.Create(suite.ctx, configAPIServer))
+	suite.Require().NoError(suite.state.Create(suite.ctx, configControllerManager))
+	suite.Require().NoError(suite.state.Create(suite.ctx, configScheduler))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertControlPlaneStaticPods(
+				[]string{
+					"kube-apiserver",
+					"kube-controller-manager",
+					"kube-scheduler",
+				},
+			)
+		},
+	))
+}
+
+func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraMounts() {
+	secretStatus := k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, k8s.StaticPodSecretsStaticPodID)
+	configAPIServer := config.NewK8sControlPlaneAPIServer()
+	configAPIServer.SetAPIServer(config.K8sControlPlaneAPIServerSpec{
+		ExtraVolumes: []config.K8sExtraVolume{
+			{
+				Name:      "foo",
+				HostPath:  "/var/lib",
+				MountPath: "/var/foo",
+				ReadOnly:  true,
+			},
+		},
+	})
+
+	configControllerManager := config.NewK8sControlPlaneControllerManager()
+	configScheduler := config.NewK8sControlPlaneScheduler()
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, secretStatus))
+	suite.Require().NoError(suite.state.Create(suite.ctx, configAPIServer))
+	suite.Require().NoError(suite.state.Create(suite.ctx, configControllerManager))
+	suite.Require().NoError(suite.state.Create(suite.ctx, configScheduler))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertControlPlaneStaticPods(
+				[]string{
+					"kube-apiserver",
+					"kube-controller-manager",
+					"kube-scheduler",
+				},
+			)
+		},
+	))
+
+	r, err := suite.state.Get(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.StaticPodType, "kube-apiserver", resource.VersionUndefined))
+	suite.Require().NoError(err)
+
+	apiServerPod := r.(*k8s.StaticPod).Pod()
+
+	suite.Assert().Len(apiServerPod.Spec.Volumes, 2)
+	suite.Assert().Len(apiServerPod.Spec.Containers[0].VolumeMounts, 2)
+
+	suite.Assert().Equal(v1.Volume{
+		Name: "secrets",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: constants.KubernetesAPIServerSecretsDir,
+			},
+		},
+	}, apiServerPod.Spec.Volumes[0])
+
+	suite.Assert().Equal(v1.Volume{
+		Name: "foo",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: "/var/lib",
+			},
+		},
+	}, apiServerPod.Spec.Volumes[1])
+
+	suite.Assert().Equal(v1.VolumeMount{
+		Name:      "secrets",
+		MountPath: constants.KubernetesAPIServerSecretsDir,
+		ReadOnly:  true,
+	}, apiServerPod.Spec.Containers[0].VolumeMounts[0])
+
+	suite.Assert().Equal(v1.VolumeMount{
+		Name:      "foo",
+		MountPath: "/var/foo",
+		ReadOnly:  true,
+	}, apiServerPod.Spec.Containers[0].VolumeMounts[1])
+}
+
+func (suite *ControlPlaneStaticPodSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	suite.Assert().NoError(suite.state.Create(context.Background(), k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, "-")))
+	suite.Assert().NoError(suite.state.Create(context.Background(), config.NewK8sManifests()))
+}
+
+func TestControlPlaneStaticPodSuite(t *testing.T) {
+	suite.Run(t, new(ControlPlaneStaticPodSuite))
+}

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -67,6 +67,7 @@ func (suite *ManifestSuite) startRuntime() {
 	}()
 }
 
+//nolint: dupl
 func (suite *ManifestSuite) assertManifests(manifests []string) error {
 	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.ManifestType, "", resource.VersionUndefined))
 	if err != nil {

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -290,6 +290,7 @@ type CNI interface {
 type APIServer interface {
 	Image() string
 	ExtraArgs() map[string]string
+	ExtraVolumes() []VolumeMount
 }
 
 // ControllerManager defines the requirements for a config that pertains to controller manager related
@@ -297,6 +298,7 @@ type APIServer interface {
 type ControllerManager interface {
 	Image() string
 	ExtraArgs() map[string]string
+	ExtraVolumes() []VolumeMount
 }
 
 // Proxy defines the requirements for a config that pertains to the kube-proxy
@@ -318,6 +320,7 @@ type Proxy interface {
 type Scheduler interface {
 	Image() string
 	ExtraArgs() map[string]string
+	ExtraVolumes() []VolumeMount
 }
 
 // Etcd defines the requirements for a config that pertains to etcd related
@@ -372,4 +375,12 @@ type Encryption interface {
 // SystemDiskEncryption accumulates settings for all system partitions encryption.
 type SystemDiskEncryption interface {
 	Get(label string) Encryption
+}
+
+// VolumeMount describes extra volume mount for the static pods.
+type VolumeMount interface {
+	Name() string
+	HostPath() string
+	MountPath() string
+	ReadOnly() bool
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -350,6 +350,17 @@ func (a *APIServerConfig) ExtraArgs() map[string]string {
 	return a.ExtraArgsConfig
 }
 
+// ExtraVolumes implements the config.Provider interface.
+func (a *APIServerConfig) ExtraVolumes() []config.VolumeMount {
+	volumes := make([]config.VolumeMount, 0, len(a.ExtraVolumesConfig))
+
+	for _, volume := range a.ExtraVolumesConfig {
+		volumes = append(volumes, volume)
+	}
+
+	return volumes
+}
+
 // ControllerManager implements the config.Provider interface.
 func (c *ClusterConfig) ControllerManager() config.ControllerManager {
 	if c.ControllerManagerConfig == nil {
@@ -373,6 +384,17 @@ func (c *ControllerManagerConfig) Image() string {
 // ExtraArgs implements the config.Provider interface.
 func (c *ControllerManagerConfig) ExtraArgs() map[string]string {
 	return c.ExtraArgsConfig
+}
+
+// ExtraVolumes implements the config.Provider interface.
+func (c *ControllerManagerConfig) ExtraVolumes() []config.VolumeMount {
+	volumes := make([]config.VolumeMount, 0, len(c.ExtraVolumesConfig))
+
+	for _, volume := range c.ExtraVolumesConfig {
+		volumes = append(volumes, volume)
+	}
+
+	return volumes
 }
 
 // Proxy implements the config.Provider interface.
@@ -449,8 +471,23 @@ func (s *SchedulerConfig) ExtraArgs() map[string]string {
 	return s.ExtraArgsConfig
 }
 
+// ExtraVolumes implements the config.Provider interface.
+func (s *SchedulerConfig) ExtraVolumes() []config.VolumeMount {
+	volumes := make([]config.VolumeMount, 0, len(s.ExtraVolumesConfig))
+
+	for _, volume := range s.ExtraVolumesConfig {
+		volumes = append(volumes, volume)
+	}
+
+	return volumes
+}
+
 // Etcd implements the config.Provider interface.
 func (c *ClusterConfig) Etcd() config.Etcd {
+	if c.EtcdConfig == nil {
+		c.EtcdConfig = &EtcdConfig{}
+	}
+
 	return c.EtcdConfig
 }
 
@@ -1261,4 +1298,24 @@ func (e *SystemDiskEncryptionConfig) Get(label string) config.Encryption {
 	}
 
 	return nil
+}
+
+// HostPath implements the config.VolumeMount interface.
+func (v VolumeMountConfig) HostPath() string {
+	return v.VolumeHostPath
+}
+
+// MountPath implements the config.VolumeMount interface.
+func (v VolumeMountConfig) MountPath() string {
+	return v.VolumeMountPath
+}
+
+// Name implements the config.VolumeMount interface.
+func (v VolumeMountConfig) Name() string {
+	return strings.ReplaceAll(v.VolumeMountPath, "/", "-")
+}
+
+// ReadOnly implements the config.VolumeMount interface.
+func (v VolumeMountConfig) ReadOnly() bool {
+	return v.VolumeReadOnly
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -39,6 +39,15 @@ func init() {
 	})
 }
 
+func mustParseURL(uri string) *url.URL {
+	u, err := url.Parse(uri)
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}
+
 var (
 	// Examples section.
 
@@ -301,6 +310,14 @@ var (
 
 	clusterAdminKubeconfigExample = AdminKubeconfigConfig{
 		AdminKubeconfigCertLifetime: time.Hour,
+	}
+
+	clusterEndpointExample1 = &Endpoint{
+		mustParseURL("https://1.2.3.4:6443"),
+	}
+
+	clusterEndpointExample2 = &Endpoint{
+		mustParseURL("https://cluster1.internal:6443"),
 	}
 
 	kubeletExtraMountsExample = []specs.Mount{
@@ -854,8 +871,8 @@ type ControlPlaneConfig struct {
 	//     Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
 	//     It is single-valued, and may optionally include a port number.
 	//   examples:
-	//     - value: '"https://1.2.3.4:6443"'
-	//     - value: '"https://cluster1.internal:6443"'
+	//     - value: clusterEndpointExample1
+	//     - value: clusterEndpointExample2
 	Endpoint *Endpoint `yaml:"endpoint"`
 	//   description: |
 	//     The port that the API server listens on internally.
@@ -875,6 +892,9 @@ type APIServerConfig struct {
 	//     Extra arguments to supply to the API server.
 	ExtraArgsConfig map[string]string `yaml:"extraArgs,omitempty"`
 	//   description: |
+	//     Extra volumes to mount to the API server static pod.
+	ExtraVolumesConfig []VolumeMountConfig `yaml:"extraVolumes,omitempty"`
+	//   description: |
 	//     Extra certificate subject alternative names for the API server's certificate.
 	CertSANs []string `yaml:"certSANs,omitempty"`
 }
@@ -889,6 +909,9 @@ type ControllerManagerConfig struct {
 	//   description: |
 	//     Extra arguments to supply to the controller manager.
 	ExtraArgsConfig map[string]string `yaml:"extraArgs,omitempty"`
+	//   description: |
+	//     Extra volumes to mount to the controller manager static pod.
+	ExtraVolumesConfig []VolumeMountConfig `yaml:"extraVolumes,omitempty"`
 }
 
 // ProxyConfig represents the kube proxy configuration options.
@@ -922,6 +945,9 @@ type SchedulerConfig struct {
 	//   description: |
 	//     Extra arguments to supply to the scheduler.
 	ExtraArgsConfig map[string]string `yaml:"extraArgs,omitempty"`
+	//   description: |
+	//     Extra volumes to mount to the scheduler static pod.
+	ExtraVolumesConfig []VolumeMountConfig `yaml:"extraVolumes,omitempty"`
 }
 
 // EtcdConfig represents the etcd configuration options.
@@ -1467,4 +1493,23 @@ type SystemDiskEncryptionConfig struct {
 	//   description: |
 	//     Ephemeral partition encryption.
 	EphemeralPartition *EncryptionConfig `yaml:"ephemeral,omitempty"`
+}
+
+// VolumeMountConfig struct describes extra volume mount for the static pods.
+type VolumeMountConfig struct {
+	//   description: |
+	//     Path on the host.
+	//   examples:
+	//     - value: '"/var/lib/auth"'
+	VolumeHostPath string `yaml:"hostPath"`
+	//   description: |
+	//     Path in the container.
+	//   examples:
+	//     - value: '"/etc/kubernetes/auth"'
+	VolumeMountPath string `yaml:"mountPath"`
+	//   description: |
+	//     Mount the volume read only.
+	//   examples:
+	//     - value: true
+	VolumeReadOnly bool `yaml:"readonly,omitempty"`
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -51,6 +51,7 @@ var (
 	RegistryAuthConfigDoc         encoder.Doc
 	RegistryTLSConfigDoc          encoder.Doc
 	SystemDiskEncryptionConfigDoc encoder.Doc
+	VolumeMountConfigDoc          encoder.Doc
 )
 
 func init() {
@@ -614,9 +615,9 @@ func init() {
 	EndpointDoc.Comments[encoder.LineComment] = "Endpoint represents the endpoint URL parsed out of the machine config."
 	EndpointDoc.Description = "Endpoint represents the endpoint URL parsed out of the machine config."
 
-	EndpointDoc.AddExample("", "https://1.2.3.4:6443")
+	EndpointDoc.AddExample("", clusterEndpointExample1)
 
-	EndpointDoc.AddExample("", "https://cluster1.internal:6443")
+	EndpointDoc.AddExample("", clusterEndpointExample2)
 	EndpointDoc.AppearsIn = []encoder.Appearance{
 		{
 			TypeName:  "ControlPlaneConfig",
@@ -643,9 +644,9 @@ func init() {
 	ControlPlaneConfigDoc.Fields[0].Description = "Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.\nIt is single-valued, and may optionally include a port number."
 	ControlPlaneConfigDoc.Fields[0].Comments[encoder.LineComment] = "Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname."
 
-	ControlPlaneConfigDoc.Fields[0].AddExample("", "https://1.2.3.4:6443")
+	ControlPlaneConfigDoc.Fields[0].AddExample("", clusterEndpointExample1)
 
-	ControlPlaneConfigDoc.Fields[0].AddExample("", "https://cluster1.internal:6443")
+	ControlPlaneConfigDoc.Fields[0].AddExample("", clusterEndpointExample2)
 	ControlPlaneConfigDoc.Fields[1].Name = "localAPIServerPort"
 	ControlPlaneConfigDoc.Fields[1].Type = "int"
 	ControlPlaneConfigDoc.Fields[1].Note = ""
@@ -663,7 +664,7 @@ func init() {
 			FieldName: "apiServer",
 		},
 	}
-	APIServerConfigDoc.Fields = make([]encoder.Doc, 3)
+	APIServerConfigDoc.Fields = make([]encoder.Doc, 4)
 	APIServerConfigDoc.Fields[0].Name = "image"
 	APIServerConfigDoc.Fields[0].Type = "string"
 	APIServerConfigDoc.Fields[0].Note = ""
@@ -676,11 +677,16 @@ func init() {
 	APIServerConfigDoc.Fields[1].Note = ""
 	APIServerConfigDoc.Fields[1].Description = "Extra arguments to supply to the API server."
 	APIServerConfigDoc.Fields[1].Comments[encoder.LineComment] = "Extra arguments to supply to the API server."
-	APIServerConfigDoc.Fields[2].Name = "certSANs"
-	APIServerConfigDoc.Fields[2].Type = "[]string"
+	APIServerConfigDoc.Fields[2].Name = "extraVolumes"
+	APIServerConfigDoc.Fields[2].Type = "[]VolumeMountConfig"
 	APIServerConfigDoc.Fields[2].Note = ""
-	APIServerConfigDoc.Fields[2].Description = "Extra certificate subject alternative names for the API server's certificate."
-	APIServerConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra certificate subject alternative names for the API server's certificate."
+	APIServerConfigDoc.Fields[2].Description = "Extra volumes to mount to the API server static pod."
+	APIServerConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra volumes to mount to the API server static pod."
+	APIServerConfigDoc.Fields[3].Name = "certSANs"
+	APIServerConfigDoc.Fields[3].Type = "[]string"
+	APIServerConfigDoc.Fields[3].Note = ""
+	APIServerConfigDoc.Fields[3].Description = "Extra certificate subject alternative names for the API server's certificate."
+	APIServerConfigDoc.Fields[3].Comments[encoder.LineComment] = "Extra certificate subject alternative names for the API server's certificate."
 
 	ControllerManagerConfigDoc.Type = "ControllerManagerConfig"
 	ControllerManagerConfigDoc.Comments[encoder.LineComment] = "ControllerManagerConfig represents the kube controller manager configuration options."
@@ -693,7 +699,7 @@ func init() {
 			FieldName: "controllerManager",
 		},
 	}
-	ControllerManagerConfigDoc.Fields = make([]encoder.Doc, 2)
+	ControllerManagerConfigDoc.Fields = make([]encoder.Doc, 3)
 	ControllerManagerConfigDoc.Fields[0].Name = "image"
 	ControllerManagerConfigDoc.Fields[0].Type = "string"
 	ControllerManagerConfigDoc.Fields[0].Note = ""
@@ -706,6 +712,11 @@ func init() {
 	ControllerManagerConfigDoc.Fields[1].Note = ""
 	ControllerManagerConfigDoc.Fields[1].Description = "Extra arguments to supply to the controller manager."
 	ControllerManagerConfigDoc.Fields[1].Comments[encoder.LineComment] = "Extra arguments to supply to the controller manager."
+	ControllerManagerConfigDoc.Fields[2].Name = "extraVolumes"
+	ControllerManagerConfigDoc.Fields[2].Type = "[]VolumeMountConfig"
+	ControllerManagerConfigDoc.Fields[2].Note = ""
+	ControllerManagerConfigDoc.Fields[2].Description = "Extra volumes to mount to the controller manager static pod."
+	ControllerManagerConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra volumes to mount to the controller manager static pod."
 
 	ProxyConfigDoc.Type = "ProxyConfig"
 	ProxyConfigDoc.Comments[encoder.LineComment] = "ProxyConfig represents the kube proxy configuration options."
@@ -755,7 +766,7 @@ func init() {
 			FieldName: "scheduler",
 		},
 	}
-	SchedulerConfigDoc.Fields = make([]encoder.Doc, 2)
+	SchedulerConfigDoc.Fields = make([]encoder.Doc, 3)
 	SchedulerConfigDoc.Fields[0].Name = "image"
 	SchedulerConfigDoc.Fields[0].Type = "string"
 	SchedulerConfigDoc.Fields[0].Note = ""
@@ -768,6 +779,11 @@ func init() {
 	SchedulerConfigDoc.Fields[1].Note = ""
 	SchedulerConfigDoc.Fields[1].Description = "Extra arguments to supply to the scheduler."
 	SchedulerConfigDoc.Fields[1].Comments[encoder.LineComment] = "Extra arguments to supply to the scheduler."
+	SchedulerConfigDoc.Fields[2].Name = "extraVolumes"
+	SchedulerConfigDoc.Fields[2].Type = "[]VolumeMountConfig"
+	SchedulerConfigDoc.Fields[2].Note = ""
+	SchedulerConfigDoc.Fields[2].Description = "Extra volumes to mount to the scheduler static pod."
+	SchedulerConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra volumes to mount to the scheduler static pod."
 
 	EtcdConfigDoc.Type = "EtcdConfig"
 	EtcdConfigDoc.Comments[encoder.LineComment] = "EtcdConfig represents the etcd configuration options."
@@ -1600,6 +1616,46 @@ func init() {
 	SystemDiskEncryptionConfigDoc.Fields[1].Note = ""
 	SystemDiskEncryptionConfigDoc.Fields[1].Description = "Ephemeral partition encryption."
 	SystemDiskEncryptionConfigDoc.Fields[1].Comments[encoder.LineComment] = "Ephemeral partition encryption."
+
+	VolumeMountConfigDoc.Type = "VolumeMountConfig"
+	VolumeMountConfigDoc.Comments[encoder.LineComment] = "VolumeMountConfig struct describes extra volume mount for the static pods."
+	VolumeMountConfigDoc.Description = "VolumeMountConfig struct describes extra volume mount for the static pods."
+	VolumeMountConfigDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "APIServerConfig",
+			FieldName: "extraVolumes",
+		},
+		{
+			TypeName:  "ControllerManagerConfig",
+			FieldName: "extraVolumes",
+		},
+		{
+			TypeName:  "SchedulerConfig",
+			FieldName: "extraVolumes",
+		},
+	}
+	VolumeMountConfigDoc.Fields = make([]encoder.Doc, 3)
+	VolumeMountConfigDoc.Fields[0].Name = "hostPath"
+	VolumeMountConfigDoc.Fields[0].Type = "string"
+	VolumeMountConfigDoc.Fields[0].Note = ""
+	VolumeMountConfigDoc.Fields[0].Description = "Path on the host."
+	VolumeMountConfigDoc.Fields[0].Comments[encoder.LineComment] = "Path on the host."
+
+	VolumeMountConfigDoc.Fields[0].AddExample("", "/var/lib/auth")
+	VolumeMountConfigDoc.Fields[1].Name = "mountPath"
+	VolumeMountConfigDoc.Fields[1].Type = "string"
+	VolumeMountConfigDoc.Fields[1].Note = ""
+	VolumeMountConfigDoc.Fields[1].Description = "Path in the container."
+	VolumeMountConfigDoc.Fields[1].Comments[encoder.LineComment] = "Path in the container."
+
+	VolumeMountConfigDoc.Fields[1].AddExample("", "/etc/kubernetes/auth")
+	VolumeMountConfigDoc.Fields[2].Name = "readonly"
+	VolumeMountConfigDoc.Fields[2].Type = "bool"
+	VolumeMountConfigDoc.Fields[2].Note = ""
+	VolumeMountConfigDoc.Fields[2].Description = "Mount the volume read only."
+	VolumeMountConfigDoc.Fields[2].Comments[encoder.LineComment] = "Mount the volume read only."
+
+	VolumeMountConfigDoc.Fields[2].AddExample("", true)
 }
 
 func (_ Config) Doc() *encoder.Doc {
@@ -1762,6 +1818,10 @@ func (_ SystemDiskEncryptionConfig) Doc() *encoder.Doc {
 	return &SystemDiskEncryptionConfigDoc
 }
 
+func (_ VolumeMountConfig) Doc() *encoder.Doc {
+	return &VolumeMountConfigDoc
+}
+
 // GetConfigurationDoc returns documentation for the file ./v1alpha1_types_doc.go.
 func GetConfigurationDoc() *encoder.FileDoc {
 	return &encoder.FileDoc{
@@ -1808,6 +1868,7 @@ func GetConfigurationDoc() *encoder.FileDoc {
 			&RegistryAuthConfigDoc,
 			&RegistryTLSConfigDoc,
 			&SystemDiskEncryptionConfigDoc,
+			&VolumeMountConfigDoc,
 		},
 	}
 }

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -36,6 +36,14 @@ type K8sControlPlane struct {
 	spec interface{}
 }
 
+// K8sExtraVolume is a configuration of extra volume.
+type K8sExtraVolume struct {
+	Name      string `yaml:"name"`
+	HostPath  string `yaml:"hostPath"`
+	MountPath string `yaml:"mountPath"`
+	ReadOnly  bool   `yaml:"readonly"`
+}
+
 // K8sControlPlaneAPIServerSpec is configuration for kube-apiserver.
 type K8sControlPlaneAPIServerSpec struct {
 	Image                string            `yaml:"image"`
@@ -45,6 +53,7 @@ type K8sControlPlaneAPIServerSpec struct {
 	LocalPort            int               `yaml:"localPort"`
 	ServiceCIDR          string            `yaml:"serviceCIDR"`
 	ExtraArgs            map[string]string `yaml:"extraArgs"`
+	ExtraVolumes         []K8sExtraVolume  `yaml:"extraVolumes"`
 }
 
 // K8sControlPlaneControllerManagerSpec is configuration for kube-controller-manager.
@@ -54,12 +63,14 @@ type K8sControlPlaneControllerManagerSpec struct {
 	PodCIDR       string            `yaml:"podCIDR"`
 	ServiceCIDR   string            `yaml:"serviceCIDR"`
 	ExtraArgs     map[string]string `yaml:"extraArgs"`
+	ExtraVolumes  []K8sExtraVolume  `yaml:"extraVolumes"`
 }
 
 // K8sControlPlaneSchedulerSpec is configuration for kube-scheduler.
 type K8sControlPlaneSchedulerSpec struct {
-	Image     string            `yaml:"image"`
-	ExtraArgs map[string]string `yaml:"extraArgs"`
+	Image        string            `yaml:"image"`
+	ExtraArgs    map[string]string `yaml:"extraArgs"`
+	ExtraVolumes []K8sExtraVolume  `yaml:"extraVolumes"`
 }
 
 // K8sManifestsSpec is configuration for manifests.

--- a/pkg/resources/k8s/static_pod.go
+++ b/pkg/resources/k8s/static_pod.go
@@ -86,6 +86,11 @@ func (r *StaticPod) ResourceDefinition() core.ResourceDefinitionSpec {
 	}
 }
 
+// Pod returns pod definition.
+func (r *StaticPod) Pod() *v1.Pod {
+	return r.spec.Pod
+}
+
 // SetPod sets pod definition.
 func (r *StaticPod) SetPod(podSpec *v1.Pod) {
 	r.spec.Pod = podSpec

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -2093,6 +2093,19 @@ Extra arguments to supply to the API server.
 
 <div class="dd">
 
+<code>extraVolumes</code>  <i>[]<a href="#volumemountconfig">VolumeMountConfig</a></i>
+
+</div>
+<div class="dt">
+
+Extra volumes to mount to the API server static pod.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
 <code>certSANs</code>  <i>[]string</i>
 
 </div>
@@ -2157,6 +2170,19 @@ image: k8s.gcr.io/kube-controller-manager:v1.20.4
 <div class="dt">
 
 Extra arguments to supply to the controller manager.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>extraVolumes</code>  <i>[]<a href="#volumemountconfig">VolumeMountConfig</a></i>
+
+</div>
+<div class="dt">
+
+Extra volumes to mount to the controller manager static pod.
 
 </div>
 
@@ -2311,6 +2337,19 @@ image: k8s.gcr.io/kube-scheduler:v1.20.4
 <div class="dt">
 
 Extra arguments to supply to the scheduler.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>extraVolumes</code>  <i>[]<a href="#volumemountconfig">VolumeMountConfig</a></i>
+
+</div>
+<div class="dt">
+
+Extra volumes to mount to the scheduler static pod.
 
 </div>
 
@@ -4461,6 +4500,95 @@ State partition encryption.
 <div class="dt">
 
 Ephemeral partition encryption.
+
+</div>
+
+<hr />
+
+
+
+
+
+## VolumeMountConfig
+VolumeMountConfig struct describes extra volume mount for the static pods.
+
+Appears in:
+
+
+- <code><a href="#apiserverconfig">APIServerConfig</a>.extraVolumes</code>
+
+- <code><a href="#controllermanagerconfig">ControllerManagerConfig</a>.extraVolumes</code>
+
+- <code><a href="#schedulerconfig">SchedulerConfig</a>.extraVolumes</code>
+
+
+
+<hr />
+
+<div class="dd">
+
+<code>hostPath</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Path on the host.
+
+
+
+Examples:
+
+
+``` yaml
+hostPath: /var/lib/auth
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>mountPath</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Path in the container.
+
+
+
+Examples:
+
+
+``` yaml
+mountPath: /etc/kubernetes/auth
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>readonly</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Mount the volume read only.
+
+
+
+Examples:
+
+
+``` yaml
+readonly: true
+```
+
 
 </div>
 


### PR DESCRIPTION
This allows to mount extra volumes into Talos-managed control plane
static pods. With additional options like extra files, any additional
content/configuration can be mounted.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

