### PR TITLE
chore: apply coverage analysis to all packages

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
   status:
     project:
       default:
-        target: 26%
+        target: 15%
         threshold: 0.5%
         base: auto
         if_ci_failed: success

--- a/Dockerfile
+++ b/Dockerfile
@@ -369,7 +369,7 @@ RUN unlink /etc/ssl
 COPY --from=rootfs / /
 ARG TESTPKGS
 ENV PLATFORM container
-RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 -p 4 ${TESTPKGS}
+RUN --security=insecure --mount=type=cache,id=testspace,target=/tmp --mount=type=cache,target=/.cache go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 -p 4 ${TESTPKGS}
 FROM scratch AS unit-tests
 COPY --from=unit-tests-runner /src/coverage.txt /coverage.txt
 


### PR DESCRIPTION
This allows us to see test coverage of packages that can't be unit-tested directly.

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
