### PR TITLE
fix: sanitize volume name better in static pod extra volumes

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
@@ -144,7 +144,7 @@ func (suite *K8sControlPlaneSuite) TestReconcileExtraVolumes() {
 				ExtraVolumesConfig: []v1alpha1.VolumeMountConfig{
 					{
 						VolumeHostPath:  "/var/lib",
-						VolumeMountPath: "/var/foo",
+						VolumeMountPath: "/var/foo/",
 					},
 				},
 			},
@@ -175,9 +175,9 @@ func (suite *K8sControlPlaneSuite) TestReconcileExtraVolumes() {
 
 	suite.Assert().Equal([]config.K8sExtraVolume{
 		{
-			Name:      "-var-foo",
+			Name:      "var-foo",
 			HostPath:  "/var/lib",
-			MountPath: "/var/foo",
+			MountPath: "/var/foo/",
 			ReadOnly:  false,
 		},
 	}, apiServerCfg.ExtraVolumes)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -1312,7 +1312,7 @@ func (v VolumeMountConfig) MountPath() string {
 
 // Name implements the config.VolumeMount interface.
 func (v VolumeMountConfig) Name() string {
-	return strings.ReplaceAll(v.VolumeMountPath, "/", "-")
+	return strings.Trim(strings.ReplaceAll(strings.ReplaceAll(v.VolumeMountPath, "/", "-"), "_", "-"), "-")
 }
 
 // ReadOnly implements the config.VolumeMount interface.


### PR DESCRIPTION
Volume name should be DNS name, so make sure we don't have any leading
or trailing dashes in the generated volume name.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

