### PR TITLE
backport: fix: command `etcd remove-member` shouldn't remove etcd data directory

### DIFF
--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -151,14 +151,27 @@ func validateMemberHealth(ctx context.Context, memberURIs []string) (err error) 
 	return c.ValidateQuorum(ctx)
 }
 
-// LeaveCluster removes the current member from the etcd cluster.
+// LeaveCluster removes the current member from the etcd cluster and nukes etcd data directory.
 func (c *Client) LeaveCluster(ctx context.Context) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
 	}
 
-	return c.RemoveMember(ctx, hostname)
+	if err = c.RemoveMember(ctx, hostname); err != nil {
+		return err
+	}
+
+	if err = system.Services(nil).Stop(ctx, "etcd"); err != nil {
+		return fmt.Errorf("failed to stop etcd: %w", err)
+	}
+
+	// Once the member is removed, the data is no longer valid.
+	if err = os.RemoveAll(constants.EtcdDataPath); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", constants.EtcdDataPath, err)
+	}
+
+	return nil
 }
 
 // RemoveMember removes the member from the etcd cluster.
@@ -188,15 +201,6 @@ func (c *Client) RemoveMember(ctx context.Context, hostname string) error {
 	_, err = c.MemberRemove(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("failed to remove member %d: %w", *id, err)
-	}
-
-	if err = system.Services(nil).Stop(ctx, "etcd"); err != nil {
-		return fmt.Errorf("failed to stop etcd: %w", err)
-	}
-
-	// Once the member is removed, the data is no longer valid.
-	if err = os.RemoveAll(constants.EtcdDataPath); err != nil {
-		return fmt.Errorf("failed to remove %s: %w", constants.EtcdDataPath, err)
 	}
 
 	return nil


### PR DESCRIPTION
There are two APIs and `talosctl` commands:

* `etcd leave` removes the member from the cluster and removes etcd
data directory for the called node
* `etcd remove-member <node>` removes some other node from the etcd
cluster, but it doesn't affect called node state

This fixes confusing naming of the methods vs. what they're doing.

Fixes #3340

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit ce795f1cea9d78c26edbcd4a40bb5d3637fde629)

