### PR TITLE
fix: chmod etcd PKI path to fix virtual IP for upgrades with persistence

### DIFF
--- a/internal/app/machined/pkg/system/services/networkd.go
+++ b/internal/app/machined/pkg/system/services/networkd.go
@@ -92,6 +92,11 @@ func (n *Networkd) Runner(r runtime.Runtime) (runner.Runner, error) {
 			return nil, err
 		}
 
+		// Fix up permissions, as after upgrade with preserve EtcdPKIPath might retain old 0o644 permissions
+		if err := os.Chmod(constants.EtcdPKIPath, 0o700); err != nil {
+			return nil, err
+		}
+
 		mounts = append(mounts,
 			specs.Mount{Type: "bind", Destination: constants.EtcdPKIPath, Source: constants.EtcdPKIPath, Options: []string{"rbind", "ro"}},
 		)


### PR DESCRIPTION
On upgrade with persistenct, etcd PKI path retains old mode 0600 which
breaks networkd bind mount for etcd certs.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

