### PR TITLE
backport: conver-k8s output, CRI registry config fix, provision tests fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,8 @@ provision-tests-track-%:
 		INTEGRATION_TEST_RUN="TestIntegration/.+-TR$*" \
 		INTEGRATION_TEST_TRACK="$*" \
 		CUSTOM_CNI_URL=$(CUSTOM_CNI_URL) \
-		REGISTRY=$(IMAGE_REGISTRY)
+		REGISTRY=$(IMAGE_REGISTRY) \
+		ARTIFACTS=$(ARTIFACTS)
 
 # Assets for releases
 

--- a/cmd/talosctl/cmd/talos/convert-k8s.go
+++ b/cmd/talosctl/cmd/talos/convert-k8s.go
@@ -33,6 +33,11 @@ var convertOptions k8s.ConvertOptions
 func init() {
 	convertK8sCmd.Flags().StringVar(&convertOptions.ControlPlaneEndpoint, "endpoint", "", "the cluster control plane endpoint")
 	convertK8sCmd.Flags().BoolVar(&convertOptions.ForceYes, "force", false, "skip prompts, assume yes")
+	convertK8sCmd.Flags().BoolVar(&convertOptions.OnlyRemoveInitializedKey, "remove-initialized-key", false, "only remove bootkube initialized key (used in manual conversion)")
+
+	// hiding this flag as it should only be used in manual process (and it's documented there), but should never be used in automatic conversion
+	convertK8sCmd.Flags().MarkHidden("remove-initialized-key") //nolint: errcheck
+
 	addCommand(convertK8sCmd)
 }
 

--- a/hack/test/provision-tests.sh
+++ b/hack/test/provision-tests.sh
@@ -40,4 +40,8 @@ case "${CUSTOM_CNI_URL:-false}" in
     ;;
 esac
 
