### PR TITLE
fix: trim endpoints/nodes from arguments in talosctl config

### DIFF
--- a/cmd/talosctl/cmd/talos/config.go
+++ b/cmd/talosctl/cmd/talos/config.go
@@ -45,6 +45,10 @@ var configEndpointCmd = &cobra.Command{
 			return err
 		}
 
+		for i := range args {
+			args[i] = strings.TrimSpace(args[i])
+		}
+
 		c.Contexts[c.Context].Endpoints = args
 		if err := c.Save(Talosconfig); err != nil {
 			return fmt.Errorf("error writing config: %w", err)
@@ -65,6 +69,10 @@ var configNodeCmd = &cobra.Command{
 		c, err := openConfigAndContext("")
 		if err != nil {
 			return err
+		}
+
+		for i := range args {
+			args[i] = strings.TrimSpace(args[i])
 		}
 
 		c.Contexts[c.Context].Nodes = args


### PR DESCRIPTION
When copy-pasting extra space might be added around an argument to the
`talosctl config endpoints/nodes`, which breaks the config as the
endpoint doesn't parse anymore as IP address.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

