### PR TITLE
docs: update path for kernel downloads in qemu docs

### DIFF
--- a/website/content/docs/v0.10/Local Platforms/qemu.md
+++ b/website/content/docs/v0.10/Local Platforms/qemu.md
@@ -61,15 +61,15 @@ These files can be downloaded from the Talos release:
 
 ```bash
 mkdir -p _out/
-curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz-<arch> -L -o _out/vmlinuz-<arch>
+curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs-<arch>.xz -L -o _out/initramfs-<arch>.xz
 ```
 
 For example version `v0.10.0`:
 
 ```bash
-curl https://github.com/talos-systems/talos/releases/latest/download/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/latest/download/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/v0.10.0/vmlinuz-amd64 -L -o _out/vmlinuz-amd64
+curl https://github.com/talos-systems/talos/releases/download/v0.10.0/initramfs-amd64.xz -L -o _out/initramfs-amd64.xz
 ```
 
 ## Create the Cluster

--- a/website/content/docs/v0.7/Local Platforms/qemu.md
+++ b/website/content/docs/v0.7/Local Platforms/qemu.md
@@ -60,15 +60,15 @@ These files can be downloaded from the Talos release:
 
 ```bash
 mkdir -p _out/
-curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz-<arch> -L -o _out/vmlinuz-<arch>
+curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs-<arch>.xz -L -o _out/initramfs-<arch>.xz
 ```
 
 For example version `v0.7.0`:
 
 ```bash
-curl https://github.com/talos-systems/talos/releases/download/v0.7.0/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/download/v0.7.0/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/v0.7.0/vmlinuz-amd64 -L -o _out/vmlinuz-amd64
+curl https://github.com/talos-systems/talos/releases/download/v0.7.0/initramfs-amd64.xz -L -o _out/initramfs-amd64.xz
 ```
 
 ## Create the Cluster

--- a/website/content/docs/v0.8/Local Platforms/qemu.md
+++ b/website/content/docs/v0.8/Local Platforms/qemu.md
@@ -61,15 +61,15 @@ These files can be downloaded from the Talos release:
 
 ```bash
 mkdir -p _out/
-curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz-<arch> -L -o _out/vmlinuz-<arch>
+curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs-<arch>.xz -L -o _out/initramfs-<arch>.xz
 ```
 
 For example version `v0.8.0`:
 
 ```bash
-curl https://github.com/talos-systems/talos/releases/download/v0.8.0/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/download/v0.8.0/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/v0.8.0/vmlinuz-amd64 -L -o _out/vmlinuz-amd64
+curl https://github.com/talos-systems/talos/releases/download/v0.8.0/initramfs-amd64.xz -L -o _out/initramfs-amd64.xz
 ```
 
 ## Create the Cluster

--- a/website/content/docs/v0.9/Local Platforms/qemu.md
+++ b/website/content/docs/v0.9/Local Platforms/qemu.md
@@ -61,15 +61,15 @@ These files can be downloaded from the Talos release:
 
 ```bash
 mkdir -p _out/
-curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/<version>/vmlinuz-<arch> -L -o _out/vmlinuz-<arch>
+curl https://github.com/talos-systems/talos/releases/download/<version>/initramfs-<arch>.xz -L -o _out/initramfs-<arch>.xz
 ```
 
 For example version `v0.9.0`:
 
 ```bash
-curl https://github.com/talos-systems/talos/releases/latest/download/vmlinuz -L -o _out/vmlinuz
-curl https://github.com/talos-systems/talos/releases/latest/download/initramfs.xz -L -o _out/initramfs.xz
+curl https://github.com/talos-systems/talos/releases/download/v0.9.0/vmlinuz-amd64 -L -o _out/vmlinuz-amd64
+curl https://github.com/talos-systems/talos/releases/download/v0.9.0/initramfs-amd64.xz -L -o _out/initramfs-amd64.xz
 ```
 
 ## Create the Cluster


### PR DESCRIPTION
This PR fixes a docs bug where the name of the kernel and init to
download were incorrect for qemu.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
