### PR TITLE
fix: properly populate AllowSchedulingOnMasters option in gen config RPC

### DIFF
--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -90,9 +90,9 @@ func Generate(ctx context.Context, in *machine.GenerateConfigurationRequest) (re
 					CNIUrls: in.ClusterConfig.ClusterNetwork.CniConfig.Urls,
 				}))
 			}
-
-			options = append(options, generate.WithAllowSchedulingOnMasters(in.ClusterConfig.AllowSchedulingOnMasters))
 		}
+
+		options = append(options, generate.WithAllowSchedulingOnMasters(in.ClusterConfig.AllowSchedulingOnMasters))
 
 		var (
 			input         *generate.Input


### PR DESCRIPTION
Previosly it was set only if NetworkConfig is not nil.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>