### PR TITLE
fix: move containerd CRI config files under `/var/`

### DIFF
--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -80,19 +80,19 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 		&v1alpha1.MachineFile{
 			FileContent:     `cacert`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/ca/some.host:123.crt",
+			FilePath:        "/var/etc/cri/ca/some.host:123.crt",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
 			FileContent:     `clientcert`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/client/some.host:123.crt",
+			FilePath:        "/var/etc/cri/client/some.host:123.crt",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
 			FileContent:     `clientkey`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/client/some.host:123.key",
+			FilePath:        "/var/etc/cri/client/some.host:123.key",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
@@ -111,9 +111,9 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
             identitytoken = "token"
           [plugins.cri.registry.configs."some.host:123".tls]
             insecure_skip_verify = true
-            ca_file = "/etc/cri/ca/some.host:123.crt"
-            cert_file = "/etc/cri/client/some.host:123.crt"
-            key_file = "/etc/cri/client/some.host:123.key"
+            ca_file = "/var/etc/cri/ca/some.host:123.crt"
+            cert_file = "/var/etc/cri/client/some.host:123.crt"
+            key_file = "/var/etc/cri/client/some.host:123.key"
 `,
 			FilePermissions: 0o644,
 			FilePath:        constants.CRIContainerdConfig,

--- a/internal/pkg/containers/cri/containerd/containerd.go
+++ b/internal/pkg/containers/cri/containerd/containerd.go
@@ -21,8 +21,8 @@ import (
 //
 //nolint:gocyclo
 func GenerateRegistriesConfig(r config.Registries) ([]config.File, error) {
-	caPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "ca")
-	clientPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "client")
+	caPath := filepath.Join("/var", filepath.Dir(constants.CRIContainerdConfig), "ca")
+	clientPath := filepath.Join("/var", filepath.Dir(constants.CRIContainerdConfig), "client")
 
 	var ctrdCfg Config
 	ctrdCfg.Plugins.CRI.Registry.Mirrors = make(map[string]Mirror)


### PR DESCRIPTION
Talos user files task prohibits file creation under `/etc`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

