### PR TITLE
backport: chore: remove old `osctl` reference

### DIFF
--- a/cmd/talosctl/cmd/completion.go
+++ b/cmd/talosctl/cmd/completion.go
@@ -47,7 +47,7 @@ Note for zsh users: [1] zsh completions are only supported in versions of zsh >=
 # Load the talosctl completion code for zsh[1] into the current shell
 	source <(talosctl completion zsh)
 # Set the talosctl completion code for zsh[1] to autoload on startup
-talosctl completion zsh > "${fpath[1]}/_osctl"`,
+talosctl completion zsh > "${fpath[1]}/_talosctl"`,
 	ValidArgs: []string{"bash", "zsh"},
 	Args:      cobra.ExactValidArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -276,7 +276,7 @@ talosctl completion SHELL [flags]
 # Load the talosctl completion code for zsh[1] into the current shell
 	source <(talosctl completion zsh)
 # Set the talosctl completion code for zsh[1] to autoload on startup
-talosctl completion zsh > "${fpath[1]}/_osctl"
+talosctl completion zsh > "${fpath[1]}/_talosctl"
 ```
 
 ### Options


### PR DESCRIPTION
One place was missed.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@gmail.com>

(cherry picked from commit f7d276b854c4c06f85155c517cc1de7109a53359)