### PR TITLE
test: update 0.9.x version in upgrade tests to 0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.50.0
 SONOBUOY_URL ?= https://github.com/vmware-tanzu/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.8.5 v0.9.0
+RELEASES ?= v0.8.5 v0.9.1
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -71,7 +71,7 @@ type upgradeSpec struct {
 
 const (
 	previousRelease = "v0.8.5"
-	stableRelease   = "v0.9.0" // or soon-to-be-stable
+	stableRelease   = "v0.9.1" // or soon-to-be-stable
 	// The current version (the one being built on CI) is DefaultSettings.CurrentVersion.
 
 	previousK8sVersion = "1.20.1"      // constants.DefaultKubernetesVersion in the previousRelease


### PR DESCRIPTION
Version 0.9.1 contains a fix for concurrent map write on unmount which
was frequently breaking our upgrade tests.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
