### PR TITLE
feat: allow external cloud provides configration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ WORKDIR /src
 RUN --mount=type=cache,target=/.cache go mod download
 RUN --mount=type=cache,target=/.cache go mod verify
 
-# The generate target generates code from protobuf service definitions.
+# The generate target generates code from protobuf service definitions and machinery config.
 
 FROM build AS generate-build
 # Common needs to be at or near the top to satisfy the subsequent imports

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ hack-test-%: ## Runs the specied script in ./hack/test with well known environme
 # Generators
 
 .PHONY: generate
-generate: ## Generates source code from protobuf definitions.
+generate: ## Generates code from protobuf service definitions and machinery config.
 	@$(MAKE) local-$@ DEST=./ PLATFORM=linux/amd64
 
 .PHONY: docs

--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -27,7 +27,7 @@ find ${PREFIX} -type f -name \*.static -print0 | xargs -0 rm -rf || true
 find ${PREFIX}/{lib,usr/lib} -type f \( -name \*.so* -a ! -name \*dbg \) -exec strip --strip-unneeded {} ';' || true
 find ${PREFIX}/{bin,sbin,usr/bin,usr/sbin} -type f -exec strip --strip-all {} ';' || true
 
-# Remove header files, man files, and any other non-rutime dependencies.
+# Remove header files, man files, and any other non-runtime dependencies.
 rm -rf ${PREFIX}/{lib,usr/lib}/pkgconfig/ \
        ${PREFIX}/{include,usr/include}/* \
        ${PREFIX}/{share,usr/share}/* \

--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -58,7 +58,7 @@ function setup {
   export VPC_ID=vpc-ff5c5687
   export SUBNET=subnet-c4e9b3a0
   export CLOUD_PROVIDER_VERSION=v1.20.0-alpha.0
-  
+
   ## Control plane vars
   export CP_COUNT=3
   export CP_INSTANCE_TYPE=t3.large
@@ -79,7 +79,6 @@ function setup {
   ${CLUSTERCTL} config cluster ${NAME_PREFIX} \
     --kubeconfig /tmp/e2e/docker/kubeconfig \
     --from https://github.com/talos-systems/cluster-api-templates/blob/main/aws/standard/standard.yaml > ${TMP}/cluster.yaml
-  
 }
 
 setup

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -180,7 +180,6 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"--requestheader-username-headers=X-Remote-User",
 		fmt.Sprintf("--proxy-client-cert-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "front-proxy-client.crt")),
 		fmt.Sprintf("--proxy-client-key-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "front-proxy-client.key")),
-		fmt.Sprintf("--cloud-provider=%s", cfg.CloudProvider),
 		"--enable-bootstrap-token-auth=true",
 		"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256", //nolint:lll
 		fmt.Sprintf("--encryption-provider-config=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "encryptionconfig.yaml")),
@@ -205,6 +204,10 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver.crt")),
 		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver.key")),
 		"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+	}
+
+	if cfg.CloudProvider != "" {
+		args = append(args, fmt.Sprintf("--cloud-provider=%s", cfg.CloudProvider))
 	}
 
 	for k, v := range cfg.ExtraArgs {
@@ -284,7 +287,6 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 		"/go-runner",
 		"/usr/local/bin/kube-controller-manager",
 		"--allocate-node-cidrs=true",
-		fmt.Sprintf("--cloud-provider=%s", cfg.CloudProvider),
 		fmt.Sprintf("--cluster-cidr=%s", cfg.PodCIDR),
 		fmt.Sprintf("--service-cluster-ip-range=%s", cfg.ServiceCIDR),
 		fmt.Sprintf("--cluster-signing-cert-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.crt")),
@@ -295,6 +297,10 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 		fmt.Sprintf("--root-ca-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.crt")),
 		fmt.Sprintf("--service-account-private-key-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "service-account.key")),
 		"--profiling=false",
+	}
+
+	if cfg.CloudProvider != "" {
+		args = append(args, fmt.Sprintf("--cloud-provider=%s", cfg.CloudProvider))
 	}
 
 	for k, v := range cfg.ExtraArgs {

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -288,6 +288,12 @@ func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 		"hostname-override": nodename,
 	}
 
+	// Disallow --cloud-provider flag in extraArgs only if external cloud provider is enabled via our config
+	// for an easier transition from previous versions where it could be configured via extraArgs + extraManifests.
+	if r.Config().Cluster().ExternalCloudProvider().Enabled() {
+		denyListArgs["cloud-provider"] = "external"
+	}
+
 	extraArgs := argsbuilder.Args(r.Config().Machine().Kubelet().ExtraArgs())
 
 	for k := range denyListArgs {

--- a/internal/pkg/kubeconfig/admin_test.go
+++ b/internal/pkg/kubeconfig/admin_test.go
@@ -45,7 +45,7 @@ func (suite *AdminSuite) TestGenerate() {
 						URL: u,
 					},
 				},
-				AdminKubeconfigConfig: v1alpha1.AdminKubeconfigConfig{
+				AdminKubeconfigConfig: &v1alpha1.AdminKubeconfigConfig{
 					AdminKubeconfigCertLifetime: time.Hour,
 				},
 			}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -268,6 +268,8 @@ type ClusterConfig interface {
 	Network() ClusterNetwork
 	LocalAPIServerPort() int
 	CoreDNS() CoreDNS
+	// ExternalCloudProvider returns external cloud provider settings.
+	ExternalCloudProvider() ExternalCloudProvider
 	ExtraManifestURLs() []string
 	ExtraManifestHeaderMap() map[string]string
 	AdminKubeconfig() AdminKubeconfig
@@ -351,6 +353,14 @@ type Token interface {
 // coredns options.
 type CoreDNS interface {
 	Image() string
+}
+
+// ExternalCloudProvider defines settings for external cloud provider.
+type ExternalCloudProvider interface {
+	// Enabled returns true if external cloud provider is enabled.
+	Enabled() bool
+	// ManifestURLs returns external cloud provider manifest URLs if it is enabled.
+	ManifestURLs() []string
 }
 
 // AdminKubeconfig defines settings for admin kubeconfig.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -133,6 +133,15 @@ func (c *ClusterConfig) CoreDNS() config.CoreDNS {
 	return c.CoreDNSConfig
 }
 
+// ExternalCloudProvider implements the config.ClusterConfig interface.
+func (c *ClusterConfig) ExternalCloudProvider() config.ExternalCloudProvider {
+	if c.ExternalCloudProviderConfig == nil {
+		return &ExternalCloudProviderConfig{}
+	}
+
+	return c.ExternalCloudProviderConfig
+}
+
 // ExtraManifestURLs implements the config.ClusterConfig interface.
 func (c *ClusterConfig) ExtraManifestURLs() []string {
 	return c.ExtraManifests
@@ -145,6 +154,10 @@ func (c *ClusterConfig) ExtraManifestHeaderMap() map[string]string {
 
 // AdminKubeconfig implements the config.ClusterConfig interface.
 func (c *ClusterConfig) AdminKubeconfig() config.AdminKubeconfig {
+	if c.AdminKubeconfigConfig == nil {
+		return &AdminKubeconfigConfig{}
+	}
+
 	return c.AdminKubeconfigConfig
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_externalcloudproviderconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_externalcloudproviderconfig.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1
+
+// Enabled implements the config.ExternalCloudProvider interface.
+func (ecp *ExternalCloudProviderConfig) Enabled() bool {
+	return ecp.ExternalEnabled
+}
+
+// ManifestURLs implements the config.ExternalCloudProvider interface.
+func (ecp *ExternalCloudProviderConfig) ManifestURLs() []string {
+	return ecp.ExternalManifests
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -927,7 +927,7 @@ func (c *CoreDNS) Image() string {
 }
 
 // CertLifetime implements the config.Provider interface.
-func (a AdminKubeconfigConfig) CertLifetime() time.Duration {
+func (a *AdminKubeconfigConfig) CertLifetime() time.Duration {
 	if a.AdminKubeconfigCertLifetime == 0 {
 		return constants.KubernetesAdminCertDefaultLifetime
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider_test.go
@@ -98,9 +98,13 @@ func TestApplyDynamicConfig(t *testing.T) {
 func TestInterfaces(t *testing.T) {
 	t.Parallel()
 
-	assert.Implements(t, (*config.APIServer)(nil), (*v1alpha1.APIServerConfig)(nil))
 	assert.Implements(t, (*config.ClusterConfig)(nil), (*v1alpha1.ClusterConfig)(nil))
+	assert.Implements(t, (*config.Token)(nil), (*v1alpha1.ClusterConfig)(nil))
+	assert.Implements(t, (*config.ClusterNetwork)(nil), (*v1alpha1.ClusterConfig)(nil))
+
+	assert.Implements(t, (*config.APIServer)(nil), (*v1alpha1.APIServerConfig)(nil))
 	assert.Implements(t, (*config.ControllerManager)(nil), (*v1alpha1.ControllerManagerConfig)(nil))
 	assert.Implements(t, (*config.Etcd)(nil), (*v1alpha1.EtcdConfig)(nil))
+	assert.Implements(t, (*config.ExternalCloudProvider)(nil), (*v1alpha1.ExternalCloudProviderConfig)(nil))
 	assert.Implements(t, (*config.Scheduler)(nil), (*v1alpha1.SchedulerConfig)(nil))
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -330,7 +330,15 @@ var (
 		CoreDNSImage: (&CoreDNS{}).Image(),
 	}
 
-	clusterAdminKubeconfigExample = AdminKubeconfigConfig{
+	clusterExternalCloudProviderConfigExample = &ExternalCloudProviderConfig{
+		ExternalEnabled: true,
+		ExternalManifests: []string{
+			"https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml",
+			"https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml",
+		},
+	}
+
+	clusterAdminKubeconfigExample = &AdminKubeconfigConfig{
 		AdminKubeconfigCertLifetime: time.Hour,
 	}
 
@@ -684,6 +692,11 @@ type ClusterConfig struct {
 	//     - value: clusterCoreDNSExample
 	CoreDNSConfig *CoreDNS `yaml:"coreDNS,omitempty"`
 	//   description: |
+	//     External cloud provider configuration.
+	//   examples:
+	//     - value: clusterExternalCloudProviderConfigExample
+	ExternalCloudProviderConfig *ExternalCloudProviderConfig `yaml:"externalCloudProvider,omitempty"`
+	//   description: |
 	//     A list of urls that point to additional manifests.
 	//     These will get automatically deployed as part of the bootstrap.
 	//   examples:
@@ -694,7 +707,7 @@ type ClusterConfig struct {
 	//        }
 	ExtraManifests []string `yaml:"extraManifests,omitempty"`
 	//   description: |
-	//     A map of key value pairs that will be added while fetching the ExtraManifests.
+	//     A map of key value pairs that will be added while fetching the extraManifests.
 	//   examples:
 	//     - value: >
 	//         map[string]string{
@@ -707,7 +720,7 @@ type ClusterConfig struct {
 	//     Certificate lifetime can be configured.
 	//   examples:
 	//     - value: clusterAdminKubeconfigExample
-	AdminKubeconfigConfig AdminKubeconfigConfig `yaml:"adminKubeconfig,omitempty"`
+	AdminKubeconfigConfig *AdminKubeconfigConfig `yaml:"adminKubeconfig,omitempty"`
 	//   description: |
 	//     Allows running workload on master nodes.
 	//   values:
@@ -1188,6 +1201,28 @@ type CNIConfig struct {
 	//   description: |
 	//     URLs containing manifests to apply for the CNI.
 	CNIUrls []string `yaml:"urls,omitempty"`
+}
+
+// ExternalCloudProviderConfig contains external cloud provider configuration.
+type ExternalCloudProviderConfig struct {
+	//   description: |
+	//     Enable external cloud provider.
+	//   values:
+	//     - true
+	//     - yes
+	//     - false
+	//     - no
+	ExternalEnabled bool `yaml:"enabled,omitempty"`
+	//   description: |
+	//     A list of urls that point to additional manifests for an external cloud provider.
+	//     These will get automatically deployed as part of the bootstrap.
+	//   examples:
+	//     - value: >
+	//        []string{
+	//         "https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml",
+	//         "https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml",
+	//        }
+	ExternalManifests []string `yaml:"manifests,omitempty"`
 }
 
 // AdminKubeconfigConfig contains admin kubeconfig settings.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -11,50 +11,51 @@ import (
 )
 
 var (
-	ConfigDoc                     encoder.Doc
-	MachineConfigDoc              encoder.Doc
-	ClusterConfigDoc              encoder.Doc
-	KubeletConfigDoc              encoder.Doc
-	NetworkConfigDoc              encoder.Doc
-	InstallConfigDoc              encoder.Doc
-	InstallDiskSizeMatcherDoc     encoder.Doc
-	InstallDiskSelectorDoc        encoder.Doc
-	TimeConfigDoc                 encoder.Doc
-	RegistriesConfigDoc           encoder.Doc
-	PodCheckpointerDoc            encoder.Doc
-	CoreDNSDoc                    encoder.Doc
-	EndpointDoc                   encoder.Doc
-	ControlPlaneConfigDoc         encoder.Doc
-	APIServerConfigDoc            encoder.Doc
-	ControllerManagerConfigDoc    encoder.Doc
-	ProxyConfigDoc                encoder.Doc
-	SchedulerConfigDoc            encoder.Doc
-	EtcdConfigDoc                 encoder.Doc
-	ClusterNetworkConfigDoc       encoder.Doc
-	CNIConfigDoc                  encoder.Doc
-	AdminKubeconfigConfigDoc      encoder.Doc
-	MachineDiskDoc                encoder.Doc
-	DiskPartitionDoc              encoder.Doc
-	EncryptionConfigDoc           encoder.Doc
-	EncryptionKeyDoc              encoder.Doc
-	EncryptionKeyStaticDoc        encoder.Doc
-	EncryptionKeyNodeIDDoc        encoder.Doc
-	MachineFileDoc                encoder.Doc
-	ExtraHostDoc                  encoder.Doc
-	DeviceDoc                     encoder.Doc
-	DHCPOptionsDoc                encoder.Doc
-	DeviceWireguardConfigDoc      encoder.Doc
-	DeviceWireguardPeerDoc        encoder.Doc
-	DeviceVIPConfigDoc            encoder.Doc
-	BondDoc                       encoder.Doc
-	VlanDoc                       encoder.Doc
-	RouteDoc                      encoder.Doc
-	RegistryMirrorConfigDoc       encoder.Doc
-	RegistryConfigDoc             encoder.Doc
-	RegistryAuthConfigDoc         encoder.Doc
-	RegistryTLSConfigDoc          encoder.Doc
-	SystemDiskEncryptionConfigDoc encoder.Doc
-	VolumeMountConfigDoc          encoder.Doc
+	ConfigDoc                      encoder.Doc
+	MachineConfigDoc               encoder.Doc
+	ClusterConfigDoc               encoder.Doc
+	KubeletConfigDoc               encoder.Doc
+	NetworkConfigDoc               encoder.Doc
+	InstallConfigDoc               encoder.Doc
+	InstallDiskSizeMatcherDoc      encoder.Doc
+	InstallDiskSelectorDoc         encoder.Doc
+	TimeConfigDoc                  encoder.Doc
+	RegistriesConfigDoc            encoder.Doc
+	PodCheckpointerDoc             encoder.Doc
+	CoreDNSDoc                     encoder.Doc
+	EndpointDoc                    encoder.Doc
+	ControlPlaneConfigDoc          encoder.Doc
+	APIServerConfigDoc             encoder.Doc
+	ControllerManagerConfigDoc     encoder.Doc
+	ProxyConfigDoc                 encoder.Doc
+	SchedulerConfigDoc             encoder.Doc
+	EtcdConfigDoc                  encoder.Doc
+	ClusterNetworkConfigDoc        encoder.Doc
+	CNIConfigDoc                   encoder.Doc
+	ExternalCloudProviderConfigDoc encoder.Doc
+	AdminKubeconfigConfigDoc       encoder.Doc
+	MachineDiskDoc                 encoder.Doc
+	DiskPartitionDoc               encoder.Doc
+	EncryptionConfigDoc            encoder.Doc
+	EncryptionKeyDoc               encoder.Doc
+	EncryptionKeyStaticDoc         encoder.Doc
+	EncryptionKeyNodeIDDoc         encoder.Doc
+	MachineFileDoc                 encoder.Doc
+	ExtraHostDoc                   encoder.Doc
+	DeviceDoc                      encoder.Doc
+	DHCPOptionsDoc                 encoder.Doc
+	DeviceWireguardConfigDoc       encoder.Doc
+	DeviceWireguardPeerDoc         encoder.Doc
+	DeviceVIPConfigDoc             encoder.Doc
+	BondDoc                        encoder.Doc
+	VlanDoc                        encoder.Doc
+	RouteDoc                       encoder.Doc
+	RegistryMirrorConfigDoc        encoder.Doc
+	RegistryConfigDoc              encoder.Doc
+	RegistryAuthConfigDoc          encoder.Doc
+	RegistryTLSConfigDoc           encoder.Doc
+	SystemDiskEncryptionConfigDoc  encoder.Doc
+	VolumeMountConfigDoc           encoder.Doc
 )
 
 func init() {
@@ -241,7 +242,7 @@ func init() {
 			FieldName: "cluster",
 		},
 	}
-	ClusterConfigDoc.Fields = make([]encoder.Doc, 19)
+	ClusterConfigDoc.Fields = make([]encoder.Doc, 20)
 	ClusterConfigDoc.Fields[0].Name = "controlPlane"
 	ClusterConfigDoc.Fields[0].Type = "ControlPlaneConfig"
 	ClusterConfigDoc.Fields[0].Note = ""
@@ -345,39 +346,46 @@ func init() {
 	ClusterConfigDoc.Fields[14].Comments[encoder.LineComment] = "Core DNS specific configuration options."
 
 	ClusterConfigDoc.Fields[14].AddExample("", clusterCoreDNSExample)
-	ClusterConfigDoc.Fields[15].Name = "extraManifests"
-	ClusterConfigDoc.Fields[15].Type = "[]string"
+	ClusterConfigDoc.Fields[15].Name = "externalCloudProvider"
+	ClusterConfigDoc.Fields[15].Type = "ExternalCloudProviderConfig"
 	ClusterConfigDoc.Fields[15].Note = ""
-	ClusterConfigDoc.Fields[15].Description = "A list of urls that point to additional manifests.\nThese will get automatically deployed as part of the bootstrap."
-	ClusterConfigDoc.Fields[15].Comments[encoder.LineComment] = "A list of urls that point to additional manifests."
+	ClusterConfigDoc.Fields[15].Description = "External cloud provider configuration."
+	ClusterConfigDoc.Fields[15].Comments[encoder.LineComment] = "External cloud provider configuration."
 
-	ClusterConfigDoc.Fields[15].AddExample("", []string{
+	ClusterConfigDoc.Fields[15].AddExample("", clusterExternalCloudProviderConfigExample)
+	ClusterConfigDoc.Fields[16].Name = "extraManifests"
+	ClusterConfigDoc.Fields[16].Type = "[]string"
+	ClusterConfigDoc.Fields[16].Note = ""
+	ClusterConfigDoc.Fields[16].Description = "A list of urls that point to additional manifests.\nThese will get automatically deployed as part of the bootstrap."
+	ClusterConfigDoc.Fields[16].Comments[encoder.LineComment] = "A list of urls that point to additional manifests."
+
+	ClusterConfigDoc.Fields[16].AddExample("", []string{
 		"https://www.example.com/manifest1.yaml",
 		"https://www.example.com/manifest2.yaml",
 	})
-	ClusterConfigDoc.Fields[16].Name = "extraManifestHeaders"
-	ClusterConfigDoc.Fields[16].Type = "map[string]string"
-	ClusterConfigDoc.Fields[16].Note = ""
-	ClusterConfigDoc.Fields[16].Description = "A map of key value pairs that will be added while fetching the ExtraManifests."
-	ClusterConfigDoc.Fields[16].Comments[encoder.LineComment] = "A map of key value pairs that will be added while fetching the ExtraManifests."
+	ClusterConfigDoc.Fields[17].Name = "extraManifestHeaders"
+	ClusterConfigDoc.Fields[17].Type = "map[string]string"
+	ClusterConfigDoc.Fields[17].Note = ""
+	ClusterConfigDoc.Fields[17].Description = "A map of key value pairs that will be added while fetching the extraManifests."
+	ClusterConfigDoc.Fields[17].Comments[encoder.LineComment] = "A map of key value pairs that will be added while fetching the extraManifests."
 
-	ClusterConfigDoc.Fields[16].AddExample("", map[string]string{
+	ClusterConfigDoc.Fields[17].AddExample("", map[string]string{
 		"Token":       "1234567",
 		"X-ExtraInfo": "info",
 	})
-	ClusterConfigDoc.Fields[17].Name = "adminKubeconfig"
-	ClusterConfigDoc.Fields[17].Type = "AdminKubeconfigConfig"
-	ClusterConfigDoc.Fields[17].Note = ""
-	ClusterConfigDoc.Fields[17].Description = "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured."
-	ClusterConfigDoc.Fields[17].Comments[encoder.LineComment] = "Settings for admin kubeconfig generation."
-
-	ClusterConfigDoc.Fields[17].AddExample("", clusterAdminKubeconfigExample)
-	ClusterConfigDoc.Fields[18].Name = "allowSchedulingOnMasters"
-	ClusterConfigDoc.Fields[18].Type = "bool"
+	ClusterConfigDoc.Fields[18].Name = "adminKubeconfig"
+	ClusterConfigDoc.Fields[18].Type = "AdminKubeconfigConfig"
 	ClusterConfigDoc.Fields[18].Note = ""
-	ClusterConfigDoc.Fields[18].Description = "Allows running workload on master nodes."
-	ClusterConfigDoc.Fields[18].Comments[encoder.LineComment] = "Allows running workload on master nodes."
-	ClusterConfigDoc.Fields[18].Values = []string{
+	ClusterConfigDoc.Fields[18].Description = "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured."
+	ClusterConfigDoc.Fields[18].Comments[encoder.LineComment] = "Settings for admin kubeconfig generation."
+
+	ClusterConfigDoc.Fields[18].AddExample("", clusterAdminKubeconfigExample)
+	ClusterConfigDoc.Fields[19].Name = "allowSchedulingOnMasters"
+	ClusterConfigDoc.Fields[19].Type = "bool"
+	ClusterConfigDoc.Fields[19].Note = ""
+	ClusterConfigDoc.Fields[19].Description = "Allows running workload on master nodes."
+	ClusterConfigDoc.Fields[19].Comments[encoder.LineComment] = "Allows running workload on master nodes."
+	ClusterConfigDoc.Fields[19].Values = []string{
 		"true",
 		"yes",
 		"false",
@@ -972,6 +980,40 @@ func init() {
 	CNIConfigDoc.Fields[1].Note = ""
 	CNIConfigDoc.Fields[1].Description = "URLs containing manifests to apply for the CNI."
 	CNIConfigDoc.Fields[1].Comments[encoder.LineComment] = "URLs containing manifests to apply for the CNI."
+
+	ExternalCloudProviderConfigDoc.Type = "ExternalCloudProviderConfig"
+	ExternalCloudProviderConfigDoc.Comments[encoder.LineComment] = "ExternalCloudProviderConfig contains external cloud provider configuration."
+	ExternalCloudProviderConfigDoc.Description = "ExternalCloudProviderConfig contains external cloud provider configuration."
+
+	ExternalCloudProviderConfigDoc.AddExample("", clusterExternalCloudProviderConfigExample)
+	ExternalCloudProviderConfigDoc.AppearsIn = []encoder.Appearance{
+		{
+			TypeName:  "ClusterConfig",
+			FieldName: "externalCloudProvider",
+		},
+	}
+	ExternalCloudProviderConfigDoc.Fields = make([]encoder.Doc, 2)
+	ExternalCloudProviderConfigDoc.Fields[0].Name = "enabled"
+	ExternalCloudProviderConfigDoc.Fields[0].Type = "bool"
+	ExternalCloudProviderConfigDoc.Fields[0].Note = ""
+	ExternalCloudProviderConfigDoc.Fields[0].Description = "Enable external cloud provider."
+	ExternalCloudProviderConfigDoc.Fields[0].Comments[encoder.LineComment] = "Enable external cloud provider."
+	ExternalCloudProviderConfigDoc.Fields[0].Values = []string{
+		"true",
+		"yes",
+		"false",
+		"no",
+	}
+	ExternalCloudProviderConfigDoc.Fields[1].Name = "manifests"
+	ExternalCloudProviderConfigDoc.Fields[1].Type = "[]string"
+	ExternalCloudProviderConfigDoc.Fields[1].Note = ""
+	ExternalCloudProviderConfigDoc.Fields[1].Description = "A list of urls that point to additional manifests for an external cloud provider.\nThese will get automatically deployed as part of the bootstrap."
+	ExternalCloudProviderConfigDoc.Fields[1].Comments[encoder.LineComment] = "A list of urls that point to additional manifests for an external cloud provider."
+
+	ExternalCloudProviderConfigDoc.Fields[1].AddExample("", []string{
+		"https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml",
+		"https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml",
+	})
 
 	AdminKubeconfigConfigDoc.Type = "AdminKubeconfigConfig"
 	AdminKubeconfigConfigDoc.Comments[encoder.LineComment] = "AdminKubeconfigConfig contains admin kubeconfig settings."
@@ -1859,6 +1901,10 @@ func (_ CNIConfig) Doc() *encoder.Doc {
 	return &CNIConfigDoc
 }
 
+func (_ ExternalCloudProviderConfig) Doc() *encoder.Doc {
+	return &ExternalCloudProviderConfigDoc
+}
+
 func (_ AdminKubeconfigConfig) Doc() *encoder.Doc {
 	return &AdminKubeconfigConfigDoc
 }
@@ -1978,6 +2024,7 @@ func GetConfigurationDoc() *encoder.FileDoc {
 			&EtcdConfigDoc,
 			&ClusterNetworkConfigDoc,
 			&CNIConfigDoc,
+			&ExternalCloudProviderConfigDoc,
 			&AdminKubeconfigConfigDoc,
 			&MachineDiskDoc,
 			&DiskPartitionDoc,

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -29,6 +29,8 @@ func (m runtimeMode) RequiresInstall() bool {
 }
 
 func TestValidate(t *testing.T) {
+	t.Parallel()
+
 	endpointURL, err := url.Parse("https://localhost:6443/")
 	require.NoError(t, err)
 
@@ -43,10 +45,7 @@ func TestValidate(t *testing.T) {
 			config: &v1alpha1.Config{
 				ConfigVersion: "v1alpha1",
 			},
-			expectedError: `1 error occurred:
-	* machine instructions are required
-
-`,
+			expectedError: "1 error occurred:\n\t* machine instructions are required\n\n",
 		},
 		{
 			name: "NoMachineInstall",
@@ -76,10 +75,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			requiresInstall: true,
-			expectedError: `1 error occurred:
-	* install instructions are required in "runtimeMode(true)" mode
-
-`,
+			expectedError:   "1 error occurred:\n\t* install instructions are required in \"runtimeMode(true)\" mode\n\n",
 		},
 		{
 			name: "MachineInstallDisk",
@@ -100,10 +96,108 @@ func TestValidate(t *testing.T) {
 			},
 			requiresInstall: true,
 		},
+
+		{
+			name: "ExternalCloudProviderEnabled",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ExternalCloudProviderConfig: &v1alpha1.ExternalCloudProviderConfig{
+						ExternalEnabled: true,
+						ExternalManifests: []string{
+							"https://www.example.com/manifest1.yaml",
+							"https://www.example.com/manifest2.yaml",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ExternalCloudProviderEnabledNoManifests",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ExternalCloudProviderConfig: &v1alpha1.ExternalCloudProviderConfig{
+						ExternalEnabled: true,
+					},
+				},
+			},
+		},
+		{
+			name: "ExternalCloudProviderDisabled",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ExternalCloudProviderConfig: &v1alpha1.ExternalCloudProviderConfig{},
+				},
+			},
+		},
+		{
+			name: "ExternalCloudProviderExtraManifests",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ExternalCloudProviderConfig: &v1alpha1.ExternalCloudProviderConfig{
+						ExternalManifests: []string{
+							"https://www.example.com/manifest1.yaml",
+							"https://www.example.com/manifest2.yaml",
+						},
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* external cloud provider is disabled, but manifests are provided\n\n",
+		},
+		{
+			name: "ExternalCloudProviderInvalidManifests",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ExternalCloudProviderConfig: &v1alpha1.ExternalCloudProviderConfig{
+						ExternalEnabled: true,
+						ExternalManifests: []string{
+							"/manifest.yaml",
+						},
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* invalid external cloud provider manifest url \"/manifest.yaml\": hostname must not be blank\n\n",
+		},
 	} {
 		test := test
 
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := test.config.Validate(runtimeMode{test.requiresInstall}, config.WithLocal())
 
 			if test.expectedError == "" {

--- a/website/content/docs/v0.10/Reference/configuration.md
+++ b/website/content/docs/v0.10/Reference/configuration.md
@@ -1127,6 +1127,34 @@ coreDNS:
 
 <div class="dd">
 
+<code>externalCloudProvider</code>  <i><a href="#externalcloudproviderconfig">ExternalCloudProviderConfig</a></i>
+
+</div>
+<div class="dt">
+
+External cloud provider configuration.
+
+
+
+Examples:
+
+
+``` yaml
+externalCloudProvider:
+    enabled: true # Enable external cloud provider.
+    # A list of urls that point to additional manifests for an external cloud provider.
+    manifests:
+        - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
+        - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
 <code>extraManifests</code>  <i>[]string</i>
 
 </div>
@@ -1158,7 +1186,7 @@ extraManifests:
 </div>
 <div class="dt">
 
-A map of key value pairs that will be added while fetching the ExtraManifests.
+A map of key value pairs that will be added while fetching the extraManifests.
 
 
 
@@ -2859,6 +2887,79 @@ Name of CNI to use.
 <div class="dt">
 
 URLs containing manifests to apply for the CNI.
+
+</div>
+
+<hr />
+
+
+
+
+
+## ExternalCloudProviderConfig
+ExternalCloudProviderConfig contains external cloud provider configuration.
+
+Appears in:
+
+
+- <code><a href="#clusterconfig">ClusterConfig</a>.externalCloudProvider</code>
+
+
+``` yaml
+enabled: true # Enable external cloud provider.
+# A list of urls that point to additional manifests for an external cloud provider.
+manifests:
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
+```
+
+<hr />
+
+<div class="dd">
+
+<code>enabled</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Enable external cloud provider.
+
+
+Valid values:
+
+
+  - <code>true</code>
+
+  - <code>yes</code>
+
+  - <code>false</code>
+
+  - <code>no</code>
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>manifests</code>  <i>[]string</i>
+
+</div>
+<div class="dt">
+
+A list of urls that point to additional manifests for an external cloud provider.
+These will get automatically deployed as part of the bootstrap.
+
+
+
+Examples:
+
+
+``` yaml
+manifests:
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
+    - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
+```
+
 
 </div>
 


### PR DESCRIPTION
Closes #3312.

Requires changes/reorganization in cluster-api-templates. Draft: https://github.com/AlekSi/talos-cluster-api-templates/pull/1/files

- [x] you linked an issue (if applicable)
- [x] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
