### PR TITLE
fix: stop and clean up installer container  correctly

### DIFF
--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -47,6 +47,8 @@ func RunInstallerContainer(disk, platform, ref string, reg config.Registries, op
 		return err
 	}
 
+	defer client.Close() //nolint: errcheck
+
 	var img containerd.Image
 
 	if !options.Pull {
@@ -121,6 +123,8 @@ func RunInstallerContainer(disk, platform, ref string, reg config.Registries, op
 		return err
 	}
 
+	defer container.Delete(ctx, containerd.WithSnapshotCleanup) //nolint: errcheck
+
 	f, err := os.OpenFile("/dev/kmsg", os.O_RDWR|unix.O_CLOEXEC|unix.O_NONBLOCK|unix.O_NOCTTY, 0o666)
 	if err != nil {
 		return fmt.Errorf("failed to open /dev/kmsg: %w", err)
@@ -136,6 +140,8 @@ func RunInstallerContainer(disk, platform, ref string, reg config.Registries, op
 	if err != nil {
 		return err
 	}
+
+	defer t.Delete(ctx) //nolint: errcheck
 
 	if err = t.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start %q task: %w", "upgrade", err)


### PR DESCRIPTION
This fixes an issue when Talos on clean shutdown after install waits for
the process to terminate, that process is `containerd-shim` which is
still running because container wasn't cleaned up correctly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

