### PR TITLE
feat: bypass lock if ACPI reboot/shutdown issued

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -199,7 +199,7 @@ func (s *Server) Reboot(ctx context.Context, in *empty.Empty) (reply *machine.Re
 	}
 
 	go func() {
-		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in, runtime.WithTakeover()); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("reboot failed:", err)
 			}
@@ -265,7 +265,7 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 	}
 
 	go func() {
-		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in, runtime.WithForce()); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceReboot, in, runtime.WithForce(), runtime.WithTakeover()); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("reboot failed:", err)
 			}
@@ -327,7 +327,7 @@ func (s *Server) Shutdown(ctx context.Context, in *empty.Empty) (reply *machine.
 	}
 
 	go func() {
-		if err := s.Controller.Run(context.Background(), runtime.SequenceShutdown, in); err != nil {
+		if err := s.Controller.Run(context.Background(), runtime.SequenceShutdown, in, runtime.WithTakeover()); err != nil {
 			if !runtime.IsRebootError(err) {
 				log.Println("shutdown failed:", err)
 			}

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -231,7 +231,7 @@ func run() error {
 	system.Services(c.Runtime()).LoadAndStart(&services.Machined{Controller: c})
 
 	// Boot the machine.
-	if err = c.Run(ctx, runtime.SequenceBoot, nil); err != nil {
+	if err = c.Run(ctx, runtime.SequenceBoot, nil); err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
 

--- a/internal/app/machined/pkg/runtime/controller.go
+++ b/internal/app/machined/pkg/runtime/controller.go
@@ -27,7 +27,8 @@ type Phase struct {
 
 // ControllerOptions represents the options for a controller.
 type ControllerOptions struct {
-	Force bool
+	Force    bool
+	Takeover bool
 }
 
 // ControllerOption represents an option setter.
@@ -37,6 +38,15 @@ type ControllerOption func(o *ControllerOptions) error
 func WithForce() ControllerOption {
 	return func(o *ControllerOptions) error {
 		o.Force = true
+
+		return nil
+	}
+}
+
+// WithTakeover sets the take option to true.
+func WithTakeover() ControllerOption {
+	return func(o *ControllerOptions) error {
+		o.Takeover = true
 
 		return nil
 	}


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/2997

Listen for restart events in parallel with the boot sequence and cancel
the context if got `RestartEvent`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>