### PR TITLE
chore: fix `make help` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ export HELP_MENU_HEADER
 
 help: ## This help menu.
 	@echo "$$HELP_MENU_HEADER"
-	@grep -E '^[a-zA-Z%_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9%_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 # Build Abstractions
 


### PR DESCRIPTION
`e2e-%` was missing due to bad regex.