### PR TITLE
fix: allow `convert-k8s --remove-initialized-keys` with K8s cp is down

### DIFF
--- a/cmd/talosctl/cmd/talos/convert-k8s.go
+++ b/cmd/talosctl/cmd/talos/convert-k8s.go
@@ -24,6 +24,10 @@ Talos node configuration to reflect changes made since the boostrap time. Once c
 tool releases static pods and deletes self-hosted DaemonSets.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(Nodes) > 0 {
+			convertOptions.Node = Nodes[0]
+		}
+
 		return WithClient(convertKubernetes)
 	},
 }

--- a/pkg/cluster/kubernetes/convert.go
+++ b/pkg/cluster/kubernetes/convert.go
@@ -45,6 +45,8 @@ type ConvertOptions struct {
 	ForceYes                 bool
 	OnlyRemoveInitializedKey bool
 
+	Node string
+
 	masterNodes []string
 }
 
@@ -58,6 +60,11 @@ type ConvertProvider interface {
 //
 //nolint:gocyclo,cyclop
 func ConvertToStaticPods(ctx context.Context, cluster ConvertProvider, options ConvertOptions) error {
+	// only used in manual conversion process
+	if options.OnlyRemoveInitializedKey {
+		return removeInitializedKey(ctx, cluster, options.Node)
+	}
+
 	var err error
 
 	k8sClient, err := cluster.K8sHelper(ctx)
@@ -72,11 +79,6 @@ func ConvertToStaticPods(ctx context.Context, cluster ConvertProvider, options C
 
 	if len(options.masterNodes) == 0 {
 		return fmt.Errorf("no master nodes discovered")
-	}
-
-	// only used in manual conversion process
-	if options.OnlyRemoveInitializedKey {
-		return removeInitializedKey(ctx, cluster, options.masterNodes[0])
 	}
 
 	fmt.Printf("discovered master nodes %q\n", options.masterNodes)


### PR DESCRIPTION
The command `--remove-initialized-key` is the last resort to convert
control plane when control plane is down for whatever reason, so it
should work when control plane is not available.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

