### PR TITLE
fix: publish rockpi4 image to release artifacts

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -534,6 +534,7 @@ local release = {
       '_out/metal-amd64.tar.gz',
       '_out/metal-arm64.tar.gz',
       '_out/metal-rpi_4-arm64.img.xz',
+      '_out/metal-rockpi_4-arm64.img.xz',
       '_out/metal-rock64-arm64.img.xz',
       '_out/metal-bananapi_m64-arm64.img.xz',
       '_out/metal-libretech_all_h3_cc_h5-arm64.img.xz',


### PR DESCRIPTION
Attempt #2. Forgot to add it to .drone.jsonnet also :facepalm:

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>