### PR TITLE
chore: update provision/upgrade tests to 0.9.0-alpha.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.19.0
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.7.1 v0.8.3
+RELEASES ?= v0.8.4 v0.9.0-alpha.3
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -71,11 +71,11 @@ type upgradeSpec struct {
 }
 
 const (
-	previousRelease = "v0.7.1"
-	stableRelease   = "v0.8.3"
+	previousRelease = "v0.8.4"
+	stableRelease   = "v0.9.0-alpha.3"
 
-	previousK8sVersion = "1.19.4"
-	stableK8sVersion   = "1.20.1"
+	previousK8sVersion = "1.20.1"
+	stableK8sVersion   = "1.20.4"
 	currentK8sVersion  = "1.20.4"
 )
 
@@ -109,7 +109,7 @@ func upgradeBetweenTwoLastReleases() upgradeSpec {
 		TargetInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
 		TargetVersion:        stableRelease,
 		TargetK8sVersion:     stableK8sVersion,
-		TargetSelfHosted:     true,
+		TargetSelfHosted:     false,
 
 		MasterNodes: DefaultSettings.MasterNodes,
 		WorkerNodes: DefaultSettings.WorkerNodes,
@@ -126,12 +126,10 @@ func upgradeStableReleaseToCurrent() upgradeSpec {
 		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
 		SourceVersion:        stableRelease,
 		SourceK8sVersion:     stableK8sVersion,
-		SourceSelfHosted:     true,
 
 		TargetInstallerImage: fmt.Sprintf("%s/%s:%s", DefaultSettings.TargetInstallImageRegistry, images.DefaultInstallerImageName, DefaultSettings.CurrentVersion),
 		TargetVersion:        DefaultSettings.CurrentVersion,
 		TargetK8sVersion:     currentK8sVersion,
-		TargetSelfHosted:     false,
 
 		MasterNodes: DefaultSettings.MasterNodes,
 		WorkerNodes: DefaultSettings.WorkerNodes,
@@ -150,12 +148,10 @@ func upgradeCurrentReleaseToCurrent() upgradeSpec {
 		SourceInstallerImage: installerImage,
 		SourceVersion:        DefaultSettings.CurrentVersion,
 		SourceK8sVersion:     currentK8sVersion,
-		SourceSelfHosted:     true,
 
 		TargetInstallerImage: installerImage,
 		TargetVersion:        DefaultSettings.CurrentVersion,
 		TargetK8sVersion:     currentK8sVersion,
-		TargetSelfHosted:     true,
 
 		MasterNodes: DefaultSettings.MasterNodes,
 		WorkerNodes: DefaultSettings.WorkerNodes,
@@ -174,12 +170,10 @@ func upgradeSingeNodePreserve() upgradeSpec {
 		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
 		SourceVersion:        stableRelease,
 		SourceK8sVersion:     stableK8sVersion,
-		SourceSelfHosted:     true,
 
 		TargetInstallerImage: fmt.Sprintf("%s/%s:%s", DefaultSettings.TargetInstallImageRegistry, images.DefaultInstallerImageName, DefaultSettings.CurrentVersion),
 		TargetVersion:        DefaultSettings.CurrentVersion,
 		TargetK8sVersion:     currentK8sVersion,
-		TargetSelfHosted:     false,
 
 		MasterNodes:     1,
 		WorkerNodes:     0,
@@ -197,12 +191,10 @@ func upgradeSingeNodeStage() upgradeSpec {
 		SourceInstallerImage: fmt.Sprintf("%s:%s", "ghcr.io/talos-systems/installer", stableRelease),
 		SourceVersion:        stableRelease,
 		SourceK8sVersion:     stableK8sVersion,
-		SourceSelfHosted:     true,
 
 		TargetInstallerImage: fmt.Sprintf("%s/%s:%s", DefaultSettings.TargetInstallImageRegistry, images.DefaultInstallerImageName, DefaultSettings.CurrentVersion),
 		TargetVersion:        DefaultSettings.CurrentVersion,
 		TargetK8sVersion:     currentK8sVersion,
-		TargetSelfHosted:     false,
 
 		MasterNodes:     1,
 		WorkerNodes:     0,

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -71,11 +71,6 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	cmdline.SetAll(kernel.DefaultArgs)
 
-	// backwards compatibility to boot initrd from Talos < 0.8
-	// we can remove it once we stop testing upgrades from versions < 0.8
-	cmdline.Append("slub_debug", "P")
-	cmdline.Append("page_poison", "1")
-
 	// required to get kernel console
 	cmdline.Append("console", arch.Console())
 


### PR DESCRIPTION
This drops support for 0.7.x in upgrade tests, and bumps tests to use
version 0.9.0-alpha.3 as the next stable (it will eventually graduate to
0.9.0).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

