### PR TITLE
Repair pine64 support

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -538,6 +538,7 @@ local release = {
       '_out/metal-rpi_4-arm64.img.xz',
       '_out/metal-rockpi_4-arm64.img.xz',
       '_out/metal-rock64-arm64.img.xz',
+      '_out/metal-pine64-arm64.img.xz',
       '_out/metal-bananapi_m64-arm64.img.xz',
       '_out/metal-libretech_all_h3_cc_h5-arm64.img.xz',
       '_out/openstack-amd64.tar.gz',

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ sbc-%: ## Builds the specified SBC image. Valid options are rpi_4, rock64, banan
 	@docker pull $(REGISTRY_AND_USERNAME)/installer:$(TAG)
 	@docker run --rm -v /dev:/dev --privileged $(REGISTRY_AND_USERNAME)/installer:$(TAG) image --platform metal --arch arm64 --board $* --tar-to-stdout | tar xz -C $(ARTIFACTS)
 
-sbcs: sbc-rpi_4 sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 sbc-rockpi_4 ## Builds all known SBC images (Raspberry Pi 4 Model B, Rock64, Banana Pi M64, Radxa ROCK Pi 4, and Libre Computer Board ALL-H3-CC).
+sbcs: sbc-rpi_4 sbc-rock64 sbc-bananapi_m64 sbc-libretech_all_h3_cc_h5 sbc-rockpi_4 sbc-pine64 ## Builds all known SBC images (Raspberry Pi 4 Model B, Rock64, Banana Pi M64, Radxa ROCK Pi 4, pine64, and Libre Computer Board ALL-H3-CC).
 
 .PHONY: iso
 iso: ## Builds the ISO and outputs it to the artifact directory.

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/pine64/pine64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/pine64/pine64.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	bin       = fmt.Sprintf("/usr/install/u-boot/%s/u-boot-sunxi-with-spl.bin", constants.BoardPine64)
+	bin       = fmt.Sprintf("usr/install/arm64/u-boot/%s/u-boot-sunxi-with-spl.bin", constants.BoardPine64)
 	off int64 = 1024 * 8
 	dtb       = "/dtb/allwinner/sun50i-a64-pine64-plus.dtb"
 )
@@ -33,7 +33,7 @@ type Pine64 struct{}
 
 // Name implements the runtime.Board.
 func (b *Pine64) Name() string {
-	return constants.BoardBananaPiM64
+	return constants.BoardPine64
 }
 
 // Install implements the runtime.Board.
@@ -72,7 +72,7 @@ func (b Pine64) Install(disk string) (err error) {
 		return err
 	}
 
-	src := "/usr/install" + dtb
+	src := "/usr/install/arm64" + dtb
 	dst := "/boot/EFI" + dtb
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -43,10 +43,10 @@ const (
 	// BoardBananaPiM64 is the  name of the Banana Pi M64.
 	BoardBananaPiM64 = "bananapi_m64"
 
-	// BoardPine64 is the  name of the Pine64 Rock64.
+	// BoardPine64 is the  name of the Pine64.
 	BoardPine64 = "pine64"
 
-	// BoardRock64 is the  name of the Pine64 Rock64.
+	// BoardRock64 is the  name of the Rock64.
 	BoardRock64 = "rock64"
 
 	// BoardRockpi4 is the name of the Radxa Rock pi 4.


### PR DESCRIPTION
# Pull Request

Apparantly, I submitted non working Pine64 support earlier in #3559. I messed up my git checkout and pushed the wrong branch. Also, the board was not included in `sbcs` make target or Drone CI. This commit fixes all these things. 

## Why? (reasoning)

Without this commit, there is non functioning pine64 support

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)
