### PR TITLE
test: update upgrade tests to 0.10 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/downlo
 SONOBUOY_VERSION ?= 0.50.0
 SONOBUOY_URL ?= https://github.com/vmware-tanzu/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.8.5 v0.9.1
+RELEASES ?= v0.9.1 v0.10.0-alpha.2
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 


### PR DESCRIPTION
In preparation for going 0.10 beta, start testing upgrades to 0.10, drop
0.8 and self-hosted control plane handling in the tests.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

