### PR TITLE
chore: make conformance pipeline depend on cron-default

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -484,7 +484,7 @@ local conformance_pipelines = [
   Pipeline('conformance-qemu', default_pipeline_steps + [conformance_k8s_qemu]) + conformance_trigger(['conformance-qemu']),
 
   // cron pipelines, triggered on schedule events
-  Pipeline('cron-conformance-qemu', default_pipeline_steps + [conformance_k8s_qemu]) + cron_trigger(['nightly']),
+  Pipeline('cron-conformance-qemu', default_pipeline_steps + [conformance_k8s_qemu], [default_cron_pipeline]) + cron_trigger(['nightly']),
 ];
 
 // Cloud images pipeline.


### PR DESCRIPTION
This fixes the dependency in the nightly run to make sure artifacts are
rebuilt fresh before triggering conformance run (every other step did
that, but not this one).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
