### PR TITLE
fix: check if OVF env is empty

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -73,6 +73,12 @@ func readConfigFromOvf(extraConfig *rpcvmx.Config, key string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to unmarshall XML from OVF env: %w", err)
 	}
 
+	if ovfEnv.Property == nil || ovfEnv.Property.Properties == nil { // no data in OVF env
+		log.Printf("empty OVF env")
+
+		return nil, nil
+	}
+
 	log.Printf("searching for property '%s' in OVF", key)
 
 	for _, property := range ovfEnv.Property.Properties { // iterate to check if our key is present


### PR DESCRIPTION
# Pull Request

## What? (description)
This introduces a check if the VMWare OVF environment is empty, so the code does not die if it is.

## Why? (reasoning)
To get the OVA working without OVF env vars. See #3513

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
