### PR TITLE
feat: validate the machine configuration in the installer container

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1369,11 +1369,17 @@ func Upgrade(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 
 		logger.Printf("performing upgrade via %q", in.GetImage())
 
+		configBytes, err := r.Config().Bytes()
+		if err != nil {
+			return fmt.Errorf("error marshaling configuration: %w", err)
+		}
+
 		// We pull the installer image when we receive an upgrade request. No need
 		// to pull it again.
 		err = install.RunInstallerContainer(
 			devname, r.State().Platform().Name(),
 			in.GetImage(),
+			configBytes,
 			r.Config().Machine().Registries(),
 			install.OptionsFromUpgradeRequest(r, in)...,
 		)
@@ -1596,6 +1602,11 @@ func UnmountEphemeralPartition(seq runtime.Sequence, data interface{}) (runtime.
 // Install mounts or installs the system partitions.
 func Install(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
+		configBytes, err := r.Config().Bytes()
+		if err != nil {
+			return fmt.Errorf("error marshaling configuration: %w", err)
+		}
+
 		switch {
 		case !r.State().Machine().Installed():
 			installerImage := r.Config().Machine().Install().Image()
@@ -1614,6 +1625,7 @@ func Install(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 				disk,
 				r.State().Platform().Name(),
 				installerImage,
+				configBytes,
 				r.Config().Machine().Registries(),
 				install.WithForce(true),
 				install.WithZero(r.Config().Machine().Install().Zero()),
@@ -1639,6 +1651,7 @@ func Install(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc,
 			err = install.RunInstallerContainer(
 				devname, r.State().Platform().Name(),
 				r.State().Machine().StagedInstallImageRef(),
+				configBytes,
 				r.Config().Machine().Registries(),
 				install.WithOptions(options),
 			)

--- a/internal/app/machined/pkg/system/runner/containerd/stdin.go
+++ b/internal/app/machined/pkg/system/runner/containerd/stdin.go
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package containerd
+
+import (
+	"context"
+	"io"
+
+	"github.com/containerd/containerd"
+)
+
+// StdinCloser wraps io.Reader providing a signal when reader is read till EOF.
+type StdinCloser struct {
+	Stdin  io.Reader
+	Closer chan struct{}
+}
+
+func (s *StdinCloser) Read(p []byte) (int, error) {
+	n, err := s.Stdin.Read(p)
+	if err == io.EOF {
+		close(s.Closer)
+	}
+
+	return n, err
+}
+
+// WaitAndClose closes containerd task stdin when StdinCloser is exhausted.
+func (s *StdinCloser) WaitAndClose(ctx context.Context, task containerd.Task) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-s.Closer:
+		//nolint:errcheck
+		task.CloseIO(ctx, containerd.WithStdinCloser)
+	}
+}

--- a/pkg/machinery/config/configloader/configloader.go
+++ b/pkg/machinery/config/configloader/configloader.go
@@ -7,6 +7,7 @@ package configloader
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,6 +17,9 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/config/decoder"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 )
+
+// ErrNoConfig is returned when no configuration was found in the input.
+var ErrNoConfig = errors.New("config not found")
 
 // newConfig initializes and returns a Configurator.
 func newConfig(source []byte) (config config.Provider, err error) {
@@ -34,7 +38,7 @@ func newConfig(source []byte) (config config.Provider, err error) {
 		}
 	}
 
-	return nil, fmt.Errorf("config not found")
+	return nil, ErrNoConfig
 }
 
 // NewFromFile will take a filepath and attempt to parse a config file from it.
@@ -58,7 +62,7 @@ func NewFromStdin() (config.Provider, error) {
 
 	config, err := NewFromBytes(buf.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("failed load config from stdin: %v", err)
+		return nil, fmt.Errorf("failed load config from stdin: %w", err)
 	}
 
 	return config, nil


### PR DESCRIPTION
Talos validates machine configuration at boot time, and refuses to boot
if machine configuration is invalid.

As machine configuration validation rules might change over time, we
need to prevent a scenario when after an upgrade machine configuration
becomes invalid, as there's no way to roll back properly.

Machine configuration is submitted over stdin to the installer
container, and installer container validates it using the new version of
Talos (which is going to be installed).

If the config is not sent over stdin, installer assumes old version of
Talos and proceeds.

This should be backported to 0.9 to allow config validation on upgrade
to 0.10.

Fixes #3419

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

