### PR TITLE
docs: update redirects to Talos 0.10

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -2,5 +2,5 @@
 #
 # The Netlify documentation says that the following redirect rules are
 # equivalent, but that is not what is observed in practice.
-/docs/latest /docs/v0.9
-/docs/latest/ /docs/v0.9
+/docs/latest /docs/v0.10
+/docs/latest/ /docs/v0.10


### PR DESCRIPTION
Our latest version should be 0.10 now.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

