### PR TITLE
test: provide a way to force different boot order in provision library

### DIFF
--- a/pkg/provision/providers/qemu/launch.go
+++ b/pkg/provision/providers/qemu/launch.go
@@ -44,6 +44,7 @@ type LaunchConfig struct {
 	KernelArgs        string
 	MachineType       string
 	MonitorPath       string
+	DefaultBootOrder  string
 	EnableKVM         bool
 	BootloaderEnabled bool
 	NodeUUID          uuid.UUID
@@ -220,7 +221,7 @@ func checkPartitions(config *LaunchConfig) (bool, error) {
 //
 //nolint:gocyclo
 func launchVM(config *LaunchConfig) error {
-	bootOrder := "cn"
+	bootOrder := config.DefaultBootOrder
 
 	if config.controller.ForcePXEBoot() {
 		bootOrder = "nc"

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -100,6 +100,11 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		return provision.NodeInfo{}, fmt.Errorf("error finding listen address for the API: %w", err)
 	}
 
+	defaultBootOrder := "cn"
+	if nodeReq.DefaultBootOrder != "" {
+		defaultBootOrder = nodeReq.DefaultBootOrder
+	}
+
 	launchConfig := LaunchConfig{
 		QemuExecutable:    arch.QemuExecutable(),
 		DiskPaths:         diskPaths,
@@ -110,6 +115,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		PFlashImages:      pflashImages,
 		MonitorPath:       state.GetRelativePath(fmt.Sprintf("%s.monitor", nodeReq.Name)),
 		EnableKVM:         opts.TargetArch == runtime.GOARCH,
+		DefaultBootOrder:  defaultBootOrder,
 		BootloaderEnabled: opts.BootloaderEnabled,
 		NodeUUID:          nodeUUID,
 		Config:            nodeConfig,

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -143,6 +143,10 @@ type NodeRequest struct {
 	Ports []string
 	// SkipInjectingConfig disables reading configuration from http server
 	SkipInjectingConfig bool
+	// DefaultBootOrder overrides default boot order "cn" (disk, then network boot).
+	//
+	// BootOrder can be forced to be "nc" (PXE boot) via the API in QEMU provisioner.
+	DefaultBootOrder string
 
 	// PXE-booted VMs
 	PXEBooted        bool


### PR DESCRIPTION
There's no change to the default behavior. This change is going to be
used with Sidero/Sfyra.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
