### PR TITLE
feat: implement inline manifests in the machine configuration

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -42,7 +42,7 @@ preface = """\
 * Talos `system` services now run without container images on initramfs from the single executable; this change reduces RAM usage, initramfs size and boot time..
 """
 
-    [notes.machineconfig]
+    [notes.machineconfig-1]
         title = "Install Disk Selector"
         description = """\
 Install section of the machine config now has `diskSelector` field that allows querying install disk using the list of qualifiers:
@@ -57,6 +57,12 @@ Install section of the machine config now has `diskSelector` field that allows q
 ```
 
 `talosctl disks -n <node> -i` can be used to check allowed disk qualifiers when the node is running in the maintenance mode.
+"""
+
+    [notes.machineconfig-2]
+        title = "Inline Kubernetes Manifests"
+        description = """\
+* boostrap manifests can now be submitted in the configuration body using the `cluster.inlineManifests` field.
 """
 
 [make_deps]

--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -245,6 +245,7 @@ func (ctrl *K8sControlPlaneController) manageExtraManifestsConfig(ctx context.Co
 
 		for _, url := range cfgProvider.Cluster().Network().CNI().URLs() {
 			spec.ExtraManifests = append(spec.ExtraManifests, config.ExtraManifest{
+				Name:     url,
 				URL:      url,
 				Priority: "05", // push CNI to the top
 			})
@@ -252,6 +253,7 @@ func (ctrl *K8sControlPlaneController) manageExtraManifestsConfig(ctx context.Co
 
 		for _, url := range cfgProvider.Cluster().ExternalCloudProvider().ManifestURLs() {
 			spec.ExtraManifests = append(spec.ExtraManifests, config.ExtraManifest{
+				Name:     url,
 				URL:      url,
 				Priority: "30", // after default manifests
 			})
@@ -259,9 +261,18 @@ func (ctrl *K8sControlPlaneController) manageExtraManifestsConfig(ctx context.Co
 
 		for _, url := range cfgProvider.Cluster().ExtraManifestURLs() {
 			spec.ExtraManifests = append(spec.ExtraManifests, config.ExtraManifest{
+				Name:         url,
 				URL:          url,
 				Priority:     "99", // make sure extra manifests come last, when PSP is already created
 				ExtraHeaders: cfgProvider.Cluster().ExtraManifestHeaderMap(),
+			})
+		}
+
+		for _, manifest := range cfgProvider.Cluster().InlineManifests() {
+			spec.ExtraManifests = append(spec.ExtraManifests, config.ExtraManifest{
+				Name:           manifest.Name(),
+				Priority:       "99", // make sure extra manifests come last, when PSP is already created
+				InlineManifest: manifest.Contents(),
 			})
 		}
 

--- a/internal/app/machined/pkg/controllers/k8s/extra_manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/extra_manifest_test.go
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
+	"github.com/talos-systems/os-runtime/pkg/resource"
+	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
+	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
+
+	k8sctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
+)
+
+type ExtraManifestSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *ExtraManifestSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	logger := log.New(log.Writer(), "controller-runtime: ", log.Flags())
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.ExtraManifestController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *ExtraManifestSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+//nolint:dupl
+func (suite *ExtraManifestSuite) assertExtraManifests(manifests []string) error {
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.ManifestType, "", resource.VersionUndefined))
+	if err != nil {
+		return retry.UnexpectedError(err)
+	}
+
+	ids := make([]string, 0, len(resources.Items))
+
+	for _, res := range resources.Items {
+		ids = append(ids, res.Metadata().ID())
+	}
+
+	if !reflect.DeepEqual(manifests, ids) {
+		return retry.ExpectedError(fmt.Errorf("expected %q, got %q", manifests, ids))
+	}
+
+	return nil
+}
+
+func (suite *ExtraManifestSuite) TestReconcileInlineManifests() {
+	configExtraManifests := config.NewK8sExtraManifests()
+	configExtraManifests.SetExtraManifests(config.K8sExtraManifestsSpec{
+		ExtraManifests: []config.ExtraManifest{
+			{
+				Name:     "namespaces",
+				Priority: "99",
+				InlineManifest: strings.TrimSpace(`
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: ci
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: build
+`),
+			},
+		},
+	})
+
+	serviceNetworkd := v1alpha1.NewService("networkd")
+	serviceNetworkd.SetRunning(true)
+	serviceNetworkd.SetHealthy(true)
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, configExtraManifests))
+	suite.Require().NoError(suite.state.Create(suite.ctx, serviceNetworkd))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertExtraManifests(
+				[]string{
+					"99-namespaces",
+				},
+			)
+		},
+	))
+
+	r, err := suite.state.Get(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.ManifestType, "99-namespaces", resource.VersionUndefined))
+	suite.Require().NoError(err)
+
+	manifest := r.(*k8s.Manifest) //nolint:errcheck,forcetypeassert
+
+	suite.Assert().Len(manifest.Objects(), 2)
+	suite.Assert().Equal("ci", manifest.Objects()[0].GetName())
+	suite.Assert().Equal("build", manifest.Objects()[1].GetName())
+}
+
+func (suite *ExtraManifestSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	suite.Assert().NoError(suite.state.Create(context.Background(), v1alpha1.NewService("foo")))
+	suite.Assert().NoError(suite.state.Create(context.Background(), config.NewK8sManifests()))
+}
+
+func TestExtraManifestSuite(t *testing.T) {
+	suite.Run(t, new(ExtraManifestSuite))
+}

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -273,6 +273,7 @@ type ClusterConfig interface {
 	ExternalCloudProvider() ExternalCloudProvider
 	ExtraManifestURLs() []string
 	ExtraManifestHeaderMap() map[string]string
+	InlineManifests() []InlineManifest
 	AdminKubeconfig() AdminKubeconfig
 	ScheduleOnMasters() bool
 }
