### PR TITLE
fix: address several issues in TUI installer

### DIFF
--- a/internal/pkg/tui/components/form.go
+++ b/internal/pkg/tui/components/form.go
@@ -138,7 +138,7 @@ func (item *Item) createFormItems() ([]tview.Primitive, error) {
 
 				formItem = table
 				table.SetRowSelectedFunc(func(row int) {
-					v.Set(reflect.ValueOf(table.GetValue(row, 0))) // always pick the first column
+					v.Set(reflect.ValueOf(table.GetValue(row-1, 0))) // always pick the second column
 				})
 			} else {
 				dropdown := tview.NewDropDown()

--- a/internal/pkg/tui/installer/state.go
+++ b/internal/pkg/tui/installer/state.go
@@ -125,6 +125,10 @@ func NewState(ctx context.Context, installer *Installer, conn *Connection) (*Sta
 	for _, iface := range interfaces.Messages[0].Interfaces {
 		status := ""
 
+		if (net.Flags(iface.Flags)&net.FlagLoopback) != 0 || iface.Hardwareaddr == "" {
+			continue
+		}
+
 		if (net.Flags(iface.Flags) & net.FlagUp) != 0 {
 			status = " (UP)"
 		}
@@ -304,6 +308,10 @@ func configureAdapter(installer *Installer, opts *machineapi.GenerateConfigurati
 
 				adapterConfiguration.AddMenuButton("Apply", false).SetSelectedFunc(func() {
 					goBack()
+
+					if adapterSettings.Dhcp {
+						adapterSettings.Cidr = ""
+					}
 
 					if deviceIndex == -1 {
 						opts.MachineConfig.NetworkConfig.Interfaces = append(


### PR DESCRIPTION
- Table row selection was 1 element off, so disk selector wasn't quite
working.
- Reduce amount of interfaces on the last screen: show only ones that
have physical addresses (changing some settings for lo0 for example was
 making TUI generate incorrect configs)

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>