### PR TITLE
fix: prevent panic in validate config if `machine.install` is missing

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -73,24 +73,24 @@ func (c *Config) Validate(mode config.RuntimeMode, options ...config.ValidationO
 	if mode.RequiresInstall() {
 		if c.MachineConfig.MachineInstall == nil {
 			result = multierror.Append(result, fmt.Errorf("install instructions are required in %q mode", mode))
-		}
-
-		if opts.Local {
-			if c.MachineConfig.MachineInstall.InstallDisk == "" && len(c.MachineConfig.MachineInstall.DiskMatchers()) == 0 {
-				result = multierror.Append(result, fmt.Errorf("either install disk or diskSelector should be defined"))
-			}
 		} else {
-			disk, err := c.MachineConfig.MachineInstall.Disk()
-
-			if err != nil {
-				result = multierror.Append(result, err)
-			} else {
-				if disk == "" {
-					result = multierror.Append(result, fmt.Errorf("an install disk is required in %q mode", mode))
+			if opts.Local {
+				if c.MachineConfig.MachineInstall.InstallDisk == "" && len(c.MachineConfig.MachineInstall.DiskMatchers()) == 0 {
+					result = multierror.Append(result, fmt.Errorf("either install disk or diskSelector should be defined"))
 				}
+			} else {
+				disk, err := c.MachineConfig.MachineInstall.Disk()
 
-				if _, err := os.Stat(disk); os.IsNotExist(err) {
-					result = multierror.Append(result, fmt.Errorf("specified install disk does not exist: %q", c.MachineConfig.MachineInstall.InstallDisk))
+				if err != nil {
+					result = multierror.Append(result, err)
+				} else {
+					if disk == "" {
+						result = multierror.Append(result, fmt.Errorf("an install disk is required in %q mode", mode))
+					}
+
+					if _, err := os.Stat(disk); os.IsNotExist(err) {
+						result = multierror.Append(result, fmt.Errorf("specified install disk does not exist: %q", c.MachineConfig.MachineInstall.InstallDisk))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #3382

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

