### PR TITLE
fix: update osType in OVA other3xLinux64Guest"

### DIFF
--- a/cmd/installer/pkg/ova/ova.go
+++ b/cmd/installer/pkg/ova/ova.go
@@ -48,7 +48,7 @@ const ovfTpl = `<?xml version="1.0" encoding="UTF-8"?>
   <VirtualSystem ovf:id="vm">
     <Info>A virtual machine</Info>
     <Name>talos</Name>
-    <OperatingSystemSection ovf:id="101" vmw:osType="otherLinux64Guest">
+    <OperatingSystemSection ovf:id="101" vmw:osType="other3xLinux64Guest">
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>
     <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">


### PR DESCRIPTION
# Pull Request

## What? (description)
This changes the osType field in the ova to `other3xLinux64Guest` in order to have VMware accept it when deploying manually.

## Why? (reasoning)
To be able to deploy the OVA directly into the vSphere HTML UI. See #3515.

## Acceptance

Please use the following checklist:

- [X] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`)
- [X] you formatted your code (`make fmt`)
- [X] you linted your code (`make lint`)
- [X] you generated documentation (`make docs`)
- [X] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
