### PR TITLE
feat: add `--on-reboot` flag to talosctl edit/patch machineConfig

### DIFF
--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -27,6 +27,7 @@ import (
 var editCmdFlags struct {
 	namespace string
 	immediate bool
+	onReboot  bool
 }
 
 // editCmd represents the edit command.
@@ -132,6 +133,7 @@ or 'notepad' for Windows.`,
 					_, err = c.ApplyConfiguration(parentCtx, &machine.ApplyConfigurationRequest{
 						Data:      edited,
 						Immediate: editCmdFlags.immediate,
+						OnReboot:  editCmdFlags.onReboot,
 					})
 					if err != nil {
 						lastError = err.Error()
@@ -160,5 +162,6 @@ or 'notepad' for Windows.`,
 func init() {
 	editCmd.Flags().StringVar(&editCmdFlags.namespace, "namespace", "", "resource namespace (default is to use default namespace per resource)")
 	editCmd.Flags().BoolVar(&editCmdFlags.immediate, "immediate", false, "apply the change immediately (without a reboot)")
+	editCmd.Flags().BoolVar(&editCmdFlags.onReboot, "on-reboot", false, "apply the change on next reboot")
 	addCommand(editCmd)
 }

--- a/cmd/talosctl/cmd/talos/patch.go
+++ b/cmd/talosctl/cmd/talos/patch.go
@@ -29,6 +29,7 @@ var patchCmdFlags struct {
 	patch     string
 	patchFile string
 	immediate bool
+	onReboot  bool
 }
 
 // patchCmd represents the edit command.
@@ -87,6 +88,7 @@ var patchCmd = &cobra.Command{
 				_, err = c.ApplyConfiguration(ctx, &machine.ApplyConfigurationRequest{
 					Data:      patched,
 					Immediate: patchCmdFlags.immediate,
+					OnReboot:  patchCmdFlags.onReboot,
 				})
 
 				if bytes.Equal(
@@ -120,5 +122,6 @@ func init() {
 	patchCmd.Flags().StringVar(&patchCmdFlags.patchFile, "patch-file", "", "a file containing a patch to be applied to the resource.")
 	patchCmd.Flags().StringVarP(&patchCmdFlags.patch, "patch", "p", "", "the patch to be applied to the resource file.")
 	patchCmd.Flags().BoolVar(&patchCmdFlags.immediate, "immediate", false, "apply the change immediately (without a reboot)")
+	patchCmd.Flags().BoolVar(&patchCmdFlags.onReboot, "on-reboot", false, "apply the change on next reboot")
 	addCommand(patchCmd)
 }

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -723,6 +723,7 @@ talosctl edit <type> [<id>] [flags]
   -h, --help               help for edit
       --immediate          apply the change immediately (without a reboot)
       --namespace string   resource namespace (default is to use default namespace per resource)
+      --on-reboot          apply the change on next reboot
 ```
 
 ### Options inherited from parent commands
@@ -1479,6 +1480,7 @@ talosctl patch <type> [<id>] [flags]
   -h, --help                help for patch
       --immediate           apply the change immediately (without a reboot)
       --namespace string    resource namespace (default is to use default namespace per resource)
+      --on-reboot           apply the change on next reboot
   -p, --patch string        the patch to be applied to the resource file.
       --patch-file string   a file containing a patch to be applied to the resource.
 ```


### PR DESCRIPTION
This allows to apply config even if sequencer is locked to recover from
confguration mistakes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

