### PR TITLE
fix: Add talos.config to the vApp Properties in VMware OVA

### DIFF
--- a/cmd/installer/pkg/ova/ova.go
+++ b/cmd/installer/pkg/ova/ova.go
@@ -47,6 +47,14 @@ const ovfTpl = `<?xml version="1.0" encoding="UTF-8"?>
   <VirtualSystem ovf:id="vm">
     <Info>A virtual machine</Info>
     <Name>talos</Name>
+    <ProductSection ovf:required="false">
+      <Info>Talos Virtual Appliance</Info>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="talos.config" ovf:value="">
+        <Label>Talos config data</Label>
+        <Description>Inline Talos config</Description>
+      </Property>
+    </ProductSection>
     <OperatingSystemSection ovf:id="101" vmw:osType="other3xLinux64Guest">
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>


### PR DESCRIPTION
# Pull Request

## What? (description)
This will add `talos.config` to the VMware vApp properties, this will allow the OVA to be deployed including the talos config.
see issue: #3669 

## Why? (reasoning)
Currently the code reads the talos.config from the OVF, however since the property (talos.config) is not defined you cannot set it when deploying the OVA to vSphere.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
