### PR TITLE
test: implement `talosctl conformance` command to run e2e tests

### DIFF
--- a/cmd/talosctl/cmd/talos/conformance.go
+++ b/cmd/talosctl/cmd/talos/conformance.go
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package talos
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/talos-systems/talos/pkg/cluster"
+	"github.com/talos-systems/talos/pkg/cluster/sonobuoy"
+	"github.com/talos-systems/talos/pkg/machinery/client"
+)
+
+// conformanceCmd represents the conformance command.
+var conformanceCmd = &cobra.Command{
+	Use:   "conformance",
+	Short: "Run conformance tests",
+	Long:  ``,
+}
+
+var conformanceKubernetesCmdFlags struct {
+	mode string
+}
+
+var conformanceKubernetesCmd = &cobra.Command{
+	Use:     "kubernetes",
+	Aliases: []string{"k8s"},
+	Short:   "Run Kubernetes conformance tests",
+	Long:    ``,
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return WithClient(func(ctx context.Context, c *client.Client) error {
+			clientProvider := &cluster.ConfigClientProvider{
+				DefaultClient: c,
+			}
+			defer clientProvider.Close() //nolint:errcheck
+
+			state := struct {
+				cluster.K8sProvider
+			}{
+				K8sProvider: &cluster.KubernetesClient{
+					ClientProvider: clientProvider,
+					ForceEndpoint:  healthCmdFlags.forceEndpoint,
+				},
+			}
+
+			switch conformanceKubernetesCmdFlags.mode {
+			case "fast":
+				return sonobuoy.FastConformance(ctx, &state)
+			case "certified":
+				return sonobuoy.CertifiedConformance(ctx, &state)
+			default:
+				return fmt.Errorf("unsupported conformance mode %v", conformanceKubernetesCmdFlags.mode)
+			}
+		})
+	},
+}
+
+func init() {
+	conformanceKubernetesCmd.Flags().StringVar(&conformanceKubernetesCmdFlags.mode, "mode", "fast", "conformance test mode: [fast, certified]")
+	conformanceCmd.AddCommand(conformanceKubernetesCmd)
+	addCommand(conformanceCmd)
+}

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -67,9 +67,10 @@ function create_cluster {
     --provisioner "${PROVISIONER}" \
     --name "${CLUSTER_NAME}" \
     --masters=3 \
+    --workers="${QEMU_WORKERS:-1}" \
     --mtu 1450 \
     --memory 2048 \
-    --cpus 2.0 \
+    --cpus "${QEMU_CPUS:-2}" \
     --cidr 172.20.1.0/24 \
     --user-disk /var/lib/extra:100MB \
     --user-disk /var/lib/p1:100MB:/var/lib/p2:100MB \
@@ -91,7 +92,17 @@ function destroy_cluster() {
 }
 
 create_cluster
-get_kubeconfig
-run_talos_integration_test
-run_kubernetes_integration_test
+
+case "${TEST_MODE:-default}" in
+  fast-conformance)
+    run_kubernetes_conformance_test fast
+    ;;
+  *)
+    get_kubeconfig
+    run_talos_integration_test
+    run_kubernetes_integration_test
+    ;;
+esac
+
+
 destroy_cluster

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -169,6 +169,10 @@ function run_talos_integration_test_docker {
   "${INTEGRATION_TEST}" -test.v -talos.talosctlpath "${TALOSCTL}" -talos.kubectlpath "${KUBECTL}" -talos.k8sendpoint 127.0.0.1:6443 -talos.provisioner "${PROVISIONER}" -talos.name "${CLUSTER_NAME}" ${TEST_RUN} ${TEST_SHORT}
 }
 
