### PR TITLE
feat: talosctl: allow v-prefixed k8s versions

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -405,7 +405,7 @@ func create(ctx context.Context) (err error) {
 				&bundle.InputOptions{
 					ClusterName: clusterName,
 					Endpoint:    fmt.Sprintf("https://%s:%d", defaultInternalLB, constants.DefaultControlPlanePort),
-					KubeVersion: kubernetesVersion,
+					KubeVersion: strings.TrimPrefix(kubernetesVersion, "v"),
 					GenOptions:  genOptions,
 				}),
 		)

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -145,7 +145,7 @@ func genV1Alpha1Config(args []string) error {
 			&bundle.InputOptions{
 				ClusterName: args[0],
 				Endpoint:    args[1],
-				KubeVersion: kubernetesVersion,
+				KubeVersion: strings.TrimPrefix(kubernetesVersion, "v"),
 				GenOptions: append(genOptions,
 					generate.WithInstallDisk(installDisk),
 					generate.WithInstallImage(installImage),


### PR DESCRIPTION
Accept both `1.19.2` and `v1.19.2` formats for kubernetes versions in
`talosctl gen`.

Fixes #3155

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
