### PR TITLE
fix: redirect warnings in manifest apply k8s client

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
@@ -142,6 +142,10 @@ func (ctrl *ManifestApplyController) Run(ctx context.Context, r controller.Runti
 				return fmt.Errorf("error loading kubeconfig: %w", err)
 			}
 
+			kubeconfig.WarningHandler = rest.NewWarningWriter(logger.Writer(), rest.WarningWriterOptions{
+				Deduplicate: true,
+			})
+
 			dc, err = discovery.NewDiscoveryClientForConfig(kubeconfig)
 			if err != nil {
 				return fmt.Errorf("error building discovery client: %w", err)


### PR DESCRIPTION
These warnings by default go to stderr, so to server console and flood
console with messages. Send warnings to the logger, so they stay
within controller-runtime logs.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

