### PR TITLE
feat: bring in Linux 5.10.27, support for 32-bit time syscalls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-alpha.0-3-g41b8073
-PKGS ?= v0.5.0-alpha.0-3-gfdf4866
+PKGS ?= v0.5.0-alpha.0-4-g60ce626
 EXTRAS ?= v0.3.0-alpha.0-1-gc0fa0c0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.23-talos"
+	DefaultKernelVersion = "5.10.27-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This provides binary compatibility for really old binaries using 32-bit
time.

See also: talos-systems/pkgs#259

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
