### PR TITLE
fix: check retryable network errors by interface

### DIFF
--- a/pkg/kubernetes/errors.go
+++ b/pkg/kubernetes/errors.go
@@ -19,14 +19,16 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNREFUSED) {
 		return true
 	}
 
-	netErr := &net.OpError{}
+	var netErr net.Error
 
 	if errors.As(err, &netErr) {
-		return netErr.Temporary() || netErr.Timeout() || errors.Is(netErr.Err, syscall.ECONNREFUSED)
+		if netErr.Temporary() || netErr.Timeout() {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
Looks like tls errors implement the interface, but they are not derived
from the `*net.OpError`, so this check should catch more errors.

Fixes #3457

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

