### PR TITLE
fix: stop networkd before leaving etcd on 'reset' path

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -312,10 +312,6 @@ func (*Sequencer) Reset(r runtime.Runtime, in runtime.ResetOptions) []runtime.Ph
 			"drain",
 			CordonAndDrainNode,
 		).AppendWhen(
-			in.GetGraceful() && (r.Config().Machine().Type() != machine.TypeJoin),
-			"leave",
-			LeaveEtcd,
-		).AppendWhen(
 			in.GetGraceful(),
 			"cleanup",
 			RemoveAllPods,
@@ -325,6 +321,10 @@ func (*Sequencer) Reset(r runtime.Runtime, in runtime.ResetOptions) []runtime.Ph
 			"cleanup",
 			StopAllPods,
 			StopNetworkd,
+		).AppendWhen(
+			in.GetGraceful() && (r.Config().Machine().Type() != machine.TypeJoin),
+			"leave",
+			LeaveEtcd,
 		).AppendList(
 			stopAllPhaselist(r),
 		).AppendWhen(


### PR DESCRIPTION
The problem is with VIP and `reset` sequence: the order of operations
was that `etcd` was stopped first while `networkd` was still running,
and if the node owned the VIP at the time of the reset action, the lease
will be lost (as client connection is gone), so VIP will be unassigned
for a pretty long time.

This PR changes the order of operations: first, stop `networkd` and
other pods, and leave `etcd` last, so that VIP is released, and
`kube-apiserver` for example isn't left hanging on the node while `etcd`
is gone.

Fixes #3500

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
