### PR TITLE
WIP: add Pine64 SBC support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0
-PKGS ?= v0.5.0-3-gb56f36b
+PKGS ?= v0.5.0-4-gde9c582
 EXTRAS ?= v0.3.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0
@@ -205,7 +205,7 @@ image-%: ## Builds the specified image. Valid options are aws, azure, digital-oc
 
 images: image-aws image-azure image-digital-ocean image-gcp image-metal image-openstack image-vmware ## Builds all known images (AWS, Azure, DigitalOcean, GCP, Metal, Openstack, and VMware).
 
-sbc-%: ## Builds the specified SBC image. Valid options are rpi_4, rock64, bananapi_m64, libretech_all_h3_cc_h5, and rockpi_4 (e.g. sbc-rpi_4)
+sbc-%: ## Builds the specified SBC image. Valid options are rpi_4, rock64, bananapi_m64, libretech_all_h3_cc_h5, rockpi_4 and pine64 (e.g. sbc-rpi_4)
 	@docker pull $(REGISTRY_AND_USERNAME)/installer:$(TAG)
 	@docker run --rm -v /dev:/dev --privileged $(REGISTRY_AND_USERNAME)/installer:$(TAG) image --platform metal --arch arm64 --board $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/board.go
@@ -14,6 +14,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	bananapim64 "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board/bananapi_m64"
 	libretechallh3cch5 "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board/libretech_all_h3_cc_h5"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board/pine64"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rock64"
 	rockpi4 "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rockpi4"
 	rpi4 "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4"
@@ -52,6 +53,8 @@ func newBoard(board string) (b runtime.Board, err error) {
 		b = &rpi4.RPi4{}
 	case constants.BoardBananaPiM64:
 		b = &bananapim64.BananaPiM64{}
+	case constants.BoardPine64:
+		b = &pine64.Pine64{}
 	case constants.BoardRock64:
 		b = &rock64.Rock64{}
 	case constants.BoardRockpi4:

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/pine64/pine64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/pine64/pine64.go
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package pine64
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/talos-systems/go-procfs/procfs"
+	"golang.org/x/sys/unix"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/copy"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+)
+
+var (
+	bin       = fmt.Sprintf("/usr/install/u-boot/%s/u-boot-sunxi-with-spl.bin", constants.BoardPine64)
+	off int64 = 1024 * 8
+	dtb       = "/dtb/allwinner/sun50i-a64-pine64-plus.dtb"
+)
+
+// Pine64 represents the Pine64 board
+//
+// References:
+//	- http://linux-sunxi.org/Pine64
+type Pine64 struct{}
+
+// Name implements the runtime.Board.
+func (b *Pine64) Name() string {
+	return constants.BoardBananaPiM64
+}
+
+// Install implements the runtime.Board.
+func (b Pine64) Install(disk string) (err error) {
+	var f *os.File
+
+	if f, err = os.OpenFile(disk, os.O_RDWR|unix.O_CLOEXEC, 0o666); err != nil {
+		return err
+	}
+	//nolint:errcheck
+	defer f.Close()
+
+	var uboot []byte
+
+	uboot, err = ioutil.ReadFile(bin)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("writing %s at offset %d", bin, off)
+
+	var n int
+
+	n, err = f.WriteAt(uboot, off)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("wrote %d bytes", n)
+
+	// NB: In the case that the block device is a loopback device, we sync here
+	// to esure that the file is written before the loopback device is
+	// unmounted.
+	err = f.Sync()
+	if err != nil {
+		return err
+	}
+
+	src := "/usr/install" + dtb
+	dst := "/boot/EFI" + dtb
+
+	err = os.MkdirAll(filepath.Dir(dst), 0o600)
+	if err != nil {
+		return err
+	}
+
+	err = copy.File(src, dst)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// KernelArgs implements the runtime.Board.
+func (b Pine64) KernelArgs() procfs.Parameters {
+	return []*procfs.Parameter{
+		procfs.NewParameter("console").Append("tty0").Append("ttyS0,115200"),
+	}
+}
+
+// PartitionOptions implements the runtime.Board.
+func (b Pine64) PartitionOptions() *runtime.PartitionOptions {
+	return &runtime.PartitionOptions{PartitionsOffset: 2048}
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -43,6 +43,9 @@ const (
 	// BoardBananaPiM64 is the  name of the Banana Pi M64.
 	BoardBananaPiM64 = "bananapi_m64"
 
+	// BoardPine64 is the  name of the Pine64 Rock64.
+	BoardPine64 = "pine64"
+
 	// BoardRock64 is the  name of the Pine64 Rock64.
 	BoardRock64 = "rock64"
 

--- a/website/content/docs/v0.11/Single Board Computers/pine64.md
+++ b/website/content/docs/v0.11/Single Board Computers/pine64.md
@@ -1,0 +1,57 @@
+---
+title: "Pine64"
+description: "Installing Talos on a Pine64 SBC using raw disk image."
+---
+
+## Prerequisites
+
+You will need
+
+- `talosctl`
+- an SD card
+
+Download the latest alpha `talosctl`.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+## Download the Image
+
+Download the image and decompress it:
+
+```bash
+curl -LO https://github.com/talos-systems/talos/releases/latest/download/metal-pine64-arm64.img.xz
+xz -d metal-pine64-arm64.img.xz
+```
+
+## Writing the Image
+
+The path to your SD card can be found using `fdisk` on Linux or `diskutil` on macOS.
+In this example, we will assume `/dev/mmcblk0`.
+
+Now `dd` the image to your SD card:
+
+```bash
+sudo dd if=metal-pine64-arm64.img of=/dev/mmcblk0 conv=fsync bs=4M
+```
+
+## Bootstrapping the Node
+
+Insert the SD card to your board, turn it on and wait for the console to show you the instructions for bootstrapping the node.
+Following the instructions in the console output to connect to the interactive installer:
+
+```bash
+talosctl apply-config --insecure --interactive --nodes <node IP or DNS name>
+```
+
+Once the interactive installation is applied, the cluster will form and you can then use `kubectl`.
+
+## Retrieve the `kubeconfig`
+
+Retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl kubeconfig
+```


### PR DESCRIPTION
# Pull Request

## What? (description)

This PR adds support for the Pine64 and Pine64+ SBC.

## Why? (reasoning)

My Pine64 SBC really needs Talos. And Talos needs even more SBC support

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
