### PR TITLE
fix: require leader on etcd member operations

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -1691,6 +1691,8 @@ func (s *Server) EtcdMemberList(ctx context.Context, in *machine.EtcdMemberListR
 	//nolint:errcheck
 	defer client.Close()
 
+	ctx = clientv3.WithRequireLeader(ctx)
+
 	resp, err := client.MemberList(ctx)
 	if err != nil {
 		return nil, err
@@ -1723,6 +1725,8 @@ func (s *Server) EtcdRemoveMember(ctx context.Context, in *machine.EtcdRemoveMem
 	//nolint:errcheck
 	defer client.Close()
 
+	ctx = clientv3.WithRequireLeader(ctx)
+
 	if err = client.RemoveMember(ctx, in.Member); err != nil {
 		return nil, fmt.Errorf("failed to remove member: %w", err)
 	}
@@ -1746,6 +1750,8 @@ func (s *Server) EtcdLeaveCluster(ctx context.Context, in *machine.EtcdLeaveClus
 	//nolint:errcheck
 	defer client.Close()
 
+	ctx = clientv3.WithRequireLeader(ctx)
+
 	if err = client.LeaveCluster(ctx); err != nil {
 		return nil, fmt.Errorf("failed to leave cluster: %w", err)
 	}
@@ -1768,6 +1774,8 @@ func (s *Server) EtcdForfeitLeadership(ctx context.Context, in *machine.EtcdForf
 
 	//nolint:errcheck
 	defer client.Close()
+
+	ctx = clientv3.WithRequireLeader(ctx)
 
 	leader, err := client.ForfeitLeadership(ctx)
 	if err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -32,6 +32,7 @@ import (
 	"github.com/talos-systems/go-cmd/pkg/cmd"
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-retry/retry"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"golang.org/x/sys/unix"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 
@@ -1191,6 +1192,8 @@ func LeaveEtcd(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFun
 
 		//nolint:errcheck
 		defer client.Close()
+
+		ctx = clientv3.WithRequireLeader(ctx)
 
 		if err = client.LeaveCluster(ctx); err != nil {
 			return fmt.Errorf("failed to leave cluster: %w", err)

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -213,6 +213,8 @@ func addMember(ctx context.Context, r runtime.Runtime, addrs []string, name stri
 	//nolint:errcheck
 	defer client.Close()
 
+	ctx = clientv3.WithRequireLeader(ctx)
+
 	list, err := client.MemberList(ctx)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
This fix is not obvious on whether we need it actually or not, but what
I've seen in the tests seems to be around the fact that added member is
not visible in the member list fetched after the add command succeeds.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
