### PR TITLE
chore: re-import talos-systems/os-runtime as cosi-project/runtime

### DIFF
--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/emicklei/dot"
 	"github.com/spf13/cobra"
-	"github.com/talos-systems/os-runtime/pkg/resource"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 

--- a/cmd/talosctl/cmd/talos/output/json.go
+++ b/cmd/talosctl/cmd/talos/output/json.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd/talosctl/cmd/talos/output/output.go
+++ b/cmd/talosctl/cmd/talos/output/output.go
@@ -8,8 +8,8 @@ package output
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 )
 
 // Writer interface.

--- a/cmd/talosctl/cmd/talos/output/table.go
+++ b/cmd/talosctl/cmd/talos/output/table.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"k8s.io/client-go/util/jsonpath"
 )
 

--- a/cmd/talosctl/cmd/talos/output/yaml.go
+++ b/cmd/talosctl/cmd/talos/output/yaml.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"gopkg.in/yaml.v3"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/containernetworking/plugins v0.9.1
 	github.com/coreos/go-iptables v0.5.0
 	github.com/coreos/go-semver v0.3.0
+	github.com/cosi-project/runtime v0.0.0-20210409233936-10d6103c19ab
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.4+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -74,7 +75,6 @@ require (
 	github.com/talos-systems/go-smbios v0.0.0-20201228201610-fb425d4727e6
 	github.com/talos-systems/grpc-proxy v0.2.0
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
-	github.com/talos-systems/os-runtime v0.0.0-20210401122348-86d9e090bdc4
 	github.com/talos-systems/talos/pkg/machinery v0.0.0-20210302191918-8ffb55943c71
 	github.com/u-root/u-root v7.0.0+incompatible
 	github.com/vmware-tanzu/sonobuoy v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/coreos/go-systemd/v22 v22.1.0 h1:kq/SbG2BCKLkDKkjQf5OWwKWUKj1lgs3lFI4
 github.com/coreos/go-systemd/v22 v22.1.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cosi-project/runtime v0.0.0-20210409233936-10d6103c19ab h1:u8p7SXdsdYV89RnXtPExlvIKDrXLeGhAUo66LmOtYV4=
+github.com/cosi-project/runtime v0.0.0-20210409233936-10d6103c19ab/go.mod h1:ebaL1B5YO0vy0YuhHS59QrRfZEYPNB9U3bzdLrlUfzo=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -1032,8 +1034,6 @@ github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1L
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa h1:XqOMTt0Q6mjsk8Dea5wUpgcdtf+AzesH11m4AozWSxw=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/os-runtime v0.0.0-20210401122348-86d9e090bdc4 h1:mVlqonAE7QgFWn1g9p2b+EBC4Lk57TexASvp7tHglRc=
-github.com/talos-systems/os-runtime v0.0.0-20210401122348-86d9e090bdc4/go.mod h1:358qvRxAR16NdF8fiitixPgECx4Pj32yXLHAWYWZc/g=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_inspect.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_inspect.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/talos-systems/os-runtime/pkg/controller"
 
 	inspectapi "github.com/talos-systems/talos/pkg/machinery/api/inspect"
 )

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_resource.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_resource.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/state"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"

--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 
 	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	talosnet "github.com/talos-systems/net"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
 
 	"github.com/talos-systems/talos/pkg/images"
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"

--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
@@ -14,13 +14,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-retry/retry"
-	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
 
 	configctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"

