### PR TITLE
fix: resolve the issue with DHCP lease not being renewed

### DIFF
--- a/internal/app/networkd/pkg/address/dhcp4.go
+++ b/internal/app/networkd/pkg/address/dhcp4.go
@@ -207,10 +207,24 @@ func (d *DHCP4) discover(ctx context.Context, logger *log.Logger) error {
 	}
 
 	mods := []dhcpv4.Modifier{dhcpv4.WithRequestedOptions(opts...)}
+	clientOpts := []nclient4.ClientOpt{}
+
+	if d.Offer != nil {
+		// do not use broadcast, but send the packet to DHCP server directly
+		addr, err := net.ResolveUDPAddr("udp", d.Offer.ServerIPAddr.String()+":67")
+		if err != nil {
+			return err
+		}
+
+		// by default it's set to 0.0.0.0 which actually breaks lease renew
+		d.Offer.ClientIPAddr = d.Offer.YourIPAddr
+
+		clientOpts = append(clientOpts, nclient4.WithServerAddr(addr))
+	}
 
 	// TODO expose this ( nclient4.WithDebugLogger() ) with some
 	// debug logging option
-	cli, err := nclient4.New(d.NetIf.Name)
+	cli, err := nclient4.New(d.NetIf.Name, clientOpts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Very easily reproduced when you start a node with a Dynamic IP.
Normally it should renew lease after TTL/2, but that doesn't happen, so
the node starts to get next IP one after another.

After looking at packets sent by other clients, found out that they
have `Client IP address` equal to the IP given by the DHCP server.

Additionally, changed DHCP client to send `Request` packets directly to the DHCP server after getting an offer.
It looks like DHCP spec states that you should use unicast request directly to DHCP server, not broadcast.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>