### PR TITLE
feat: add --config-patch parameter to talosctl gen config

### DIFF
--- a/website/content/docs/v0.10/Bare Metal Platforms/digital-rebar.md
+++ b/website/content/docs/v0.10/Bare Metal Platforms/digital-rebar.md
@@ -37,6 +37,7 @@ created talosconfig
 > If you think this should be added to the docs, please [create a issue](https://github.com/talos-systems/talos/issues).
 
 At this point, you can modify the generated configs to your liking.
+Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/docs/v0.10/Bare Metal Platforms/equinix-metal.md
+++ b/website/content/docs/v0.10/Bare Metal Platforms/equinix-metal.md
@@ -58,6 +58,7 @@ created talosconfig
 
 Now add the required shebang (e.g. `#!talos`) at the top of `init.yaml`, `controlplane.yaml`, and `join.yaml`
 At this point, you can modify the generated configs to your liking.
+Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/docs/v0.10/Bare Metal Platforms/matchbox.md
+++ b/website/content/docs/v0.10/Bare Metal Platforms/matchbox.md
@@ -26,6 +26,7 @@ created talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
+Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/docs/v0.10/Cloud Platforms/aws.md
+++ b/website/content/docs/v0.10/Cloud Platforms/aws.md
@@ -149,6 +149,7 @@ created talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
+Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/docs/v0.10/Cloud Platforms/digitalocean.md
+++ b/website/content/docs/v0.10/Cloud Platforms/digitalocean.md
@@ -63,6 +63,7 @@ created talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
+Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 

--- a/website/content/docs/v0.10/Cloud Platforms/gcp.md
+++ b/website/content/docs/v0.10/Cloud Platforms/gcp.md
@@ -119,6 +119,8 @@ LB_PUBLIC_IP=$(gcloud compute forwarding-rules describe talos-fwd-rule \
 talosctl gen config talos-k8s-gcp-tutorial https://${LB_PUBLIC_IP}:443
 ```
 
+Additionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
+
 ### Compute Creation
 
 We are now ready to create our GCP nodes.

--- a/website/content/docs/v0.10/Cloud Platforms/openstack.md
+++ b/website/content/docs/v0.10/Cloud Platforms/openstack.md
@@ -94,6 +94,8 @@ LB_PUBLIC_IP=$(openstack loadbalancer show talos-control-plane -f json | jq -r .
 talosctl gen config talos-k8s-openstack-tutorial https://${LB_PUBLIC_IP}:6443
 ```
 
+Additionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
+
 ### Compute Creation
 
 We are now ready to create our Openstack nodes.

--- a/website/content/docs/v0.10/Reference/cli.md
+++ b/website/content/docs/v0.10/Reference/cli.md
@@ -988,6 +988,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
 
 ```
       --additional-sans strings     additional Subject-Alt-Names for the APIServer certificate
+      --config-patch string         patch generated machineconfigs
       --dns-domain string           the dns domain to use for cluster (default "cluster.local")
   -h, --help                        help for config
       --install-disk string         the disk to install to (default "/dev/sda")

--- a/website/content/docs/v0.10/Virtualized Platforms/vmware.md
+++ b/website/content/docs/v0.10/Virtualized Platforms/vmware.md
@@ -40,6 +40,7 @@ created talosconfig
 ```
 
 At this point, you can modify the generated configs to your liking.
+Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3410

Same as in `talosctl cluster create`. Will apply RFC6902 json patch
during the config generation if specified.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>