### PR TITLE
fix: upgrade-k8s bug with empty config values and provision script

### DIFF
--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -366,7 +366,7 @@ func (suite *UpgradeSuite) setupCluster() {
 		&bundle.InputOptions{
 			ClusterName: clusterName,
 			Endpoint:    suite.controlPlaneEndpoint,
-			KubeVersion: "", // keep empty so that default version is used per Talos version
+			KubeVersion: suite.spec.SourceK8sVersion,
 			GenOptions: append(
 				genOptions,
 				generate.WithEndpointList(masterEndpoints),


### PR DESCRIPTION
First, if the config for some component image (e.g. `apiServer`) is empty,
Talos pushes default image which is unknown to the script, so verify
that change is not no-op, as otherwise script will hang forvever waiting
for k8s control plane config update.

Second, with bootkube bootstrap it was fine to omit explicit kubernetes
version in upgrade test, but with Talos-managed that means that after
Talos upgrade Kubernetes gets upgraded as well (as Talos config doesn't
contain K8s version, and defaults are used). This is not what we want to
test actually.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

