### PR TITLE
feat: support JSON output in `talosctl get`, event types

### DIFF
--- a/cmd/talosctl/cmd/talos/output/json.go
+++ b/cmd/talosctl/cmd/talos/output/json.go
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package output
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+	"gopkg.in/yaml.v3"
+)
+
+// JSON outputs resources in JSON format.
+type JSON struct {
+	withEvents bool
+}
+
+// NewJSON initializes JSON resource output.
+func NewJSON() *JSON {
+	return &JSON{}
+}
+
+// WriteHeader implements output.Writer interface.
+func (j *JSON) WriteHeader(definition resource.Resource, withEvents bool) error {
+	j.withEvents = withEvents
+
+	return nil
+}
+
+// WriteResource implements output.Writer interface.
+func (j *JSON) WriteResource(node string, r resource.Resource, event state.EventType) error {
+	out, err := resource.MarshalYAML(r)
+	if err != nil {
+		return err
+	}
+
+	yamlBytes, err := yaml.Marshal(out)
+	if err != nil {
+		return err
+	}
+
+	var data map[string]interface{}
+
+	err = yaml.Unmarshal(yamlBytes, &data)
+	if err != nil {
+		return err
+	}
+
+	data["node"] = node
+
+	if j.withEvents {
+		data["event"] = strings.ToLower(event.String())
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+
+	return enc.Encode(data)
+}
+
+// Flush implements output.Writer interface.
+func (j *JSON) Flush() error {
+	return nil
+}

--- a/cmd/talosctl/cmd/talos/output/output.go
+++ b/cmd/talosctl/cmd/talos/output/output.go
@@ -26,6 +26,8 @@ func NewWriter(format string) (Writer, error) {
 		return NewTable(), nil
 	case "yaml":
 		return NewYAML(), nil
+	case "json":
+		return NewJSON(), nil
 	default:
 		return nil, fmt.Errorf("output format %q is not supported", format)
 	}

--- a/cmd/talosctl/cmd/talos/output/yaml.go
+++ b/cmd/talosctl/cmd/talos/output/yaml.go
@@ -7,6 +7,7 @@ package output
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/talos-systems/os-runtime/pkg/resource"
 	"github.com/talos-systems/os-runtime/pkg/state"
@@ -16,6 +17,7 @@ import (
 // YAML outputs resources in YAML format.
 type YAML struct {
 	needDashes bool
+	withEvents bool
 }
 
 // NewYAML initializes YAML resource output.
@@ -25,6 +27,8 @@ func NewYAML() *YAML {
 
 // WriteHeader implements output.Writer interface.
 func (y *YAML) WriteHeader(definition resource.Resource, withEvents bool) error {
+	y.withEvents = withEvents
+
 	return nil
 }
 
@@ -42,6 +46,10 @@ func (y *YAML) WriteResource(node string, r resource.Resource, event state.Event
 	y.needDashes = true
 
 	fmt.Fprintf(os.Stdout, "node: %s\n", node)
+
+	if y.withEvents {
+		fmt.Fprintf(os.Stdout, "event: %s\n", strings.ToLower(event.String()))
+	}
 
 	return yaml.NewEncoder(os.Stdout).Encode(out)
 }

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/talos-systems/go-smbios v0.0.0-20200807005123-80196199691e
 	github.com/talos-systems/grpc-proxy v0.2.0
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
-	github.com/talos-systems/os-runtime v0.0.0-20210302191935-8b3f192ecca2
+	github.com/talos-systems/os-runtime v0.0.0-20210303124137-84c3c875eb2b
 	github.com/talos-systems/talos/pkg/machinery v0.0.0-20200818212414-6a7cc0264819
 	github.com/u-root/u-root v7.0.0+incompatible
 	github.com/vmware-tanzu/sonobuoy v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -972,8 +972,8 @@ github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1L
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa h1:XqOMTt0Q6mjsk8Dea5wUpgcdtf+AzesH11m4AozWSxw=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/os-runtime v0.0.0-20210302191935-8b3f192ecca2 h1:uWBn8UTaAN6oekZGSKuYhmg6Bha5Lg/T08ApLyjgRTQ=
-github.com/talos-systems/os-runtime v0.0.0-20210302191935-8b3f192ecca2/go.mod h1:Z+1phKVJ0IWH+Jd2DGufL8WKqxd3xt1xlcsxcU18ZL0=
+github.com/talos-systems/os-runtime v0.0.0-20210303124137-84c3c875eb2b h1:QM8V1t0QivzQzl4uuTkFDSlNzdUyG1/8bRAVwDRPQIo=
+github.com/talos-systems/os-runtime v0.0.0-20210303124137-84c3c875eb2b/go.mod h1:Z+1phKVJ0IWH+Jd2DGufL8WKqxd3xt1xlcsxcU18ZL0=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
-	github.com/talos-systems/os-runtime v0.0.0-20210302191935-8b3f192ecca2
+	github.com/talos-systems/os-runtime v0.0.0-20210303124137-84c3c875eb2b
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 // indirect
 	golang.org/x/text v0.3.4 // indirect

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -101,8 +101,8 @@ github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54/go.mod h1:O
 github.com/talos-systems/go-retry v0.2.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa h1:XqOMTt0Q6mjsk8Dea5wUpgcdtf+AzesH11m4AozWSxw=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/os-runtime v0.0.0-20210302191935-8b3f192ecca2 h1:uWBn8UTaAN6oekZGSKuYhmg6Bha5Lg/T08ApLyjgRTQ=
-github.com/talos-systems/os-runtime v0.0.0-20210302191935-8b3f192ecca2/go.mod h1:Z+1phKVJ0IWH+Jd2DGufL8WKqxd3xt1xlcsxcU18ZL0=
+github.com/talos-systems/os-runtime v0.0.0-20210303124137-84c3c875eb2b h1:QM8V1t0QivzQzl4uuTkFDSlNzdUyG1/8bRAVwDRPQIo=
+github.com/talos-systems/os-runtime v0.0.0-20210303124137-84c3c875eb2b/go.mod h1:Z+1phKVJ0IWH+Jd2DGufL8WKqxd3xt1xlcsxcU18ZL0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=


### PR DESCRIPTION
This adds support for `-o json` (easier to use `jq` to query additional
data), and prints event name in `--watch` mode.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

