### PR TITLE
feat: update linux kernel to 5.10.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.3.0-21-g0026740
-PKGS ?= v0.3.0-77-gbf4b778
+PKGS ?= v0.3.0-78-g04e6d12
 EXTRAS ?= v0.1.0-9-g302cc61
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.17-talos"
+	DefaultKernelVersion = "5.10.19-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This PR pulls in a new version of pkgs which includes a linux kernel
bump.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
