### PR TITLE
fix: repair zsh completion

### DIFF
--- a/cmd/talosctl/cmd/completion.go
+++ b/cmd/talosctl/cmd/completion.go
@@ -60,7 +60,11 @@ talosctl completion zsh > "${fpath[1]}/_talosctl"`,
 		case "bash":
 			return rootCmd.GenBashCompletion(os.Stdout)
 		case "zsh":
-			return rootCmd.GenZshCompletion(os.Stdout)
+			err := rootCmd.GenZshCompletion(os.Stdout)
+			// cobra does not hook the completion, so let's do it manually
+			fmt.Printf("compdef _talosctl talosctl")
+
+			return err
 		default:
 			return fmt.Errorf("unsupported shell %q", args[0])
 		}


### PR DESCRIPTION
# Pull Request

## What? (description)
ZSH completion was broken in `talosctl`. Cobra does not hook the ZSH generated completion rules, as it appears. Tools with working ZSH cobra completion (such as `helm` and `kubectl`) do so by printing the hook (`compdef _<completion> <tool>`) themselves.

Fixes #3318

## Why? (reasoning)
To get shell completion working for ZSH users (they are the best users!)

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
