### PR TITLE
feat: implement CPU and Memory stats controller

### DIFF
--- a/internal/app/machined/pkg/controllers/perf/perf.go
+++ b/internal/app/machined/pkg/controllers/perf/perf.go
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/prometheus/procfs"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/pkg/resources/perf"
+)
+
+const updateInterval = time.Second * 30
+
+// StatsController manages v1alpha1.Stats which is the current snaphot of the machine CPU and Memory consumption.
+type StatsController struct{}
+
+// Name implements controller.StatsController interface.
+func (ctrl *StatsController) Name() string {
+	return "perf.StatsController"
+}
+
+// Inputs implements controller.StatsController interface.
+func (ctrl *StatsController) Inputs() []controller.Input {
+	return nil
+}
+
+// Outputs implements controller.StatsController interface.
+func (ctrl *StatsController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: perf.CPUType,
+			Kind: controller.OutputExclusive,
+		},
+		{
+			Type: perf.MemoryType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.StatsController interface.
+func (ctrl *StatsController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	ticker := time.NewTicker(updateInterval)
+
+	defer ticker.Stop()
+
+	var (
+		fs  procfs.FS
+		err error
+	)
+
+	fs, err = procfs.NewDefaultFS()
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-r.EventCh():
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := ctrl.updateMemory(ctx, r, &fs); err != nil {
+			return err
+		}
+
+		if err := ctrl.updateCPU(ctx, r, &fs); err != nil {
+			return err
+		}
+	}
+}
+
+func (ctrl *StatsController) updateCPU(ctx context.Context, r controller.Runtime, fs *procfs.FS) error {
+	cpu := perf.NewCPU()
+
+	stat, err := fs.Stat()
+	if err != nil {
+		return err
+	}
+
+	return r.Modify(ctx, cpu, func(r resource.Resource) error {
+		r.(*perf.CPU).Update(&stat)
+
+		return nil
+	})
+}
+
+func (ctrl *StatsController) updateMemory(ctx context.Context, r controller.Runtime, fs *procfs.FS) error {
+	mem := perf.NewMemory()
+
+	info, err := fs.Meminfo()
+	if err != nil {
+		return err
+	}
+
+	return r.Modify(ctx, mem, func(r resource.Resource) error {
+		r.(*perf.Memory).Update(&info)
+
+		return nil
+	})
+}