@@ -402,4 +403,10 @@ type VolumeMount interface {
 	HostPath() string
 	MountPath() string
 	ReadOnly() bool
+}
+
+// InlineManifest describes inline manifest for the cluster boostrap.
+type InlineManifest interface {
+	Name() string
+	Contents() string
 }

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -90,6 +90,7 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		ClusterServiceAccount:         in.Certs.K8sServiceAccount,
 		BootstrapToken:                in.Secrets.BootstrapToken,
 		ClusterAESCBCEncryptionSecret: in.Secrets.AESCBCEncryptionSecret,
+		ClusterInlineManifests:        v1alpha1.ClusterInlineManifests{},
 	}
 
 	config.MachineConfig = machine

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_clusterconfig.go
@@ -152,6 +152,17 @@ func (c *ClusterConfig) ExtraManifestHeaderMap() map[string]string {
 	return c.ExtraManifestHeaders
 }
 
+// InlineManifests implements the config.ClusterConfig interface.
+func (c *ClusterConfig) InlineManifests() []config.InlineManifest {
+	manifests := make([]config.InlineManifest, len(c.ClusterInlineManifests))
+
+	for i := range manifests {
+		manifests[i] = c.ClusterInlineManifests[i]
+	}
+
+	return manifests
+}
+
 // AdminKubeconfig implements the config.ClusterConfig interface.
 func (c *ClusterConfig) AdminKubeconfig() config.AdminKubeconfig {
 	if c.AdminKubeconfigConfig == nil {

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_inlinemanifest.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_inlinemanifest.go
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1
+
+// Name implements the config.InlineManifest interface.
+func (m ClusterInlineManifest) Name() string {
+	return m.InlineManifestName
+}
+
+// Contents implements the config.InlineManifest interface.
+func (m ClusterInlineManifest) Contents() string {
+	return m.InlineManifestContents
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
@@ -428,6 +429,18 @@ var (
 			"https://raw.githubusercontent.com/cilium/cilium/v1.8/install/kubernetes/quick-install.yaml",
 		},
 	}
+
+	clusterInlineManifestsExample = ClusterInlineManifests{
+		{
+			InlineManifestName: "namespace-ci",
+			InlineManifestContents: strings.TrimSpace(`
+apiVersion: v1
+kind: Namespace
+metadata:
+	name: ci
+`),
+		},
+	}
 )
 
 // Config defines the v1alpha1 configuration file.
@@ -716,6 +729,12 @@ type ClusterConfig struct {
 	//           "X-ExtraInfo": "info",
 	//         }
 	ExtraManifestHeaders map[string]string `yaml:"extraManifestHeaders,omitempty"`
+	//   description: |
+	//     A list of inline Kubernetes manifests.
+	//     These will get automatically deployed as part of the bootstrap.
+	//   examples:
+	//     - value: clusterInlineManifestsExample
+	ClusterInlineManifests ClusterInlineManifests `yaml:"inlineManifests,omitempty"`
 	//   description: |
 	//     Settings for admin kubeconfig generation.
 	//     Certificate lifetime can be configured.
@@ -1723,4 +1742,22 @@ type VolumeMountConfig struct {
 	//   examples:
 	//     - value: true
 	VolumeReadOnly bool `yaml:"readonly,omitempty"`
+}
+
+// ClusterInlineManifests is a list of ClusterInlineManifest.
+type ClusterInlineManifests []ClusterInlineManifest
+
+// ClusterInlineManifest struct describes inline bootstrap manifests for the user.
+type ClusterInlineManifest struct {
+	//   description: |
+	//     Name of the manifest.
+	//     Name should be unique.
+	//   examples:
+	//     - value: '"csi"'
+	InlineManifestName string `yaml:"name"`
+	//   description: |
+	//     Manifest contents as a string.
+	//   examples:
+	//     - value: '"/etc/kubernetes/auth"'
+	InlineManifestContents string `yaml:"contents"`
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -56,6 +56,7 @@ var (
 	RegistryTLSConfigDoc           encoder.Doc
 	SystemDiskEncryptionConfigDoc  encoder.Doc
 	VolumeMountConfigDoc           encoder.Doc
+	ClusterInlineManifestDoc       encoder.Doc
 )
 
 func init() {
@@ -242,7 +243,7 @@ func init() {
 			FieldName: "cluster",
 		},
 	}
-	ClusterConfigDoc.Fields = make([]encoder.Doc, 20)
+	ClusterConfigDoc.Fields = make([]encoder.Doc, 21)
 	ClusterConfigDoc.Fields[0].Name = "controlPlane"
 	ClusterConfigDoc.Fields[0].Type = "ControlPlaneConfig"
 	ClusterConfigDoc.Fields[0].Note = ""
@@ -373,19 +374,26 @@ func init() {
 		"Token":       "1234567",
 		"X-ExtraInfo": "info",
 	})
-	ClusterConfigDoc.Fields[18].Name = "adminKubeconfig"
-	ClusterConfigDoc.Fields[18].Type = "AdminKubeconfigConfig"
+	ClusterConfigDoc.Fields[18].Name = "inlineManifests"
+	ClusterConfigDoc.Fields[18].Type = "ClusterInlineManifests"
 	ClusterConfigDoc.Fields[18].Note = ""
-	ClusterConfigDoc.Fields[18].Description = "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured."
-	ClusterConfigDoc.Fields[18].Comments[encoder.LineComment] = "Settings for admin kubeconfig generation."
+	ClusterConfigDoc.Fields[18].Description = "A list of inline Kubernetes manifests.\nThese will get automatically deployed as part of the bootstrap."
+	ClusterConfigDoc.Fields[18].Comments[encoder.LineComment] = "A list of inline Kubernetes manifests."
 
-	ClusterConfigDoc.Fields[18].AddExample("", clusterAdminKubeconfigExample)
-	ClusterConfigDoc.Fields[19].Name = "allowSchedulingOnMasters"
-	ClusterConfigDoc.Fields[19].Type = "bool"
+	ClusterConfigDoc.Fields[18].AddExample("", clusterInlineManifestsExample)
+	ClusterConfigDoc.Fields[19].Name = "adminKubeconfig"
+	ClusterConfigDoc.Fields[19].Type = "AdminKubeconfigConfig"
 	ClusterConfigDoc.Fields[19].Note = ""
-	ClusterConfigDoc.Fields[19].Description = "Allows running workload on master nodes."
-	ClusterConfigDoc.Fields[19].Comments[encoder.LineComment] = "Allows running workload on master nodes."
-	ClusterConfigDoc.Fields[19].Values = []string{
+	ClusterConfigDoc.Fields[19].Description = "Settings for admin kubeconfig generation.\nCertificate lifetime can be configured."
+	ClusterConfigDoc.Fields[19].Comments[encoder.LineComment] = "Settings for admin kubeconfig generation."
+
+	ClusterConfigDoc.Fields[19].AddExample("", clusterAdminKubeconfigExample)
+	ClusterConfigDoc.Fields[20].Name = "allowSchedulingOnMasters"
+	ClusterConfigDoc.Fields[20].Type = "bool"
+	ClusterConfigDoc.Fields[20].Note = ""
+	ClusterConfigDoc.Fields[20].Description = "Allows running workload on master nodes."
+	ClusterConfigDoc.Fields[20].Comments[encoder.LineComment] = "Allows running workload on master nodes."
+	ClusterConfigDoc.Fields[20].Values = []string{
 		"true",
 		"yes",
 		"false",
@@ -1820,6 +1828,25 @@ func init() {
 	VolumeMountConfigDoc.Fields[2].Comments[encoder.LineComment] = "Mount the volume read only."
 
 	VolumeMountConfigDoc.Fields[2].AddExample("", true)
+
+	ClusterInlineManifestDoc.Type = "ClusterInlineManifest"
+	ClusterInlineManifestDoc.Comments[encoder.LineComment] = "ClusterInlineManifest struct describes inline bootstrap manifests for the user."
+	ClusterInlineManifestDoc.Description = "ClusterInlineManifest struct describes inline bootstrap manifests for the user."
+	ClusterInlineManifestDoc.Fields = make([]encoder.Doc, 2)
+	ClusterInlineManifestDoc.Fields[0].Name = "name"
+	ClusterInlineManifestDoc.Fields[0].Type = "string"
+	ClusterInlineManifestDoc.Fields[0].Note = ""
+	ClusterInlineManifestDoc.Fields[0].Description = "Name of the manifest.\nName should be unique."
+	ClusterInlineManifestDoc.Fields[0].Comments[encoder.LineComment] = "Name of the manifest."
+
+	ClusterInlineManifestDoc.Fields[0].AddExample("", "csi")
+	ClusterInlineManifestDoc.Fields[1].Name = "contents"
+	ClusterInlineManifestDoc.Fields[1].Type = "string"
+	ClusterInlineManifestDoc.Fields[1].Note = ""
+	ClusterInlineManifestDoc.Fields[1].Description = "Manifest contents as a string."
+	ClusterInlineManifestDoc.Fields[1].Comments[encoder.LineComment] = "Manifest contents as a string."
+
+	ClusterInlineManifestDoc.Fields[1].AddExample("", "/etc/kubernetes/auth")
 }
 
 func (_ Config) Doc() *encoder.Doc {
@@ -2002,6 +2029,10 @@ func (_ VolumeMountConfig) Doc() *encoder.Doc {
 	return &VolumeMountConfigDoc
 }
 
+func (_ ClusterInlineManifest) Doc() *encoder.Doc {
+	return &ClusterInlineManifestDoc
+}
+
 // GetConfigurationDoc returns documentation for the file ./v1alpha1_types_doc.go.
 func GetConfigurationDoc() *encoder.FileDoc {
 	return &encoder.FileDoc{
@@ -2053,6 +2084,7 @@ func GetConfigurationDoc() *encoder.FileDoc {
 			&RegistryTLSConfigDoc,
 			&SystemDiskEncryptionConfigDoc,
 			&VolumeMountConfigDoc,
+			&ClusterInlineManifestDoc,
 		},
 	}
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -243,6 +243,37 @@ func TestValidate(t *testing.T) {
 			},
 			expectedError: "1 error occurred:\n\t* invalid external cloud provider manifest url \"/manifest.yaml\": hostname must not be blank\n\n",
 		},
+		{
+			name: "InlineManifests",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					ClusterInlineManifests: v1alpha1.ClusterInlineManifests{
+						{
+							InlineManifestName: "",
+						},
+						{
+							InlineManifestName: "foo",
+						},
+						{
+							InlineManifestName: "bar",
+						},
+						{
+							InlineManifestName: "foo",
+						},
+					},
+				},
+			},
+			expectedError: "2 errors occurred:\n\t* inline manifest name can't be empty\n\t* inline manifest name \"foo\" is duplicate\n\n",
+		},
 	} {
 		test := test
 

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -100,9 +100,11 @@ type K8sManifestsSpec struct {
 
 // ExtraManifest defines a single extra manifest to download.
 type ExtraManifest struct {
-	URL          string            `yaml:"url"`
-	Priority     string            `yaml:"priority"`
-	ExtraHeaders map[string]string `yaml:"extraHeaders"`
+	Name           string            `yaml:"name"`
+	URL            string            `yaml:"url"`
+	Priority       string            `yaml:"priority"`
+	ExtraHeaders   map[string]string `yaml:"extraHeaders"`
+	InlineManifest string            `yaml:"inlineManifest"`
 }
 
 // K8sExtraManifestsSpec is a configuration for extra manifests.

--- a/website/content/docs/v0.10/Reference/configuration.md
+++ b/website/content/docs/v0.10/Reference/configuration.md
@@ -1206,6 +1206,36 @@ extraManifestHeaders:
 
 <div class="dd">
 
+<code>inlineManifests</code>  <i>ClusterInlineManifests</i>
+
+</div>
+<div class="dt">
+
+A list of inline Kubernetes manifests.
+These will get automatically deployed as part of the bootstrap.
+
+
+
+Examples:
+
+
+``` yaml
+inlineManifests:
+    - name: namespace-ci # Name of the manifest.
+      contents: |- # Manifest contents as a string.
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+        	name: ci
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
 <code>adminKubeconfig</code>  <i><a href="#adminkubeconfigconfig">AdminKubeconfigConfig</a></i>
 
 </div>
@@ -4985,6 +5015,65 @@ Examples:
 
 ``` yaml
 readonly: true
+```
+
+
+</div>
+
+<hr />
+
+
+
+
+
+## ClusterInlineManifest
+ClusterInlineManifest struct describes inline bootstrap manifests for the user.
+
+
+
+
+<hr />
+
+<div class="dd">
+
+<code>name</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Name of the manifest.
+Name should be unique.
+
+
+
+Examples:
+
+
+``` yaml
+name: csi
+```
+
+
+</div>
+
+<hr />
+
+<div class="dd">
+
+<code>contents</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+Manifest contents as a string.
+
+
+
+Examples:
+
+
+``` yaml
+contents: /etc/kubernetes/auth
 ```
 
 


### PR DESCRIPTION
Inline manifests work exactly same way as extra manifests, but the
manifest itself can be stored in the config body.

Example config patch:

```
--config-patch '[{"op": "replace", "path": "/cluster/inlineManifests", "value": [{"name": "foo", "contents": "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: ci\n"}]}]'
```

Fixes #3416 

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
