### PR TITLE
fix: ignore EOF errors from Kubernetes API when converting control plane

### DIFF
--- a/pkg/cluster/kubernetes/kubernetes.go
+++ b/pkg/cluster/kubernetes/kubernetes.go
@@ -7,6 +7,7 @@ package kubernetes
 
 import (
 	"errors"
+	"io"
 	"net"
 	"syscall"
 
@@ -15,6 +16,10 @@ import (
 
 func retryableError(err error) bool {
 	if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) || apierrors.IsInternalError(err) {
+		return true
+	}
+
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 


### PR DESCRIPTION
During the conversion process, API server goes down, so we can see lots
of network errors including EOF.

Fixes #3404

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
