### PR TITLE
fix: ignore connection refused errors when updating/converting cp

### DIFF
--- a/pkg/cluster/kubernetes/convert.go
+++ b/pkg/cluster/kubernetes/convert.go
@@ -458,7 +458,7 @@ func waitForStaticPods(ctx context.Context, cluster ConvertProvider, options *Co
 			LabelSelector: fmt.Sprintf("k8s-app = %s", k8sApp),
 		})
 		if err != nil {
-			if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+			if retryableError(err) {
 				return retry.ExpectedError(err)
 			}
 
@@ -538,7 +538,7 @@ func disablePodCheckpointer(ctx context.Context, cluster ConvertProvider) error 
 
 		checkpoints, err = getActiveCheckpoints(ctx, k8sClient)
 		if err != nil {
-			if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+			if retryableError(err) {
 				return retry.ExpectedError(err)
 			}
 
@@ -601,7 +601,7 @@ func deleteDaemonset(ctx context.Context, cluster ConvertProvider, k8sApp string
 	if err = retry.Constant(time.Minute, retry.WithUnits(100*time.Millisecond)).Retry(func() error {
 		err = k8sClient.AppsV1().DaemonSets(namespace).Delete(ctx, k8sApp, v1.DeleteOptions{})
 		if err != nil {
-			if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+			if retryableError(err) {
 				return retry.ExpectedError(err)
 			}
 
@@ -622,7 +622,7 @@ func deleteDaemonset(ctx context.Context, cluster ConvertProvider, k8sApp string
 			LabelSelector: fmt.Sprintf("k8s-app = %s", k8sApp),
 		})
 		if err != nil {
-			if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+			if retryableError(err) {
 				return retry.ExpectedError(err)
 			}
 

--- a/pkg/cluster/kubernetes/self_hosted.go
+++ b/pkg/cluster/kubernetes/self_hosted.go
@@ -14,7 +14,6 @@ import (
 	"github.com/talos-systems/go-retry/retry"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
@@ -126,7 +125,7 @@ func updateDaemonset(ctx context.Context, clientset *kubernetes.Clientset, ds st
 	return retry.Constant(5*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
 		daemonset, err = clientset.AppsV1().DaemonSets(namespace).Get(ctx, ds, metav1.GetOptions{})
 		if err != nil {
-			if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+			if retryableError(err) {
 				return retry.ExpectedError(err)
 			}
 

--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/talos-systems/go-retry/retry"
 	"github.com/talos-systems/os-runtime/pkg/state"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/talos-systems/talos/pkg/cluster"
@@ -217,7 +216,7 @@ func checkPodStatus(ctx context.Context, cluster UpgradeProvider, service, node,
 		LabelSelector: fmt.Sprintf("k8s-app = %s", service),
 	})
 	if err != nil {
-		if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+		if retryableError(err) {
 			return retry.ExpectedError(err)
 		}
 


### PR DESCRIPTION
Without loadbalancer, when api-server goes down, there will be
connection refused errors which should be retried.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

