### PR TITLE
docs: fix links in the documentation

### DIFF
--- a/website/content/docs/v0.9/Bare Metal Platforms/digital-rebar.md
+++ b/website/content/docs/v0.9/Bare Metal Platforms/digital-rebar.md
@@ -5,10 +5,10 @@ description: "In this guide we will create an Kubernetes cluster with 1 worker n
 
 ## Prerequisites
 
-- 3 nodes (please see [hardware requirements](/v0.9/en/guides/getting-started#system-requirements))
+- 3 nodes (please see [hardware requirements](../../guides/getting-started#system-requirements))
 - Loadbalancer
 - Digital Rebar Server
-- Talosctl access (see [talosctl setup](/v0.9/en/guides/getting-started/talosctl))
+- Talosctl access (see [talosctl setup](../../guides/getting-started/talosctl))
 
 ## Creating a Cluster
 

--- a/website/content/docs/v0.9/Guides/air-gapped.md
+++ b/website/content/docs/v0.9/Guides/air-gapped.md
@@ -3,14 +3,14 @@ title: Air-gapped Environments
 ---
 
 In this guide we will create a Talos cluster running in an air-gapped environment with all the required images being pulled from an internal registry.
-We will use the [QEMU](qemu) provisioner available in `talosctl` to create a local cluster, but the same approach could be used to deploy Talos in bigger air-gapped networks.
+We will use the [QEMU](../../local-platforms/qemu/) provisioner available in `talosctl` to create a local cluster, but the same approach could be used to deploy Talos in bigger air-gapped networks.
 
 ## Requirements
 
 The follow are requirements for this guide:
 
 - Docker 18.03 or greater
-- Requirements for the Talos [QEMU](qemu) cluster
+- Requirements for the Talos [QEMU](../../local-platforms/qemu/) cluster
 
 ## Identifying Images
 

--- a/website/content/docs/v0.9/Guides/configuring-pull-through-cache.md
+++ b/website/content/docs/v0.9/Guides/configuring-pull-through-cache.md
@@ -20,7 +20,7 @@ To see a live demo of this writeup, see the video below:
 The follow are requirements for creating the set of caching proxies:
 
 - Docker 18.03 or greater
-- Local cluster requirements for either [docker](docker) or [QEMU](qemu).
+- Local cluster requirements for either [docker](../../local-platforms/docker/) or [QEMU](../../local-platforms/qemu/).
 
 ## Launch the Caching Docker Registry Proxies
 
@@ -62,7 +62,7 @@ host port (5000, 5001, 5002, 5003 and 5004).
 
 ## Using Caching Registries with `QEMU` Local Cluster
 
-With a [QEMU](qemu) local cluster, a bridge interface is created on the host.
+With a [QEMU](../../local-platforms/qemu/) local cluster, a bridge interface is created on the host.
 As registry containers expose their ports on the host, we can use bridge IP to direct proxy requests.
 
 ```bash
@@ -82,7 +82,7 @@ The first time cluster boots, images are pulled and cached, so next cluster boot
 
 ## Using Caching Registries with `docker` Local Cluster
 
-With a [docker](docker) local cluster we can use docker bridge IP, default value for that IP is `172.17.0.1`.
+With a [docker](../../local-platforms/docker/) local cluster we can use docker bridge IP, default value for that IP is `172.17.0.1`.
 On Linux, the docker bridge address can be inspected with `ip addr show docker0`.
 
 ```bash

--- a/website/content/docs/v0.9/Guides/configuring-the-cluster-endpoint.md
+++ b/website/content/docs/v0.9/Guides/configuring-the-cluster-endpoint.md
@@ -31,7 +31,7 @@ The configuration can either be done on a Loadbalancer, or simply trough DNS.
 For example:
 
 > This is in the config file for the cluster e.g. init.yaml, controlplane.yaml and join.yaml.
-> for more details, please see: [v1alpha1 endpoint configuration](/v0.9/en/configuration/v1alpha1#controlplane)
+> for more details, please see: [v1alpha1 endpoint configuration](../../reference/configuration/#controlplaneconfig)
 
 ```yaml
 .....

--- a/website/content/docs/v0.9/Guides/configuring-wireguard-network.md
+++ b/website/content/docs/v0.9/Guides/configuring-wireguard-network.md
@@ -98,4 +98,4 @@ network:
 
 When `networkd` gets this configuration it will create the device, configure it and will bring it up (equivalent to `ip link set up dev wg0`).
 
-All supported config parameters are described in the [Machine Config Reference](/docs/v0.9/reference/configuration/#devicewireguardconfig).
+All supported config parameters are described in the [Machine Config Reference](../../reference/configuration/#devicewireguardconfig).

--- a/website/content/docs/v0.9/Guides/editing-machine-configuration.md
+++ b/website/content/docs/v0.9/Guides/editing-machine-configuration.md
@@ -3,7 +3,7 @@ title: "Editing Machine Configuration"
 description: "How to edit and patch Talos machine configuration, with reboot, immediately, or stage update on reboot."
 ---
 
-Talos node state is fully defined by [machine configuration](../Reference/configuration/).
+Talos node state is fully defined by [machine configuration](../../reference/configuration/).
 Initial configuration is delivered to the node at bootstrap time, but configuration can be updated while the node is running.
 
 > Note: Be sure that config is persisted so that configuration updates are not overwritten on reboots.

--- a/website/content/docs/v0.9/Introduction/what-is-new.md
+++ b/website/content/docs/v0.9/Introduction/what-is-new.md
@@ -10,7 +10,7 @@ This change makes bootstrap process much more stable and resilient to failures.
 For single control plane node clusters it eliminates bugs with control plane being unavailable after a reboot.
 As control plane configuration is managed via Talos API, even if control plane configuration was wrong and
 API server is not available, change can be rolled back using `talosctl` to bring the control plane back up.
-When upgrading from Talos 0.8, control plane can be [converted](../Guides/converting-control-plane/) to run as static pods.
+When upgrading from Talos 0.8, control plane can be [converted](../../guides/converting-control-plane/) to run as static pods.
 
 ## ECDSA Certificates and Keys for Kubernetes
 
@@ -20,7 +20,7 @@ leads to much faster bootstrap and boot times.
 
 ## Immediate Machine Configuration Updates
 
-Changes to `.cluster` part of Talos machine configuration can now be applied immediately (without a reboot).
+Changes to `.cluster` part of Talos machine configuration can now be [applied immediately](../../guides/editing-machine-configuration) (without a reboot).
 This allows for example updating versions of control plane components, adding additional arguments or modifying bootstrap manifests.
 Future versions of Talos will expand on that to allow most of the machine configuration to be applied without a reboot.
 
@@ -30,7 +30,7 @@ Talos now supports encryption for `STATE` and `EPHEMERAL` partitions of the syst
 `STATE` partition holds machine configuration and `EPHEMERAL` partition is mounted as `/var` which stores container runtime
 state, configuration files laid on top of Talos read-only immutable root filesystem.
 Encryption key in Talos 0.9 is derived from the Node UUID which is unique machine identifier provided by the manufacturer.
-Disk encryption is not enabled by default, it needs to be [enabled](../Guides/disk-encryption/) via machine configuration.
+Disk encryption is not enabled by default, it needs to be [enabled](../../guides/disk-encryption/) via machine configuration.
 
 ## Virtual IP for the Control Plane Endpoint
 

--- a/website/content/docs/v0.9/Learn More/components.md
+++ b/website/content/docs/v0.9/Learn More/components.md
@@ -9,15 +9,15 @@ In this section, we discuss the various components that underpin Talos.
 
 | Component                | Description                                                                                                                                                                                                                                                                                                   |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [apid](apid)             | When interacting with Talos, the gRPC API endpoint you interact with directly is provided by `apid`. `apid` acts as the gateway for all component interactions and forwards the requests to `routerd`.                                                                                                     |
-| [containerd](containerd) | An industry-standard container runtime with an emphasis on simplicity, robustness, and portability. To learn more, see the [containerd website](https://containerd.io).                                                                                                                                         |
-| [machined](machined)     | Talos replacement for the traditional Linux init-process. Specially designed to run Kubernetes and does not allow starting arbitrary user services.                                                                                                                                                           |
-| [networkd](networkd)     | Handles all of the host level network configuration. The configuration is defined under the `networking` key                                                                                                                                                                                                      |
-| [timed](timed)           | Handles the host time synchronization by acting as a NTP-client.                                                                                                                                                                                                                                              |
-| [kernel](kernel)         | The Linux kernel included with Talos is configured according to the recommendations outlined in the [Kernel Self Protection Project](http://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project).                                                                                                       |
-| [routerd](routerd)       | Responsible for routing an incoming API request from `apid` to the appropriate backend (e.g. `networkd`, `machined` and `timed`).                                                                                                                                                                                  |
-| [trustd](trustd)         | To run and operate a Kubernetes cluster, a certain level of trust is required. Based on the concept of a 'Root of Trust', `trustd` is a simple daemon responsible for establishing trust within the system.                                                                                                    |
-| [udevd](udevd)           | Implementation of `eudev` into `machined`. `eudev` is Gentoo's fork of udev, systemd's device file manager for the Linux kernel. It manages device nodes in /dev and handles all user space actions when adding or removing devices. To learn more, see the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Eudev). |
+| apid             | When interacting with Talos, the gRPC API endpoint you interact with directly is provided by `apid`. `apid` acts as the gateway for all component interactions and forwards the requests to `routerd`.                                                                                                     |
+| containerd | An industry-standard container runtime with an emphasis on simplicity, robustness, and portability. To learn more, see the [containerd website](https://containerd.io).                                                                                                                                         |
+| machined     | Talos replacement for the traditional Linux init-process. Specially designed to run Kubernetes and does not allow starting arbitrary user services.                                                                                                                                                           |
+| networkd     | Handles all of the host level network configuration. The configuration is defined under the `networking` key                                                                                                                                                                                                      |
+| timed           | Handles the host time synchronization by acting as a NTP-client.                                                                                                                                                                                                                                              |
+| kernel         | The Linux kernel included with Talos is configured according to the recommendations outlined in the [Kernel Self Protection Project](http://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project).                                                                                                       |
+| routerd       | Responsible for routing an incoming API request from `apid` to the appropriate backend (e.g. `networkd`, `machined` and `timed`).                                                                                                                                                                                  |
+| trustd         | To run and operate a Kubernetes cluster, a certain level of trust is required. Based on the concept of a 'Root of Trust', `trustd` is a simple daemon responsible for establishing trust within the system.                                                                                                    |
+| udevd           | Implementation of `eudev` into `machined`. `eudev` is Gentoo's fork of udev, systemd's device file manager for the Linux kernel. It manages device nodes in /dev and handles all user space actions when adding or removing devices. To learn more, see the [Gentoo Wiki](https://wiki.gentoo.org/wiki/Eudev). |
 
 ### apid
 
@@ -85,13 +85,13 @@ To that extent, `machined` is relatively static in that it does not allow for ar
 Only the services necessary to run Kubernetes and manage the node are available.
 This includes:
 
-- [containerd](containerd)
-- [kubeadm](kubeadm)
+- containerd
+- kubeadm
 - [kubelet](https://kubernetes.io/docs/concepts/overview/components/)
-- [networkd](networkd)
-- [timed](timed)
-- [trustd](trustd)
-- [udevd](udevd)
+- networkd
+- timed
+- trustd
+- udevd
 
 ### networkd
 


### PR DESCRIPTION
Gridsome forces folders to be lower-case.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
