### PR TITLE
fix: get rid of data race in encoder and fix concurrent map access

### DIFF
--- a/pkg/machinery/config/encoder/markdown.go
+++ b/pkg/machinery/config/encoder/markdown.go
@@ -21,7 +21,7 @@ var markdownTemplate = `
 Examples:
 
 {{ range $example := .Examples }}
-{{ yaml $example.Value $.Name }}
+{{ yaml $example.GetValue $.Name }}
 {{ end }}
 {{ end }}
 
@@ -43,7 +43,7 @@ Appears in:
 {{ if $struct.Examples -}}
 
 {{ range $example := $struct.Examples }}
-{{ yaml $example.Value "" }}
+{{ yaml $example.GetValue "" }}
 {{- end -}}
 {{ end }}
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3377  https://github.com/talos-systems/talos/issues/3380

Fixed data race in the encoder documentation examples by using `sync.Once`.
We only need to generate them once anyways and then it's not a big deal
that we are using the same pointers everywhere as they're pretty much
constant.

As of `system.go`, looks like we actually have concurrent operations for
partitions unmount. Just added a mutex there.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>