### PR TITLE
feat: show short options in talosctl kubeconfig

### DIFF
--- a/cmd/talosctl/cmd/talos/kubeconfig.go
+++ b/cmd/talosctl/cmd/talos/kubeconfig.go
@@ -166,7 +166,7 @@ func askOverwriteOrRename(prompt string) (kubeconfig.ConflictDecision, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	for {
-		fmt.Printf("%s [rename/overwrite]: ", prompt)
+		fmt.Printf("%s [(r)ename/(o)verwrite]: ", prompt)
 
 		response, err := reader.ReadString('\n')
 		if err != nil {


### PR DESCRIPTION
This PR just fixes a teeny usability problem I saw yesterday with Steve,
where it's not immediately clear that you don't have to type the entire
word when you encounter an existing context when pulling kubeconfig.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