--- a/internal/app/machined/pkg/controllers/config/machine_type.go
+++ b/internal/app/machined/pkg/controllers/config/machine_type.go
@@ -10,9 +10,9 @@ import (
 	"log"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/resources/config"

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -13,13 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-retry/retry"
-	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
 	v1 "k8s.io/api/core/v1"
 
 	k8sctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"

--- a/internal/app/machined/pkg/controllers/k8s/extra_manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/extra_manifest.go
@@ -14,11 +14,11 @@ import (
 	"path/filepath"
 
 	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-multierror"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
 
 	"github.com/talos-systems/talos/pkg/resources/config"
 	"github.com/talos-systems/talos/pkg/resources/k8s"

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
@@ -16,9 +16,9 @@ import (
 	"time"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"gopkg.in/yaml.v3"
 
 	"github.com/talos-systems/talos/pkg/kubernetes/kubelet"

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -13,9 +13,9 @@ import (
 	"text/template"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/talos-systems/talos/pkg/resources/config"
 	"github.com/talos-systems/talos/pkg/resources/k8s"

--- a/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
@@ -11,9 +11,9 @@ import (
 	"sort"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -13,13 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-retry/retry"
-	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
 
 	k8sctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"
 	"github.com/talos-systems/talos/pkg/machinery/constants"

--- a/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
@@ -15,10 +15,10 @@ import (
 	stdlibtemplate "text/template"
 
 	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/talos-systems/crypto/x509"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
 
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/resources/k8s"

--- a/internal/app/machined/pkg/controllers/secrets/etcd.go
+++ b/internal/app/machined/pkg/controllers/secrets/etcd.go
@@ -10,9 +10,9 @@ import (
 	"log"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/talos-systems/talos/internal/pkg/etcd"
 	"github.com/talos-systems/talos/pkg/resources/secrets"

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/talos-systems/crypto/x509"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
 
 	"github.com/talos-systems/talos/internal/pkg/kubeconfig"
 	"github.com/talos-systems/talos/pkg/machinery/config"

--- a/internal/app/machined/pkg/controllers/secrets/root.go
+++ b/internal/app/machined/pkg/controllers/secrets/root.go
@@ -10,9 +10,9 @@ import (
 	"log"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"

--- a/internal/app/machined/pkg/controllers/time/sync.go
+++ b/internal/app/machined/pkg/controllers/time/sync.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/pkg/ntp"

--- a/internal/app/machined/pkg/controllers/time/sync_test.go
+++ b/internal/app/machined/pkg/controllers/time/sync_test.go
@@ -13,13 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-retry/retry"
-	"github.com/talos-systems/os-runtime/pkg/controller/runtime"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
 
 	timectrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/time"
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"

--- a/internal/app/machined/pkg/controllers/v1alpha1/boostrap_status.go
+++ b/internal/app/machined/pkg/controllers/v1alpha1/boostrap_status.go
@@ -10,9 +10,9 @@ import (
 	"log"
 
 	"github.com/AlekSi/pointer"
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"

--- a/internal/app/machined/pkg/controllers/v1alpha1/service.go
+++ b/internal/app/machined/pkg/controllers/v1alpha1/service.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"sync"
 
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"

--- a/internal/app/machined/pkg/runtime/controller.go
+++ b/internal/app/machined/pkg/runtime/controller.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/talos-systems/os-runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/controller"
 )
 
 // TaskSetupFunc defines the function that a task will execute for a specific runtime

--- a/internal/app/machined/pkg/runtime/state.go
+++ b/internal/app/machined/pkg/runtime/state.go
@@ -5,9 +5,9 @@
 package runtime
 
 import (
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/talos-systems/go-blockdevice/blockdevice/probe"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/disk"
 	"github.com/talos-systems/talos/pkg/machinery/config"

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -8,8 +8,8 @@ import (
 	"context"
 	"log"
 
-	"github.com/talos-systems/os-runtime/pkg/controller"
-	osruntime "github.com/talos-systems/os-runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/controller"
+	osruntime "github.com/cosi-project/runtime/pkg/controller/runtime"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/config"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -7,11 +7,11 @@ package v1alpha2
 import (
 	"context"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/resources/config"

--- a/pkg/cluster/kubernetes/convert.go
+++ b/pkg/cluster/kubernetes/convert.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/talos-systems/crypto/x509"
 	"github.com/talos-systems/go-retry/retry"
-	"github.com/talos-systems/os-runtime/pkg/resource"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"github.com/talos-systems/go-retry/retry"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/talos-systems/talos/pkg/cluster"

--- a/pkg/machinery/client/resources.go
+++ b/pkg/machinery/client/resources.go
@@ -7,8 +7,8 @@ package client
 import (
 	"context"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"google.golang.org/grpc"
 
 	"github.com/talos-systems/talos/pkg/machinery/api/common"

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef
 	github.com/containerd/containerd v1.4.4
 	github.com/containerd/go-cni v1.0.1
+	github.com/cosi-project/runtime v0.0.0-20210409233936-10d6103c19ab
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/ghodss/yaml v1.0.0
@@ -23,7 +24,6 @@ require (
 	github.com/talos-systems/crypto v0.2.1-0.20210202170911-39584f1b6e54
 	github.com/talos-systems/go-blockdevice v0.2.1-0.20210407132431-1d830a25f64f
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
-	github.com/talos-systems/os-runtime v0.0.0-20210401122348-86d9e090bdc4
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/genproto v0.0.0-20210302174412-5ede27ff9881

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -15,6 +15,8 @@ github.com/containerd/go-cni v1.0.1 h1:VXr2EkOPD0v1gu7CKfof6XzEIDzsE/dI9yj/W7PSW
 github.com/containerd/go-cni v1.0.1/go.mod h1:+vUpYxKvAF72G9i1WoDOiPGRtQpqsNW/ZHtSlv++smU=
 github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjMCbgybcKI=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/cosi-project/runtime v0.0.0-20210409233936-10d6103c19ab h1:u8p7SXdsdYV89RnXtPExlvIKDrXLeGhAUo66LmOtYV4=
+github.com/cosi-project/runtime v0.0.0-20210409233936-10d6103c19ab/go.mod h1:ebaL1B5YO0vy0YuhHS59QrRfZEYPNB9U3bzdLrlUfzo=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -113,8 +115,6 @@ github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1
 github.com/talos-systems/go-retry v0.2.1-0.20210119124456-b9dc1a990133/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa h1:XqOMTt0Q6mjsk8Dea5wUpgcdtf+AzesH11m4AozWSxw=
 github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa/go.mod h1:VreSAyRmxMtqussAHSKMKkJQa1YwBTSVfkmE4Jydam4=
-github.com/talos-systems/os-runtime v0.0.0-20210401122348-86d9e090bdc4 h1:mVlqonAE7QgFWn1g9p2b+EBC4Lk57TexASvp7tHglRc=
-github.com/talos-systems/os-runtime v0.0.0-20210401122348-86d9e090bdc4/go.mod h1:358qvRxAR16NdF8fiitixPgECx4Pj32yXLHAWYWZc/g=
 github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b h1:8pnPjZJU0SYanlmHnhMTeR8OR148K9yStwBz1GsjBsQ=
 github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/resources/config/config.go
+++ b/pkg/resources/config/config.go
@@ -5,7 +5,7 @@
 // Package config provides resources which hold Talos node configuration.
 package config
 
-import "github.com/talos-systems/os-runtime/pkg/resource"
+import "github.com/cosi-project/runtime/pkg/resource"
 
 // NamespaceName contains configuration resources.
 const NamespaceName resource.Namespace = "config"

--- a/pkg/resources/config/config_test.go
+++ b/pkg/resources/config/config_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/stretchr/testify/assert"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
 
 	"github.com/talos-systems/talos/pkg/resources/config"
 )

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -7,8 +7,8 @@ package config
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
 // K8sControlPlaneType is type of K8sControlPlane resource.

--- a/pkg/resources/config/machine_config.go
+++ b/pkg/resources/config/machine_config.go
@@ -7,8 +7,8 @@ package config
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/configloader"

--- a/pkg/resources/config/machine_type.go
+++ b/pkg/resources/config/machine_type.go
@@ -7,8 +7,8 @@ package config
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 )

--- a/pkg/resources/k8s/k8s.go
+++ b/pkg/resources/k8s/k8s.go
@@ -5,7 +5,7 @@
 // Package k8s provides resources which interface with Kubernetes.
 package k8s
 
-import "github.com/talos-systems/os-runtime/pkg/resource"
+import "github.com/cosi-project/runtime/pkg/resource"
 
 // ControlPlaneNamespaceName contains resources supporting Kubernetes control plane.
 const ControlPlaneNamespaceName resource.Namespace = "controlplane"

--- a/pkg/resources/k8s/k8s_test.go
+++ b/pkg/resources/k8s/k8s_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/stretchr/testify/assert"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
 
 	"github.com/talos-systems/talos/pkg/resources/k8s"
 )

--- a/pkg/resources/k8s/manifest.go
+++ b/pkg/resources/k8s/manifest.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )

--- a/pkg/resources/k8s/manifest_status.go
+++ b/pkg/resources/k8s/manifest_status.go
@@ -7,8 +7,8 @@ package k8s
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
 // ManifestStatusType is type of ManifestStatus resource.

--- a/pkg/resources/k8s/secrets_status.go
+++ b/pkg/resources/k8s/secrets_status.go
@@ -7,8 +7,8 @@ package k8s
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
 // SecretsStatusType is type of SecretsStatus resource.

--- a/pkg/resources/k8s/static_pod.go
+++ b/pkg/resources/k8s/static_pod.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/resources/k8s/static_pod_status.go
+++ b/pkg/resources/k8s/static_pod_status.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/resources/secrets/etcd.go
+++ b/pkg/resources/secrets/etcd.go
@@ -7,9 +7,9 @@ package secrets
 import (
 	"fmt"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/talos-systems/crypto/x509"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
 )
 
 // EtcdType is type of Etcd resource.

--- a/pkg/resources/secrets/kubernetes.go
+++ b/pkg/resources/secrets/kubernetes.go
@@ -7,9 +7,9 @@ package secrets
 import (
 	"fmt"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/talos-systems/crypto/x509"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
 )
 
 // KubernetesType is type of Kubernetes resource.

--- a/pkg/resources/secrets/root.go
+++ b/pkg/resources/secrets/root.go
@@ -9,9 +9,9 @@ import (
 	"net"
 	"net/url"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/talos-systems/crypto/x509"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
 )
 
 // RootType is type of Root secret resource.

--- a/pkg/resources/secrets/secrets.go
+++ b/pkg/resources/secrets/secrets.go
@@ -5,7 +5,7 @@
 // Package secrets provides resources which store secrets.
 package secrets
 
-import "github.com/talos-systems/os-runtime/pkg/resource"
+import "github.com/cosi-project/runtime/pkg/resource"
 
 // NamespaceName contains resources containing secret material.
 const NamespaceName resource.Namespace = "secrets"

--- a/pkg/resources/secrets/secrets_test.go
+++ b/pkg/resources/secrets/secrets_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/stretchr/testify/assert"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
 
 	"github.com/talos-systems/talos/pkg/resources/secrets"
 )

--- a/pkg/resources/time/condition.go
+++ b/pkg/resources/time/condition.go
@@ -7,8 +7,8 @@ package time
 import (
 	"context"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 
 	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
 )

--- a/pkg/resources/time/status.go
+++ b/pkg/resources/time/status.go
@@ -7,8 +7,8 @@ package time
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 
 	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
 )

--- a/pkg/resources/time/time_test.go
+++ b/pkg/resources/time/time_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/stretchr/testify/assert"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
 
 	"github.com/talos-systems/talos/pkg/resources/time"
 )

--- a/pkg/resources/v1alpha1/bootstrap_status.go
+++ b/pkg/resources/v1alpha1/bootstrap_status.go
@@ -7,8 +7,8 @@ package v1alpha1
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
 // BootstrapStatusType is type of BootstrapStatus resource.

--- a/pkg/resources/v1alpha1/service.go
+++ b/pkg/resources/v1alpha1/service.go
@@ -7,8 +7,8 @@ package v1alpha1
 import (
 	"fmt"
 
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/resource/meta"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
 )
 
 // ServiceType is type of Service resource.

--- a/pkg/resources/v1alpha1/v1alpha1.go
+++ b/pkg/resources/v1alpha1/v1alpha1.go
@@ -5,7 +5,7 @@
 // Package v1alpha1 provides resources which implement "glue" code from v1alpha1 Talos init system.
 package v1alpha1
 
-import "github.com/talos-systems/os-runtime/pkg/resource"
+import "github.com/cosi-project/runtime/pkg/resource"
 
 // NamespaceName contains resources linking v1alpha2 components with v1alpha1 Talos runtime.
 const NamespaceName resource.Namespace = "runtime"

--- a/pkg/resources/v1alpha1/v1alpha1_test.go
+++ b/pkg/resources/v1alpha1/v1alpha1_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
 	"github.com/stretchr/testify/assert"
-	"github.com/talos-systems/os-runtime/pkg/resource"
-	"github.com/talos-systems/os-runtime/pkg/state"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/inmem"
-	"github.com/talos-systems/os-runtime/pkg/state/impl/namespaced"
-	"github.com/talos-systems/os-runtime/pkg/state/registry"
 
 	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
 )


### PR DESCRIPTION
No changes, just import path change (as project got moved).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
