### PR TITLE
refactor: rename *.Status() to *.TypedSpec() in the resources

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -84,7 +84,7 @@ func (ctrl *ControlPlaneStaticPodController) Run(ctx context.Context, r controll
 			return err
 		}
 
-		secretsVersion := secretsStatusResource.(*k8s.SecretsStatus).Status().Version
+		secretsVersion := secretsStatusResource.(*k8s.SecretsStatus).TypedSpec().Version
 
 		for _, pod := range []struct {
 			f  func(context.Context, controller.Runtime, *zap.Logger, *config.K8sControlPlane, string) error

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_static_pod_controller.go
@@ -169,7 +169,7 @@ func (ctrl *KubeletStaticPodController) Run(ctx context.Context, r controller.Ru
 			return err
 		}
 
-		if bootstrapStatus.(*v1alpha1.BootstrapStatus).Status().SelfHostedControlPlane {
+		if bootstrapStatus.(*v1alpha1.BootstrapStatus).TypedSpec().SelfHostedControlPlane {
 			logger.Info("skipped as running self-hosted control plane")
 
 			if err = ctrl.cleanupPods(logger, nil); err != nil {

--- a/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_apply.go
@@ -109,7 +109,7 @@ func (ctrl *ManifestApplyController) Run(ctx context.Context, r controller.Runti
 			return err
 		}
 
-		if bootstrapStatus.(*v1alpha1.BootstrapStatus).Status().SelfHostedControlPlane {
+		if bootstrapStatus.(*v1alpha1.BootstrapStatus).TypedSpec().SelfHostedControlPlane {
 			logger.Info("skipped as running self-hosted control plane")
 
 			continue
@@ -162,7 +162,7 @@ func (ctrl *ManifestApplyController) Run(ctx context.Context, r controller.Runti
 		}
 
 		if err = r.Modify(ctx, k8s.NewManifestStatus(k8s.ControlPlaneNamespaceName), func(r resource.Resource) error {
-			status := r.(*k8s.ManifestStatus).Status()
+			status := r.(*k8s.ManifestStatus).TypedSpec()
 
 			status.ManifestsApplied = make([]string, 0, len(manifests.Items))
 

--- a/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/render_secrets_static_pod.go
@@ -298,8 +298,8 @@ func (ctrl *RenderSecretsStaticPodController) Run(ctx context.Context, r control
 		}
 
 		if err = r.Modify(ctx, k8s.NewSecretsStatus(k8s.ControlPlaneNamespaceName, k8s.StaticPodSecretsStaticPodID), func(r resource.Resource) error {
-			r.(*k8s.SecretsStatus).Status().Ready = true
-			r.(*k8s.SecretsStatus).Status().Version = secretsRes.Metadata().Version().String()
+			r.(*k8s.SecretsStatus).TypedSpec().Ready = true
+			r.(*k8s.SecretsStatus).TypedSpec().Version = secretsRes.Metadata().Version().String()
 
 			return nil
 		}); err != nil {

--- a/internal/app/machined/pkg/controllers/network/address_config.go
+++ b/internal/app/machined/pkg/controllers/network/address_config.go
@@ -164,7 +164,7 @@ func (ctrl *AddressConfigController) apply(ctx context.Context, r controller.Run
 			ctx,
 			network.NewAddressSpec(network.ConfigNamespaceName, id),
 			func(r resource.Resource) error {
-				*r.(*network.AddressSpec).Status() = address
+				*r.(*network.AddressSpec).TypedSpec() = address
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/address_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_config_test.go
@@ -109,8 +109,8 @@ func (suite *AddressConfigSuite) TestLoopback() {
 				"default/lo/127.0.0.1/8",
 				"default/lo/::1/128",
 			}, func(r *network.AddressSpec) error {
-				suite.Assert().Equal("lo", r.Status().LinkName)
-				suite.Assert().Equal(nethelpers.ScopeHost, r.Status().Scope)
+				suite.Assert().Equal("lo", r.TypedSpec().LinkName)
+				suite.Assert().Equal(nethelpers.ScopeHost, r.TypedSpec().Scope)
 
 				return nil
 			})
@@ -129,7 +129,7 @@ func (suite *AddressConfigSuite) TestCmdline() {
 			return suite.assertAddresses([]string{
 				"cmdline/eth1/172.20.0.2/24",
 			}, func(r *network.AddressSpec) error {
-				suite.Assert().Equal("eth1", r.Status().LinkName)
+				suite.Assert().Equal("eth1", r.TypedSpec().LinkName)
 
 				return nil
 			})
@@ -166,8 +166,8 @@ func (suite *AddressConfigSuite) TestCmdlineNoNetmask() {
 			return suite.assertAddresses([]string{
 				fmt.Sprintf("cmdline/%s/172.20.0.2/32", ifaceName),
 			}, func(r *network.AddressSpec) error {
-				suite.Assert().Equal(ifaceName, r.Status().LinkName)
-				suite.Assert().Equal(network.ConfigCmdline, r.Status().ConfigLayer)
+				suite.Assert().Equal(ifaceName, r.TypedSpec().LinkName)
+				suite.Assert().Equal(network.ConfigCmdline, r.TypedSpec().ConfigLayer)
 
 				return nil
 			})

--- a/internal/app/machined/pkg/controllers/network/address_merge.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge.go
@@ -75,10 +75,10 @@ func (ctrl *AddressMergeController) Run(ctx context.Context, r controller.Runtim
 
 		for _, res := range list.Items {
 			address := res.(*network.AddressSpec) //nolint:errcheck,forcetypeassert
-			id := network.AddressID(address.Status().LinkName, address.Status().Address)
+			id := network.AddressID(address.TypedSpec().LinkName, address.TypedSpec().Address)
 
 			existing, ok := addresses[id]
-			if ok && existing.Status().ConfigLayer > address.Status().ConfigLayer {
+			if ok && existing.TypedSpec().ConfigLayer > address.TypedSpec().ConfigLayer {
 				// skip this address, as existing one is higher layer
 				continue
 			}
@@ -92,7 +92,7 @@ func (ctrl *AddressMergeController) Run(ctx context.Context, r controller.Runtim
 			if err = r.Modify(ctx, network.NewAddressSpec(network.NamespaceName, id), func(res resource.Resource) error {
 				addr := res.(*network.AddressSpec) //nolint:errcheck,forcetypeassert
 
-				*addr.Status() = *address.Status()
+				*addr.TypedSpec() = *address.TypedSpec()
 
 				return nil
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/network/address_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge_test.go
@@ -114,7 +114,7 @@ func (suite *AddressMergeSuite) assertNoAddress(id string) error {
 
 func (suite *AddressMergeSuite) TestMerge() {
 	loopback := network.NewAddressSpec(network.ConfigNamespaceName, "default/lo/127.0.0.1/8")
-	*loopback.Status() = network.AddressSpecSpec{
+	*loopback.TypedSpec() = network.AddressSpecSpec{
 		Address:     netaddr.MustParseIPPrefix("127.0.0.1/8"),
 		LinkName:    "lo",
 		Family:      nethelpers.FamilyInet4,
@@ -123,7 +123,7 @@ func (suite *AddressMergeSuite) TestMerge() {
 	}
 
 	dhcp := network.NewAddressSpec(network.ConfigNamespaceName, "dhcp/eth0/10.0.0.1/8")
-	*dhcp.Status() = network.AddressSpecSpec{
+	*dhcp.TypedSpec() = network.AddressSpecSpec{
 		Address:     netaddr.MustParseIPPrefix("10.0.0.1/8"),
 		LinkName:    "eth0",
 		Family:      nethelpers.FamilyInet4,
@@ -132,7 +132,7 @@ func (suite *AddressMergeSuite) TestMerge() {
 	}
 
 	static := network.NewAddressSpec(network.ConfigNamespaceName, "configuration/eth0/10.0.0.35/32")
-	*static.Status() = network.AddressSpecSpec{
+	*static.TypedSpec() = network.AddressSpecSpec{
 		Address:     netaddr.MustParseIPPrefix("10.0.0.35/32"),
 		LinkName:    "eth0",
 		Family:      nethelpers.FamilyInet4,
@@ -141,7 +141,7 @@ func (suite *AddressMergeSuite) TestMerge() {
 	}
 
 	override := network.NewAddressSpec(network.ConfigNamespaceName, "configuration/eth0/10.0.0.1/8")
-	*override.Status() = network.AddressSpecSpec{
+	*override.TypedSpec() = network.AddressSpecSpec{
 		Address:     netaddr.MustParseIPPrefix("10.0.0.1/8"),
 		LinkName:    "eth0",
 		Family:      nethelpers.FamilyInet4,
@@ -162,11 +162,11 @@ func (suite *AddressMergeSuite) TestMerge() {
 			}, func(r *network.AddressSpec) error {
 				switch r.Metadata().ID() {
 				case "lo/127.0.0.1/8":
-					suite.Assert().Equal(*loopback.Status(), *r.Status())
+					suite.Assert().Equal(*loopback.TypedSpec(), *r.TypedSpec())
 				case "eth0/10.0.0.1/8":
-					suite.Assert().Equal(*override.Status(), *r.Status())
+					suite.Assert().Equal(*override.TypedSpec(), *r.TypedSpec())
 				case "eth0/10.0.0.35/32":
-					suite.Assert().Equal(*static.Status(), *r.Status())
+					suite.Assert().Equal(*static.TypedSpec(), *r.TypedSpec())
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/address_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_spec_test.go
@@ -126,7 +126,7 @@ func (suite *AddressSpecSuite) assertNoLinkAddress(linkName, address string) err
 
 func (suite *AddressSpecSuite) TestLoopback() {
 	loopback := network.NewAddressSpec(network.NamespaceName, "lo/127.0.0.1/8")
-	*loopback.Status() = network.AddressSpecSpec{
+	*loopback.TypedSpec() = network.AddressSpecSpec{
 		Address:     netaddr.MustParseIPPrefix("127.11.0.1/32"),
 		LinkName:    "lo",
 		Family:      nethelpers.FamilyInet4,
@@ -171,7 +171,7 @@ func (suite *AddressSpecSuite) TestDummy() {
 	defer conn.Close() //nolint:errcheck
 
 	dummy := network.NewAddressSpec(network.NamespaceName, "dummy/10.0.0.1/8")
-	*dummy.Status() = network.AddressSpecSpec{
+	*dummy.TypedSpec() = network.AddressSpecSpec{
 		Address:     netaddr.MustParseIPPrefix("10.0.0.1/8"),
 		LinkName:    dummyInterface,
 		Family:      nethelpers.FamilyInet4,

--- a/internal/app/machined/pkg/controllers/network/address_status.go
+++ b/internal/app/machined/pkg/controllers/network/address_status.go
@@ -115,7 +115,7 @@ func (ctrl *AddressStatusController) Run(ctx context.Context, r controller.Runti
 			id := network.AddressID(linkLookup[addr.Index], ipPrefix)
 
 			if err = r.Modify(ctx, network.NewAddressStatus(network.NamespaceName, id), func(r resource.Resource) error {
-				status := r.(*network.AddressStatus).Status()
+				status := r.(*network.AddressStatus).TypedSpec()
 
 				status.Address = ipPrefix
 				status.Local, _ = netaddr.FromStdIPRaw(addr.Attributes.Local)

--- a/internal/app/machined/pkg/controllers/network/link_config.go
+++ b/internal/app/machined/pkg/controllers/network/link_config.go
@@ -175,7 +175,7 @@ func (ctrl *LinkConfigController) apply(ctx context.Context, r controller.Runtim
 			ctx,
 			network.NewLinkSpec(network.ConfigNamespaceName, id),
 			func(r resource.Resource) error {
-				*r.(*network.LinkSpec).Status() = link
+				*r.(*network.LinkSpec).TypedSpec() = link
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/link_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_config_test.go
@@ -107,10 +107,10 @@ func (suite *LinkConfigSuite) TestLoopback() {
 			return suite.assertLinks([]string{
 				"default/lo",
 			}, func(r *network.LinkSpec) error {
-				suite.Assert().Equal("lo", r.Status().Name)
-				suite.Assert().True(r.Status().Up)
-				suite.Assert().False(r.Status().Logical)
-				suite.Assert().Equal(network.ConfigDefault, r.Status().ConfigLayer)
+				suite.Assert().Equal("lo", r.TypedSpec().Name)
+				suite.Assert().True(r.TypedSpec().Up)
+				suite.Assert().False(r.TypedSpec().Logical)
+				suite.Assert().Equal(network.ConfigDefault, r.TypedSpec().ConfigLayer)
 
 				return nil
 			})
@@ -129,10 +129,10 @@ func (suite *LinkConfigSuite) TestCmdline() {
 			return suite.assertLinks([]string{
 				"cmdline/eth1",
 			}, func(r *network.LinkSpec) error {
-				suite.Assert().Equal("eth1", r.Status().Name)
-				suite.Assert().True(r.Status().Up)
-				suite.Assert().False(r.Status().Logical)
-				suite.Assert().Equal(network.ConfigCmdline, r.Status().ConfigLayer)
+				suite.Assert().Equal("eth1", r.TypedSpec().Name)
+				suite.Assert().True(r.TypedSpec().Up)
+				suite.Assert().False(r.TypedSpec().Logical)
+				suite.Assert().Equal(network.ConfigCmdline, r.TypedSpec().ConfigLayer)
 
 				return nil
 			})
@@ -234,41 +234,41 @@ func (suite *LinkConfigSuite) TestMachineConfiguration() {
 				"configuration/dummy0",
 				"configuration/wireguard0",
 			}, func(r *network.LinkSpec) error {
-				suite.Assert().Equal(network.ConfigMachineConfiguration, r.Status().ConfigLayer)
+				suite.Assert().Equal(network.ConfigMachineConfiguration, r.TypedSpec().ConfigLayer)
 
-				switch r.Status().Name {
+				switch r.TypedSpec().Name {
 				case "eth0", "eth1":
-					suite.Assert().True(r.Status().Up)
-					suite.Assert().False(r.Status().Logical)
+					suite.Assert().True(r.TypedSpec().Up)
+					suite.Assert().False(r.TypedSpec().Logical)
 				case "eth0.24", "eth0.48":
-					suite.Assert().True(r.Status().Up)
-					suite.Assert().True(r.Status().Logical)
-					suite.Assert().Equal(nethelpers.LinkEther, r.Status().Type)
-					suite.Assert().Equal(network.LinkKindVLAN, r.Status().Kind)
-					suite.Assert().Equal("eth0", r.Status().ParentName)
-					suite.Assert().Equal(nethelpers.VLANProtocol8021Q, r.Status().VLAN.Protocol)
+					suite.Assert().True(r.TypedSpec().Up)
+					suite.Assert().True(r.TypedSpec().Logical)
+					suite.Assert().Equal(nethelpers.LinkEther, r.TypedSpec().Type)
+					suite.Assert().Equal(network.LinkKindVLAN, r.TypedSpec().Kind)
+					suite.Assert().Equal("eth0", r.TypedSpec().ParentName)
+					suite.Assert().Equal(nethelpers.VLANProtocol8021Q, r.TypedSpec().VLAN.Protocol)
 
-					if r.Status().Name == "eth0.24" {
-						suite.Assert().EqualValues(24, r.Status().VLAN.VID)
+					if r.TypedSpec().Name == "eth0.24" {
+						suite.Assert().EqualValues(24, r.TypedSpec().VLAN.VID)
 					} else {
-						suite.Assert().EqualValues(48, r.Status().VLAN.VID)
+						suite.Assert().EqualValues(48, r.TypedSpec().VLAN.VID)
 					}
 				case "eth2", "eth3":
-					suite.Assert().False(r.Status().Up)
-					suite.Assert().False(r.Status().Logical)
-					suite.Assert().Equal("bond0", r.Status().MasterName)
+					suite.Assert().False(r.TypedSpec().Up)
+					suite.Assert().False(r.TypedSpec().Logical)
+					suite.Assert().Equal("bond0", r.TypedSpec().MasterName)
 				case "bond0":
-					suite.Assert().True(r.Status().Up)
-					suite.Assert().True(r.Status().Logical)
-					suite.Assert().Equal(nethelpers.LinkEther, r.Status().Type)
-					suite.Assert().Equal(network.LinkKindBond, r.Status().Kind)
-					suite.Assert().Equal(nethelpers.BondModeXOR, r.Status().BondMaster.Mode)
-					suite.Assert().True(r.Status().BondMaster.UseCarrier)
+					suite.Assert().True(r.TypedSpec().Up)
+					suite.Assert().True(r.TypedSpec().Logical)
+					suite.Assert().Equal(nethelpers.LinkEther, r.TypedSpec().Type)
+					suite.Assert().Equal(network.LinkKindBond, r.TypedSpec().Kind)
+					suite.Assert().Equal(nethelpers.BondModeXOR, r.TypedSpec().BondMaster.Mode)
+					suite.Assert().True(r.TypedSpec().BondMaster.UseCarrier)
 				case "wireguard0":
-					suite.Assert().True(r.Status().Up)
-					suite.Assert().True(r.Status().Logical)
-					suite.Assert().Equal(nethelpers.LinkNone, r.Status().Type)
-					suite.Assert().Equal(network.LinkKindWireguard, r.Status().Kind)
+					suite.Assert().True(r.TypedSpec().Up)
+					suite.Assert().True(r.TypedSpec().Logical)
+					suite.Assert().Equal(nethelpers.LinkNone, r.TypedSpec().Type)
+					suite.Assert().Equal(network.LinkKindWireguard, r.TypedSpec().Kind)
 					suite.Assert().Equal(network.WireguardSpec{
 						PrivateKey: "ABC",
 						Peers: []network.WireguardPeer{
@@ -281,7 +281,7 @@ func (suite *LinkConfigSuite) TestMachineConfiguration() {
 								},
 							},
 						},
-					}, r.Status().Wireguard)
+					}, r.TypedSpec().Wireguard)
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/link_merge.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge.go
@@ -76,12 +76,12 @@ func (ctrl *LinkMergeController) Run(ctx context.Context, r controller.Runtime, 
 			left := list.Items[i].(*network.LinkSpec)  //nolint:errcheck,forcetypeassert
 			right := list.Items[j].(*network.LinkSpec) //nolint:errcheck,forcetypeassert
 
-			if left.Status().Name < right.Status().Name {
+			if left.TypedSpec().Name < right.TypedSpec().Name {
 				return false
 			}
 
-			if left.Status().Name == right.Status().Name {
-				return left.Status().ConfigLayer < right.Status().ConfigLayer
+			if left.TypedSpec().Name == right.TypedSpec().Name {
+				return left.TypedSpec().ConfigLayer < right.TypedSpec().ConfigLayer
 			}
 
 			return true
@@ -92,12 +92,12 @@ func (ctrl *LinkMergeController) Run(ctx context.Context, r controller.Runtime, 
 
 		for _, res := range list.Items {
 			link := res.(*network.LinkSpec) //nolint:errcheck,forcetypeassert
-			id := network.LinkID(link.Status().Name)
+			id := network.LinkID(link.TypedSpec().Name)
 
 			existing, ok := links[id]
 			if !ok {
-				links[id] = link.Status()
-			} else if err = existing.Merge(link.Status()); err != nil {
+				links[id] = link.TypedSpec()
+			} else if err = existing.Merge(link.TypedSpec()); err != nil {
 				logger.Warn("error merging links", zap.Error(err))
 			}
 		}
@@ -108,7 +108,7 @@ func (ctrl *LinkMergeController) Run(ctx context.Context, r controller.Runtime, 
 			if err = r.Modify(ctx, network.NewLinkSpec(network.NamespaceName, id), func(res resource.Resource) error {
 				l := res.(*network.LinkSpec) //nolint:errcheck,forcetypeassert
 
-				*l.Status() = *link
+				*l.TypedSpec() = *link
 
 				return nil
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/network/link_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge_test.go
@@ -112,14 +112,14 @@ func (suite *LinkMergeSuite) assertNoLinks(id string) error {
 
 func (suite *LinkMergeSuite) TestMerge() {
 	loopback := network.NewLinkSpec(network.ConfigNamespaceName, "default/lo")
-	*loopback.Status() = network.LinkSpecSpec{
+	*loopback.TypedSpec() = network.LinkSpecSpec{
 		Name:        "lo",
 		Up:          true,
 		ConfigLayer: network.ConfigDefault,
 	}
 
 	dhcp := network.NewLinkSpec(network.ConfigNamespaceName, "dhcp/eth0")
-	*dhcp.Status() = network.LinkSpecSpec{
+	*dhcp.TypedSpec() = network.LinkSpecSpec{
 		Name:        "eth0",
 		Up:          true,
 		MTU:         1450,
@@ -127,7 +127,7 @@ func (suite *LinkMergeSuite) TestMerge() {
 	}
 
 	static := network.NewLinkSpec(network.ConfigNamespaceName, "configuration/eth0")
-	*static.Status() = network.LinkSpecSpec{
+	*static.TypedSpec() = network.LinkSpecSpec{
 		Name:        "eth0",
 		Up:          true,
 		MTU:         1500,
@@ -146,9 +146,9 @@ func (suite *LinkMergeSuite) TestMerge() {
 			}, func(r *network.LinkSpec) error {
 				switch r.Metadata().ID() {
 				case "lo":
-					suite.Assert().Equal(*loopback.Status(), *r.Status())
+					suite.Assert().Equal(*loopback.TypedSpec(), *r.TypedSpec())
 				case "eth0":
-					suite.Assert().EqualValues(1500, r.Status().MTU) // static should override dhcp
+					suite.Assert().EqualValues(1500, r.TypedSpec().MTU) // static should override dhcp
 				}
 
 				return nil
@@ -165,11 +165,11 @@ func (suite *LinkMergeSuite) TestMerge() {
 			}, func(r *network.LinkSpec) error {
 				switch r.Metadata().ID() {
 				case "lo":
-					suite.Assert().Equal(*loopback.Status(), *r.Status())
+					suite.Assert().Equal(*loopback.TypedSpec(), *r.TypedSpec())
 				case "eth0":
 					// reconcile happens eventually, so give it some time
-					if r.Status().MTU != 1450 {
-						return retry.ExpectedErrorf("MTU %d != 1450", r.Status().MTU)
+					if r.TypedSpec().MTU != 1450 {
+						return retry.ExpectedErrorf("MTU %d != 1450", r.TypedSpec().MTU)
 					}
 				}
 

--- a/internal/app/machined/pkg/controllers/network/link_status.go
+++ b/internal/app/machined/pkg/controllers/network/link_status.go
@@ -166,7 +166,7 @@ func (ctrl *LinkStatusController) reconcile(ctx context.Context, r controller.Ru
 		}
 
 		if err = r.Modify(ctx, network.NewLinkStatus(network.NamespaceName, link.Attributes.Name), func(r resource.Resource) error {
-			status := r.(*network.LinkStatus).Status()
+			status := r.(*network.LinkStatus).TypedSpec()
 
 			status.Index = link.Index
 			status.HardwareAddr = nethelpers.HardwareAddr(link.Attributes.Address)

--- a/internal/app/machined/pkg/controllers/network/link_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_status_test.go
@@ -118,8 +118,8 @@ func (suite *LinkStatusSuite) TestLoopbackInterface() {
 	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertInterfaces([]string{"lo"}, func(r *network.LinkStatus) error {
-				suite.Assert().Equal("loopback", r.Status().Type.String())
-				suite.Assert().EqualValues(65536, r.Status().MTU)
+				suite.Assert().Equal("loopback", r.TypedSpec().Type.String())
+				suite.Assert().EqualValues(65536, r.TypedSpec().MTU)
 
 				return nil
 			})
@@ -153,9 +153,9 @@ func (suite *LinkStatusSuite) TestDummyInterface() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertInterfaces([]string{dummyInterface}, func(r *network.LinkStatus) error {
-				suite.Assert().Equal("ether", r.Status().Type.String())
-				suite.Assert().EqualValues(1400, r.Status().MTU)
-				suite.Assert().Equal(nethelpers.OperStateDown, r.Status().OperationalState)
+				suite.Assert().Equal("ether", r.TypedSpec().Type.String())
+				suite.Assert().EqualValues(1400, r.TypedSpec().MTU)
+				suite.Assert().Equal(nethelpers.OperStateDown, r.TypedSpec().OperationalState)
 
 				return nil
 			})
@@ -171,8 +171,8 @@ func (suite *LinkStatusSuite) TestDummyInterface() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertInterfaces([]string{dummyInterface}, func(r *network.LinkStatus) error {
-				if r.Status().OperationalState != nethelpers.OperStateUp && r.Status().OperationalState != nethelpers.OperStateUnknown {
-					return retry.ExpectedError(fmt.Errorf("operational state is not up: %s", r.Status().OperationalState))
+				if r.TypedSpec().OperationalState != nethelpers.OperStateUp && r.TypedSpec().OperationalState != nethelpers.OperStateUnknown {
+					return retry.ExpectedError(fmt.Errorf("operational state is not up: %s", r.TypedSpec().OperationalState))
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -154,7 +154,7 @@ func (ctrl *RouteConfigController) apply(ctx context.Context, r controller.Runti
 			ctx,
 			network.NewRouteSpec(network.ConfigNamespaceName, id),
 			func(r resource.Resource) error {
-				*r.(*network.RouteSpec).Status() = route
+				*r.(*network.RouteSpec).TypedSpec() = route
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/network/route_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_config_test.go
@@ -108,10 +108,10 @@ func (suite *RouteConfigSuite) TestCmdline() {
 			return suite.assertRoutes([]string{
 				"cmdline//172.20.0.1",
 			}, func(r *network.RouteSpec) error {
-				suite.Assert().Equal("eth1", r.Status().OutLinkName)
-				suite.Assert().Equal(network.ConfigCmdline, r.Status().ConfigLayer)
-				suite.Assert().Equal(nethelpers.FamilyInet4, r.Status().Family)
-				suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.Status().Priority)
+				suite.Assert().Equal("eth1", r.TypedSpec().OutLinkName)
+				suite.Assert().Equal(network.ConfigCmdline, r.TypedSpec().ConfigLayer)
+				suite.Assert().Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
+				suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
 
 				return nil
 			})
@@ -201,20 +201,20 @@ func (suite *RouteConfigSuite) TestMachineConfiguration() {
 			}, func(r *network.RouteSpec) error {
 				switch r.Metadata().ID() {
 				case "configuration//2001:470:6d:30e:8ed2:b60c:9d2f:803b":
-					suite.Assert().Equal("eth2", r.Status().OutLinkName)
-					suite.Assert().Equal(nethelpers.FamilyInet6, r.Status().Family)
-					suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.Status().Priority)
+					suite.Assert().Equal("eth2", r.TypedSpec().OutLinkName)
+					suite.Assert().Equal(nethelpers.FamilyInet6, r.TypedSpec().Family)
+					suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
 				case "configuration/10.0.3.0/24/10.0.3.1":
-					suite.Assert().Equal("eth0.24", r.Status().OutLinkName)
-					suite.Assert().Equal(nethelpers.FamilyInet4, r.Status().Family)
-					suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.Status().Priority)
+					suite.Assert().Equal("eth0.24", r.TypedSpec().OutLinkName)
+					suite.Assert().Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
+					suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
 				case "configuration/192.168.0.0/18/192.168.0.25":
-					suite.Assert().Equal("eth3", r.Status().OutLinkName)
-					suite.Assert().Equal(nethelpers.FamilyInet4, r.Status().Family)
-					suite.Assert().EqualValues(25, r.Status().Priority)
+					suite.Assert().Equal("eth3", r.TypedSpec().OutLinkName)
+					suite.Assert().Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
+					suite.Assert().EqualValues(25, r.TypedSpec().Priority)
 				}
 
-				suite.Assert().Equal(network.ConfigMachineConfiguration, r.Status().ConfigLayer)
+				suite.Assert().Equal(network.ConfigMachineConfiguration, r.TypedSpec().ConfigLayer)
 
 				return nil
 			})

--- a/internal/app/machined/pkg/controllers/network/route_merge.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge.go
@@ -75,10 +75,10 @@ func (ctrl *RouteMergeController) Run(ctx context.Context, r controller.Runtime,
 
 		for _, res := range list.Items {
 			route := res.(*network.RouteSpec) //nolint:errcheck,forcetypeassert
-			id := network.RouteID(route.Status().Destination, route.Status().Gateway)
+			id := network.RouteID(route.TypedSpec().Destination, route.TypedSpec().Gateway)
 
 			existing, ok := routes[id]
-			if ok && existing.Status().ConfigLayer > route.Status().ConfigLayer {
+			if ok && existing.TypedSpec().ConfigLayer > route.TypedSpec().ConfigLayer {
 				// skip this route, as existing one is higher layer
 				continue
 			}
@@ -92,7 +92,7 @@ func (ctrl *RouteMergeController) Run(ctx context.Context, r controller.Runtime,
 			if err = r.Modify(ctx, network.NewRouteSpec(network.NamespaceName, id), func(res resource.Resource) error {
 				rt := res.(*network.RouteSpec) //nolint:errcheck,forcetypeassert
 
-				*rt.Status() = *route.Status()
+				*rt.TypedSpec() = *route.TypedSpec()
 
 				return nil
 			}); err != nil {

--- a/internal/app/machined/pkg/controllers/network/route_merge_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge_test.go
@@ -114,7 +114,7 @@ func (suite *RouteMergeSuite) assertNoRoute(id string) error {
 
 func (suite *RouteMergeSuite) TestMerge() {
 	cmdline := network.NewRouteSpec(network.ConfigNamespaceName, "cmdline//10.5.0.3")
-	*cmdline.Status() = network.RouteSpecSpec{
+	*cmdline.TypedSpec() = network.RouteSpecSpec{
 		Gateway:     netaddr.MustParseIP("10.5.0.3"),
 		OutLinkName: "eth0",
 		Family:      nethelpers.FamilyInet4,
@@ -125,7 +125,7 @@ func (suite *RouteMergeSuite) TestMerge() {
 	}
 
 	dhcp := network.NewRouteSpec(network.ConfigNamespaceName, "dhcp//10.5.0.3")
-	*dhcp.Status() = network.RouteSpecSpec{
+	*dhcp.TypedSpec() = network.RouteSpecSpec{
 		Gateway:     netaddr.MustParseIP("10.5.0.3"),
 		OutLinkName: "eth0",
 		Family:      nethelpers.FamilyInet4,
@@ -136,7 +136,7 @@ func (suite *RouteMergeSuite) TestMerge() {
 	}
 
 	static := network.NewRouteSpec(network.ConfigNamespaceName, "configuration/10.0.0.35/32/10.0.0.34")
-	*static.Status() = network.RouteSpecSpec{
+	*static.TypedSpec() = network.RouteSpecSpec{
 		Destination: netaddr.MustParseIPPrefix("10.0.0.35/32"),
 		Gateway:     netaddr.MustParseIP("10.0.0.34"),
 		OutLinkName: "eth0",
@@ -159,9 +159,9 @@ func (suite *RouteMergeSuite) TestMerge() {
 			}, func(r *network.RouteSpec) error {
 				switch r.Metadata().ID() {
 				case "/10.5.0.3":
-					suite.Assert().Equal(*dhcp.Status(), *r.Status())
+					suite.Assert().Equal(*dhcp.TypedSpec(), *r.TypedSpec())
 				case "10.0.0.35/32/10.0.0.34":
-					suite.Assert().Equal(*static.Status(), *r.Status())
+					suite.Assert().Equal(*static.TypedSpec(), *r.TypedSpec())
 				}
 
 				return nil
@@ -178,12 +178,12 @@ func (suite *RouteMergeSuite) TestMerge() {
 			}, func(r *network.RouteSpec) error {
 				switch r.Metadata().ID() {
 				case "/10.5.0.3":
-					if *cmdline.Status() != *r.Status() {
+					if *cmdline.TypedSpec() != *r.TypedSpec() {
 						// using retry here, as it might not be reconciled immediately
 						return retry.ExpectedError(fmt.Errorf("not equal yet"))
 					}
 				case "10.0.0.35/32/10.0.0.34":
-					suite.Assert().Equal(*static.Status(), *r.Status())
+					suite.Assert().Equal(*static.TypedSpec(), *r.TypedSpec())
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/network/route_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec_test.go
@@ -127,7 +127,7 @@ func (suite *RouteSpecSuite) assertNoRoute(destination netaddr.IPPrefix, gateway
 
 func (suite *RouteSpecSuite) TestLoopback() {
 	loopback := network.NewRouteSpec(network.NamespaceName, "loopback")
-	*loopback.Status() = network.RouteSpecSpec{
+	*loopback.TypedSpec() = network.RouteSpecSpec{
 		Family:      nethelpers.FamilyInet4,
 		Destination: netaddr.MustParseIPPrefix("127.0.11.0/24"),
 		Gateway:     netaddr.MustParseIP("127.0.11.1"),
@@ -173,7 +173,7 @@ func (suite *RouteSpecSuite) TestLoopback() {
 func (suite *RouteSpecSuite) TestDefaultRoute() {
 	// adding default route with high metric to avoid messing up with the actual default route
 	def := network.NewRouteSpec(network.NamespaceName, "default")
-	*def.Status() = network.RouteSpecSpec{
+	*def.TypedSpec() = network.RouteSpecSpec{
 		Family:      nethelpers.FamilyInet4,
 		Destination: netaddr.IPPrefix{},
 		Gateway:     netaddr.MustParseIP("127.0.11.2"),
@@ -204,7 +204,7 @@ func (suite *RouteSpecSuite) TestDefaultRoute() {
 	_, err := suite.state.UpdateWithConflicts(suite.ctx, def.Metadata(), func(r resource.Resource) error {
 		defR := r.(*network.RouteSpec) //nolint:forcetypeassert,errcheck
 
-		defR.Status().Priority = 1048577
+		defR.TypedSpec().Priority = 1048577
 
 		return nil
 	})

--- a/internal/app/machined/pkg/controllers/network/route_status.go
+++ b/internal/app/machined/pkg/controllers/network/route_status.go
@@ -109,7 +109,7 @@ func (ctrl *RouteStatusController) Run(ctx context.Context, r controller.Runtime
 			id := network.RouteID(dstPrefix, gatewayAddr)
 
 			if err = r.Modify(ctx, network.NewRouteStatus(network.NamespaceName, id), func(r resource.Resource) error {
-				status := r.(*network.RouteStatus).Status()
+				status := r.(*network.RouteStatus).TypedSpec()
 
 				status.Family = nethelpers.Family(route.Family)
 				status.Destination = dstPrefix

--- a/internal/app/machined/pkg/controllers/network/route_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_status_test.go
@@ -100,12 +100,12 @@ func (suite *RouteStatusSuite) TestRoutes() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertRoutes([]string{"127.0.0.0/8/"}, func(r *network.RouteStatus) error {
-				suite.Assert().True(r.Status().Source.IP.IsLoopback())
-				suite.Assert().Equal("lo", r.Status().OutLinkName)
-				suite.Assert().Equal(nethelpers.TableLocal, r.Status().Table)
-				suite.Assert().Equal(nethelpers.ScopeHost, r.Status().Scope)
-				suite.Assert().Equal(nethelpers.TypeLocal, r.Status().Type)
-				suite.Assert().Equal(nethelpers.ProtocolKernel, r.Status().Protocol)
+				suite.Assert().True(r.TypedSpec().Source.IP.IsLoopback())
+				suite.Assert().Equal("lo", r.TypedSpec().OutLinkName)
+				suite.Assert().Equal(nethelpers.TableLocal, r.TypedSpec().Table)
+				suite.Assert().Equal(nethelpers.ScopeHost, r.TypedSpec().Scope)
+				suite.Assert().Equal(nethelpers.TypeLocal, r.TypedSpec().Type)
+				suite.Assert().Equal(nethelpers.ProtocolKernel, r.TypedSpec().Protocol)
 
 				return nil
 			})

--- a/internal/app/machined/pkg/controllers/v1alpha1/boostrap_status.go
+++ b/internal/app/machined/pkg/controllers/v1alpha1/boostrap_status.go
@@ -109,7 +109,7 @@ func (ctrl *BootstrapStatusController) readInitialized(ctx context.Context, r co
 		logger.Info("bootkube initialized status not found")
 
 		return r.Modify(ctx, v1alpha1.NewBootstrapStatus(), func(r resource.Resource) error {
-			r.(*v1alpha1.BootstrapStatus).Status().SelfHostedControlPlane = false
+			r.(*v1alpha1.BootstrapStatus).TypedSpec().SelfHostedControlPlane = false
 
 			return nil
 		})
@@ -118,7 +118,7 @@ func (ctrl *BootstrapStatusController) readInitialized(ctx context.Context, r co
 	logger.Info("found bootkube initialized status in etcd")
 
 	if err = r.Modify(ctx, v1alpha1.NewBootstrapStatus(), func(r resource.Resource) error {
-		r.(*v1alpha1.BootstrapStatus).Status().SelfHostedControlPlane = true
+		r.(*v1alpha1.BootstrapStatus).TypedSpec().SelfHostedControlPlane = true
 
 		return nil
 	}); err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1774,7 +1774,7 @@ func CheckControlPlaneStatus(seq runtime.Sequence, data interface{}) (runtime.Ta
 			return nil
 		}
 
-		if res.(*resourcev1alpha1.BootstrapStatus).Status().SelfHostedControlPlane {
+		if res.(*resourcev1alpha1.BootstrapStatus).TypedSpec().SelfHostedControlPlane {
 			log.Printf("WARNING: Talos is running self-hosted control plane, convert to static pods using `talosctl convert-k8s`.")
 		}
 

--- a/pkg/resources/k8s/manifest_status.go
+++ b/pkg/resources/k8s/manifest_status.go
@@ -62,8 +62,8 @@ func (r *ManifestStatus) DeepCopy() resource.Resource {
 	}
 }
 
-// Status returns ManifestStatusSpec.
-func (r *ManifestStatus) Status() *ManifestStatusSpec {
+// TypedSpec returns ManifestStatusSpec.
+func (r *ManifestStatus) TypedSpec() *ManifestStatusSpec {
 	return &r.spec
 }
 

--- a/pkg/resources/k8s/secrets_status.go
+++ b/pkg/resources/k8s/secrets_status.go
@@ -82,7 +82,7 @@ func (r *SecretsStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *SecretsStatus) Status() *SecretsStatusSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *SecretsStatus) TypedSpec() *SecretsStatusSpec {
 	return &r.spec
 }

--- a/pkg/resources/network/address_spec.go
+++ b/pkg/resources/network/address_spec.go
@@ -77,7 +77,7 @@ func (r *AddressSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *AddressSpec) Status() *AddressSpecSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *AddressSpec) TypedSpec() *AddressSpecSpec {
 	return &r.spec
 }

--- a/pkg/resources/network/address_status.go
+++ b/pkg/resources/network/address_status.go
@@ -81,7 +81,7 @@ func (r *AddressStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *AddressStatus) Status() *AddressStatusSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *AddressStatus) TypedSpec() *AddressStatusSpec {
 	return &r.spec
 }

--- a/pkg/resources/network/link_spec.go
+++ b/pkg/resources/network/link_spec.go
@@ -145,7 +145,7 @@ func (r *LinkSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *LinkSpec) Status() *LinkSpecSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *LinkSpec) TypedSpec() *LinkSpecSpec {
 	return &r.spec
 }

--- a/pkg/resources/network/link_status.go
+++ b/pkg/resources/network/link_status.go
@@ -113,7 +113,7 @@ func (r *LinkStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *LinkStatus) Status() *LinkStatusSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *LinkStatus) TypedSpec() *LinkStatusSpec {
 	return &r.spec
 }

--- a/pkg/resources/network/route_spec.go
+++ b/pkg/resources/network/route_spec.go
@@ -82,7 +82,7 @@ func (r *RouteSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *RouteSpec) Status() *RouteSpecSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *RouteSpec) TypedSpec() *RouteSpecSpec {
 	return &r.spec
 }

--- a/pkg/resources/network/route_status.go
+++ b/pkg/resources/network/route_status.go
@@ -100,7 +100,7 @@ func (r *RouteStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status sets pod status.
-func (r *RouteStatus) Status() *RouteStatusSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *RouteStatus) TypedSpec() *RouteStatusSpec {
 	return &r.spec
 }

--- a/pkg/resources/v1alpha1/bootstrap_status.go
+++ b/pkg/resources/v1alpha1/bootstrap_status.go
@@ -77,7 +77,7 @@ func (r *BootstrapStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Status returns .spec.
-func (r *BootstrapStatus) Status() *BootstrapStatusSpec {
+// TypedSpec allows to access the Spec with the proper type.
+func (r *BootstrapStatus) TypedSpec() *BootstrapStatusSpec {
 	return &r.spec
 }


### PR DESCRIPTION
It was a bad choice to name the method which returns resource spec
typecasted to the proper Go type as `Status()`, as certainly `Status`
has a different meaning for resources. So rename the method accordingly
to be `TypedSpec()`.

No functional or user-visbile changes, just renames.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
