### PR TITLE
fix: allow empty list for CNI URLs

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -98,10 +98,8 @@ func (c *Config) Validate(mode config.RuntimeMode, options ...config.ValidationO
 
 	if c.Machine().Type() == machine.TypeInit {
 		switch c.Cluster().Network().CNI().Name() {
-		case "custom":
-			if len(c.Cluster().Network().CNI().URLs()) == 0 {
-				result = multierror.Append(result, errors.New("at least one url should be specified if using \"custom\" option for CNI"))
-			}
+		case constants.CustomCNI:
+			// custom CNI with URLs or an empty list of manifests which will get applied
 		case constants.DefaultCNI:
 			// it's flannel bby
 		default:


### PR DESCRIPTION
This PR fixes a bug where, only when init nodes were used, we were
throwing an error during validation if there were no URLs in the list
for custom CNIs. We actually allow this empty list now so folks can
BYO-CNI.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

Will fix #3300 