### PR TITLE
chore: fix conform with scopes

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -31,8 +31,7 @@ policies:
           - talosctl
           - kernel
           - security
-          - ^v0.8
-          - '*'
+          - ^v0.11
   - type: license
     spec:
       skipPaths:

--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ release-artifacts:
 
 .PHONY: conformance
 conformance: ## Performs policy checks against the commit and source code.
-	docker run --rm -it -v $(PWD):/src -w /src docker.io/autonomy/conform:v0.1.0-alpha.19
+	docker run --rm -it -v $(PWD):/src -w /src docker.io/autonomy/conform:v0.1.0-alpha.20
 
 .PHONY: release-notes
 release-notes:


### PR DESCRIPTION
In recent versions of conform, scope is regexp so `*` is not a valid
regexp.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

> See `make help` for a description of the available targets.
