### PR TITLE
docs: fixup typo in encryption guide command

### DIFF
--- a/website/content/docs/v0.10/Guides/disk-encryption.md
+++ b/website/content/docs/v0.10/Guides/disk-encryption.md
@@ -153,7 +153,7 @@ talosctl apply-config -f config.yaml -n <node ip> --on-reboot
 Wipe the partition you're going to encrypt:
 
 ```bash
-talosctl reset --system-labels-to-wipe EPHEMERAL -n <none> --reboot=true
+talosctl reset --system-labels-to-wipe EPHEMERAL -n <node ip> --reboot=true
 ```
 
 That's it!

--- a/website/content/docs/v0.9/Guides/disk-encryption.md
+++ b/website/content/docs/v0.9/Guides/disk-encryption.md
@@ -153,7 +153,7 @@ talosctl apply-config -f config.yaml -n <node ip> --on-reboot
 Wipe the partition you're going to encrypt:
 
 ```bash
-talosctl reset --system-labels-to-wipe EPHEMERAL -n <none> --reboot=true
+talosctl reset --system-labels-to-wipe EPHEMERAL -n <node ip> --reboot=true
 ```
 
 That's it!


### PR DESCRIPTION
# Pull Request

## What? (description)

Fixes a typo in a documented command for going from an unencrypted
EPHEMERAL partition to an encrypted one.

## Why? (reasoning)

Because typos are bad, mkay? ;)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
