### PR TITLE
docs: make v0.9 the default docs

### DIFF
--- a/website/gridsome.config.js
+++ b/website/gridsome.config.js
@@ -30,13 +30,13 @@ module.exports = {
       {
         version: "v0.9",
         url: "/docs/v0.9/",
-        latest: false,
-        prerelease: true,
+        latest: true,
+        prerelease: false,
       },
       {
         version: "v0.8",
         url: "/docs/v0.8/",
-        latest: true,
+        latest: false,
         prerelease: false,
       },
       {

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -2,5 +2,5 @@
 #
 # The Netlify documentation says that the following redirect rules are
 # equivalent, but that is not what is observed in practice.
-/docs/latest /docs/v0.8
-/docs/latest/ /docs/v0.8
+/docs/latest /docs/v0.9
+/docs/latest/ /docs/v0.9


### PR DESCRIPTION
This makes the v0.9 release the default documentation.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
