### PR TITLE
chore: build both Darwin and Linux versions of talosctl

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -191,7 +191,7 @@ local Pipeline(name, steps=[], depends_on=[], with_docker=true, disable_clone=fa
 
 local generate = Step("generate", target="generate docs", depends_on=[setup_ci]);
 local check_dirty = Step("check-dirty", depends_on=[generate]);
-local build = Step("build", target="talosctl kernel initramfs installer talos", depends_on=[check_dirty], environment={"IMAGE_REGISTRY": local_registry, "PUSH": true});
+local build = Step("build", target="talosctl-linux talosctl-darwin kernel initramfs installer talos", depends_on=[check_dirty], environment={"IMAGE_REGISTRY": local_registry, "PUSH": true});
 local lint = Step("lint", depends_on=[build]);
 local talosctl_cni_bundle = Step('talosctl-cni-bundle', depends_on=[build, lint]);
 local iso_amd64 = Step("iso-amd64", target="iso", depends_on=[build], environment={"IMAGE_REGISTRY": local_registry});


### PR DESCRIPTION
This showed up as missing Darwin talosctl in the release.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

