### PR TITLE
chore: use REGISTRY_MIRROR_FLAGS if defined

### DIFF
--- a/hack/test/e2e.sh
+++ b/hack/test/e2e.sh
@@ -221,6 +221,7 @@ function build_registry_mirrors {
       REGISTRY_MIRROR_FLAGS="${REGISTRY_MIRROR_FLAGS} --registry-mirror ${registry}=http://${addr}:5000"
     done
   else
-    REGISTRY_MIRROR_FLAGS=
+    # use the value from the environment, if present
+    REGISTRY_MIRROR_FLAGS=${REGISTRY_MIRROR_FLAGS:-}
   fi
 }


### PR DESCRIPTION
REGISTRY_MIRROR_FLAGS can be already defined in the environment with .env or .envrc file.
Use it for easier and faster local e2e tests.
