### PR TITLE
fix: mkdir source of the extra mounts for the kubelet

### DIFF
--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -172,7 +172,13 @@ func (k *Kubelet) Runner(r runtime.Runtime) (runner.Runner, error) {
 	// TODO(andrewrynhard): We should verify that the mount source is
 	// allowlisted. There is the potential that a user can expose
 	// sensitive information.
-	mounts = append(mounts, r.Config().Machine().Kubelet().ExtraMounts()...)
+	for _, mount := range r.Config().Machine().Kubelet().ExtraMounts() {
+		if err = os.MkdirAll(mount.Source, 0o700); err != nil {
+			return nil, err
+		}
+
+		mounts = append(mounts, mount)
+	}
 
 	env := []string{}
 	for key, val := range r.Config().Machine().Env() {

--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -60,6 +60,10 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 			}
 		}
 
+		if err := bundle.ApplyJSONPatch(options.JSONPatch); err != nil {
+			return nil, fmt.Errorf("error patching configs: %w", err)
+		}
+
 		// Pull existing talosconfig
 		talosConfig, err := os.Open(filepath.Join(options.ExistingConfigs, "talosconfig"))
 		if err != nil {
@@ -118,6 +122,10 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 		case machine.TypeJoin:
 			bundle.JoinCfg = generatedConfig
 		}
+	}
+
+	if err = bundle.ApplyJSONPatch(options.JSONPatch); err != nil {
+		return nil, fmt.Errorf("error patching configs: %w", err)
 	}
 
 	bundle.TalosCfg, err = generate.Talosconfig(input, options.InputOptions.GenOptions...)

--- a/pkg/machinery/config/types/v1alpha1/bundle/options.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/options.go
@@ -4,7 +4,11 @@
 
 package bundle
 
-import "github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/generate"
+import (
+	jsonpatch "github.com/evanphx/json-patch"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/generate"
+)
 
 // Option controls config options specific to config bundle generation.
 type Option func(o *Options) error
@@ -22,6 +26,7 @@ type Options struct {
 	ExistingConfigs string // path to existing config files
 	Verbose         bool   // wheither to write any logs during generate
 	InputOptions    *InputOptions
+	JSONPatch       jsonpatch.Patch
 }
 
 // DefaultOptions returns default options.
@@ -53,6 +58,15 @@ func WithInputOptions(inputOpts *InputOptions) Option {
 func WithVerbose(verbose bool) Option {
 	return func(o *Options) error {
 		o.Verbose = verbose
+
+		return nil
+	}
+}
+
+// WithJSONPatch allows patching every config in a bundle with a patch.
+func WithJSONPatch(patch jsonpatch.Patch) Option {
+	return func(o *Options) error {
+		o.JSONPatch = append(o.JSONPatch, patch...)
 
 		return nil
 	}

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -82,6 +82,7 @@ talosctl cluster create [flags]
       --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.9.0-alpha.5/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                    CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                     CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
+      --config-patch string                     patch generated machineconfigs
       --cpus string                             the share of CPUs as fraction (each container/VM) (default "2.0")
       --crashdump                               print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string                   install custom CNI from the URL (Talos cluster)


### PR DESCRIPTION
This makes sure source directory exists before performing mount
operation.

Also adds an ability to patch the config bundle configs with JSON patch,
which is exposed in `talosctl cluster create`, this allowed me to easily
test this fix:

```
talosctl cluster create ... --config-patch='[{"op": "add", "path": "/machine/kubelet/extraMounts", "value": [{"destination": "/var/log/containers", "type": "bind", "source": "/var/log/containers", "options": ["rshared", "rbind", "rw"]}]}]'
```

Fixes #3254

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

