### PR TITLE
fix: update in-cluster kubeconfig validity to match other certs

### DIFF
--- a/internal/integration/api/events.go
+++ b/internal/integration/api/events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/talos-systems/talos/internal/integration/base"
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
+	machinetype "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
 // EventsSuite verifies Events API.
@@ -36,7 +37,7 @@ func (suite *EventsSuite) SetupTest() {
 	// make sure API calls have timeout
 	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 30*time.Second)
 
-	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode())
+	suite.nodeCtx = client.WithNodes(suite.ctx, suite.RandomDiscoveredNode(machinetype.TypeJoin))
 }
 
 // TearDownTest ...

--- a/pkg/resources/secrets/etcd.go
+++ b/pkg/resources/secrets/etcd.go
@@ -21,7 +21,7 @@ const EtcdID = resource.ID("etcd")
 // Etcd contains etcd generated secrets.
 type Etcd struct {
 	md   resource.Metadata
-	spec interface{}
+	spec *EtcdCertsSpec
 }
 
 // EtcdCertsSpec describes etcd certs secrets.
@@ -57,9 +57,11 @@ func (r *Etcd) String() string {
 
 // DeepCopy implements resource.Resource.
 func (r *Etcd) DeepCopy() resource.Resource {
+	specCopy := *r.spec
+
 	return &Etcd{
 		md:   r.md,
-		spec: r.spec,
+		spec: &specCopy,
 	}
 }
 
@@ -74,5 +76,5 @@ func (r *Etcd) ResourceDefinition() core.ResourceDefinitionSpec {
 
 // Certs returns .spec.
 func (r *Etcd) Certs() *EtcdCertsSpec {
-	return r.spec.(*EtcdCertsSpec)
+	return r.spec
 }

--- a/pkg/resources/secrets/kubernetes.go
+++ b/pkg/resources/secrets/kubernetes.go
@@ -21,7 +21,7 @@ const KubernetesID = resource.ID("k8s-certs")
 // Kubernetes contains K8s generated secrets.
 type Kubernetes struct {
 	md   resource.Metadata
-	spec interface{}
+	spec *KubernetesCertsSpec
 }
 
 // KubernetesCertsSpec describes generated Kubernetes certificates.
@@ -61,9 +61,11 @@ func (r *Kubernetes) String() string {
 
 // DeepCopy implements resource.Resource.
 func (r *Kubernetes) DeepCopy() resource.Resource {
+	specCopy := *r.spec
+
 	return &Kubernetes{
 		md:   r.md,
-		spec: r.spec,
+		spec: &specCopy,
 	}
 }
 
@@ -78,5 +80,5 @@ func (r *Kubernetes) ResourceDefinition() core.ResourceDefinitionSpec {
 
 // Certs returns .spec.
 func (r *Kubernetes) Certs() *KubernetesCertsSpec {
-	return r.spec.(*KubernetesCertsSpec)
+	return r.spec
 }

--- a/pkg/resources/secrets/root.go
+++ b/pkg/resources/secrets/root.go
@@ -86,9 +86,22 @@ func (r *Root) String() string {
 
 // DeepCopy implements resource.Resource.
 func (r *Root) DeepCopy() resource.Resource {
+	var specCopy interface{}
+
+	switch v := r.spec.(type) {
+	case *RootEtcdSpec:
+		vv := *v
+		specCopy = &vv
+	case *RootKubernetesSpec:
+		vv := *v
+		specCopy = &vv
+	default:
+		panic("unexpected spec type")
+	}
+
 	return &Root{
 		md:   r.md,
-		spec: r.spec,
+		spec: specCopy,
 	}
 }
 


### PR DESCRIPTION
Talos generates in-cluster kubeconfig for the kube-scheduler and
kube-controller-manager to authenticate to kube-apiserver. Bug was that
validity of that kubeconfig was set to 24h by mistake. Fix that by
bumping validity to default for other Kubernetes certs (1 year).

Add a certificate refresh at 50% of the validity.

Fix bugs with copying secret resources which was leading to updates not
being propagated correctly.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
