### PR TITLE
docs(upgrading-talos): fix typo for stage flag

### DIFF
--- a/website/content/docs/v0.10/Guides/upgrading-talos.md
+++ b/website/content/docs/v0.10/Guides/upgrading-talos.md
@@ -38,7 +38,7 @@ There is an option to this command: `--preserve`, which can be used to explicitl
 In most cases, it is correct to just let Talos perform its default action.
 However, if you are running a single-node control-plane, you will want to make sure that `--preserve=true`.
 
-If Talos fails to run the upgrade, the `--staged` flag may be used to perform the upgrade after a reboot
+If Talos fails to run the upgrade, the `--stage` flag may be used to perform the upgrade after a reboot
 which is followed by another reboot to upgraded version.
 
 <!--

--- a/website/content/docs/v0.9/Guides/upgrading-talos.md
+++ b/website/content/docs/v0.9/Guides/upgrading-talos.md
@@ -69,7 +69,7 @@ There is an option to this command: `--preserve`, which can be used to explicitl
 In most cases, it is correct to just let Talos perform its default action.
 However, if you are running a single-node control-plane, you will want to make sure that `--preserve=true`.
 
-If Talos fails to run the upgrade, the `--staged` flag may be used to perform the upgrade after a reboot
+If Talos fails to run the upgrade, the `--stage` flag may be used to perform the upgrade after a reboot
 which is followed by another reboot to upgraded version.
 
 <!--


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Found typo in the upgrading talos docs. It mentioned `--staged` flag, but it appears the flag is `--stage`.

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
