### PR TITLE
fix: don't write to config object on access

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -104,7 +104,7 @@ func (c *ClusterConfig) Config(t machine.Type) (string, error) {
 // Etcd implements the config.ClusterConfig interface.
 func (c *ClusterConfig) Etcd() config.Etcd {
 	if c.EtcdConfig == nil {
-		c.EtcdConfig = &EtcdConfig{}
+		return &EtcdConfig{}
 	}
 
 	return c.EtcdConfig

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_etcdconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_etcdconfig.go
@@ -37,7 +37,7 @@ func (e *EtcdConfig) CA() *x509.PEMEncodedCertificateAndKey {
 // ExtraArgs implements the config.Etcd interface.
 func (e *EtcdConfig) ExtraArgs() map[string]string {
 	if e.EtcdExtraArgs == nil {
-		e.EtcdExtraArgs = make(map[string]string)
+		return make(map[string]string)
 	}
 
 	return e.EtcdExtraArgs

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_network_options.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_network_options.go
@@ -34,7 +34,7 @@ func WithNetworkNameservers(nameservers ...string) NetworkConfigOption {
 // WithNetworkInterfaceIgnore marks interface as ignored.
 func WithNetworkInterfaceIgnore(iface string) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		cfg.GetDevice(iface).DeviceIgnore = true
+		cfg.getDevice(iface).DeviceIgnore = true
 
 		return nil
 	}
@@ -43,7 +43,7 @@ func WithNetworkInterfaceIgnore(iface string) NetworkConfigOption {
 // WithNetworkInterfaceDHCP enables DHCP for the interface.
 func WithNetworkInterfaceDHCP(iface string, enable bool) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		cfg.GetDevice(iface).DeviceDHCP = true
+		cfg.getDevice(iface).DeviceDHCP = true
 
 		return nil
 	}
@@ -52,7 +52,7 @@ func WithNetworkInterfaceDHCP(iface string, enable bool) NetworkConfigOption {
 // WithNetworkInterfaceDHCPv4 enables DHCPv4 for the interface.
 func WithNetworkInterfaceDHCPv4(iface string, enable bool) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		dev := cfg.GetDevice(iface)
+		dev := cfg.getDevice(iface)
 
 		if dev.DeviceDHCPOptions == nil {
 			dev.DeviceDHCPOptions = &DHCPOptions{}
@@ -67,7 +67,7 @@ func WithNetworkInterfaceDHCPv4(iface string, enable bool) NetworkConfigOption {
 // WithNetworkInterfaceDHCPv6 enables DHCPv6 for the interface.
 func WithNetworkInterfaceDHCPv6(iface string, enable bool) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		dev := cfg.GetDevice(iface)
+		dev := cfg.getDevice(iface)
 
 		if dev.DeviceDHCPOptions == nil {
 			dev.DeviceDHCPOptions = &DHCPOptions{}
@@ -82,7 +82,7 @@ func WithNetworkInterfaceDHCPv6(iface string, enable bool) NetworkConfigOption {
 // WithNetworkInterfaceCIDR configures interface for static addressing.
 func WithNetworkInterfaceCIDR(iface, cidr string) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		cfg.GetDevice(iface).DeviceCIDR = cidr
+		cfg.getDevice(iface).DeviceCIDR = cidr
 
 		return nil
 	}
@@ -91,7 +91,7 @@ func WithNetworkInterfaceCIDR(iface, cidr string) NetworkConfigOption {
 // WithNetworkInterfaceMTU configures interface MTU.
 func WithNetworkInterfaceMTU(iface string, mtu int) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		cfg.GetDevice(iface).DeviceMTU = mtu
+		cfg.getDevice(iface).DeviceMTU = mtu
 
 		return nil
 	}
@@ -100,7 +100,7 @@ func WithNetworkInterfaceMTU(iface string, mtu int) NetworkConfigOption {
 // WithNetworkInterfaceWireguard configures interface for Wireguard.
 func WithNetworkInterfaceWireguard(iface string, wireguardConfig *DeviceWireguardConfig) NetworkConfigOption {
 	return func(_ machine.Type, cfg *NetworkConfig) error {
-		cfg.GetDevice(iface).DeviceWireguardConfig = wireguardConfig
+		cfg.getDevice(iface).DeviceWireguardConfig = wireguardConfig
 
 		return nil
 	}
@@ -113,7 +113,7 @@ func WithNetworkInterfaceVirtualIP(iface, cidr string) NetworkConfigOption {
 			return nil
 		}
 
-		cfg.GetDevice(iface).DeviceVIPConfig = &DeviceVIPConfig{
+		cfg.getDevice(iface).DeviceVIPConfig = &DeviceVIPConfig{
 			SharedIP: cidr,
 		}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -237,7 +237,7 @@ func (m *MachineConfig) Server() string {
 // Sysctls implements the config.Provider interface.
 func (m *MachineConfig) Sysctls() map[string]string {
 	if m.MachineSysctls == nil {
-		m.MachineSysctls = make(map[string]string)
+		return make(map[string]string)
 	}
 
 	return m.MachineSysctls
@@ -285,12 +285,8 @@ func (k *KubeletConfig) Image() string {
 
 // ExtraArgs implements the config.Provider interface.
 func (k *KubeletConfig) ExtraArgs() map[string]string {
-	if k == nil {
-		k = &KubeletConfig{}
-	}
-
-	if k.KubeletExtraArgs == nil {
-		k.KubeletExtraArgs = make(map[string]string)
+	if k == nil || k.KubeletExtraArgs == nil {
+		return make(map[string]string)
 	}
 
 	return k.KubeletExtraArgs
@@ -432,8 +428,10 @@ func (n *NetworkConfig) Devices() []config.Device {
 	return interfaces
 }
 
-// GetDevice adds or returns existing Device by name.
-func (n *NetworkConfig) GetDevice(name string) *Device {
+// getDevice adds or returns existing Device by name.
+//
+// This method mutates configuration, but it's only used in config generation.
+func (n *NetworkConfig) getDevice(name string) *Device {
 	for _, dev := range n.NetworkInterfaces {
 		if dev.DeviceInterface == name {
 			return dev


### PR DESCRIPTION
This avoids data race on config access: config object might be accessed
concurrently and it should be read-only on access.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
