### PR TITLE
feat: add ability to mark MBR partition bootable

### DIFF
--- a/cmd/installer/cmd/install.go
+++ b/cmd/installer/cmd/install.go
@@ -74,6 +74,10 @@ func runInstallCmd() (err error) {
 				log.Printf("  %s", warning)
 			}
 		}
+
+		if config.Machine().Install().LegacyBIOSSupport() {
+			options.LegacyBIOSSupport = true
+		}
 	}
 
 	return install.Install(p, seq, options)

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -26,16 +26,17 @@ import (
 
 // Options represents the set of options available for an install.
 type Options struct {
-	ConfigSource    string
-	Disk            string
-	Platform        string
-	Arch            string
-	Board           string
-	ExtraKernelArgs []string
-	Bootloader      bool
-	Upgrade         bool
-	Force           bool
-	Zero            bool
+	ConfigSource      string
+	Disk              string
+	Platform          string
+	Arch              string
+	Board             string
+	ExtraKernelArgs   []string
+	Bootloader        bool
+	Upgrade           bool
+	Force             bool
+	Zero              bool
+	LegacyBIOSSupport bool
 }
 
 // Install installs Talos.

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.2.1-0.20210526123943-7776057f5086
-	github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0
+	github.com/talos-systems/go-blockdevice v0.2.1-0.20210526155905-30c2bc3cb62a
 	github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0
 	github.com/talos-systems/go-debug v0.2.1-0.20210525175311-3d0a6e1bf5e3
 	github.com/talos-systems/go-kmsg v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1214,8 +1214,9 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.2.1-0.20210526123943-7776057f5086 h1:SAyrAftTtxzEUqr9alFt1iezS5vuwCm7/yE8ydR0h+A=
 github.com/talos-systems/crypto v0.2.1-0.20210526123943-7776057f5086/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0 h1:EdawBvWE2v9+oiT6vFfUJB9cSTNWRPwcIamCyHEtthQ=
 github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210526155905-30c2bc3cb62a h1:NLuIVKi5tBnRMgxk185AVGmMUzlRcggb2Abrw9uUq3E=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210526155905-30c2bc3cb62a/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0 h1:DI+BjK+fcrLBc70Fi50dZocQcaHosqsuWHrGHKp2NzE=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-debug v0.2.1-0.20210525175311-3d0a6e1bf5e3 h1:beG97JtuU5oIL+ArSOKbJxbfsCfELOQ5VZu4RuSBJHU=

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -22,6 +22,13 @@ Talos installer image (for any arch) now contains artifacts for both `amd64` and
 This means that e.g. images for arm64 SBCs can be generated on amd64 host.
 """
 
+    [notes.legacy_bios]
+        title = "Legacy BIOS Support"
+        description = """\
+Added an option to the `machine.install` section of the machine config that can enable marking MBR partition bootable
+for the machines that have legacy BIOS which does not support GPT partitioning scheme.
+"""
+
     [notes.components]
         title = "Component Updates"
         description = """\

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -81,6 +81,7 @@ type Install interface {
 	Disk() (string, error)
 	ExtraKernelArgs() []string
 	Zero() bool
+	LegacyBIOSSupport() bool
 	WithBootloader() bool
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -905,6 +905,11 @@ func (i *InstallConfig) Zero() bool {
 	return i.InstallWipe
 }
 
+// LegacyBIOSSupport implements the config.Provider interface.
+func (i *InstallConfig) LegacyBIOSSupport() bool {
+	return i.InstallLegacyBIOSSupport
+}
+
 // WithBootloader implements the config.Provider interface.
 func (i *InstallConfig) WithBootloader() bool {
 	return i.InstallBootloader

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -841,6 +841,10 @@ type InstallConfig struct {
 	//     - false
 	//     - no
 	InstallWipe bool `yaml:"wipe"`
+	//   description: |
+	//     Indicates if MBR partition should be marked as bootable (active).
+	//     Should be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.
+	InstallLegacyBIOSSupport bool `yaml:"legacyBIOSSupport,omitempty"`
 }
 
 // InstallDiskSizeMatcher disk size condition parser.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -490,7 +490,7 @@ func init() {
 			FieldName: "install",
 		},
 	}
-	InstallConfigDoc.Fields = make([]encoder.Doc, 6)
+	InstallConfigDoc.Fields = make([]encoder.Doc, 7)
 	InstallConfigDoc.Fields[0].Name = "disk"
 	InstallConfigDoc.Fields[0].Type = "string"
 	InstallConfigDoc.Fields[0].Note = ""
@@ -543,6 +543,11 @@ func init() {
 		"false",
 		"no",
 	}
+	InstallConfigDoc.Fields[6].Name = "legacyBIOSSupport"
+	InstallConfigDoc.Fields[6].Type = "bool"
+	InstallConfigDoc.Fields[6].Note = ""
+	InstallConfigDoc.Fields[6].Description = "Indicates if MBR partition should be marked as bootable (active).\nShould be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme."
+	InstallConfigDoc.Fields[6].Comments[encoder.LineComment] = "Indicates if MBR partition should be marked as bootable (active)."
 
 	InstallDiskSizeMatcherDoc.Type = "InstallDiskSizeMatcher"
 	InstallDiskSizeMatcherDoc.Comments[encoder.LineComment] = "InstallDiskSizeMatcher disk size condition parser."

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.2.1-0.20210526123943-7776057f5086
-	github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0
+	github.com/talos-systems/go-blockdevice v0.2.1-0.20210526155905-30c2bc3cb62a
 	github.com/talos-systems/net v0.2.1-0.20210212213224-05190541b0fa
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
 	golang.org/x/sys v0.0.0-20210324051608-47abb6519492 // indirect

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -106,8 +106,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/talos-systems/crypto v0.2.1-0.20210526123943-7776057f5086 h1:SAyrAftTtxzEUqr9alFt1iezS5vuwCm7/yE8ydR0h+A=
 github.com/talos-systems/crypto v0.2.1-0.20210526123943-7776057f5086/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0 h1:EdawBvWE2v9+oiT6vFfUJB9cSTNWRPwcIamCyHEtthQ=
-github.com/talos-systems/go-blockdevice v0.2.1-0.20210510233948-1292574643e0/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210526155905-30c2bc3cb62a h1:NLuIVKi5tBnRMgxk185AVGmMUzlRcggb2Abrw9uUq3E=
+github.com/talos-systems/go-blockdevice v0.2.1-0.20210526155905-30c2bc3cb62a/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.2.1-0.20210119124456-b9dc1a990133/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=

--- a/website/content/docs/v0.11/Reference/configuration.md
+++ b/website/content/docs/v0.11/Reference/configuration.md
@@ -1805,6 +1805,20 @@ Valid values:
 
 <hr />
 
+<div class="dd">
+
+<code>legacyBIOSSupport</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Indicates if MBR partition should be marked as bootable (active).
+Should be enabled only for the systems with legacy BIOS that doesn't support GPT partitioning scheme.
+
+</div>
+
+<hr />
+
 
 
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3532

Machine install section now has `markMBRBootable` option.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>