### PR TITLE
chore: use new release tool for changelogs and release notes

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,11 +2,16 @@
 
 set -e
 
+RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+
+function release-tool {
+  docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null
+  docker run --rm -w /src -v "${PWD}":/src:ro "${RELEASE_TOOL_IMAGE}" -l -d -n -t "${1}" ./hack/release.toml
+}
+
 function changelog {
   if [ "$#" -eq 1 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/chglog/config.yml --tag-filter-pattern "^${1}" "${1}.0-alpha.1.."
-  elif [ "$#" -eq 0 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/chglog/config.yml
+    echo "$(release-tool ${1})\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
   else
     echo 1>&2 "Usage: $0 changelog [tag]"
     exit 1
@@ -14,9 +19,9 @@ function changelog {
 }
 
 function release-notes {
-  git-chglog --output ${1} -c ./hack/chglog/config.yml "${2}"
+  release-tool "${2}" > "${1}"
 
-  echo -e '## Images\n\n```' >> ${1}
+  echo -e '\n## Images\n\n```' >> ${1}
   ${ARTIFACTS}/talosctl-linux-amd64 images >> ${1}
   echo -e '```\n' >> ${1}
 }
@@ -50,9 +55,10 @@ then
 else
   cat <<EOF
 Usage:
-  commit:       Create the official release commit message.
+  commit:        Create the official release commit message.
   cherry-pick:   Cherry-pick a commit into a release branch.
-  changelog:    Update the specified CHANGELOG.
+  changelog:     Update the specified CHANGELOG.
+  release-notes: Create release notes for GitHub release.
 EOF
 
   exit 1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -1,0 +1,37 @@
+# commit to be tagged for new release
+commit = "HEAD"
+
+project_name = "Talos"
+github_repo = "talos-systems/talos"
+match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
+
+# previous release
+previous = "v0.9.0-beta.0"
+
+pre_release = true
+
+preface = """\
+"""
+
+[notes]
+
+    [notes.sbcs]
+        title = "SBCs"
+        description = """\
+* u-boot version was updated to fix the boot and USB issues on Raspberry Pi 4 8GiB version.
+* added support for Rock Pi 4.
+"""
+
+[make_deps]
+
+    [make_deps.tools]
+        variable = "TOOLS"
+        repository = "github.com/talos-systems/tools"
+
+    [make_deps.pkgs]
+        variable = "PKGS"
+        repository = "github.com/talos-systems/pkgs"
+
+    [make_deps.extras]
+        variable = "EXTRAS"
+        repository = "github.com/talos-systems/extras"


### PR DESCRIPTION
This replaces `git-chglog` with the `talos-systems/release-tool`.

We need to make sure we update `hack/release.toml` as we do PRs to make
sure we highlight any important feature or update as we go.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
