### PR TITLE
fix: stop networkd and pods before leaving etcd on upgrade

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -371,14 +371,14 @@ func (*Sequencer) StageUpgrade(r runtime.Runtime, in *machineapi.UpgradeRequest)
 	case runtime.ModeContainer:
 		return nil
 	default:
-		phases = phases.AppendWhen(
-			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
-			"leave",
-			LeaveEtcd,
-		).Append(
+		phases = phases.Append(
 			"cleanup",
 			StopAllPods,
 			StopNetworkd,
+		).AppendWhen(
+			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
+			"leave",
+			LeaveEtcd,
 		).AppendList(
 			stopAllPhaselist(r),
 		).Append(
@@ -402,10 +402,6 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 			"drain",
 			CordonAndDrainNode,
 		).AppendWhen(
-			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
-			"leave",
-			LeaveEtcd,
-		).AppendWhen(
 			!in.GetPreserve(),
 			"cleanup",
 			RemoveAllPods,
@@ -415,6 +411,10 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 			"cleanup",
 			StopAllPods,
 			StopNetworkd,
+		).AppendWhen(
+			!in.GetPreserve() && (r.Config().Machine().Type() != machine.TypeJoin),
+			"leave",
+			LeaveEtcd,
 		).Append(
 			"stopServices",
 			StopServicesForUpgrade,


### PR DESCRIPTION
The change is essentially same as #3590, but applied to the upgrade path
which is very similar to the reset path.

We have to stop networkd (and remove the VIP/lease on the VIP) before we
leave and stop etcd. Plus we stop the kube-apiserver before the etcd is
stopped, so that we don't have unhealthy kube-apiserver.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
