### PR TITLE
fix: properly pass disk type selector from config to matcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640
-	github.com/talos-systems/go-blockdevice v0.2.1-0.20210506211452-b77400e0a726
+	github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0
 	github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0
 	github.com/talos-systems/go-kmsg v0.1.0
 	github.com/talos-systems/go-loadbalancer v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1027,8 +1027,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 h1:b6uOv7YOFK0
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640 h1:dDChkGwqk1jcRO0k63VTgGzt1UrY20UiDS3yNcCLW0k=
 github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210506211452-b77400e0a726 h1:VgOeqHQsKIHeSISiE4LVapZM1Lv3HVGWECiCrMixkwg=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210506211452-b77400e0a726/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0 h1:EdawBvWE2v9+oiT6vFfUJB9cSTNWRPwcIamCyHEtthQ=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0 h1:DI+BjK+fcrLBc70Fi50dZocQcaHosqsuWHrGHKp2NzE=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-kmsg v0.1.0 h1:juoZn+XioduYvtie6nqi/miKGJPLYSBNXRv5jRe6+lE=

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -885,6 +885,10 @@ func (i *InstallConfig) DiskMatchers() []disk.Matcher {
 			matchers = append(matchers, disk.WithModalias(selector.Modalias))
 		}
 
+		if disk.Type(selector.Type) != disk.TypeUnknown {
+			matchers = append(matchers, disk.WithType(disk.Type(selector.Type)))
+		}
+
 		return matchers
 	}
 

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640
-	github.com/talos-systems/go-blockdevice v0.2.1-0.20210506211452-b77400e0a726
+	github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -106,8 +106,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640 h1:dDChkGwqk1jcRO0k63VTgGzt1UrY20UiDS3yNcCLW0k=
 github.com/talos-systems/crypto v0.2.1-0.20210427105118-4f80b976b640/go.mod h1:OXCK52Q0dzm88YRG4VdTBdidkPUtqrCxCyW7bUs4DAw=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210506211452-b77400e0a726 h1:VgOeqHQsKIHeSISiE4LVapZM1Lv3HVGWECiCrMixkwg=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210506211452-b77400e0a726/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0 h1:EdawBvWE2v9+oiT6vFfUJB9cSTNWRPwcIamCyHEtthQ=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.2.1-0.20210119124456-b9dc1a990133/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=


### PR DESCRIPTION
Also updated go-blockdevice library that makes disk type string case
insensitive.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>