### PR TITLE
feat: add USB serial drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0
-PKGS ?= v0.5.0-4-gde9c582
+PKGS ?= v0.5.0-5-g350aa6f
 EXTRAS ?= v0.3.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0


### PR DESCRIPTION
# Pull Request

## What? (description)
This commit adds support for:
- PL2303
- CP210x
- CH341
- FTDI SIO

## Why? (reasoning)
I'd like to use Talos to measure utilities (water, energy) in my home.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
