### PR TITLE
docs: update cloud images for Talos v0.9.3

### DIFF
--- a/website/src/data/cloud-images.json
+++ b/website/src/data/cloud-images.json
@@ -489,250 +489,290 @@
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
+    "region": "us-east-2",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-091ec45dfbcfee3e0"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-south-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-07a8f297eb1a122bb"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-south-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0a26ca9557581ab4d"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-south-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0969d9c2051b96e58"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ca-central-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-0ee3fb21fa8460fe1"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-south-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-04c5558fabe7ac261"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
     "region": "ca-central-1",
     "arch": "arm64",
     "type": "hvm",
-    "id": "ami-02367c867f252f431"
+    "id": "ami-028fdd24d0f5cd6fe"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "us-east-2",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0fa15b54ffd448e69"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
     "region": "us-east-1",
     "arch": "amd64",
     "type": "hvm",
-    "id": "ami-05cdaf5837708ba49"
+    "id": "ami-06d5ea91e8430e0b2"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "us-east-2",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-00d8edce31c41f6b9"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-west-3",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0f89a6acf962b9a84"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-west-2",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0ab3228c2442d962f"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-west-3",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-029421a3e62583302"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-central-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-06405c65400d7af5a"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-central-1",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-0f8201c9cea4ab3cd"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-west-2",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-01ba16616a5c8eea2"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-west-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0edc0bedb38550778"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "us-west-2",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-0abd696737a82caa9"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-north-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0dce80f5550ebe8b4"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-north-1",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-0e412c3e893e601d6"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "eu-west-1",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-07ab00ad86efe59d8"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "us-west-1",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-07f4c25029d96d4a0"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "us-west-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-053dc722d046347d7"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "sa-east-1",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-0116f8912d253cb1d"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-northeast-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-063285d29bedf0a6a"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "sa-east-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-051cc3eff0981dc23"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-northeast-2",
-    "arch": "arm64",
-    "type": "hvm",
-    "id": "ami-07568dc427ce24aa6"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-southeast-1",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0bc7f51e55b9562d1"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
     "region": "us-east-1",
     "arch": "arm64",
     "type": "hvm",
-    "id": "ami-06c89f4e127c9803d"
+    "id": "ami-0db57fa9429bc2e10"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-southeast-2",
-    "arch": "amd64",
-    "type": "hvm",
-    "id": "ami-0f192c8ebfea24c3d"
-  },
-  {
-    "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-southeast-1",
+    "version": "v0.9.3",
+    "region": "us-east-2",
     "arch": "arm64",
     "type": "hvm",
-    "id": "ami-0088f1112127d593d"
+    "id": "ami-050decc665180623c"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-northeast-2",
+    "version": "v0.9.3",
+    "region": "eu-central-1",
     "arch": "amd64",
     "type": "hvm",
-    "id": "ami-0e9544704321f1239"
+    "id": "ami-0a9bb10f7ba4005be"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
-    "region": "ap-southeast-2",
+    "version": "v0.9.3",
+    "region": "us-west-2",
     "arch": "arm64",
     "type": "hvm",
-    "id": "ami-063a56a0a91169927"
+    "id": "ami-0d44b1382afc4aec2"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
     "region": "us-west-2",
     "arch": "amd64",
     "type": "hvm",
-    "id": "ami-016466266f3fc6117"
+    "id": "ami-03eb72de1cff1b3a6"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
+    "region": "eu-central-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-04b43d959dea94867"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-west-2",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-07905ee641b8c9707"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-north-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-0aac2b7f6e6e4165f"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-west-2",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0146a0771fcbc363c"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-west-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-0b48cec54894a4761"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-north-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0efa72d5b08842537"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-west-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0cba23676c5b1387d"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "us-west-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-09717b6de2278709c"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "us-west-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-034413bd243951981"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "eu-west-3",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0b89c25cf3e114987"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
     "region": "ap-northeast-3",
     "arch": "amd64",
     "type": "hvm",
-    "id": "ami-021c4a4a7f3e1318c"
+    "id": "ami-0f25b8442937c089c"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
+    "region": "eu-west-3",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-090aba34b01a2a6b8"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
     "region": "ap-northeast-3",
     "arch": "arm64",
     "type": "hvm",
-    "id": "ami-0aa209fb78f6bf352"
+    "id": "ami-0456217d630aaef50"
   },
   {
     "cloud": "aws",
-    "version": "v0.9.0",
+    "version": "v0.9.3",
+    "region": "sa-east-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-0f97b01b268404c33"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "sa-east-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0bd7760952404d288"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-northeast-2",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-0130fdee881df448b"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-northeast-2",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0598fbe460580cbd2"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-southeast-2",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-026ea2c8016fc368a"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-southeast-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-018077171e5ece3fb"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-southeast-2",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-008e873a2cff0e1dd"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-northeast-1",
+    "arch": "amd64",
+    "type": "hvm",
+    "id": "ami-025b1033e7e6516d0"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
     "region": "ap-northeast-1",
     "arch": "arm64",
     "type": "hvm",
-    "id": "ami-0a51cb31d3f7a6160"
+    "id": "ami-075b312f396ebe8cc"
+  },
+  {
+    "cloud": "aws",
+    "version": "v0.9.3",
+    "region": "ap-southeast-1",
+    "arch": "arm64",
+    "type": "hvm",
+    "id": "ami-0d82959d393ff3d08"
   }
 ]


### PR DESCRIPTION
Replaces AWS images with the latest 0.9.3, as 0.9.2/0.9.1 contain many
important fixes vs. 0.9.0 release we have today.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
