### PR TITLE
feat: add ability to disable comments in talosctl gen config

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -32,6 +32,7 @@ import (
 	"github.com/talos-systems/talos/pkg/images"
 	clientconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
 	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/bundle"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/generate"
@@ -436,7 +437,7 @@ func create(ctx context.Context) (err error) {
 			types = append([]machine.Type{machine.TypeInit}, types...)
 		}
 
-		if err = configBundle.Write(".", types...); err != nil {
+		if err = configBundle.Write(".", encoder.CommentsAll, types...); err != nil {
 			return err
 		}
 	}

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -19,13 +19,14 @@ import (
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/mgmt/helpers"
 	"github.com/talos-systems/talos/pkg/images"
 	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/bundle"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/generate"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
-var (
+var genConfigCmdFlags struct {
 	additionalSANs    []string
 	configVersion     string
 	dnsDomain         string
@@ -36,7 +37,9 @@ var (
 	outputDir         string
 	registryMirrors   []string
 	persistConfig     bool
-)
+	withExamples      bool
+	withDocs          bool
+}
 
 // genConfigCmd represents the gen config command.
 var genConfigCmd = &cobra.Command{
@@ -77,7 +80,7 @@ var genConfigCmd = &cobra.Command{
 			return fmt.Errorf("error validating the cluster endpoint URL: %w", err)
 		}
 
-		switch configVersion {
+		switch genConfigCmdFlags.configVersion {
 		case "v1alpha1":
 			return genV1Alpha1Config(args)
 		}
@@ -106,21 +109,21 @@ func fixControlPlaneEndpoint(u *url.URL) *url.URL {
 func genV1Alpha1Config(args []string) error {
 	// If output dir isn't specified, set to the current working dir
 	var err error
-	if outputDir == "" {
-		outputDir, err = os.Getwd()
+	if genConfigCmdFlags.outputDir == "" {
+		genConfigCmdFlags.outputDir, err = os.Getwd()
 		if err != nil {
 			return fmt.Errorf("failed to get working dir: %w", err)
 		}
 	}
 
 	// Create dir path, ignoring "already exists" messages
-	if err = os.MkdirAll(outputDir, os.ModePerm); err != nil && !os.IsExist(err) {
+	if err = os.MkdirAll(genConfigCmdFlags.outputDir, os.ModePerm); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to create output dir: %w", err)
 	}
 
 	var genOptions []generate.GenOption //nolint:prealloc
 
-	for _, registryMirror := range registryMirrors {
+	for _, registryMirror := range genConfigCmdFlags.registryMirrors {
 		components := strings.SplitN(registryMirror, "=", 2)
 		if len(components) != 2 {
 			return fmt.Errorf("invalid registry mirror spec: %q", registryMirror)
@@ -129,10 +132,10 @@ func genV1Alpha1Config(args []string) error {
 		genOptions = append(genOptions, generate.WithRegistryMirror(components[0], components[1]))
 	}
 
-	if talosVersion != "" {
+	if genConfigCmdFlags.talosVersion != "" {
 		var versionContract *config.VersionContract
 
-		versionContract, err = config.ParseContractFromVersion(talosVersion)
+		versionContract, err = config.ParseContractFromVersion(genConfigCmdFlags.talosVersion)
 		if err != nil {
 			return fmt.Errorf("invalid talos-version: %w", err)
 		}
@@ -145,13 +148,13 @@ func genV1Alpha1Config(args []string) error {
 			&bundle.InputOptions{
 				ClusterName: args[0],
 				Endpoint:    args[1],
-				KubeVersion: strings.TrimPrefix(kubernetesVersion, "v"),
+				KubeVersion: strings.TrimPrefix(genConfigCmdFlags.kubernetesVersion, "v"),
 				GenOptions: append(genOptions,
-					generate.WithInstallDisk(installDisk),
-					generate.WithInstallImage(installImage),
-					generate.WithAdditionalSubjectAltNames(additionalSANs),
-					generate.WithDNSDomain(dnsDomain),
-					generate.WithPersist(persistConfig),
+					generate.WithInstallDisk(genConfigCmdFlags.installDisk),
+					generate.WithInstallImage(genConfigCmdFlags.installImage),
+					generate.WithAdditionalSubjectAltNames(genConfigCmdFlags.additionalSANs),
+					generate.WithDNSDomain(genConfigCmdFlags.dnsDomain),
+					generate.WithPersist(genConfigCmdFlags.persistConfig),
 				),
 			},
 		),
@@ -160,7 +163,16 @@ func genV1Alpha1Config(args []string) error {
 		return fmt.Errorf("failed to generate config bundle: %w", err)
 	}
 
-	if err = configBundle.Write(outputDir, machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin); err != nil {
+	commentsFlags := encoder.CommentsDisabled
+	if genConfigCmdFlags.withDocs {
+		commentsFlags |= encoder.CommentsDocs
+	}
+
+	if genConfigCmdFlags.withExamples {
+		commentsFlags |= encoder.CommentsExamples
+	}
+
+	if err = configBundle.Write(genConfigCmdFlags.outputDir, commentsFlags, machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin); err != nil {
 		return err
 	}
 
@@ -172,7 +184,7 @@ func genV1Alpha1Config(args []string) error {
 		return fmt.Errorf("failed to marshal config: %+v", err)
 	}
 
-	fullFilePath := filepath.Join(outputDir, "talosconfig")
+	fullFilePath := filepath.Join(genConfigCmdFlags.outputDir, "talosconfig")
 
 	if err = ioutil.WriteFile(fullFilePath, data, 0o644); err != nil {
 		return fmt.Errorf("%w", err)
@@ -185,14 +197,16 @@ func genV1Alpha1Config(args []string) error {
 
 func init() {
 	genCmd.AddCommand(genConfigCmd)
-	genConfigCmd.Flags().StringVar(&installDisk, "install-disk", "/dev/sda", "the disk to install to")
-	genConfigCmd.Flags().StringVar(&installImage, "install-image", helpers.DefaultImage(images.DefaultInstallerImageRepository), "the image used to perform an installation")
-	genConfigCmd.Flags().StringSliceVar(&additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
-	genConfigCmd.Flags().StringVar(&dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
-	genConfigCmd.Flags().StringVar(&configVersion, "version", "v1alpha1", "the desired machine config version to generate")
-	genConfigCmd.Flags().StringVar(&talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
-	genConfigCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", "", "desired kubernetes version to run")
-	genConfigCmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "destination to output generated files")
-	genConfigCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
-	genConfigCmd.Flags().BoolVarP(&persistConfig, "persist", "p", true, "the desired persist value for configs")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.installDisk, "install-disk", "/dev/sda", "the disk to install to")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.installImage, "install-image", helpers.DefaultImage(images.DefaultInstallerImageRepository), "the image used to perform an installation")
+	genConfigCmd.Flags().StringSliceVar(&genConfigCmdFlags.additionalSANs, "additional-sans", []string{}, "additional Subject-Alt-Names for the APIServer certificate")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.configVersion, "version", "v1alpha1", "the desired machine config version to generate")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.kubernetesVersion, "kubernetes-version", "", "desired kubernetes version to run")
+	genConfigCmd.Flags().StringVarP(&genConfigCmdFlags.outputDir, "output-dir", "o", "", "destination to output generated files")
+	genConfigCmd.Flags().StringSliceVar(&genConfigCmdFlags.registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
+	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.persistConfig, "persist", "p", true, "the desired persist value for configs")
+	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withExamples, "with-examples", "", true, "renders all machine configs with the commented examples")
+	genConfigCmd.Flags().BoolVarP(&genConfigCmdFlags.withDocs, "with-docs", "", true, "renders all machine configs adding the documentation for each field")
 }

--- a/pkg/machinery/config/encoder/documentation.go
+++ b/pkg/machinery/config/encoder/documentation.go
@@ -196,7 +196,7 @@ func addComments(node *yaml.Node, doc *Doc, comments ...int) {
 }
 
 //nolint:gocyclo
-func renderExample(key string, doc *Doc) string {
+func renderExample(key string, doc *Doc, flags CommentsFlags) string {
 	if doc == nil {
 		return ""
 	}
@@ -218,19 +218,19 @@ func renderExample(key string, doc *Doc) string {
 
 		e.Populate(i)
 
-		node, err := toYamlNode(defaultValue)
+		node, err := toYamlNode(defaultValue, flags)
 		if err != nil {
 			continue
 		}
 
 		node, err = toYamlNode(map[string]*yaml.Node{
 			key: node,
-		})
+		}, flags)
 		if err != nil {
 			continue
 		}
 
-		if i == 0 {
+		if i == 0 && flags.enabled(CommentsDocs) {
 			addComments(node, doc, HeadComment, LineComment)
 		}
 

--- a/pkg/machinery/config/encoder/markdown.go
+++ b/pkg/machinery/config/encoder/markdown.go
@@ -185,7 +185,7 @@ func encodeYaml(in interface{}, name string) string {
 		}
 	}
 
-	node, err := toYamlNode(in)
+	node, err := toYamlNode(in, CommentsAll)
 	if err != nil {
 		return fmt.Sprintf("yaml encoding failed %s", err)
 	}

--- a/pkg/machinery/config/encoder/options.go
+++ b/pkg/machinery/config/encoder/options.go
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package encoder
+
+// CommentsFlags comments encoding flags type.
+type CommentsFlags int
+
+func (f CommentsFlags) enabled(flag CommentsFlags) bool {
+	return (f & flag) == flag
+}
+
+const (
+	// CommentsDisabled renders no comments.
+	CommentsDisabled CommentsFlags = 0
+	// CommentsExamples enables commented yaml examples rendering.
+	CommentsExamples CommentsFlags = 1 << iota
+	// CommentsDocs enables rendering each config field short docstring.
+	CommentsDocs
+	// CommentsAll renders all comments.
+	CommentsAll = CommentsExamples | CommentsDocs
+)
+
+// Options defines encoder config.
+type Options struct {
+	Comments CommentsFlags
+}
+
+func newOptions(opts ...Option) *Options {
+	res := &Options{
+		Comments: CommentsAll,
+	}
+
+	for _, o := range opts {
+		o(res)
+	}
+
+	return res
+}
+
+// Option gives ability to alter config encoder output settings.
+type Option func(*Options)
+
+// WithComments enables comments and examples in the encoder.
+func WithComments(flags CommentsFlags) Option {
+	return func(o *Options) {
+		o.Comments = flags
+	}
+}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -15,6 +15,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/talos-systems/crypto/x509"
 
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
@@ -27,8 +28,8 @@ type Provider interface {
 	Cluster() ClusterConfig
 	Validate(RuntimeMode, ...ValidationOption) error
 	ApplyDynamicConfig(context.Context, DynamicConfigProvider) error
-	String() (string, error)
-	Bytes() ([]byte, error)
+	String(encoderOptions ...encoder.Option) (string, error)
+	Bytes(encoderOptions ...encoder.Option) ([]byte, error)
 }
 
 // MachineConfig defines the requirements for a config that pertains to machine

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_configurator_bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_configurator_bundle.go
@@ -16,6 +16,7 @@ import (
 	clientconfig "github.com/talos-systems/talos/pkg/machinery/client/config"
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/configpatcher"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )
 
@@ -49,7 +50,7 @@ func (c *ConfigBundle) TalosConfig() *clientconfig.Config {
 }
 
 // Write config files to output directory.
-func (c *ConfigBundle) Write(outputDir string, types ...machine.Type) error {
+func (c *ConfigBundle) Write(outputDir string, commentsFlags encoder.CommentsFlags, types ...machine.Type) error {
 	for _, t := range types {
 		name := strings.ToLower(t.String()) + ".yaml"
 		fullFilePath := filepath.Join(outputDir, name)
@@ -61,17 +62,17 @@ func (c *ConfigBundle) Write(outputDir string, types ...machine.Type) error {
 
 		switch t { //nolint:exhaustive
 		case machine.TypeInit:
-			configString, err = c.Init().String()
+			configString, err = c.Init().String(encoder.WithComments(commentsFlags))
 			if err != nil {
 				return err
 			}
 		case machine.TypeControlPlane:
-			configString, err = c.ControlPlane().String()
+			configString, err = c.ControlPlane().String(encoder.WithComments(commentsFlags))
 			if err != nil {
 				return err
 			}
 		case machine.TypeJoin:
-			configString, err = c.Join().String()
+			configString, err = c.Join().String(encoder.WithComments(commentsFlags))
 			if err != nil {
 				return err
 			}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -56,8 +56,8 @@ func (c *Config) Cluster() config.ClusterConfig {
 }
 
 // String implements the config.Provider interface.
-func (c *Config) String() (string, error) {
-	b, err := c.Bytes()
+func (c *Config) String(options ...encoder.Option) (string, error) {
+	b, err := c.Bytes(options...)
 	if err != nil {
 		return "", err
 	}
@@ -66,8 +66,8 @@ func (c *Config) String() (string, error) {
 }
 
 // Bytes implements the config.Provider interface.
-func (c *Config) Bytes() ([]byte, error) {
-	return encoder.NewEncoder(c).Encode()
+func (c *Config) Bytes(options ...encoder.Option) ([]byte, error) {
+	return encoder.NewEncoder(c, options...).Encode()
 }
 
 // ApplyDynamicConfig implements the config.Provider interface.

--- a/website/content/docs/v0.10/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.10/Cloud Platforms/aws.md
@@ -141,7 +141,7 @@ We will need these soon.
 Using the DNS name of the loadbalancer created earlier, generate the base configuration files for the Talos machines:
 
 ```bash
-$ talosctl gen config talos-k8s-aws-tutorial https://<load balancer IP or DNS>:<port>
+$ talosctl gen config talos-k8s-aws-tutorial https://<load balancer IP or DNS>:<port> --with-examples=false --with-docs=false
 created init.yaml
 created controlplane.yaml
 created join.yaml

--- a/website/content/docs/v0.10/Reference/cli.md
+++ b/website/content/docs/v0.10/Reference/cli.md
@@ -998,6 +998,8 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
       --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
       --talos-version string        the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
       --version string              the desired machine config version to generate (default "v1alpha1")
+      --with-docs                   renders all machine configs adding the documentation for each field (default true)
+      --with-examples               renders all machine configs with the commented examples (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3384

Instead of doing simple `--no-comments` flag, decided to use more
granular approach which allows to either disable examples, or docstring,
or both.

Thus the command looks like this:

```bash
talosctl gen config --with-docs=false --with-examples=false <...>
```

Both are enabled by default to provide better UX for users learning
Talos.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>