### PR TITLE
chore: update Linux to 5.10.28, u-boot to final 2021.04 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-alpha.0-4-g1f26def
-PKGS ?= v0.5.0-alpha.0-5-g9a6cf6b
+PKGS ?= v0.5.0-alpha.0-7-g98964cb
 EXTRAS ?= v0.3.0-alpha.0-2-gcf3934a
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.27-talos"
+	DefaultKernelVersion = "5.10.28-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
See talos-systems/pkgs#261 talos-systems/pkgs#262

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

> See `make help` for a description of the available targets.
