### PR TITLE
chore: skip building multi-arch installer for race-enabled build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ TESTPKGS ?= github.com/talos-systems/talos/...
 RELEASES ?= v0.9.3 v0.10.1
 SHORT_INTEGRATION_TEST ?=
 CUSTOM_CNI_URL ?=
+INSTALLER_ARCH ?= all
 
 VERSION_PKG = github.com/talos-systems/talos/pkg/version
 IMAGES_PKGS = github.com/talos-systems/talos/pkg/images
@@ -54,6 +55,7 @@ ifneq (, $(filter $(WITH_RACE), t true TRUE y yes 1))
 CGO_ENABLED = 1
 GO_BUILDFLAGS += -race
 GO_LDFLAGS += -linkmode=external -extldflags '-static'
+INSTALLER_ARCH = targetarch
 endif
 
 ifneq (, $(filter $(WITH_DEBUG), t true TRUE y yes 1))
@@ -81,6 +83,7 @@ COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=ARTIFACTS=$(ARTIFACTS)
 COMMON_ARGS += --build-arg=IMPORTVET=$(IMPORTVET)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
+COMMON_ARGS += --build-arg=INSTALLER_ARCH=$(INSTALLER_ARCH)
 COMMON_ARGS += --build-arg=CGO_ENABLED=$(CGO_ENABLED)
 COMMON_ARGS += --build-arg=GO_BUILDFLAGS="$(GO_BUILDFLAGS)"
 COMMON_ARGS += --build-arg=GO_LDFLAGS="$(GO_LDFLAGS)"


### PR DESCRIPTION
Go cross-compilation is not quite compatible with Go race detector, as C
toolchain is not cross-compliation ready.

Workaround is really simple: for race-enabled builds, don't build
multi-arch installer image (that is installer image which contains both
amd64 and arm64 Talos artifacts), but build installer artifacts only for
the target arch (skipping cross-compilation).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
