### PR TITLE
fix: add a check for overlay mounts in installer pre-flight checks

### DIFF
--- a/cmd/installer/pkg/install/manifest_test.go
+++ b/cmd/installer/pkg/install/manifest_test.go
@@ -233,6 +233,11 @@ func (suite *manifestSuite) TestExecuteManifestClean() {
 	})
 	suite.Require().NoError(err)
 
+	// in the tests overlay mounts should be ignored
+	dev := manifest.Devices[suite.loopbackDevice.Name()]
+	dev.SkipOverlayMountsCheck = true
+	manifest.Devices[suite.loopbackDevice.Name()] = dev
+
 	suite.Assert().NoError(manifest.Execute())
 
 	suite.verifyBlockdevice(manifest, "", "A", false, false)
@@ -249,6 +254,11 @@ func (suite *manifestSuite) TestExecuteManifestForce() {
 	})
 	suite.Require().NoError(err)
 
+	// in the tests overlay mounts should be ignored
+	dev := manifest.Devices[suite.loopbackDevice.Name()]
+	dev.SkipOverlayMountsCheck = true
+	manifest.Devices[suite.loopbackDevice.Name()] = dev
+
 	suite.Assert().NoError(manifest.Execute())
 
 	suite.verifyBlockdevice(manifest, "", "A", false, false)
@@ -263,6 +273,11 @@ func (suite *manifestSuite) TestExecuteManifestForce() {
 		Board:      constants.BoardNone,
 	})
 	suite.Require().NoError(err)
+
+	// in the tests overlay mounts should be ignored
+	dev = manifest.Devices[suite.loopbackDevice.Name()]
+	dev.SkipOverlayMountsCheck = true
+	manifest.Devices[suite.loopbackDevice.Name()] = dev
 
 	suite.Assert().NoError(manifest.Execute())
 
@@ -280,6 +295,11 @@ func (suite *manifestSuite) TestExecuteManifestPreserve() {
 	})
 	suite.Require().NoError(err)
 
+	// in the tests overlay mounts should be ignored
+	dev := manifest.Devices[suite.loopbackDevice.Name()]
+	dev.SkipOverlayMountsCheck = true
+	manifest.Devices[suite.loopbackDevice.Name()] = dev
+
 	suite.Assert().NoError(manifest.Execute())
 
 	suite.verifyBlockdevice(manifest, "", "A", false, false)
@@ -293,6 +313,11 @@ func (suite *manifestSuite) TestExecuteManifestPreserve() {
 		Board:      constants.BoardNone,
 	})
 	suite.Require().NoError(err)
+
+	// in the tests overlay mounts should be ignored
+	dev = manifest.Devices[suite.loopbackDevice.Name()]
+	dev.SkipOverlayMountsCheck = true
+	manifest.Devices[suite.loopbackDevice.Name()] = dev
 
 	suite.Assert().NoError(manifest.Execute())
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -808,8 +808,9 @@ func partitionAndFormatDisks(logger *log.Logger, r runtime.Runtime) error {
 			}
 
 			m.Devices[disk.Device()] = installer.Device{
-				Device:              disk.Device(),
-				ResetPartitionTable: true,
+				Device:                 disk.Device(),
+				ResetPartitionTable:    true,
+				SkipOverlayMountsCheck: true,
 			}
 
 			for _, part := range disk.Partitions() {


### PR DESCRIPTION
Overlay mount in `mountinfo` don't show up as mounts for any particular
block device, so the existing check doesn't catch them.

This was discovered as our current master can't upgrade because of
overlay mount for `/opt` and `apid` image in `/opt/apid` (which will be
fixed in a separate PR).

Without the check, installer fails on resetting partition table for the
disk effectively wiping the node (`device or resourse busy` error).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

