### PR TITLE
chore: fix upgrade tests by bumping 0.9 to alpha.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.19.0
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.8.4 v0.9.0-alpha.3
+RELEASES ?= v0.8.4 v0.9.0-alpha.5
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -72,7 +72,7 @@ type upgradeSpec struct {
 
 const (
 	previousRelease = "v0.8.4"
-	stableRelease   = "v0.9.0-alpha.3"
+	stableRelease   = "v0.9.0-alpha.5"
 
 	previousK8sVersion = "1.20.1"
 	stableK8sVersion   = "1.20.4"


### PR DESCRIPTION
Resources/types were renamed after alpha.4, so we need Talos API to
match expectations of the upgrade test built against master.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