-"${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.provision.mtu 1450 ${INTEGRATION_TEST_FLAGS}
+"${INTEGRATION_TEST}" -test.v \
+  -talos.talosctlpath "${TALOSCTL}" \
+  -talos.provision.mtu 1450  \
+  -talos.provision.cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
+  ${INTEGRATION_TEST_FLAGS}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -147,6 +147,7 @@ func init() {
 	flag.StringVar(&provision_test.DefaultSettings.TargetInstallImageRegistry, "talos.provision.target-installer-registry",
 		provision_test.DefaultSettings.TargetInstallImageRegistry, "image registry for target installer image (provision tests only)")
 	flag.StringVar(&provision_test.DefaultSettings.CustomCNIURL, "talos.provision.custom-cni-url", provision_test.DefaultSettings.CustomCNIURL, "custom CNI URL for the cluster (provision tests only)")
+	flag.StringVar(&provision_test.DefaultSettings.CNIBundleURL, "talos.provision.cni-bundle-url", provision_test.DefaultSettings.CNIBundleURL, "URL to download CNI bundle from")
 
 	allSuites = append(allSuites, api.GetAllSuites()...)
 	allSuites = append(allSuites, cli.GetAllSuites()...)

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -8,9 +8,14 @@
 package provision
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 var allSuites []suite.TestingSuite
@@ -45,6 +50,8 @@ type Settings struct {
 	CustomCNIURL string
 	// Enable crashdump on failure.
 	CrashdumpEnabled bool
+	// CNI bundle for QEMU provisioner.
+	CNIBundleURL string
 }
 
 // DefaultSettings filled in by test runner.
@@ -57,4 +64,10 @@ var DefaultSettings Settings = Settings{
 	MasterNodes:                3,
 	WorkerNodes:                1,
 	TargetInstallImageRegistry: "ghcr.io",
+	CNIBundleURL:               fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", trimVersion(version.Tag), constants.ArchVariable),
+}
+
+func trimVersion(version string) string {
+	// remove anything extra after semantic version core, `v0.3.2-1-abcd` -> `v0.3.2`
+	return regexp.MustCompile(`(-\d+-g[0-9a-f]+)$`).ReplaceAllString(version, "")
 }

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -80,19 +80,19 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 		&v1alpha1.MachineFile{
 			FileContent:     `cacert`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/ca/some.host:123.crt",
+			FilePath:        "/var/etc/cri/ca/some.host:123.crt",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
 			FileContent:     `clientcert`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/client/some.host:123.crt",
+			FilePath:        "/var/etc/cri/client/some.host:123.crt",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
 			FileContent:     `clientkey`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/client/some.host:123.key",
+			FilePath:        "/var/etc/cri/client/some.host:123.key",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
@@ -111,9 +111,9 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
             identitytoken = "token"
           [plugins.cri.registry.configs."some.host:123".tls]
             insecure_skip_verify = true
-            ca_file = "/etc/cri/ca/some.host:123.crt"
-            cert_file = "/etc/cri/client/some.host:123.crt"
-            key_file = "/etc/cri/client/some.host:123.key"
+            ca_file = "/var/etc/cri/ca/some.host:123.crt"
+            cert_file = "/var/etc/cri/client/some.host:123.crt"
+            key_file = "/var/etc/cri/client/some.host:123.key"
 `,
 			FilePermissions: 0o644,
 			FilePath:        constants.CRIContainerdConfig,

--- a/internal/pkg/containers/cri/containerd/containerd.go
+++ b/internal/pkg/containers/cri/containerd/containerd.go
@@ -21,8 +21,8 @@ import (
 //
 //nolint:gocyclo
 func GenerateRegistriesConfig(r config.Registries) ([]config.File, error) {
-	caPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "ca")
-	clientPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "client")
+	caPath := filepath.Join("/var", filepath.Dir(constants.CRIContainerdConfig), "ca")
+	clientPath := filepath.Join("/var", filepath.Dir(constants.CRIContainerdConfig), "client")
 
 	var ctrdCfg Config
 	ctrdCfg.Plugins.CRI.Registry.Mirrors = make(map[string]Mirror)

--- a/pkg/cluster/kubernetes/convert.go
+++ b/pkg/cluster/kubernetes/convert.go
@@ -41,8 +41,9 @@ import (
 
 // ConvertOptions are options for convert tasks.
 type ConvertOptions struct {
-	ControlPlaneEndpoint string
-	ForceYes             bool
+	ControlPlaneEndpoint     string
+	ForceYes                 bool
+	OnlyRemoveInitializedKey bool
 
 	masterNodes []string
 }
@@ -73,6 +74,11 @@ func ConvertToStaticPods(ctx context.Context, cluster ConvertProvider, options C
 		return fmt.Errorf("no master nodes discovered")
 	}
 
+	// only used in manual conversion process
+	if options.OnlyRemoveInitializedKey {
+		return removeInitializedKey(ctx, cluster, options.masterNodes[0])
+	}
+
 	fmt.Printf("discovered master nodes %q\n", options.masterNodes)
 
 	selfHosted, err := IsSelfHostedControlPlane(ctx, cluster, options.masterNodes[0])
@@ -95,7 +101,8 @@ func ConvertToStaticPods(ctx context.Context, cluster ConvertProvider, options C
 		fmt.Printf("\ttalosctl -n <master node IP> get %s\n", k8s.StaticPodType)
 		fmt.Printf("\ttalosctl -n <master node IP> get %s\n", k8s.ManifestType)
 		fmt.Println()
-		fmt.Println("bootstrap manifests will only be applied for missing resources, existing resources will not be updated")
+		fmt.Println("in order to remove self-hosted control plane, pod-checkpointer component needs to be disabled")
+		fmt.Println("once pod-checkpointer is disabled, the cluster shouldn't be rebooted until the entire conversion process is complete")
 
 		if !options.ForceYes {
 			var yes bool


### PR DESCRIPTION
This backports PRs #3283, #3287, #3293