### PR TITLE
fix: use both self-signed and Kubernetes CA to verify Kubelet cert

### DIFF
--- a/pkg/kubernetes/kubelet/kubelet.go
+++ b/pkg/kubernetes/kubelet/kubelet.go
@@ -51,7 +51,7 @@ func NewClient(clientCert, clientKey, caPEM []byte) (*Client, error) {
 
 	kubeletCert, err := ioutil.ReadFile(filepath.Join(constants.KubeletPKIDir, "kubelet.crt"))
 	if err == nil {
-		config.CAData = kubeletCert
+		config.CAData = append(config.CAData, kubeletCert...)
 	} else if err != nil {
 		// ignore if file doesn't exist, assume cert isn't self-signed
 		if !os.IsNotExist(err) {


### PR DESCRIPTION
Kubelet might be running either self-signed cert (by default) or API
server issued cert (signed by the CA). User might switch between the two
methods, so instead of guessing based on filesystem contents, accept
both Kubernetes CA and self-signed cert (if available).

Spotted by @aceat64

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

