### PR TITLE
fix: avoid data race on CRI pod stop

### DIFF
--- a/internal/pkg/cri/pods.go
+++ b/internal/pkg/cri/pods.go
@@ -185,21 +185,21 @@ func stopAndRemove(ctx context.Context, stopAction StopAction, client *Client, p
 			log.Printf("%s container %s/%s:%s", action, pod.Metadata.Namespace, pod.Metadata.Name, container.Metadata.Name)
 
 			// TODO(andrewrynhard): Can we set the timeout dynamically?
-			if err = client.StopContainer(ctx, container.Id, 30); err != nil {
-				if grpcstatus.Code(err) == codes.NotFound {
+			if criErr := client.StopContainer(ctx, container.Id, 30); criErr != nil {
+				if grpcstatus.Code(criErr) == codes.NotFound {
 					return nil
 				}
 
-				return err
+				return criErr
 			}
 
 			if stopAction == StopAndRemove {
-				if err = client.RemoveContainer(ctx, container.Id); err != nil {
-					if grpcstatus.Code(err) == codes.NotFound {
+				if criErr := client.RemoveContainer(ctx, container.Id); criErr != nil {
+					if grpcstatus.Code(criErr) == codes.NotFound {
 						return nil
 					}
 
-					return err
+					return criErr
 				}
 			}
 


### PR DESCRIPTION
Message:

```
WARNING: DATA RACE
Write at 0x00c000a9d4d0 by goroutine 154:
  github.com/talos-systems/talos/internal/pkg/cri.stopAndRemove.func1()
      /src/internal/pkg/cri/pods.go:188 +0x312
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /.cache/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Previous write at 0x00c000a9d4d0 by goroutine 276:
  github.com/talos-systems/talos/internal/pkg/cri.stopAndRemove.func1()
      /src/internal/pkg/cri/pods.go:188 +0x312
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /.cache/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

```

This bug might lead to incorrect pod stop handling at worst.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
