### PR TITLE
fix: zero out manifest contents before setting new value

### DIFF
--- a/pkg/resources/k8s/manifest.go
+++ b/pkg/resources/k8s/manifest.go
@@ -93,6 +93,7 @@ func (r *Manifest) ResourceDefinition() meta.ResourceDefinitionSpec {
 
 // SetYAML parses manifest from YAML.
 func (r *Manifest) SetYAML(yamlBytes []byte) error {
+	r.spec.Items = nil
 	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(yamlBytes)))
 
 	for {


### PR DESCRIPTION
This might lead to manifests being appended forever on changes.

Fixes #3476

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
