### PR TITLE
feat: bump k8s version to 1.20.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ OPERATING_SYSTEM := $(shell uname -s | tr "[:upper:]" "[:lower:]")
 TALOSCTL_DEFAULT_TARGET := talosctl-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_DEFAULT_TARGET := integration-test-$(OPERATING_SYSTEM)
 INTEGRATION_TEST_PROVISION_DEFAULT_TARGET := integration-test-provision-$(OPERATING_SYSTEM)
-KUBECTL_URL ?= https://storage.googleapis.com/kubernetes-release/release/v1.20.5/bin/$(OPERATING_SYSTEM)/amd64/kubectl
+KUBECTL_URL ?= https://storage.googleapis.com/kubernetes-release/release/v1.20.6/bin/$(OPERATING_SYSTEM)/amd64/kubectl
 CLUSTERCTL_VERSION ?= 0.3.14
 CLUSTERCTL_URL ?= https://github.com/kubernetes-sigs/cluster-api/releases/download/v$(CLUSTERCTL_VERSION)/clusterctl-$(OPERATING_SYSTEM)-amd64
 SONOBUOY_VERSION ?= 0.19.0
 SONOBUOY_URL ?= https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_$(OPERATING_SYSTEM)_amd64.tar.gz
 TESTPKGS ?= github.com/talos-systems/talos/...
-RELEASES ?= v0.8.4 v0.9.0-alpha.5
+RELEASES ?= v0.8.4 v0.9.1
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
 

--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -27,7 +27,7 @@ export TALOS_VERSION=v0.9
 # Kubernetes
 
 export KUBECONFIG="${TMP}/kubeconfig"
