### PR TITLE
docs: bump v0.8 release version in the SBCs guides

### DIFF
--- a/website/content/docs/v0.8/Single Board Computers/bananapi_m64.md
+++ b/website/content/docs/v0.8/Single Board Computers/bananapi_m64.md
@@ -13,7 +13,7 @@ You will need
 Download the latest alpha `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.0/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.4/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.0/metal-bananapi_m64-arm64.img.xz
+curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.4/metal-bananapi_m64-arm64.img.xz
 xz -d metal-bananapi_m64-arm64.img.xz
 ```
 

--- a/website/content/docs/v0.8/Single Board Computers/libretech_all_h3_cc_h5.md
+++ b/website/content/docs/v0.8/Single Board Computers/libretech_all_h3_cc_h5.md
@@ -13,7 +13,7 @@ You will need
 Download the latest alpha `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.0/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.4/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.0/metal-libretech_all_h3_cc_h5-arm64.img.xz
+curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.4/metal-libretech_all_h3_cc_h5-arm64.img.xz
 xz -d metal-libretech_all_h3_cc_h5-arm64.img.xz
 ```
 

--- a/website/content/docs/v0.8/Single Board Computers/rock64.md
+++ b/website/content/docs/v0.8/Single Board Computers/rock64.md
@@ -13,7 +13,7 @@ You will need
 Download the latest alpha `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.0/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.4/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -22,7 +22,7 @@ chmod +x /usr/local/bin/talosctl
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.0/metal-rock64-arm64.img.xz
+curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.4/metal-rock64-arm64.img.xz
 xz -d metal-rock64-arm64.img.xz
 ```
 

--- a/website/content/docs/v0.8/Single Board Computers/rpi_4.md
+++ b/website/content/docs/v0.8/Single Board Computers/rpi_4.md
@@ -13,7 +13,7 @@ You will need
 Download the latest alpha `talosctl`.
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.0/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/download/v0.8.4/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -45,7 +45,7 @@ Power off the Raspberry Pi and remove the SD card from it.
 Download the image and decompress it:
 
 ```bash
-curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.0/metal-rpi_4-arm64.img.xz
+curl -LO https://github.com/talos-systems/talos/releases/download/v0.8.4/metal-rpi_4-arm64.img.xz
 xz -d metal-rpi_4-arm64.img.xz
 ```
 


### PR DESCRIPTION
Makes sense to update these guides to point to the v0.8.4 as it contains
many good fixes.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>