### PR TITLE
chore: update Linux to 5.10.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_LOGIN_ENABLED ?= true
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.4.0-1-g3b25a7e
-PKGS ?= v0.4.1-1-g8e2a376
+PKGS ?= v0.4.1-2-gd471b60
 EXTRAS ?= v0.2.0-1-g0db3328
 GO_VERSION ?= 1.15
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.19-talos"
+	DefaultKernelVersion = "5.10.23-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Security kernel update.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
