### PR TITLE
feat: add `--config-patch` flag by node type

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -105,6 +105,8 @@ var (
 	encryptEphemeralPartition bool
 	useVIP                    bool
 	configPatch               string
+	configPatchControlPlane   string
+	configPatchJoin           string
 )
 
 // createCmd represents the cluster up command.
@@ -414,16 +416,34 @@ func create(ctx context.Context) (err error) {
 		)
 	}
 
-	var jsonPatch jsonpatch.Patch
+	addConfigPatch := func(configPatch string, configOpt func(jsonpatch.Patch) bundle.Option) error {
+		if configPatch == "" {
+			return nil
+		}
 
-	if configPatch != "" {
+		var jsonPatch jsonpatch.Patch
+
 		jsonPatch, err = jsonpatch.DecodePatch([]byte(configPatch))
 		if err != nil {
 			return fmt.Errorf("error parsing config JSON patch: %w", err)
 		}
+
+		configBundleOpts = append(configBundleOpts, configOpt(jsonPatch))
+
+		return nil
 	}
 
-	configBundleOpts = append(configBundleOpts, bundle.WithJSONPatch(jsonPatch))
+	if err = addConfigPatch(configPatch, bundle.WithJSONPatch); err != nil {
+		return err
+	}
+
+	if err = addConfigPatch(configPatchControlPlane, bundle.WithJSONPatchControlPlane); err != nil {
+		return err
+	}
+
+	if err = addConfigPatch(configPatchJoin, bundle.WithJSONPatchJoin); err != nil {
+		return err
+	}
 
 	configBundle, err := bundle.NewConfigBundle(configBundleOpts...)
 	if err != nil {
@@ -786,6 +806,8 @@ func init() {
 	createCmd.Flags().BoolVar(&encryptEphemeralPartition, "encrypt-ephemeral", false, "enable ephemeral partition encryption")
 	createCmd.Flags().StringVar(&talosVersion, "talos-version", "", "the desired Talos version to generate config for (if not set, defaults to image version)")
 	createCmd.Flags().BoolVar(&useVIP, "use-vip", false, "use a virtual IP for the controlplane endpoint instead of the loadbalancer")
-	createCmd.Flags().StringVar(&configPatch, "config-patch", "", "patch generated machineconfigs")
+	createCmd.Flags().StringVar(&configPatch, "config-patch", "", "patch generated machineconfigs (applied to all node types)")
+	createCmd.Flags().StringVar(&configPatchControlPlane, "config-patch-control-plane", "", "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")
+	createCmd.Flags().StringVar(&configPatchJoin, "config-patch-join", "", "patch generated machineconfigs (applied to 'join' type)")
 	Cmd.AddCommand(createCmd)
 }

--- a/pkg/machinery/config/types/v1alpha1/bundle/options.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/options.go
@@ -26,7 +26,10 @@ type Options struct {
 	ExistingConfigs string // path to existing config files
 	Verbose         bool   // wheither to write any logs during generate
 	InputOptions    *InputOptions
-	JSONPatch       jsonpatch.Patch
+
+	JSONPatch             jsonpatch.Patch
+	JSONPatchControlPlane jsonpatch.Patch
+	JSONPatchJoin         jsonpatch.Patch
 }
 
 // DefaultOptions returns default options.
@@ -67,6 +70,24 @@ func WithVerbose(verbose bool) Option {
 func WithJSONPatch(patch jsonpatch.Patch) Option {
 	return func(o *Options) error {
 		o.JSONPatch = append(o.JSONPatch, patch...)
+
+		return nil
+	}
+}
+
+// WithJSONPatchControlPlane allows patching init and controlplane config in a bundle with a patch.
+func WithJSONPatchControlPlane(patch jsonpatch.Patch) Option {
+	return func(o *Options) error {
+		o.JSONPatchControlPlane = append(o.JSONPatchControlPlane, patch...)
+
+		return nil
+	}
+}
+
+// WithJSONPatchJoin allows patching join (worker) config in a bundle with a patch.
+func WithJSONPatchJoin(patch jsonpatch.Patch) Option {
+	return func(o *Options) error {
+		o.JSONPatchJoin = append(o.JSONPatchJoin, patch...)
 
 		return nil
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_configurator_bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_configurator_bundle.go
@@ -89,7 +89,7 @@ func (c *ConfigBundle) Write(outputDir string, commentsFlags encoder.CommentsFla
 }
 
 // ApplyJSONPatch patches every config type with a patch.
-func (c *ConfigBundle) ApplyJSONPatch(patch jsonpatch.Patch) error {
+func (c *ConfigBundle) ApplyJSONPatch(patch jsonpatch.Patch, patchControlPlane, patchJoin bool) error {
 	if len(patch) == 0 {
 		return nil
 	}
@@ -117,19 +117,23 @@ func (c *ConfigBundle) ApplyJSONPatch(patch jsonpatch.Patch) error {
 
 	var err error
 
-	c.InitCfg, err = apply(c.InitCfg)
-	if err != nil {
-		return err
+	if patchControlPlane {
+		c.InitCfg, err = apply(c.InitCfg)
+		if err != nil {
+			return err
+		}
+
+		c.ControlPlaneCfg, err = apply(c.ControlPlaneCfg)
+		if err != nil {
+			return err
+		}
 	}
 
-	c.ControlPlaneCfg, err = apply(c.ControlPlaneCfg)
-	if err != nil {
-		return err
-	}
-
-	c.JoinCfg, err = apply(c.JoinCfg)
-	if err != nil {
-		return err
+	if patchJoin {
+		c.JoinCfg, err = apply(c.JoinCfg)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/website/content/docs/v0.11/Reference/cli.md
+++ b/website/content/docs/v0.11/Reference/cli.md
@@ -95,7 +95,9 @@ talosctl cluster create [flags]
       --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.10.0-alpha.2/talosctl-cni-bundle-${ARCH}.tar.gz")
       --cni-cache-dir string                    CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
       --cni-conf-dir string                     CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
-      --config-patch string                     patch generated machineconfigs
+      --config-patch string                     patch generated machineconfigs (applied to all node types)
+      --config-patch-control-plane string       patch generated machineconfigs (applied to 'init' and 'controlplane' types)
+      --config-patch-join string                patch generated machineconfigs (applied to 'join' type)
       --cpus string                             the share of CPUs as fraction (each container/VM) (default "2.0")
       --crashdump                               print debug crashdump to stderr when cluster startup fails
       --custom-cni-url string                   install custom CNI from the URL (Talos cluster)
@@ -1080,20 +1082,22 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
 ### Options
 
 ```
-      --additional-sans strings     additional Subject-Alt-Names for the APIServer certificate
-      --config-patch string         patch generated machineconfigs
-      --dns-domain string           the dns domain to use for cluster (default "cluster.local")
-  -h, --help                        help for config
-      --install-disk string         the disk to install to (default "/dev/sda")
-      --install-image string        the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
-      --kubernetes-version string   desired kubernetes version to run
-  -o, --output-dir string           destination to output generated files
-  -p, --persist                     the desired persist value for configs (default true)
-      --registry-mirror strings     list of registry mirrors to use in format: <registry host>=<mirror URL>
-      --talos-version string        the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
-      --version string              the desired machine config version to generate (default "v1alpha1")
-      --with-docs                   renders all machine configs adding the documentation for each field (default true)
-      --with-examples               renders all machine configs with the commented examples (default true)
+      --additional-sans strings             additional Subject-Alt-Names for the APIServer certificate
+      --config-patch string                 patch generated machineconfigs (applied to all node types)
+      --config-patch-control-plane string   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
+      --config-patch-join string            patch generated machineconfigs (applied to 'join' type)
+      --dns-domain string                   the dns domain to use for cluster (default "cluster.local")
+  -h, --help                                help for config
+      --install-disk string                 the disk to install to (default "/dev/sda")
+      --install-image string                the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
+      --kubernetes-version string           desired kubernetes version to run
+  -o, --output-dir string                   destination to output generated files
+  -p, --persist                             the desired persist value for configs (default true)
+      --registry-mirror strings             list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --talos-version string                the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
+      --version string                      the desired machine config version to generate (default "v1alpha1")
+      --with-docs                           renders all machine configs adding the documentation for each field (default true)
+      --with-examples                       renders all machine configs with the commented examples (default true)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
The problem is that some patches can't be applied to join config, as
some nodes don't even exist in the config, for example
`/cluster/apiServer` node, and applying such patches doesn't make any
sense.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
