### PR TITLE
feat: add the ability to disable CoreDNS

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -29,6 +29,12 @@ Added an option to the `machine.install` section of the machine config that can 
 for the machines that have legacy BIOS which does not support GPT partitioning scheme.
 """
 
+    [notes.coredns]
+        title = "CoreDNS"
+        description = """\
+Added the flag `cluster.coreDNS.disabled` to coreDNS deployment during the cluster bootstrap.
+"""
+
     [notes.components]
         title = "Component Updates"
         description = """\

--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -225,7 +225,8 @@ func (ctrl *K8sControlPlaneController) manageManifestsConfig(ctx context.Context
 			ProxyMode:      cfgProvider.Cluster().Proxy().Mode(),
 			ProxyExtraArgs: cfgProvider.Cluster().Proxy().ExtraArgs(),
 
-			CoreDNSImage: cfgProvider.Cluster().CoreDNS().Image(),
+			CoreDNSEnabled: cfgProvider.Cluster().CoreDNS().Enabled(),
+			CoreDNSImage:   cfgProvider.Cluster().CoreDNS().Image(),
 
 			DNSServiceIP:   dnsServiceIP,
 			DNSServiceIPv6: dnsServiceIPv6,

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -177,16 +177,23 @@ func (ctrl *ManifestController) render(cfg config.K8sManifestsSpec, scrt *secret
 		{"02-kube-system-sa-role-binding", kubeSystemSARoleBindingTemplate},
 		{"03-default-pod-security-policy", podSecurityPolicy},
 		{"11-kube-config-in-cluster", kubeConfigInClusterTemplate},
-		{"11-core-dns", coreDNSTemplate},
-		{"11-core-dns-svc", coreDNSSvcTemplate},
 	}
 
-	if cfg.DNSServiceIPv6 != "" {
+	if cfg.CoreDNSEnabled {
 		defaultManifests = append(defaultManifests,
 			[]manifestDesc{
-				{"11-core-dns-v6-svc", coreDNSv6SvcTemplate},
+				{"11-core-dns", coreDNSTemplate},
+				{"11-core-dns-svc", coreDNSSvcTemplate},
 			}...,
 		)
+
+		if cfg.DNSServiceIPv6 != "" {
+			defaultManifests = append(defaultManifests,
+				[]manifestDesc{
+					{"11-core-dns-v6-svc", coreDNSv6SvcTemplate},
+				}...,
+			)
+		}
 	}
 
 	if cfg.FlannelEnabled {

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -96,7 +96,8 @@ var defaultManifestSpec = config.K8sManifestsSpec{
 	ProxyEnabled: true,
 	ProxyImage:   "foo/bar",
 
-	CoreDNSImage: "foo/bar",
+	CoreDNSEnabled: true,
+	CoreDNSImage:   "foo/bar",
 
 	DNSServiceIP: "192.168.0.1",
 

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -355,6 +355,7 @@ type Token interface {
 // CoreDNS defines the requirements for a config that pertains to CoreDNS
 // coredns options.
 type CoreDNS interface {
+	Enabled() bool
 	Image() string
 }
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -915,6 +915,11 @@ func (i *InstallConfig) WithBootloader() bool {
 	return i.InstallBootloader
 }
 
+// Enabled implements the config.Provider interface.
+func (c *CoreDNS) Enabled() bool {
+	return !c.CoreDNSDisabled
+}
+
 // Image implements the config.Provider interface.
 func (c *CoreDNS) Image() string {
 	coreDNSImage := fmt.Sprintf("%s:%s", constants.CoreDNSImage, constants.DefaultCoreDNSVersion)

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1022,6 +1022,9 @@ type PodCheckpointer struct {
 // CoreDNS represents the CoreDNS config values.
 type CoreDNS struct {
 	//   description: |
+	//     Disable coredns deployment on cluster bootstrap.
+	CoreDNSDisabled bool `yaml:"disabled,omitempty"`
+	//   description: |
 	//     The `image` field is an override to the default coredns image.
 	CoreDNSImage string `yaml:"image,omitempty"`
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -702,12 +702,17 @@ func init() {
 			FieldName: "coreDNS",
 		},
 	}
-	CoreDNSDoc.Fields = make([]encoder.Doc, 1)
-	CoreDNSDoc.Fields[0].Name = "image"
-	CoreDNSDoc.Fields[0].Type = "string"
+	CoreDNSDoc.Fields = make([]encoder.Doc, 2)
+	CoreDNSDoc.Fields[0].Name = "disabled"
+	CoreDNSDoc.Fields[0].Type = "bool"
 	CoreDNSDoc.Fields[0].Note = ""
-	CoreDNSDoc.Fields[0].Description = "The `image` field is an override to the default coredns image."
-	CoreDNSDoc.Fields[0].Comments[encoder.LineComment] = "The `image` field is an override to the default coredns image."
+	CoreDNSDoc.Fields[0].Description = "Disable coredns deployment on cluster bootstrap."
+	CoreDNSDoc.Fields[0].Comments[encoder.LineComment] = "Disable coredns deployment on cluster bootstrap."
+	CoreDNSDoc.Fields[1].Name = "image"
+	CoreDNSDoc.Fields[1].Type = "string"
+	CoreDNSDoc.Fields[1].Note = ""
+	CoreDNSDoc.Fields[1].Description = "The `image` field is an override to the default coredns image."
+	CoreDNSDoc.Fields[1].Comments[encoder.LineComment] = "The `image` field is an override to the default coredns image."
 
 	EndpointDoc.Type = "Endpoint"
 	EndpointDoc.Comments[encoder.LineComment] = "Endpoint represents the endpoint URL parsed out of the machine config."

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -88,7 +88,8 @@ type K8sManifestsSpec struct {
 	ProxyMode      string            `yaml:"proxyMode"`
 	ProxyExtraArgs map[string]string `yaml:"proxyExtraArgs"`
 
-	CoreDNSImage string `yaml:"coreDNSImage"`
+	CoreDNSEnabled bool   `yaml:"coreDNSEnabled"`
+	CoreDNSImage   string `yaml:"coreDNSImage"`
 
 	DNSServiceIP   string `yaml:"dnsServiceIP"`
 	DNSServiceIPv6 string `yaml:"dnsServiceIPv6"`

--- a/website/content/docs/v0.11/Reference/configuration.md
+++ b/website/content/docs/v0.11/Reference/configuration.md
@@ -2204,6 +2204,19 @@ image: docker.io/coredns/coredns:1.8.0 # The `image` field is an override to the
 
 <div class="dd">
 
+<code>disabled</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Disable coredns deployment on cluster bootstrap.
+
+</div>
+
+<hr />
+
+<div class="dd">
+
 <code>image</code>  <i>string</i>
 
 </div>


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3556

Introduce `coredns.disabled` flag to the machine config that allows
turning off coredns deployment during cluster bootstrap.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>