### PR TITLE
fix: properly compose pattern and header in etcd members output

### DIFF
--- a/cmd/talosctl/cmd/talos/etcd.go
+++ b/cmd/talosctl/cmd/talos/etcd.go
@@ -100,8 +100,8 @@ var etcdMemberListCmd = &cobra.Command{
 					continue
 				}
 
-				for _, member := range message.Members {
-					if i == 0 {
+				for j, member := range message.Members {
+					if i == 0 && j == 0 {
 						if node != "" {
 							fmt.Fprintln(w, "NODE\tID\tHOSTNAME\tPEER URLS\tCLIENT URLS")
 							pattern = "%s\t" + pattern


### PR DESCRIPTION
Header was printed more than once.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>