### PR TITLE
docs: update AWS docs to ensure instances are tagged

### DIFF
--- a/website/content/docs/v0.10/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.10/Cloud Platforms/aws.md
@@ -176,20 +176,26 @@ aws ec2 run-instances \
     --instance-type t3.small \
     --user-data file://init.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-0}]"
 ```
 
 #### Create the Remaining Control Plane Nodes
 
 ```bash
-aws ec2 run-instances \
+CP_COUNT=1
+while [[ "$CP_COUNT" -lt 3 ]]; do
+  aws ec2 run-instances \
     --region $REGION \
     --image-id $AMI \
-    --count 2 \
+    --count 1 \
     --instance-type t3.small \
     --user-data file://controlplane.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-$CP_COUNT}]"
+  ((CP_COUNT++))
+done
 ```
 
 > Make a note of the resulting `PrivateIpAddress` from the init and controlplane nodes for later use.
@@ -205,6 +211,7 @@ aws ec2 run-instances \
     --user-data file://join.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-worker}]"
 ```
 
 ### Configure the Load Balancer

--- a/website/content/docs/v0.6/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.6/Cloud Platforms/aws.md
@@ -175,20 +175,26 @@ aws ec2 run-instances \
     --instance-type t3.small \
     --user-data file://init.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-0}]"
 ```
 
 #### Create the Remaining Control Plane Nodes
 
 ```bash
-aws ec2 run-instances \
+CP_COUNT=1
+while [[ "$CP_COUNT" -lt 3 ]]; do
+  aws ec2 run-instances \
     --region $REGION \
     --image-id $AMI \
-    --count 2 \
+    --count 1 \
     --instance-type t3.small \
     --user-data file://controlplane.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-$CP_COUNT}]"
+  ((CP_COUNT++))
+done
 ```
 
 > Make a note of the resulting `PrivateIpAddress` from the init and controlplane nodes for later use.
@@ -204,6 +210,7 @@ aws ec2 run-instances \
     --user-data file://join.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-worker}]"
 ```
 
 ### Configure the Load Balancer

--- a/website/content/docs/v0.7/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.7/Cloud Platforms/aws.md
@@ -175,20 +175,26 @@ aws ec2 run-instances \
     --instance-type t3.small \
     --user-data file://init.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-0}]"
 ```
 
 #### Create the Remaining Control Plane Nodes
 
 ```bash
-aws ec2 run-instances \
+CP_COUNT=1
+while [[ "$CP_COUNT" -lt 3 ]]; do
+  aws ec2 run-instances \
     --region $REGION \
     --image-id $AMI \
-    --count 2 \
+    --count 1 \
     --instance-type t3.small \
     --user-data file://controlplane.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-$CP_COUNT}]"
+  ((CP_COUNT++))
+done
 ```
 
 > Make a note of the resulting `PrivateIpAddress` from the init and controlplane nodes for later use.
@@ -204,6 +210,7 @@ aws ec2 run-instances \
     --user-data file://join.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-worker}]"
 ```
 
 ### Configure the Load Balancer

--- a/website/content/docs/v0.8/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.8/Cloud Platforms/aws.md
@@ -176,20 +176,26 @@ aws ec2 run-instances \
     --instance-type t3.small \
     --user-data file://init.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-0}]"
 ```
 
 #### Create the Remaining Control Plane Nodes
 
 ```bash
-aws ec2 run-instances \
+CP_COUNT=1
+while [[ "$CP_COUNT" -lt 3 ]]; do
+  aws ec2 run-instances \
     --region $REGION \
     --image-id $AMI \
-    --count 2 \
+    --count 1 \
     --instance-type t3.small \
     --user-data file://controlplane.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-$CP_COUNT}]"
+  ((CP_COUNT++))
+done
 ```
 
 > Make a note of the resulting `PrivateIpAddress` from the init and controlplane nodes for later use.
@@ -205,6 +211,7 @@ aws ec2 run-instances \
     --user-data file://join.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-worker}]"
 ```
 
 ### Configure the Load Balancer

--- a/website/content/docs/v0.9/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.9/Cloud Platforms/aws.md
@@ -176,20 +176,26 @@ aws ec2 run-instances \
     --instance-type t3.small \
     --user-data file://init.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-0}]"
 ```
 
 #### Create the Remaining Control Plane Nodes
 
 ```bash
-aws ec2 run-instances \
+CP_COUNT=1
+while [[ "$CP_COUNT" -lt 3 ]]; do
+  aws ec2 run-instances \
     --region $REGION \
     --image-id $AMI \
-    --count 2 \
+    --count 1 \
     --instance-type t3.small \
     --user-data file://controlplane.yaml \
     --subnet-id $SUBNET \
-    --security-group-ids $SECURITY_GROUP
+    --security-group-ids $SECURITY_GROUP \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-cp-$CP_COUNT}]"
+  ((CP_COUNT++))
+done
 ```
 
 > Make a note of the resulting `PrivateIpAddress` from the init and controlplane nodes for later use.
@@ -205,6 +211,7 @@ aws ec2 run-instances \
     --user-data file://join.yaml \
     --subnet-id $SUBNET \
     --security-group-ids $SECURITY_GROUP
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=talos-aws-tutorial-worker}]"
 ```
 
 ### Configure the Load Balancer


### PR DESCRIPTION
This PR updates our AWS docs so that we specify a tag when creating
instances. This makes it easier to know which VMs were created as part
of this process, as well as quickly spot the init node.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

