### PR TITLE
fix: correctly set service state in the resource

### DIFF
--- a/pkg/resources/v1alpha1/service.go
+++ b/pkg/resources/v1alpha1/service.go
@@ -71,12 +71,12 @@ func (r *Service) ResourceDefinition() core.ResourceDefinitionSpec {
 
 // SetRunning changes .spec.running.
 func (r *Service) SetRunning(running bool) {
-	r.spec.Running = true
+	r.spec.Running = running
 }
 
 // SetHealthy changes .spec.healthy.
 func (r *Service) SetHealthy(healthy bool) {
-	r.spec.Healthy = true
+	r.spec.Healthy = healthy
 }
 
 // Running returns .spec.running.


### PR DESCRIPTION
As 'healthy' was always set to true, some tasks started earlier than
expected, and specifically etcd cert was generated while the time sync
was happening leading to half-broken cert on RPi4.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

