### PR TITLE
fix: ignore 'ENOENT' (no such file directory) on mount

### DIFF
--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -134,6 +134,9 @@ func mountRetry(f RetryFunc, p *Point, isUnmount bool) (err error) {
 			switch err {
 			case unix.EBUSY:
 				return retry.ExpectedError(err)
+			case unix.ENOENT:
+				// if udevd triggers BLKRRPART ioctl, partition device entry might disappear temporarily
+				return retry.ExpectedError(err)
 			case unix.EINVAL:
 				isMounted, checkErr := p.IsMounted()
 				if checkErr != nil {


### PR DESCRIPTION
This fixes a race condition between `udevd` issuing ioctl `BLKRRPART`
when block device is closed after partitioning/formatting and Talos
trying to mount a partition. When `BLKRRPART` is issued, kernel
temporarily wipes out all the in-memory partitions killing `/dev/sdX`
devices until partition scan is done.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