+function run_kubernetes_conformance_test {
+  "${TALOSCTL}" conformance kubernetes --mode="${1}"
+}
+
 function run_kubernetes_integration_test {
   timeout=$(($(date +%s) + ${TIMEOUT}))
   until ${SONOBUOY} run \

--- a/pkg/cluster/sonobuoy/product.go
+++ b/pkg/cluster/sonobuoy/product.go
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package sonobuoy
+
+import "github.com/talos-systems/talos/pkg/version"
+
+type product struct {
+	Vendor           string `yaml:"vendor"`
+	Name             string `yaml:"name"`
+	Version          string `yaml:"version"`
+	WebsiteURL       string `yaml:"website_url"`
+	RepoURL          string `yaml:"repo_url"`
+	DocumentationURL string `yaml:"documentation_url"`
+	ProductLogoURL   string `yaml:"product_logo_url"`
+	Type             string `yaml:"type"`
+	Description      string `yaml:"description"`
+}
+
+var talos = product{
+	Vendor:           "Talos Systems",
+	Name:             "Talos",
+	Version:          version.Tag,
+	WebsiteURL:       "https://www.talos-systems.com",
+	RepoURL:          "https://github.com/talos-systems/talos",
+	DocumentationURL: "https://www.talos.dev",
+	ProductLogoURL:   "https://www.talos-systems.com/images/TalosSystems_Horizontal_Logo_FullColor_RGB-for-site.svg",
+	Type:             "installer",
+	Description:      "Talos is a modern Kubernetes-focused OS designed to be secure, immutable, and minimal.",
+}

--- a/website/content/docs/v0.10/Reference/cli.md
+++ b/website/content/docs/v0.10/Reference/cli.md
@@ -509,6 +509,58 @@ Manage the client configuration
 * [talosctl config merge](#talosctl-config-merge)	 - Merge additional contexts from another Talos config into the default config
 * [talosctl config node](#talosctl-config-node)	 - Set the node(s) for the current context
 
+## talosctl conformance kubernetes
+
+Run Kubernetes conformance tests
+
+```
+talosctl conformance kubernetes [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for kubernetes
+      --mode string   conformance test mode: [fast, certified] (default "fast")
+```
+
+### Options inherited from parent commands
+
+```
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
+```
+
+### SEE ALSO
+
+* [talosctl conformance](#talosctl-conformance)	 - Run conformance tests
+
+## talosctl conformance
+
+Run conformance tests
+
+### Options
+
+```
+  -h, --help   help for conformance
+```
+
+### Options inherited from parent commands
+
+```
+      --context string       Context to be used in command
+  -e, --endpoints strings    override default endpoints in Talos configuration
+  -n, --nodes strings        target the specified nodes
+      --talosconfig string   The path to the Talos configuration file (default "/home/user/.talos/config")
+```
+
+### SEE ALSO
+
+* [talosctl](#talosctl)	 - A CLI for out-of-band management of Kubernetes nodes created by Talos
+* [talosctl conformance kubernetes](#talosctl-conformance-kubernetes)	 - Run Kubernetes conformance tests
+
 ## talosctl containers
 
 List containers
@@ -2086,6 +2138,7 @@ A CLI for out-of-band management of Kubernetes nodes created by Talos
 * [talosctl cluster](#talosctl-cluster)	 - A collection of commands for managing local docker-based or firecracker-based clusters
 * [talosctl completion](#talosctl-completion)	 - Output shell completion code for the specified shell (bash or zsh)
 * [talosctl config](#talosctl-config)	 - Manage the client configuration
+* [talosctl conformance](#talosctl-conformance)	 - Run conformance tests
 * [talosctl containers](#talosctl-containers)	 - List containers
 * [talosctl convert-k8s](#talosctl-convert-k8s)	 - Convert Kubernetes control plane from self-hosted (bootkube) to Talos-managed (static pods).
 * [talosctl copy](#talosctl-copy)	 - Copy data out from the node


### PR DESCRIPTION
Command implements two modes:

* `fast`: conformance suite is run at maximum speed
* `certified`: conformance suite is run in serial mode, results
  are captured to produce artifacts ready for CNCF submission process

Fixes #3420

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
