### PR TITLE
chore: properly propagate context object in the controller

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -149,7 +149,7 @@ func (s *Server) ApplyConfiguration(ctx context.Context, in *machine.ApplyConfig
 		}
 
 		go func() {
-			if err := s.Controller.Run(runtime.SequenceApplyConfiguration, in); err != nil {
+			if err := s.Controller.Run(context.Background(), runtime.SequenceApplyConfiguration, in); err != nil {
 				if !runtime.IsRebootError(err) {
 					log.Println("apply configuration failed:", err)
 				}
@@ -198,7 +198,7 @@ func (s *Server) Reboot(ctx context.Context, in *empty.Empty) (reply *machine.Re
 	}
 
 	go func() {
-		if err := s.Controller.Run(runtime.SequenceReboot, in); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("reboot failed:", err)
 			}
@@ -264,7 +264,7 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 	}
 
 	go func() {
-		if err := s.Controller.Run(runtime.SequenceReboot, in, runtime.WithForce()); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in, runtime.WithForce()); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("reboot failed:", err)
 			}
@@ -295,7 +295,7 @@ func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (r
 	}
 
 	go func() {
-		if err := s.Controller.Run(runtime.SequenceBootstrap, in); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceBootstrap, in); err != nil {
 			log.Println("bootstrap failed:", err)
 
 			if err != runtime.ErrLocked {
@@ -326,7 +326,7 @@ func (s *Server) Shutdown(ctx context.Context, in *empty.Empty) (reply *machine.
 	}
 
 	go func() {
-		if err := s.Controller.Run(runtime.SequenceShutdown, in); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceShutdown, in); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("shutdown failed:", err)
 			}
@@ -426,7 +426,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 				defer mu.Unlock(ctx) // nolint: errcheck
 			}
 
-			if err := s.Controller.Run(runtime.SequenceStageUpgrade, in); err != nil {
+			if err := s.Controller.Run(context.Background(), runtime.SequenceStageUpgrade, in); err != nil {
 				if !runtime.IsRebootError(err) {
 					log.Println("reboot for staged upgrade failed:", err)
 				}
@@ -444,7 +444,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 				defer mu.Unlock(ctx) // nolint: errcheck
 			}
 
-			if err := s.Controller.Run(runtime.SequenceUpgrade, in); err != nil {
+			if err := s.Controller.Run(context.Background(), runtime.SequenceUpgrade, in); err != nil {
 				if !runtime.IsRebootError(err) {
 					log.Println("upgrade failed:", err)
 				}
@@ -543,7 +543,7 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 	}
 
 	go func() {
-		if err := s.Controller.Run(runtime.SequenceReset, &opts); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceReset, &opts); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("reset failed:", err)
 			}

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -203,7 +203,7 @@ func run() error {
 
 	// Start signal and ACPI listeners.
 	go func() {
-		if e := c.ListenForEvents(); e != nil {
+		if e := c.ListenForEvents(ctx); e != nil {
 			log.Printf("WARNING: signals and ACPI events will be ignored: %s", e)
 		}
 	}()
@@ -218,12 +218,12 @@ func run() error {
 	}()
 
 	// Initialize the machine.
-	if err = c.Run(runtime.SequenceInitialize, nil); err != nil {
+	if err = c.Run(ctx, runtime.SequenceInitialize, nil); err != nil {
 		return err
 	}
 
 	// Perform an installation if required.
-	if err = c.Run(runtime.SequenceInstall, nil); err != nil {
+	if err = c.Run(ctx, runtime.SequenceInstall, nil); err != nil {
 		return err
 	}
 
@@ -231,7 +231,7 @@ func run() error {
 	system.Services(c.Runtime()).LoadAndStart(&services.Machined{Controller: c})
 
 	// Boot the machine.
-	if err = c.Run(runtime.SequenceBoot, nil); err != nil {
+	if err = c.Run(ctx, runtime.SequenceBoot, nil); err != nil {
 		return err
 	}
 

--- a/internal/app/machined/pkg/runtime/controller.go
+++ b/internal/app/machined/pkg/runtime/controller.go
@@ -52,7 +52,7 @@ func DefaultControllerOptions() ControllerOptions {
 type Controller interface {
 	Runtime() Runtime
 	Sequencer() Sequencer
-	Run(Sequence, interface{}, ...ControllerOption) error
+	Run(context.Context, Sequence, interface{}, ...ControllerOption) error
 	V1Alpha2() V1Alpha2Controller
 }
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller_test.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller_test.go
@@ -6,6 +6,7 @@
 package v1alpha1
 
 import (
+	"context"
 	"reflect"
 	"strconv"
 	"testing"
@@ -63,6 +64,8 @@ func TestController_Run(t *testing.T) {
 		// TODO: Add test cases.
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Controller{
@@ -70,7 +73,7 @@ func TestController_Run(t *testing.T) {
 				s:         tt.fields.s,
 				semaphore: tt.fields.semaphore,
 			}
-			if err := c.Run(tt.args.seq, tt.args.data); (err != nil) != tt.wantErr {
+			if err := c.Run(ctx, tt.args.seq, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("Controller.Run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -149,6 +152,7 @@ func TestController_ListenForEvents(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 	}
+	ctx := context.Background()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -157,7 +161,7 @@ func TestController_ListenForEvents(t *testing.T) {
 				s:         tt.fields.s,
 				semaphore: tt.fields.semaphore,
 			}
-			if err := c.ListenForEvents(); (err != nil) != tt.wantErr {
+			if err := c.ListenForEvents(ctx); (err != nil) != tt.wantErr {
 				t.Errorf("Controller.ListenForEvents() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -244,6 +248,8 @@ func TestController_run(t *testing.T) {
 		// TODO: Add test cases.
 	}
 
+	ctx := context.Background()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Controller{
@@ -251,7 +257,7 @@ func TestController_run(t *testing.T) {
 				s:         tt.fields.s,
 				semaphore: tt.fields.semaphore,
 			}
-			if err := c.run(tt.args.seq, tt.args.phases, tt.args.data); (err != nil) != tt.wantErr {
+			if err := c.run(ctx, tt.args.seq, tt.args.phases, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("Controller.run() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -279,6 +285,7 @@ func TestController_runPhase(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 	}
+	ctx := context.Background()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -287,7 +294,7 @@ func TestController_runPhase(t *testing.T) {
 				s:         tt.fields.s,
 				semaphore: tt.fields.semaphore,
 			}
-			if err := c.runPhase(tt.args.phase, tt.args.seq, tt.args.data); (err != nil) != tt.wantErr {
+			if err := c.runPhase(ctx, tt.args.phase, tt.args.seq, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("Controller.runPhase() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -316,6 +323,7 @@ func TestController_runTask(t *testing.T) {
 	}{
 		// TODO: Add test cases.
 	}
+	ctx := context.Background()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -324,7 +332,7 @@ func TestController_runTask(t *testing.T) {
 				s:         tt.fields.s,
 				semaphore: tt.fields.semaphore,
 			}
-			if err := c.runTask(strconv.Itoa(tt.args.n), tt.args.f, tt.args.seq, tt.args.data); (err != nil) != tt.wantErr {
+			if err := c.runTask(ctx, strconv.Itoa(tt.args.n), tt.args.f, tt.args.seq, tt.args.data); (err != nil) != tt.wantErr {
 				t.Errorf("Controller.runTask() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1285,11 +1285,11 @@ func UncordonNode(seq runtime.Sequence, data interface{}) (runtime.TaskExecution
 			return err
 		}
 
-		if err = kubeHelper.WaitUntilReady(nodename); err != nil {
+		if err = kubeHelper.WaitUntilReady(ctx, nodename); err != nil {
 			return err
 		}
 
-		if err = kubeHelper.Uncordon(nodename, false); err != nil {
+		if err = kubeHelper.Uncordon(ctx, nodename, false); err != nil {
 			return err
 		}
 
@@ -1503,8 +1503,8 @@ func LabelNodeAsMaster(seq runtime.Sequence, data interface{}) (runtime.TaskExec
 			return err
 		}
 
-		err = retry.Constant(constants.NodeReadyTimeout, retry.WithUnits(3*time.Second), retry.WithErrorLogging(true)).Retry(func() error {
-			if err = h.LabelNodeAsMaster(nodename, !r.Config().Cluster().ScheduleOnMasters()); err != nil {
+		err = retry.Constant(constants.NodeReadyTimeout, retry.WithUnits(3*time.Second), retry.WithErrorLogging(true)).RetryWithContext(ctx, func(ctx context.Context) error {
+			if err = h.LabelNodeAsMaster(ctx, nodename, !r.Config().Cluster().ScheduleOnMasters()); err != nil {
 				return retry.ExpectedError(err)
 			}
 


### PR DESCRIPTION
This is required to correctly handle ACPI reboot or forceful reboots
during sequence that locks the controller.
Additionally fix `NoSchedule` untaint when the configuration is changed.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>