--- a/internal/app/machined/pkg/controllers/perf/perf_test.go
+++ b/internal/app/machined/pkg/controllers/perf/perf_test.go
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/perf"
+	"github.com/talos-systems/talos/pkg/logging"
+	perfresource "github.com/talos-systems/talos/pkg/resources/perf"
+)
+
+type PerfSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *PerfSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	logger := logging.Wrap(log.Writer())
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.Require().NoError(err)
+}
+
+func (suite *PerfSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *PerfSuite) TestReconcile() {
+	suite.Require().NoError(suite.runtime.RegisterController(&perf.StatsController{}))
+
+	suite.startRuntime()
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			cpu, err := suite.state.Get(suite.ctx, resource.NewMetadata(perfresource.NamespaceName, perfresource.CPUType, perfresource.CPUID, resource.VersionUndefined))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					return retry.ExpectedError(err)
+				}
+
+				return err
+			}
+
+			mem, err := suite.state.Get(suite.ctx, resource.NewMetadata(perfresource.NamespaceName, perfresource.MemoryType, perfresource.MemoryID, resource.VersionUndefined))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					return retry.ExpectedError(err)
+				}
+
+				return err
+			}
+
+			cpuSpec := cpu.Spec().(*perfresource.CPUSpec)    //nolint:errcheck,forcetypeassert
+			memSpec := mem.Spec().(*perfresource.MemorySpec) //nolint:errcheck,forcetypeassert
+
+			if len(cpuSpec.CPU) == 0 || memSpec.MemTotal == 0 {
+				return retry.ExpectedError(fmt.Errorf("cpu spec does not contain any CPU or Total memory is zero"))
+			}
+
+			return nil
+		},
+	))
+}
+
+func (suite *PerfSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+}
+
+func TestPerfSuite(t *testing.T) {
+	suite.Run(t, new(PerfSuite))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -15,6 +15,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/config"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/perf"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/secrets"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/time"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/v1alpha1"
@@ -88,6 +89,7 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&network.RouteMergeController{},
 		&network.RouteStatusController{},
 		&network.RouteSpecController{},
+		&perf.StatsController{},
 		&secrets.EtcdController{},
 		&secrets.KubernetesController{},
 		&secrets.RootController{},

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/talos-systems/talos/pkg/resources/config"
 	"github.com/talos-systems/talos/pkg/resources/k8s"
 	"github.com/talos-systems/talos/pkg/resources/network"
+	"github.com/talos-systems/talos/pkg/resources/perf"
 	"github.com/talos-systems/talos/pkg/resources/secrets"
 	"github.com/talos-systems/talos/pkg/resources/time"
 	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
@@ -59,6 +60,7 @@ func NewState() (*State, error) {
 		{secrets.NamespaceName, "Resources with secret material."},
 		{network.NamespaceName, "Networking resources."},
 		{network.ConfigNamespaceName, "Networking configuration resources."},
+		{perf.NamespaceName, "Stats resources."},
 	} {
 		if err := s.namespaceRegistry.Register(ctx, ns.name, ns.description); err != nil {
 			return nil, err
@@ -85,6 +87,8 @@ func NewState() (*State, error) {
 		&network.NodeAddress{},
 		&network.RouteStatus{},
 		&network.RouteSpec{},
+		&perf.CPU{},
+		&perf.Memory{},
 		&secrets.Etcd{},
 		&secrets.Kubernetes{},
 		&secrets.Root{},

--- a/pkg/resources/perf/cpu.go
+++ b/pkg/resources/perf/cpu.go
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/prometheus/procfs"
+)
+
+// CPUType is type of Etcd resource.
+const CPUType = resource.Type("CPUStats.perf.talos.dev")
+
+// CPUID is a resource ID of singleton instance.
+const CPUID = resource.ID("latest")
+
+// CPU represents the last CPU stats snapshot.
+type CPU struct {
+	md   resource.Metadata
+	spec CPUSpec
+}
+
+// CPUSpec represents the last CPU stats snapshot.
+type CPUSpec struct {
+	CPU             []CPUStat `yaml:"cpu"`
+	CPUTotal        CPUStat   `yaml:"cpuTotal"`
+	IRQTotal        uint64    `yaml:"irqTotal"`
+	ContextSwitches uint64    `yaml:"contextSwitches"`
+	ProcessCreated  uint64    `yaml:"processCreated"`
+	ProcessRunning  uint64    `yaml:"processRunning"`
+	ProcessBlocked  uint64    `yaml:"processBlocked"`
+	SoftIrqTotal    uint64    `yaml:"softIrqTotal"`
+}
+
+// CPUStat represents a single cpu stat.
+type CPUStat struct {
+	User      float64 `yaml:"user"`
+	Nice      float64 `yaml:"nice"`
+	System    float64 `yaml:"system"`
+	Idle      float64 `yaml:"idle"`
+	Iowait    float64 `yaml:"iowait"`
+	Irq       float64 `yaml:"irq"`
+	SoftIrq   float64 `yaml:"softIrq"`
+	Steal     float64 `yaml:"steal"`
+	Guest     float64 `yaml:"guest"`
+	GuestNice float64 `yaml:"guestNice"`
+}
+
+// NewCPU creates new default CPU stats object.
+func NewCPU() *CPU {
+	r := &CPU{
+		md: resource.NewMetadata(NamespaceName, CPUType, CPUID, resource.VersionUndefined),
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *CPU) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *CPU) Spec() interface{} {
+	return &r.spec
+}
+
+func (r *CPU) String() string {
+	return fmt.Sprintf("secrets.CPUSecrets(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *CPU) DeepCopy() resource.Resource {
+	return &CPU{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *CPU) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             CPUType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "User",
+				JSONPath: "{.cpuTotal.user}",
+			},
+			{
+				Name:     "System",
+				JSONPath: "{.cpuTotal.system}",
+			},
+		},
+	}
+}
+
+// Update current CPU snapshot.
+func (r *CPU) Update(stat *procfs.Stat) {
+	translateCPUStat := func(in procfs.CPUStat) CPUStat {
+		return CPUStat{
+			User:      in.User,
+			Nice:      in.Nice,
+			System:    in.System,
+			Idle:      in.Idle,
+			Iowait:    in.Iowait,
+			Irq:       in.IRQ,
+			SoftIrq:   in.SoftIRQ,
+			Steal:     in.Steal,
+			Guest:     in.Guest,
+			GuestNice: in.GuestNice,
+		}
+	}
+
+	translateListOfCPUStat := func(in []procfs.CPUStat) []CPUStat {
+		res := make([]CPUStat, len(in))
+
+		for i := range in {
+			res[i] = translateCPUStat(in[i])
+		}
+
+		return res
+	}
+
+	r.spec = CPUSpec{
+		CPUTotal:        translateCPUStat(stat.CPUTotal),
+		CPU:             translateListOfCPUStat(stat.CPU),
+		IRQTotal:        stat.IRQTotal,
+		ContextSwitches: stat.ContextSwitches,
+		ProcessCreated:  stat.ProcessCreated,
+		ProcessRunning:  stat.ProcessesRunning,
+		ProcessBlocked:  stat.ProcessesBlocked,
+		SoftIrqTotal:    stat.SoftIRQTotal,
+	}
+}

--- a/pkg/resources/perf/mem.go
+++ b/pkg/resources/perf/mem.go
@@ -1,0 +1,184 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf
+
+import (
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"github.com/prometheus/procfs"
+)
+
+// MemoryType is type of Etcd resource.
+const MemoryType = resource.Type("MemoryStats.perf.talos.dev")
+
+// MemoryID is a resource ID of singleton instance.
+const MemoryID = resource.ID("latest")
+
+// Memory represents the last Memory stats snapshot.
+type Memory struct {
+	md   resource.Metadata
+	spec MemorySpec
+}
+
+// MemorySpec represents the last Memory stats snapshot.
+type MemorySpec struct {
+	MemTotal          uint64 `yaml:"total"`
+	MemUsed           uint64 `yaml:"used"`
+	MemAvailable      uint64 `yaml:"available"`
+	Buffers           uint64 `yaml:"buffers"`
+	Cached            uint64 `yaml:"cached"`
+	SwapCached        uint64 `yaml:"swapCached"`
+	Active            uint64 `yaml:"active"`
+	Inactive          uint64 `yaml:"inactive"`
+	ActiveAnon        uint64 `yaml:"activeAnon"`
+	InactiveAnon      uint64 `yaml:"inactiveAnon"`
+	ActiveFile        uint64 `yaml:"activeFile"`
+	InactiveFile      uint64 `yaml:"inactiveFile"`
+	Unevictable       uint64 `yaml:"unevictable"`
+	Mlocked           uint64 `yaml:"mlocked"`
+	SwapTotal         uint64 `yaml:"swapTotal"`
+	SwapFree          uint64 `yaml:"swapFree"`
+	Dirty             uint64 `yaml:"dirty"`
+	Writeback         uint64 `yaml:"writeback"`
+	AnonPages         uint64 `yaml:"anonPages"`
+	Mapped            uint64 `yaml:"mapped"`
+	Shmem             uint64 `yaml:"shmem"`
+	Slab              uint64 `yaml:"slab"`
+	SReclaimable      uint64 `yaml:"sreclaimable"`
+	SUnreclaim        uint64 `yaml:"sunreclaim"`
+	KernelStack       uint64 `yaml:"kernelStack"`
+	PageTables        uint64 `yaml:"pageTables"`
+	NFSunstable       uint64 `yaml:"nfsunstable"`
+	Bounce            uint64 `yaml:"bounce"`
+	WritebackTmp      uint64 `yaml:"writeBacktmp"`
+	CommitLimit       uint64 `yaml:"commitLimit"`
+	CommittedAS       uint64 `yaml:"commitTedas"`
+	VmallocTotal      uint64 `yaml:"vmallocTotal"`
+	VmallocUsed       uint64 `yaml:"vmallocUsed"`
+	VmallocChunk      uint64 `yaml:"vmallocChunk"`
+	HardwareCorrupted uint64 `yaml:"hardwareCorrupted"`
+	AnonHugePages     uint64 `yaml:"anonHugePages"`
+	ShmemHugePages    uint64 `yaml:"shmemHugePages"`
+	ShmemPmdMapped    uint64 `yaml:"shmemPmdMapped"`
+	CmaTotal          uint64 `yaml:"cmaTotal"`
+	CmaFree           uint64 `yaml:"cmaFree"`
+	HugePagesTotal    uint64 `yaml:"hugePagesTotal"`
+	HugePagesFree     uint64 `yaml:"hugePagesFree"`
+	HugePagesRsvd     uint64 `yaml:"hugePagesRsvd"`
+	HugePagesSurp     uint64 `yaml:"hugePagesSurp"`
+	Hugepagesize      uint64 `yaml:"hugepagesize"`
+	DirectMap4k       uint64 `yaml:"directMap4k"`
+	DirectMap2m       uint64 `yaml:"directMap2m"`
+	DirectMap1g       uint64 `yaml:"directMap1g"`
+}
+
+// NewMemory creates new default Memory stats object.
+func NewMemory() *Memory {
+	r := &Memory{
+		md: resource.NewMetadata(NamespaceName, MemoryType, MemoryID, resource.VersionUndefined),
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Memory) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Memory) Spec() interface{} {
+	return &r.spec
+}
+
+func (r *Memory) String() string {
+	return fmt.Sprintf("secrets.MemorySecrets(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Memory) DeepCopy() resource.Resource {
+	return &Memory{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *Memory) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             MemoryType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Used",
+				JSONPath: "{.used}",
+			},
+			{
+				Name:     "Total",
+				JSONPath: "{.total}",
+			},
+		},
+	}
+}
+
+// Update current Mem snapshot.
+func (r *Memory) Update(info *procfs.Meminfo) {
+	r.spec = MemorySpec{
+		MemTotal:          pointer.GetUint64(info.MemTotal),
+		MemUsed:           pointer.GetUint64(info.MemTotal) - pointer.GetUint64(info.MemFree),
+		MemAvailable:      pointer.GetUint64(info.MemAvailable),
+		Buffers:           pointer.GetUint64(info.Buffers),
+		Cached:            pointer.GetUint64(info.Cached),
+		SwapCached:        pointer.GetUint64(info.SwapCached),
+		Active:            pointer.GetUint64(info.Active),
+		Inactive:          pointer.GetUint64(info.Inactive),
+		ActiveAnon:        pointer.GetUint64(info.ActiveAnon),
+		InactiveAnon:      pointer.GetUint64(info.InactiveAnon),
+		ActiveFile:        pointer.GetUint64(info.ActiveFile),
+		InactiveFile:      pointer.GetUint64(info.InactiveFile),
+		Unevictable:       pointer.GetUint64(info.Unevictable),
+		Mlocked:           pointer.GetUint64(info.Mlocked),
+		SwapTotal:         pointer.GetUint64(info.SwapTotal),
+		SwapFree:          pointer.GetUint64(info.SwapFree),
+		Dirty:             pointer.GetUint64(info.Dirty),
+		Writeback:         pointer.GetUint64(info.Writeback),
+		AnonPages:         pointer.GetUint64(info.AnonPages),
+		Mapped:            pointer.GetUint64(info.Mapped),
+		Shmem:             pointer.GetUint64(info.Shmem),
+		Slab:              pointer.GetUint64(info.Slab),
+		SReclaimable:      pointer.GetUint64(info.SReclaimable),
+		SUnreclaim:        pointer.GetUint64(info.SUnreclaim),
+		KernelStack:       pointer.GetUint64(info.KernelStack),
+		PageTables:        pointer.GetUint64(info.PageTables),
+		NFSunstable:       pointer.GetUint64(info.NFSUnstable),
+		Bounce:            pointer.GetUint64(info.Bounce),
+		WritebackTmp:      pointer.GetUint64(info.WritebackTmp),
+		CommitLimit:       pointer.GetUint64(info.CommitLimit),
+		CommittedAS:       pointer.GetUint64(info.CommittedAS),
+		VmallocTotal:      pointer.GetUint64(info.VmallocTotal),
+		VmallocUsed:       pointer.GetUint64(info.VmallocUsed),
+		VmallocChunk:      pointer.GetUint64(info.VmallocChunk),
+		HardwareCorrupted: pointer.GetUint64(info.HardwareCorrupted),
+		AnonHugePages:     pointer.GetUint64(info.AnonHugePages),
+		ShmemHugePages:    pointer.GetUint64(info.ShmemHugePages),
+		ShmemPmdMapped:    pointer.GetUint64(info.ShmemPmdMapped),
+		CmaTotal:          pointer.GetUint64(info.CmaTotal),
+		CmaFree:           pointer.GetUint64(info.CmaFree),
+		HugePagesTotal:    pointer.GetUint64(info.HugePagesTotal),
+		HugePagesFree:     pointer.GetUint64(info.HugePagesFree),
+		HugePagesRsvd:     pointer.GetUint64(info.HugePagesRsvd),
+		HugePagesSurp:     pointer.GetUint64(info.HugePagesSurp),
+		Hugepagesize:      pointer.GetUint64(info.Hugepagesize),
+		DirectMap4k:       pointer.GetUint64(info.DirectMap4k),
+		DirectMap2m:       pointer.GetUint64(info.DirectMap2M),
+		DirectMap1g:       pointer.GetUint64(info.DirectMap1G),
+	}
+}

