### PR TITLE
refactor: move apid, routerd, timed and trustd to single executable

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -22,6 +22,12 @@ preface = """\
 * added support for Rock Pi 4.
 """
 
+    [notes.optimize]
+        title = "Optmizations"
+        descriptions = """\
+* Talos `system` services now run without container images on initramfs from the single executable; this change reduces RAM usage, initramfs size and boot time..
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/app/apid/main.go
+++ b/internal/app/apid/main.go
@@ -2,13 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package main
+package apid
 
 import (
 	"flag"
 	"log"
 	"regexp"
-	"runtime"
 	"strings"
 
 	"github.com/talos-systems/grpc-proxy/proxy"
@@ -31,19 +30,15 @@ var (
 	useK8sEndpoints *bool
 )
 
-func init() {
-	// Explicitly disable memory profiling to save around 1.4MiB of memory.
-	runtime.MemProfileRate = 0
-
+// Main is the entrypoint of apid.
+func Main() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	endpoints = flag.String("endpoints", "", "the static list of IPs of the control plane nodes")
 	useK8sEndpoints = flag.Bool("use-kubernetes-endpoints", false, "use Kubernetes master node endpoints as control plane endpoints")
 
 	flag.Parse()
-}
 
-func main() {
 	if err := startup.RandSeed(); err != nil {
 		log.Fatalf("failed to seed RNG: %v", err)
 	}

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -24,11 +24,15 @@ import (
 	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/sys/unix"
 
+	"github.com/talos-systems/talos/internal/app/apid"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/bootloader"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/services"
+	"github.com/talos-systems/talos/internal/app/routerd"
+	"github.com/talos-systems/talos/internal/app/timed"
+	"github.com/talos-systems/talos/internal/app/trustd"
 	"github.com/talos-systems/talos/internal/pkg/mount"
 	"github.com/talos-systems/talos/pkg/machinery/api/common"
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -260,6 +264,26 @@ func run() error {
 }
 
 func main() {
+	switch os.Args[0] {
+	case "/apid":
+		apid.Main()
+
+		return
+	case "/routerd":
+		routerd.Main()
+
+		return
+	case "/timed":
+		timed.Main()
+
+		return
+	case "/trustd":
+		trustd.Main()
+
+		return
+	default:
+	}
+
 	// Setup panic handler.
 	defer recovery()
 

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -368,52 +368,6 @@ func (suite *ContainerdSuite) TestStopSigKill() {
 	<-done
 }
 
-func (suite *ContainerdSuite) TestImportSuccess() {
-	reqs := []*containerdrunner.ImportRequest{
-		{
-			Path: "/usr/images/timed.tar",
-			Options: []containerd.ImportOpt{
-				containerd.WithIndexName("testtalos/timed"),
-			},
-		},
-		{
-			Path: "/usr/images/trustd.tar",
-			Options: []containerd.ImportOpt{
-				containerd.WithIndexName("testtalos/trustd"),
-			},
-		},
-	}
-	suite.Assert().NoError(containerdrunner.NewImporter(
-		suite.containerdNamespace, containerdrunner.WithContainerdAddress(suite.containerdAddress)).Import(context.Background(), reqs...))
-
-	ctx := namespaces.WithNamespace(context.Background(), suite.containerdNamespace)
-
-	for _, imageName := range []string{"testtalos/timed", "testtalos/trustd"} {
-		image, err := suite.client.ImageService().Get(ctx, imageName)
-		suite.Require().NoError(err)
-		suite.Require().Equal(imageName, image.Name)
-	}
-}
-
-func (suite *ContainerdSuite) TestImportFail() {
-	reqs := []*containerdrunner.ImportRequest{
-		{
-			Path: "/usr/images/timed.tar",
-			Options: []containerd.ImportOpt{
-				containerd.WithIndexName("testtalos/timed2"),
-			},
-		},
-		{
-			Path: "/usr/images/nothere.tar",
-			Options: []containerd.ImportOpt{
-				containerd.WithIndexName("testtalos/nothere"),
-			},
-		},
-	}
-	suite.Assert().Error(containerdrunner.NewImporter(
-		suite.containerdNamespace, containerdrunner.WithContainerdAddress(suite.containerdAddress)).Import(context.Background(), reqs...))
-}
-
 func (suite *ContainerdSuite) TestContainerStdin() {
 	stdin := bytes.Repeat([]byte{0xde, 0xad, 0xbe, 0xef}, 2000)
 

--- a/internal/app/machined/pkg/system/services/routerd.go
+++ b/internal/app/machined/pkg/system/services/routerd.go
@@ -22,7 +22,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
-	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
@@ -39,7 +38,7 @@ func (o *Routerd) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (o *Routerd) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	return image.Import(ctx, "/usr/images/routerd.tar", "talos/routerd")
+	return nil
 }
 
 // PostFunc implements the Service interface.
@@ -58,8 +57,6 @@ func (o *Routerd) DependsOn(r runtime.Runtime) []string {
 }
 
 func (o *Routerd) Runner(r runtime.Runtime) (runner.Runner, error) {
-	image := "talos/routerd"
-
 	// Set the process arguments.
 	args := runner.Args{
 		ID: o.ID(r),
@@ -101,10 +98,11 @@ func (o *Routerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		&args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithContainerdAddress(constants.SystemContainerdAddress),
-		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			oci.WithMounts(mounts),
+			oci.WithRootFSPath("/opt/routerd"),
+			oci.WithRootFSReadonly(),
 		),
 	),
 		restart.WithType(restart.Forever),

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -20,7 +20,6 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/containerd"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/runner/restart"
-	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
@@ -36,7 +35,7 @@ func (t *Trustd) ID(r runtime.Runtime) string {
 
 // PreFunc implements the Service interface.
 func (t *Trustd) PreFunc(ctx context.Context, r runtime.Runtime) error {
-	return image.Import(ctx, "/usr/images/trustd.tar", "talos/trustd")
+	return nil
 }
 
 // PostFunc implements the Service interface.
@@ -59,8 +58,6 @@ func (t *Trustd) DependsOn(r runtime.Runtime) []string {
 }
 
 func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
-	image := "talos/trustd"
-
 	// Set the process arguments.
 	args := runner.Args{
 		ID:          t.ID(r),
@@ -90,12 +87,13 @@ func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		runner.WithStdin(stdin),
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithContainerdAddress(constants.SystemContainerdAddress),
-		runner.WithContainerImage(image),
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			containerd.WithMemoryLimit(int64(1000000*512)),
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
+			oci.WithRootFSPath("/opt/trustd"),
+			oci.WithRootFSReadonly(),
 		),
 	),
 		restart.WithType(restart.Forever),

--- a/internal/app/routerd/main.go
+++ b/internal/app/routerd/main.go
@@ -2,11 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package main
+package routerd
 
 import (
 	"log"
-	"runtime"
 
 	"github.com/talos-systems/grpc-proxy/proxy"
 	"google.golang.org/grpc"
@@ -18,12 +17,8 @@ import (
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
-func init() {
-	// Explicitly disable memory profiling to save around 1.4MiB of memory.
-	runtime.MemProfileRate = 0
-}
-
-func main() {
+// Main is the entrypoint into routerd.
+func Main() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	if err := startup.RandSeed(); err != nil {

--- a/internal/app/timed/main.go
+++ b/internal/app/timed/main.go
@@ -2,12 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package main
+package timed
 
 import (
 	"flag"
 	"log"
-	"runtime"
 
 	"github.com/talos-systems/talos/internal/app/timed/pkg/ntp"
 	"github.com/talos-systems/talos/internal/app/timed/pkg/reg"
@@ -26,18 +25,15 @@ const (
 	DefaultServer = "pool.ntp.org"
 )
 
-func init() {
-	// Explicitly disable memory profiling to save around 1.4MiB of memory.
-	runtime.MemProfileRate = 0
-
+// Main is the entrypoint into timed.
+//
+// New instantiates a new ntp instance against a given server
+// If no servers are specified, the default will be used.
+func Main() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	flag.Parse()
-}
 
-// New instantiates a new ntp instance against a given server
-// If no servers are specified, the default will be used.
-func main() {
 	if err := startup.RandSeed(); err != nil {
 		log.Fatalf("startup: %v", err)
 	}

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -2,13 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package main
+package trustd
 
 import (
 	"flag"
 	"log"
 	stdlibnet "net"
-	"runtime"
 
 	"github.com/talos-systems/crypto/tls"
 	"github.com/talos-systems/net"
@@ -24,17 +23,14 @@ import (
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
-func init() {
-	// Explicitly disable memory profiling to save around 1.4MiB of memory.
-	runtime.MemProfileRate = 0
-
+// Main is the entrypoint into trustd.
+//
+//nolint:gocyclo
+func Main() {
 	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds | log.Ltime)
 
 	flag.Parse()
-}
 
-//nolint:gocyclo
-func main() {
 	var err error
 
 	if err = startup.RandSeed(); err != nil {

--- a/internal/integration/cli/containers.go
+++ b/internal/integration/cli/containers.go
@@ -27,7 +27,7 @@ func (suite *ContainersSuite) SuiteName() string {
 func (suite *ContainersSuite) TestContainerd() {
 	suite.RunCLI([]string{"containers", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`IMAGE`)),
-		base.StdoutShouldMatch(regexp.MustCompile(`talos/routerd`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`apid`)),
 	)
 }
 

--- a/internal/pkg/containers/containerd/containerd.go
+++ b/internal/pkg/containers/containerd/containerd.go
@@ -110,7 +110,9 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 
 	img, err := cntr.Image(i.nsctx)
 	if err != nil {
-		return nil, fmt.Errorf("error getting container image for %q: %w", cntr.ID(), err)
+		if !errdefs.IsNotFound(err) {
+			return nil, fmt.Errorf("error getting container image for %q: %w", cntr.ID(), err)
+		}
 	}
 
 	task, err := cntr.Task(i.nsctx, nil)
@@ -133,7 +135,11 @@ func (i *inspector) containerInfo(cntr containerd.Container, imageList map[strin
 	cp.Name = cntr.ID()
 	cp.Display = cntr.ID()
 	cp.RestartCount = "0"
-	cp.Digest = img.Target().Digest.String()
+
+	if img != nil {
+		cp.Digest = img.Target().Digest.String()
+	}
+
 	cp.Image = cp.Digest
 
 	if imageList != nil {


### PR DESCRIPTION
This removes container images for the aforementioned services, they are
now built into `machined` executable which launches one or another
service based on `argv[0]`.

Containers are started with rootfs directory which contains only a
single executable file for the service.

This creates rootfs on squashfs for each container in
`/opt/<container>`.

Service `networkd` is not touched as it's handled in #3350.

This removes all the image imports, snapshots and other things which
were associated with the existing way to run containers.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
