### PR TITLE
backports: fix udevd mount race, CRI registry config, provision tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,8 @@ provision-tests-track-%:
 		INTEGRATION_TEST_RUN="TestIntegration/.+-TR$*" \
 		INTEGRATION_TEST_TRACK="$*" \
 		CUSTOM_CNI_URL=$(CUSTOM_CNI_URL) \
-		REGISTRY=$(REGISTRY)
+		REGISTRY=$(REGISTRY) \
+		ARTIFACTS=$(ARTIFACTS)
 
 # Assets for releases
 

--- a/hack/test/provision-tests.sh
+++ b/hack/test/provision-tests.sh
@@ -40,4 +40,8 @@ case "${CUSTOM_CNI_URL:-false}" in
     ;;
 esac
 
-"${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.provision.mtu 1450 ${INTEGRATION_TEST_FLAGS}
+"${INTEGRATION_TEST}" -test.v \
+  -talos.talosctlpath "${TALOSCTL}" \
+  -talos.provision.mtu 1450  \
+  -talos.provision.cni-bundle-url ${ARTIFACTS}/talosctl-cni-bundle-'${ARCH}'.tar.gz \
+  ${INTEGRATION_TEST_FLAGS}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -147,6 +147,7 @@ func init() {
 	flag.StringVar(&provision_test.DefaultSettings.TargetInstallImageRegistry, "talos.provision.target-installer-registry",
 		provision_test.DefaultSettings.TargetInstallImageRegistry, "image registry for target installer image (provision tests only)")
 	flag.StringVar(&provision_test.DefaultSettings.CustomCNIURL, "talos.provision.custom-cni-url", provision_test.DefaultSettings.CustomCNIURL, "custom CNI URL for the cluster (provision tests only)")
+	flag.StringVar(&provision_test.DefaultSettings.CNIBundleURL, "talos.provision.cni-bundle-url", provision_test.DefaultSettings.CNIBundleURL, "URL to download CNI bundle from")
 
 	allSuites = append(allSuites, api.GetAllSuites()...)
 	allSuites = append(allSuites, cli.GetAllSuites()...)

--- a/internal/integration/provision/provision.go
+++ b/internal/integration/provision/provision.go
@@ -8,9 +8,14 @@
 package provision
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/stretchr/testify/suite"
 
 	"github.com/talos-systems/talos/internal/integration/base"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 var allSuites []suite.TestingSuite
@@ -45,6 +50,8 @@ type Settings struct {
 	CustomCNIURL string
 	// Enable crashdump on failure.
 	CrashdumpEnabled bool
+	// CNI bundle for QEMU provisioner.
+	CNIBundleURL string
 }
 
 // DefaultSettings filled in by test runner.
@@ -57,4 +64,10 @@ var DefaultSettings Settings = Settings{
 	MasterNodes:                3,
 	WorkerNodes:                1,
 	TargetInstallImageRegistry: "ghcr.io",
+	CNIBundleURL:               fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", trimVersion(version.Tag), constants.ArchVariable),
+}
+
+func trimVersion(version string) string {
+	// remove anything extra after semantic version core, `v0.3.2-1-abcd` -> `v0.3.2`
+	return regexp.MustCompile(`(-\d+-g[0-9a-f]+)$`).ReplaceAllString(version, "")
 }

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -74,20 +73,7 @@ const (
 	currentK8sVersion  = "1.20.1"
 )
 
-var (
-	defaultNameservers = []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1")}
-	defaultCNIBinPath  = []string{"/opt/cni/bin"}
-)
-
-const (
-	defaultCNIConfDir  = "/etc/cni/conf.d"
-	defaultCNICacheDir = "/var/lib/cni"
-)
-
-func trimVersion(version string) string {
-	// remove anything extra after semantic version core, `v0.3.2-1-abcd` -> `v0.3.2`
-	return regexp.MustCompile(`(-\d+-g[0-9a-f]+)$`).ReplaceAllString(version, "")
-}
+var defaultNameservers = []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1")}
 
 // upgradeBetweenTwoLastReleases upgrades between two last releases of Talos.
 func upgradeBetweenTwoLastReleases() upgradeSpec {
@@ -193,6 +179,7 @@ type UpgradeSuite struct {
 	ctxCancel context.CancelFunc
 
 	stateDir string
+	cniDir   string
 }
 
 // SetupSuite ...
@@ -248,6 +235,7 @@ func (suite *UpgradeSuite) setupCluster() {
 	suite.Require().NoError(err)
 
 	suite.stateDir = filepath.Join(defaultStateDir, "clusters")
+	suite.cniDir = filepath.Join(defaultStateDir, "cni")
 
 	clusterName := suite.spec.ShortName
 
@@ -278,9 +266,11 @@ func (suite *UpgradeSuite) setupCluster() {
 			MTU:         DefaultSettings.MTU,
 			Nameservers: defaultNameservers,
 			CNI: provision.CNIConfig{
-				BinPath:  defaultCNIBinPath,
-				ConfDir:  defaultCNIConfDir,
-				CacheDir: defaultCNICacheDir,
+				BinPath:  []string{filepath.Join(suite.cniDir, "bin")},
+				ConfDir:  filepath.Join(suite.cniDir, "conf.d"),
+				CacheDir: filepath.Join(suite.cniDir, "cache"),
+
+				BundleURL: DefaultSettings.CNIBundleURL,
 			},
 		},
 

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -80,19 +80,19 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 		&v1alpha1.MachineFile{
 			FileContent:     `cacert`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/ca/some.host:123.crt",
+			FilePath:        "/var/etc/cri/ca/some.host:123.crt",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
 			FileContent:     `clientcert`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/client/some.host:123.crt",
+			FilePath:        "/var/etc/cri/client/some.host:123.crt",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
 			FileContent:     `clientkey`,
 			FilePermissions: 0o600,
-			FilePath:        "/etc/cri/client/some.host:123.key",
+			FilePath:        "/var/etc/cri/client/some.host:123.key",
 			FileOp:          "create",
 		},
 		&v1alpha1.MachineFile{
@@ -111,9 +111,9 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
             identitytoken = "token"
           [plugins.cri.registry.configs."some.host:123".tls]
             insecure_skip_verify = true
-            ca_file = "/etc/cri/ca/some.host:123.crt"
-            cert_file = "/etc/cri/client/some.host:123.crt"
-            key_file = "/etc/cri/client/some.host:123.key"
+            ca_file = "/var/etc/cri/ca/some.host:123.crt"
+            cert_file = "/var/etc/cri/client/some.host:123.crt"
+            key_file = "/var/etc/cri/client/some.host:123.key"
 `,
 			FilePermissions: 0o644,
 			FilePath:        constants.CRIContainerdConfig,

--- a/internal/pkg/containers/cri/containerd/containerd.go
+++ b/internal/pkg/containers/cri/containerd/containerd.go
@@ -21,8 +21,8 @@ import (
 //
 //nolint: gocyclo
 func GenerateRegistriesConfig(r config.Registries) ([]config.File, error) {
-	caPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "ca")
-	clientPath := filepath.Join(filepath.Dir(constants.CRIContainerdConfig), "client")
+	caPath := filepath.Join("/var", filepath.Dir(constants.CRIContainerdConfig), "ca")
+	clientPath := filepath.Join("/var", filepath.Dir(constants.CRIContainerdConfig), "client")
 
 	var ctrdCfg Config
 	ctrdCfg.Plugins.CRI.Registry.Mirrors = make(map[string]Mirror)

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -134,6 +134,9 @@ func mountRetry(f RetryFunc, p *Point, isUnmount bool) (err error) {
 			switch err {
 			case unix.EBUSY:
 				return retry.ExpectedError(err)
+			case unix.ENOENT:
+				// if udevd triggers BLKRRPART ioctl, partition device entry might disappear temporarily
+				return retry.ExpectedError(err)
 			case unix.EINVAL:
 				isMounted, checkErr := p.IsMounted()
 				if checkErr != nil {


### PR DESCRIPTION
See PRs #3242, #3283, #3293