### PR TITLE
chore: use Go 1.16 global install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-alpha.0-4-g1f26def
 PKGS ?= v0.5.0-alpha.0-7-g98964cb
 EXTRAS ?= v0.3.0-alpha.0-2-gcf3934a
 GO_VERSION ?= 1.16
-GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
+GOFUMPT_VERSION ?= v0.1.0
+STRINGER_VERSION ?= v0.1.0
 IMPORTVET ?= autonomy/importvet:f6b07d9
 OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)
@@ -68,6 +69,7 @@ COMMON_ARGS += --build-arg=TOOLS=$(TOOLS)
 COMMON_ARGS += --build-arg=PKGS=$(PKGS)
 COMMON_ARGS += --build-arg=EXTRAS=$(EXTRAS)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
+COMMON_ARGS += --build-arg=STRINGER_VERSION=$(STRINGER_VERSION)
 COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=IMPORTVET=$(IMPORTVET)
@@ -240,7 +242,7 @@ cloud-images: ## Uploads cloud images (AMIs, etc.) to the cloud registry.
 
 .PHONY: fmt
 fmt: ## Formats the source code.
-	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; cd /tmp && go mod init tmp && go get mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && cd - && gofumports -w -local github.com/talos-systems/talos ."
+	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) bash -c "go install mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && gofumports -w -local github.com/talos-systems/talos ."
 
 lint-%: ## Runs the specified linter. Valid options are go, protobuf, and markdown (e.g. lint-go).
 	@$(MAKE) target-lint-$* PLATFORM=linux/amd64

--- a/pkg/machinery/api/cluster/cluster_grpc.pb.go
+++ b/pkg/machinery/api/cluster/cluster_grpc.pb.go
@@ -71,8 +71,7 @@ type ClusterServiceServer interface {
 }
 
 // UnimplementedClusterServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedClusterServiceServer struct {
-}
+type UnimplementedClusterServiceServer struct{}
 
 func (UnimplementedClusterServiceServer) HealthCheck(*HealthCheckRequest, ClusterService_HealthCheckServer) error {
 	return status.Errorf(codes.Unimplemented, "method HealthCheck not implemented")

--- a/pkg/machinery/api/health/health_grpc.pb.go
+++ b/pkg/machinery/api/health/health_grpc.pb.go
@@ -94,8 +94,7 @@ type HealthServer interface {
 }
 
 // UnimplementedHealthServer must be embedded to have forward compatible implementations.
-type UnimplementedHealthServer struct {
-}
+type UnimplementedHealthServer struct{}
 
 func (UnimplementedHealthServer) Check(context.Context, *emptypb.Empty) (*HealthCheckResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Check not implemented")

--- a/pkg/machinery/api/inspect/inspect_grpc.pb.go
+++ b/pkg/machinery/api/inspect/inspect_grpc.pb.go
@@ -49,8 +49,7 @@ type InspectServiceServer interface {
 }
 
 // UnimplementedInspectServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedInspectServiceServer struct {
-}
+type UnimplementedInspectServiceServer struct{}
 
 func (UnimplementedInspectServiceServer) ControllerRuntimeDependencies(context.Context, *emptypb.Empty) (*ControllerRuntimeDependenciesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ControllerRuntimeDependencies not implemented")

--- a/pkg/machinery/api/machine/machine_grpc.pb.go
+++ b/pkg/machinery/api/machine/machine_grpc.pb.go
@@ -739,8 +739,7 @@ type MachineServiceServer interface {
 }
 
 // UnimplementedMachineServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedMachineServiceServer struct {
-}
+type UnimplementedMachineServiceServer struct{}
 
 func (UnimplementedMachineServiceServer) ApplyConfiguration(context.Context, *ApplyConfigurationRequest) (*ApplyConfigurationResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ApplyConfiguration not implemented")

--- a/pkg/machinery/api/network/network_grpc.pb.go
+++ b/pkg/machinery/api/network/network_grpc.pb.go
@@ -60,8 +60,7 @@ type NetworkServiceServer interface {
 }
 
 // UnimplementedNetworkServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedNetworkServiceServer struct {
-}
+type UnimplementedNetworkServiceServer struct{}
 
 func (UnimplementedNetworkServiceServer) Routes(context.Context, *emptypb.Empty) (*RoutesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Routes not implemented")

--- a/pkg/machinery/api/resource/resource_grpc.pb.go
+++ b/pkg/machinery/api/resource/resource_grpc.pb.go
@@ -116,8 +116,7 @@ type ResourceServiceServer interface {
 }
 
 // UnimplementedResourceServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedResourceServiceServer struct {
-}
+type UnimplementedResourceServiceServer struct{}
 
 func (UnimplementedResourceServiceServer) Get(context.Context, *GetRequest) (*GetResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Get not implemented")

--- a/pkg/machinery/api/security/security_grpc.pb.go
+++ b/pkg/machinery/api/security/security_grpc.pb.go
@@ -70,8 +70,7 @@ type SecurityServiceServer interface {
 }
 
 // UnimplementedSecurityServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedSecurityServiceServer struct {
-}
+type UnimplementedSecurityServiceServer struct{}
 
 func (UnimplementedSecurityServiceServer) Certificate(context.Context, *CertificateRequest) (*CertificateResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Certificate not implemented")

--- a/pkg/machinery/api/storage/storage_grpc.pb.go
+++ b/pkg/machinery/api/storage/storage_grpc.pb.go
@@ -49,8 +49,7 @@ type StorageServiceServer interface {
 }
 
 // UnimplementedStorageServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedStorageServiceServer struct {
-}
+type UnimplementedStorageServiceServer struct{}
 
 func (UnimplementedStorageServiceServer) Disks(context.Context, *emptypb.Empty) (*DisksResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Disks not implemented")

--- a/pkg/machinery/api/time/time_grpc.pb.go
+++ b/pkg/machinery/api/time/time_grpc.pb.go
@@ -60,8 +60,7 @@ type TimeServiceServer interface {
 }
 
 // UnimplementedTimeServiceServer must be embedded to have forward compatible implementations.
-type UnimplementedTimeServiceServer struct {
-}
+type UnimplementedTimeServiceServer struct{}
 
 func (UnimplementedTimeServiceServer) Time(context.Context, *emptypb.Empty) (*TimeResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Time not implemented")


### PR DESCRIPTION
Plus add stringer tool.

https://golang.org/doc/go1.16#go-command

> go install now accepts arguments with version suffixes (for example, go install example.com/cmd@v1.0.0). This causes go install to build and install packages in module-aware mode, ignoring the go.mod file in the current directory or any parent directory, if there is one. This is useful for installing executables without affecting the dependencies of the main module.

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
