### PR TITLE
feat: static pods improvements

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
 	v1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -261,6 +262,12 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 								ReadOnly:  true,
 							},
 						}, volumeMounts(cfg.ExtraVolumes)...),
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    apiresource.MustParse("200m"),
+								v1.ResourceMemory: apiresource.MustParse("512Mi"),
+							},
+						},
 					},
 				},
 				HostNetwork: true,
@@ -348,12 +355,19 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 						LivenessProbe: &v1.Probe{
 							Handler: v1.Handler{
 								HTTPGet: &v1.HTTPGetAction{
-									Path: "/healthz",
-									Port: intstr.FromInt(10252),
+									Path:   "/healthz",
+									Port:   intstr.FromInt(10257),
+									Scheme: v1.URISchemeHTTPS,
 								},
 							},
 							InitialDelaySeconds: 15,
 							TimeoutSeconds:      15,
+						},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    apiresource.MustParse("50m"),
+								v1.ResourceMemory: apiresource.MustParse("256Mi"),
+							},
 						},
 					},
 				},
@@ -430,12 +444,19 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 						LivenessProbe: &v1.Probe{
 							Handler: v1.Handler{
 								HTTPGet: &v1.HTTPGetAction{
-									Path: "/healthz",
-									Port: intstr.FromInt(10251),
+									Path:   "/healthz",
+									Port:   intstr.FromInt(10259),
+									Scheme: v1.URISchemeHTTPS,
 								},
 							},
 							InitialDelaySeconds: 15,
 							TimeoutSeconds:      15,
+						},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    apiresource.MustParse("10m"),
+								v1.ResourceMemory: apiresource.MustParse("64Mi"),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Static pods changes 

- switch livenessProbe to ssl port
- add request resources

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

Cannot disable insecure ports, livenessProbe will fail

## Why? (reasoning)

By security reason, we can close ports 10251, 10252 (--port=0 extraArgs param)
Add requests resources to static pods (#3562).
 
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
