### PR TITLE
feat: Linux 5.10.29 kernel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-alpha.0-4-g1f26def
-PKGS ?= v0.5.0-alpha.0-7-g98964cb
-EXTRAS ?= v0.3.0-alpha.0-2-gcf3934a
+TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0
+PKGS ?= v0.5.0
+EXTRAS ?= v0.3.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0
 STRINGER_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.28-talos"
+	DefaultKernelVersion = "5.10.29-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Also brings tools/pkgs/extras re-tagged from a stable branch for Talos
0.10 release.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
