### PR TITLE
chore: fix go generate for the machinery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,10 +163,10 @@ RUN gofumports -w -local github.com/talos-systems/talos /api/
 
 # run docgen for machinery config
 FROM build-go AS go-generate
-COPY ./pkg/machinery ./pkg/machinery
-COPY ./pkg/resources/network ./pkg/resources/network
-RUN --mount=type=cache,target=/.cache go generate ./pkg/machinery/config/types/v1alpha1/...
-RUN --mount=type=cache,target=/.cache go generate ./pkg/resources/network/...
+COPY ./pkg ./pkg
+RUN --mount=type=cache,target=/.cache go generate ./pkg/...
+WORKDIR /src/pkg/machinery
+RUN --mount=type=cache,target=/.cache go generate ./...
 
 FROM --platform=${BUILDPLATFORM} scratch AS generate
 COPY --from=generate-build /api/common/*.pb.go /pkg/machinery/api/common/


### PR DESCRIPTION
The problem is that `pkg/machinery` is a submodule, so regular go walk
over the pattern `./...` doesn't include submodules, so we have to call
explicitly for the submodule.

This also enables go generate for all `./pkg`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
