### PR TITLE
chore: switch CI to stop embedding local registry into the builds

### DIFF
--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -67,7 +67,7 @@ function create_cluster {
     --cidr 172.20.1.0/24 \
     --user-disk /var/lib/extra:100MB \
     --user-disk /var/lib/p1:100MB:/var/lib/p2:100MB \
-    --install-image ${REGISTRY:-ghcr.io}/talos-systems/installer:${INSTALLER_TAG} \
+    --install-image ${INSTALLER_IMAGE} \
     --with-init-node=false \
     --cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
     --crashdump \


### PR DESCRIPTION
This adds new `IMAGE_REGISTRY` variable (similar to `IMAGE_TAG`) which
affects only the registry image gets pushed to, but it's not built into
the binaries and images as a default registry.

This fixes a problem when release builds reference our CI local
registry.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

