### PR TITLE
chore: fix provision tests after changes to build-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,8 @@ provision-tests-track-%:
 		INTEGRATION_TEST_RUN="TestIntegration/.+-TR$*" \
 		INTEGRATION_TEST_TRACK="$*" \
 		CUSTOM_CNI_URL=$(CUSTOM_CNI_URL) \
-		REGISTRY=$(IMAGE_REGISTRY)
+		REGISTRY=$(IMAGE_REGISTRY) \
+		ARTIFACTS=$(ARTIFACTS)
 
 # Assets for releases
 

--- a/hack/test/provision-tests.sh
+++ b/hack/test/provision-tests.sh
@@ -40,4 +40,8 @@ case "${CUSTOM_CNI_URL:-false}" in
     ;;
 esac
 
-"${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.provision.mtu 1450 ${INTEGRATION_TEST_FLAGS}
+"${INTEGRATION_TEST}" -test.v \
+  -talos.talosctlpath "${TALOSCTL}" \
+  -talos.provision.mtu 1450  \
+  -talos.provision.cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
+  ${INTEGRATION_TEST_FLAGS}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -147,6 +147,7 @@ func init() {
 	flag.StringVar(&provision_test.DefaultSettings.TargetInstallImageRegistry, "talos.provision.target-installer-registry",
 		provision_test.DefaultSettings.TargetInstallImageRegistry, "image registry for target installer image (provision tests only)")
 	flag.StringVar(&provision_test.DefaultSettings.CustomCNIURL, "talos.provision.custom-cni-url", provision_test.DefaultSettings.CustomCNIURL, "custom CNI URL for the cluster (provision tests only)")
+	flag.StringVar(&provision_test.DefaultSettings.CNIBundleURL, "talos.provision.cni-bundle-url", provision_test.DefaultSettings.CNIBundleURL, "URL to download CNI bundle from")
 
 	allSuites = append(allSuites, api.GetAllSuites()...)
 	allSuites = append(allSuites, cli.GetAllSuites()...)

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -8,9 +8,14 @@
 package provision
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 var allSuites []suite.TestingSuite
@@ -45,6 +50,8 @@ type Settings struct {
 	CustomCNIURL string
 	// Enable crashdump on failure.
 	CrashdumpEnabled bool
+	// CNI bundle for QEMU provisioner.
+	CNIBundleURL string
 }
 
 // DefaultSettings filled in by test runner.
@@ -57,4 +64,10 @@ var DefaultSettings = Settings{
 	MasterNodes:                3,
 	WorkerNodes:                1,
 	TargetInstallImageRegistry: "ghcr.io",
+	CNIBundleURL:               fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", trimVersion(version.Tag), constants.ArchVariable),
+}
+
+func trimVersion(version string) string {
+	// remove anything extra after semantic version core, `v0.3.2-1-abcd` -> `v0.3.2`
+	return regexp.MustCompile(`(-\d+-g[0-9a-f]+)$`).ReplaceAllString(version, "")
 }


### PR DESCRIPTION
CNI was removed from build-container which works fine for
`talosctl cluster create` clusters as it installs its own CNI, but fails
for upgrade tests as they were never updated for the CNI bundle.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

