### PR TITLE
fix: clean up stale snapshots on container start

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 
@@ -82,6 +83,10 @@ func (c *containerdRunner) Open(ctx context.Context) error {
 		if err = oldcontainer.Delete(c.ctx, containerd.WithSnapshotCleanup); err != nil {
 			return fmt.Errorf("error deleting old container instance: %w", err)
 		}
+	}
+
+	if err = c.client.SnapshotService("").Remove(c.ctx, c.args.ID); err != nil && !errdefs.IsNotFound(err) {
+		return fmt.Errorf("error cleaning up stale snapshot: %w", err)
 	}
 
 	// Create the container.


### PR DESCRIPTION
I wasn't able to reproduce this case, but looks like containerd can get
into a state when the snapshot was left behind, but container record is
missing. This prevents the container from being started with the error:

```
failed to create container kubelet: snapshot kubelet: already exists
```

This PR should help to fix this issue by trying to remove the snapshot
by name even if the container record is not found.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