--- a/pkg/resources/perf/perf.go
+++ b/pkg/resources/perf/perf.go
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf
+
+import "github.com/cosi-project/runtime/pkg/resource"
+
+// NamespaceName contains resources related to stats.
+const NamespaceName resource.Namespace = "perf"

--- a/pkg/resources/perf/perf_test.go
+++ b/pkg/resources/perf/perf_test.go
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/cosi-project/runtime/pkg/state/registry"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/pkg/resources/perf"
+)
+
+func TestRegisterResource(t *testing.T) {
+	ctx := context.TODO()
+
+	resources := state.WrapCore(namespaced.NewState(inmem.Build))
+	resourceRegistry := registry.NewResourceRegistry(resources)
+
+	for _, resource := range []resource.Resource{
+		&perf.Memory{},
+		&perf.CPU{},
+	} {
+		assert.NoError(t, resourceRegistry.Register(ctx, resource))
+	}
+}

--- a/pkg/resources/secrets/etcd.go
+++ b/pkg/resources/secrets/etcd.go
@@ -15,7 +15,7 @@ import (
 // EtcdType is type of Etcd resource.
 const EtcdType = resource.Type("EtcdSecrets.secrets.talos.dev")
 
-// EtcdID is a resource ID of singletone instance.
+// EtcdID is a resource ID of singleton instance.
 const EtcdID = resource.ID("etcd")
 
 // Etcd contains etcd generated secrets.


### PR DESCRIPTION
Now the latest value for CPU and Memory is also represented as COSI
resources.

Was going back and forth in the implementation but in the end decided to
use dedicated yaml structures for both CPU and Memory stats because:

- JSON tags are ignored by `go-yaml`, so the output is not really great.
- protobuf Talos definition contains fields which we don't really need
in the YAML output of `talosctl get`.
- current state of Talos resource service does not support protobuf
encoding for resources.

So the plan for Theila is to just use the structure as a dynamic object
without relying on protobufs. At least for now.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>