### PR TITLE
docs: add Matrix room links

### DIFF
--- a/website/content/docs/v0.10/index.md
+++ b/website/content/docs/v0.10/index.md
@@ -8,6 +8,9 @@ title: Welcome
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Matrix: Join our Matrix channels:
+  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
+  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/talos-systems.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/talossystems)

--- a/website/content/docs/v0.11/index.md
+++ b/website/content/docs/v0.11/index.md
@@ -8,6 +8,9 @@ title: Welcome
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Matrix: Join our Matrix channels:
+  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
+  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/talos-systems.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/talossystems)

--- a/website/content/docs/v0.9/index.md
+++ b/website/content/docs/v0.9/index.md
@@ -8,6 +8,9 @@ title: Welcome
 
 - GitHub: [repo](https://github.com/talos-systems/talos)
 - Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Matrix: Join our Matrix channels:
+  - Community: [#talos:matrix.org](https://matrix.to/#/#talos:matrix.org)
+  - Support: [#talos-support:matrix.org](https://matrix.to/#/#talos-support:matrix.org)
 - Support: Questions, bugs, feature requests [GitHub Discussions](https://github.com/talos-systems/talos/discussions)
 - Forum: [community](https://groups.google.com/a/talos-systems.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/talossystems)


### PR DESCRIPTION
Add links to the Talos Matrix rooms (which are themselves linked to the
corresponding Slack channels).
