### PR TITLE
add WithRegistryCaCert

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/generate/options.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/options.go
@@ -79,6 +79,27 @@ func WithRegistryMirror(host string, endpoints ...string) GenOption {
 	}
 }
 
+// WithRegistryCACert specifies the certificate of the certificate authority which signed certificate of the registry.
+func WithRegistryCACert(host, cacert string) GenOption {
+	return func(o *GenOptions) error {
+		if o.RegistryConfig == nil {
+			o.RegistryConfig = make(map[string]*v1alpha1.RegistryConfig)
+		}
+
+		if _, ok := o.RegistryConfig[host]; !ok {
+			o.RegistryConfig[host] = &v1alpha1.RegistryConfig{}
+		}
+
+		if o.RegistryConfig[host].RegistryTLS == nil {
+			o.RegistryConfig[host].RegistryTLS = &v1alpha1.RegistryTLSConfig{}
+		}
+
+		o.RegistryConfig[host].RegistryTLS.TLSCA = v1alpha1.Base64Bytes(cacert)
+
+		return nil
+	}
+}
+
 // WithRegistryInsecureSkipVerify marks registry host to skip TLS verification.
 func WithRegistryInsecureSkipVerify(host string) GenOption {
 	return func(o *GenOptions) error {


### PR DESCRIPTION
# Pull Request

As we discussed in Slack, I added new function for the registry CA cert.
Based on my tests, CA cert is created with proper content, however, I suspect just another containerd bug because CA seems to be not in use at all even if containerd.tmpl file also has proper content.

## What? (description)

golang API to add custom CA certificate for registries.

## Why? (reasoning)

We use docker registries with self-signed certificates. Already implemented "insecure_skip_verify" option is buggy in containerd.
Related containerd issue in github: https://github.com/containerd/containerd/issues/5079

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [X] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
