### PR TITLE
fix: don't touch any partitions on upgrade with --preserve

### DIFF
--- a/cmd/installer/pkg/install/manifest.go
+++ b/cmd/installer/pkg/install/manifest.go
@@ -14,10 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/partition/gpt"
-	"github.com/talos-systems/go-blockdevice/blockdevice/util"
 	"github.com/talos-systems/go-retry/retry"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -140,15 +138,16 @@ func NewManifest(label string, sequence runtime.Sequence, bootPartitionFound boo
 
 	ephemeralTarget := EphemeralTarget(opts.Disk, NoFilesystem)
 
-	if opts.Force {
-		ephemeralTarget.Force = true
-	} else {
-		ephemeralTarget.Force = false
-		ephemeralTarget.Skip = true
-		stateTarget.Size = 0 // expand previous partition to cover whatever space is available
+	targets := []*Target{efiTarget, biosTarget, bootTarget, metaTarget, stateTarget, ephemeralTarget}
+
+	if !opts.Force {
+		for _, target := range targets {
+			target.Force = false
+			target.Skip = true
+		}
 	}
 
-	for _, target := range []*Target{efiTarget, biosTarget, bootTarget, metaTarget, stateTarget, ephemeralTarget} {
+	for _, target := range targets {
 		if target == nil {
 			continue
 		}
@@ -373,6 +372,10 @@ func (m *Manifest) preserveContents(device Device, targets []*Target) (err error
 	anyPreserveContents := false
 
 	for _, target := range targets {
+		if target.Skip {
+			continue
+		}
+
 		if target.PreserveContents {
 			anyPreserveContents = true
 
@@ -405,6 +408,10 @@ func (m *Manifest) preserveContents(device Device, targets []*Target) (err error
 	}
 
 	for _, target := range targets {
+		if target.Skip {
+			continue
+		}
+
 		if !target.PreserveContents {
 			continue
 		}
@@ -499,45 +506,4 @@ func (m *Manifest) zeroDevice(device Device) (err error) {
 	log.Printf("wiped %q with %q", device.Device, method)
 
 	return bd.Close()
-}
-
-// Partition creates a new partition on the specified device.
-func (t *Target) Partition(pt *gpt.GPT, pos int, bd *blockdevice.BlockDevice) (err error) {
-	if t.Skip {
-		part := pt.Partitions().FindByName(t.Label)
-		if part != nil {
-			log.Printf("skipped %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
-		}
-
-		return nil
-	}
-
-	log.Printf("partitioning %s - %s %q\n", t.Device, t.Label, humanize.Bytes(t.Size))
-
-	opts := []gpt.PartitionOption{
-		gpt.WithPartitionType(t.PartitionType),
-		gpt.WithPartitionName(t.Label),
-	}
-
-	if t.Size == 0 {
-		opts = append(opts, gpt.WithMaximumSize(true))
-	}
-
-	if t.LegacyBIOSBootable {
-		opts = append(opts, gpt.WithLegacyBIOSBootableAttribute(true))
-	}
-
-	part, err := pt.InsertAt(pos, t.Size, opts...)
-	if err != nil {
-		return err
-	}
-
-	t.PartitionName, err = util.PartPath(t.Device, int(part.Number))
-	if err != nil {
-		return err
-	}
-
-	log.Printf("created %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
-
-	return nil
 }

--- a/cmd/installer/pkg/install/target.go
+++ b/cmd/installer/pkg/install/target.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dustin/go-humanize"
+	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/partition/gpt"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util"
 	"golang.org/x/sys/unix"
@@ -161,7 +163,7 @@ func (t *Target) Locate(pt *gpt.GPT) (*gpt.Partition, error) {
 		if part.Name == t.Label {
 			var err error
 
-			t.PartitionName, err = util.PartPath(t.Device, int(part.Number))
+			t.PartitionName, err = part.Path()
 			if err != nil {
 				return part, err
 			}
@@ -171,6 +173,52 @@ func (t *Target) Locate(pt *gpt.GPT) (*gpt.Partition, error) {
 	}
 
 	return nil, nil
+}
+
+// Partition creates a new partition on the specified device.
+func (t *Target) Partition(pt *gpt.GPT, pos int, bd *blockdevice.BlockDevice) (err error) {
+	if t.Skip {
+		part := pt.Partitions().FindByName(t.Label)
+		if part != nil {
+			log.Printf("skipped %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
+
+			t.PartitionName, err = part.Path()
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	log.Printf("partitioning %s - %s %q\n", t.Device, t.Label, humanize.Bytes(t.Size))
+
+	opts := []gpt.PartitionOption{
+		gpt.WithPartitionType(t.PartitionType),
+		gpt.WithPartitionName(t.Label),
+	}
+
+	if t.Size == 0 {
+		opts = append(opts, gpt.WithMaximumSize(true))
+	}
+
+	if t.LegacyBIOSBootable {
+		opts = append(opts, gpt.WithLegacyBIOSBootableAttribute(true))
+	}
+
+	part, err := pt.InsertAt(pos, t.Size, opts...)
+	if err != nil {
+		return err
+	}
+
+	t.PartitionName, err = part.Path()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("created %s (%s) size %d blocks", t.PartitionName, t.Label, part.Length())
+
+	return nil
 }
 
 // Format creates a filesystem on the device/partition.

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -106,9 +106,6 @@ const (
 	// the boot path.
 	BootMountPoint = "/boot"
 
-	// LegacyBootPartitionLabel is the label of the boot partition in older versions of Talos.
-	LegacyBootPartitionLabel = "ESP"
-
 	// EphemeralPartitionLabel is the label of the partition to use for
 	// mounting at the data path.
 	EphemeralPartitionLabel = "EPHEMERAL"


### PR DESCRIPTION
This fixes a case of upgrade from 0.9.0-alpha.4 to 0.9.0-beta.0. With
introduced proper partition alignment and physical block size != 512,
partitions before ephemeral will be moved around a bit (due to the
alignment), and `STATE` partition size might change a bit.

If encryption is enabled, contents are preserved as raw bytes, so
partition size should be exactly same during restore.

Drop code (mostly tests) which handled 0.6 to 0.7 upgrades.

On upgrade with preserve don't touch any partitions, at least for 0.8 ->
0.9 layout hasn't changed.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
