### PR TITLE
chore: fix typo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -489,7 +489,7 @@ COPY --from=integration-test-provision-linux-build /src/integration.test /integr
 FROM base AS lint-go
 COPY .golangci.yml .
 ENV GOGC 50
-ENV GOLANCGCI_LINT_CACHE /.cache/lint
+ENV GOLANGCI_LINT_CACHE /.cache/lint
 RUN --mount=type=cache,target=/.cache golangci-lint run --config .golangci.yml
 WORKDIR /src/pkg/machinery
 RUN --mount=type=cache,target=/.cache golangci-lint run --config ../../.golangci.yml


### PR DESCRIPTION
Actually share golangci-lint cache.

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)