-export K8S_VERSION=1.20.5
+export K8S_VERSION=1.20.6
 
 # Sonobuoy
 

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -71,11 +71,11 @@ type upgradeSpec struct {
 
 const (
 	previousRelease = "v0.8.4"
-	stableRelease   = "v0.9.0-alpha.5"
+	stableRelease   = "v0.9.1"
 
 	previousK8sVersion = "1.20.1"
-	stableK8sVersion   = "1.20.4"
-	currentK8sVersion  = "1.20.5"
+	stableK8sVersion   = "1.20.5"
+	currentK8sVersion  = "1.20.6"
 )
 
 var defaultNameservers = []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1")}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -185,7 +185,7 @@ const (
 	SystemKubeletPKIDir = "/system/secrets/kubelet"
 
 	// DefaultKubernetesVersion is the default target version of the control plane.
-	DefaultKubernetesVersion = "1.20.5"
+	DefaultKubernetesVersion = "1.20.6"
 
 	// DefaultControlPlanePort is the default port to use for the control plane.
 	DefaultControlPlanePort = 6443

--- a/website/content/docs/v0.9/Reference/cli.md
+++ b/website/content/docs/v0.9/Reference/cli.md
@@ -103,7 +103,7 @@ talosctl cluster create [flags]
       --ipv4                                    enable IPv4 network in the cluster (default true)
       --ipv6                                    enable IPv6 network in the cluster (QEMU provisioner only)
       --iso-path string                         the ISO path to use for the initial boot (VM only)
-      --kubernetes-version string               desired kubernetes version to run (default "1.20.5")
+      --kubernetes-version string               desired kubernetes version to run (default "1.20.6")
       --masters int                             the number of masters to create (default 1)
       --memory int                              the limit on memory usage in MB (each container/VM) (default 2048)
       --mtu int                                 MTU of the cluster network (default 1500)
@@ -1887,7 +1887,7 @@ talosctl upgrade-k8s [flags]
       --endpoint string   the cluster control plane endpoint
       --from string       the Kubernetes control plane version to upgrade from
   -h, --help              help for upgrade-k8s
-      --to string         the Kubernetes control plane version to upgrade to (default "1.20.5")
+      --to string         the Kubernetes control plane version to upgrade to (default "1.20.6")
 ```
 
 ### Options inherited from parent commands

--- a/website/content/docs/v0.9/Reference/configuration.md
+++ b/website/content/docs/v0.9/Reference/configuration.md
@@ -289,7 +289,7 @@ Examples:
 
 ``` yaml
 kubelet:
-    image: ghcr.io/talos-systems/kubelet:v1.20.5 # The `image` field is an optional reference to an alternative kubelet image.
+    image: ghcr.io/talos-systems/kubelet:v1.20.6 # The `image` field is an optional reference to an alternative kubelet image.
     # The `extraArgs` field is used to provide additional flags to the kubelet.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -938,7 +938,7 @@ Examples:
 
 ``` yaml
 apiServer:
-    image: k8s.gcr.io/kube-apiserver:v1.20.5 # The container image used in the API server manifest.
+    image: k8s.gcr.io/kube-apiserver:v1.20.6 # The container image used in the API server manifest.
     # Extra arguments to supply to the API server.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -970,7 +970,7 @@ Examples:
 
 ``` yaml
 controllerManager:
-    image: k8s.gcr.io/kube-controller-manager:v1.20.5 # The container image used in the controller manager manifest.
+    image: k8s.gcr.io/kube-controller-manager:v1.20.6 # The container image used in the controller manager manifest.
     # Extra arguments to supply to the controller manager.
     extraArgs:
         feature-gates: ServerSideApply=true
@@ -997,7 +997,7 @@ Examples:
 
 ``` yaml
 proxy:
-    image: k8s.gcr.io/kube-proxy:v1.20.5 # The container image used in the kube-proxy manifest.
+    image: k8s.gcr.io/kube-proxy:v1.20.6 # The container image used in the kube-proxy manifest.
     mode: ipvs # proxy mode of kube-proxy.
     # Extra arguments to supply to kube-proxy.
     extraArgs:
@@ -1025,7 +1025,7 @@ Examples:
 
 ``` yaml
 scheduler:
-    image: k8s.gcr.io/kube-scheduler:v1.20.5 # The container image used in the scheduler manifest.
+    image: k8s.gcr.io/kube-scheduler:v1.20.6 # The container image used in the scheduler manifest.
     # Extra arguments to supply to the scheduler.
     extraArgs:
         feature-gates: AllBeta=true
@@ -1229,7 +1229,7 @@ Appears in:
 
 
 ``` yaml
-image: ghcr.io/talos-systems/kubelet:v1.20.5 # The `image` field is an optional reference to an alternative kubelet image.
+image: ghcr.io/talos-systems/kubelet:v1.20.6 # The `image` field is an optional reference to an alternative kubelet image.
 # The `extraArgs` field is used to provide additional flags to the kubelet.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -1261,7 +1261,7 @@ Examples:
 
 
 ``` yaml
-image: ghcr.io/talos-systems/kubelet:v1.20.5
+image: ghcr.io/talos-systems/kubelet:v1.20.6
 ```
 
 
@@ -2054,7 +2054,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-apiserver:v1.20.5 # The container image used in the API server manifest.
+image: k8s.gcr.io/kube-apiserver:v1.20.6 # The container image used in the API server manifest.
 # Extra arguments to supply to the API server.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -2082,7 +2082,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-apiserver:v1.20.5
+image: k8s.gcr.io/kube-apiserver:v1.20.6
 ```
 
 
@@ -2143,7 +2143,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-controller-manager:v1.20.5 # The container image used in the controller manager manifest.
+image: k8s.gcr.io/kube-controller-manager:v1.20.6 # The container image used in the controller manager manifest.
 # Extra arguments to supply to the controller manager.
 extraArgs:
     feature-gates: ServerSideApply=true
@@ -2166,7 +2166,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-controller-manager:v1.20.5
+image: k8s.gcr.io/kube-controller-manager:v1.20.6
 ```
 
 
@@ -2214,7 +2214,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-proxy:v1.20.5 # The container image used in the kube-proxy manifest.
+image: k8s.gcr.io/kube-proxy:v1.20.6 # The container image used in the kube-proxy manifest.
 mode: ipvs # proxy mode of kube-proxy.
 # Extra arguments to supply to kube-proxy.
 extraArgs:
@@ -2261,7 +2261,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-proxy:v1.20.5
+image: k8s.gcr.io/kube-proxy:v1.20.6
 ```
 
 
@@ -2310,7 +2310,7 @@ Appears in:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-scheduler:v1.20.5 # The container image used in the scheduler manifest.
+image: k8s.gcr.io/kube-scheduler:v1.20.6 # The container image used in the scheduler manifest.
 # Extra arguments to supply to the scheduler.
 extraArgs:
     feature-gates: AllBeta=true
@@ -2333,7 +2333,7 @@ Examples:
 
 
 ``` yaml
-image: k8s.gcr.io/kube-scheduler:v1.20.5
+image: k8s.gcr.io/kube-scheduler:v1.20.6
 ```
 
 


### PR DESCRIPTION
This PR brings in a newer version of 1.20.x to make sure we're not
shipping with https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#cve-2021-25735-validating-admission-webhook-does-not-observe-some-previous-fields

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>