### PR TITLE
feat: implement NodeAddress controller

### DIFF
--- a/internal/app/machined/pkg/controllers/network/node_address.go
+++ b/internal/app/machined/pkg/controllers/network/node_address.go
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// NodeAddressController manages secrets.Etcd based on configuration.
+type NodeAddressController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *NodeAddressController) Name() string {
+	return "network.NodeAddressController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *NodeAddressController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.AddressStatusType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.LinkStatusType,
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *NodeAddressController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: network.NodeAddressType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo,cyclop
+func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		// fetch link and address status resources
+		links, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.LinkStatusType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing links: %w", err)
+		}
+
+		// build "link up" lookup table
+		linksUp := make(map[uint32]struct{})
+
+		for _, r := range links.Items {
+			link := r.(*network.LinkStatus) //nolint:errcheck,forcetypeassert
+
+			if link.TypedSpec().OperationalState == nethelpers.OperStateUp || link.TypedSpec().OperationalState == nethelpers.OperStateUnknown {
+				// skip physical interfaces without carrier
+				if !link.Physical() || link.TypedSpec().LinkState {
+					linksUp[link.TypedSpec().Index] = struct{}{}
+				}
+			}
+		}
+
+		addresses, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.AddressStatusType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing links: %w", err)
+		}
+
+		var (
+			defaultAddress      netaddr.IP
+			defaultAddrLinkName string
+			current             []netaddr.IP
+			accumulative        []netaddr.IP
+		)
+
+		for _, r := range addresses.Items {
+			addr := r.(*network.AddressStatus) //nolint:errcheck,forcetypeassert
+
+			if addr.TypedSpec().Scope >= nethelpers.ScopeLink {
+				continue
+			}
+
+			ip := addr.TypedSpec().Address.IP
+
+			if ip.IsLoopback() || ip.IsMulticast() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+
+			// set defaultAddress to the smallest IP from the alphabetically first link
+			if defaultAddress.IsZero() || addr.TypedSpec().LinkName < defaultAddrLinkName || (addr.TypedSpec().LinkName == defaultAddrLinkName && ip.Compare(defaultAddress) < 0) {
+				defaultAddress = ip
+				defaultAddrLinkName = addr.TypedSpec().LinkName
+			}
+
+			if _, up := linksUp[addr.TypedSpec().LinkIndex]; up {
+				current = append(current, ip)
+			}
+
+			accumulative = append(accumulative, ip)
+		}
+
+		// sort current addresses
+		sort.Slice(current, func(i, j int) bool { return current[i].Compare(current[j]) < 0 })
+
+		// update output resources
+		if !defaultAddress.IsZero() {
+			if err = r.Modify(ctx, network.NewNodeAddress(network.NamespaceName, network.NodeAddressDefaultID), func(r resource.Resource) error {
+				spec := r.(*network.NodeAddress).TypedSpec()
+
+				// never overwrite default address if it's already set
+				// we should start handing default address updates, but for now we're not ready
+				if len(spec.Addresses) > 0 {
+					return nil
+				}
+
+				spec.Addresses = []netaddr.IP{defaultAddress}
+
+				return nil
+			}); err != nil {
+				return fmt.Errorf("error updating output resource: %w", err)
+			}
+		}
+
+		if err = r.Modify(ctx, network.NewNodeAddress(network.NamespaceName, network.NodeAddressCurrentID), func(r resource.Resource) error {
+			spec := r.(*network.NodeAddress).TypedSpec()
+
+			spec.Addresses = current
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("error updating output resource: %w", err)
+		}
+
+		if err = r.Modify(ctx, network.NewNodeAddress(network.NamespaceName, network.NodeAddressAccumulativeID), func(r resource.Resource) error {
+			spec := r.(*network.NodeAddress).TypedSpec()
+
+			for _, ip := range accumulative {
+				ip := ip
+
+				// find insert position using binary search
+				i := sort.Search(len(spec.Addresses), func(j int) bool {
+					return !spec.Addresses[j].Less(ip)
+				})
+
+				if i < len(spec.Addresses) && spec.Addresses[i].Compare(ip) == 0 {
+					continue
+				}
+
+				// insert at position i
+				spec.Addresses = append(spec.Addresses, netaddr.IP{})
+				copy(spec.Addresses[i+1:], spec.Addresses[i:])
+				spec.Addresses[i] = ip
+			}
+
+			return nil
+		}); err != nil {
+			return fmt.Errorf("error updating output resource: %w", err)
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/network/node_address_test.go
+++ b/internal/app/machined/pkg/controllers/network/node_address_test.go
@@ -1,0 +1,130 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	netctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+type NodeAddressSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *NodeAddressSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.AddressStatusController{}))
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.LinkStatusController{}))
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.NodeAddressController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *NodeAddressSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *NodeAddressSuite) assertAddresses(requiredIDs []string, check func(*network.NodeAddress) error) error {
+	missingIDs := make(map[string]struct{}, len(requiredIDs))
+
+	for _, id := range requiredIDs {
+		missingIDs[id] = struct{}{}
+	}
+
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(network.NamespaceName, network.NodeAddressType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resources.Items {
+		_, required := missingIDs[res.Metadata().ID()]
+		if !required {
+			continue
+		}
+
+		delete(missingIDs, res.Metadata().ID())
+
+		if err = check(res.(*network.NodeAddress)); err != nil {
+			return retry.ExpectedError(err)
+		}
+	}
+
+	if len(missingIDs) > 0 {
+		return retry.ExpectedError(fmt.Errorf("some resources are missing: %q", missingIDs))
+	}
+
+	return nil
+}
+
+func (suite *NodeAddressSuite) TestDefaults() {
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertAddresses([]string{
+				network.NodeAddressDefaultID,
+				network.NodeAddressCurrentID,
+				network.NodeAddressAccumulativeID,
+			}, func(r *network.NodeAddress) error {
+				addrs := r.TypedSpec().Addresses
+
+				suite.T().Logf("id %q val %s", r.Metadata().ID(), addrs)
+
+				suite.Assert().True(sort.SliceIsSorted(addrs, func(i, j int) bool {
+					return addrs[i].Compare(addrs[j]) < 0
+				}), "addresses %s", addrs)
+
+				if r.Metadata().ID() == network.NodeAddressDefaultID {
+					suite.Assert().Len(addrs, 1)
+				} else {
+					suite.Assert().GreaterOrEqual(len(addrs), 1)
+				}
+
+				return nil
+			})
+		}))
+}
+
+func TestNodeAddressSuite(t *testing.T) {
+	suite.Run(t, new(NodeAddressSuite))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -75,10 +75,13 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&network.AddressMergeController{},
 		&network.AddressSpecController{},
 		&network.AddressStatusController{},
-		&network.LinkConfigController{},
+		&network.LinkConfigController{
+			Cmdline: procfs.ProcCmdline(),
+		},
 		&network.LinkMergeController{},
 		&network.LinkStatusController{},
 		&network.LinkSpecController{},
+		&network.NodeAddressController{},
 		&network.RouteConfigController{
 			Cmdline: procfs.ProcCmdline(),
 		},

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -82,6 +82,7 @@ func NewState() (*State, error) {
 		&network.LinkRefresh{},
 		&network.LinkStatus{},
 		&network.LinkSpec{},
+		&network.NodeAddress{},
 		&network.RouteStatus{},
 		&network.RouteSpec{},
 		&secrets.Etcd{},

--- a/pkg/resources/network/address_status.go
+++ b/pkg/resources/network/address_status.go
@@ -77,7 +77,16 @@ func (r *AddressStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 		Type:             AddressStatusType,
 		Aliases:          []resource.Type{"address", "addresses"},
 		DefaultNamespace: NamespaceName,
-		PrintColumns:     []meta.PrintColumn{},
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Address",
+				JSONPath: `{.address}`,
+			},
+			{
+				Name:     "Link",
+				JSONPath: `{.linkName}`,
+			},
+		},
 	}
 }
 

--- a/pkg/resources/network/link_status.go
+++ b/pkg/resources/network/link_status.go
@@ -117,3 +117,8 @@ func (r *LinkStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 func (r *LinkStatus) TypedSpec() *LinkStatusSpec {
 	return &r.spec
 }
+
+// Physical checks if the link is physical ethernet.
+func (r *LinkStatus) Physical() bool {
+	return r.TypedSpec().Type == nethelpers.LinkEther && r.TypedSpec().Kind == ""
+}

--- a/pkg/resources/network/network_test.go
+++ b/pkg/resources/network/network_test.go
@@ -30,6 +30,7 @@ func TestRegisterResource(t *testing.T) {
 		&network.LinkRefresh{},
 		&network.LinkStatus{},
 		&network.LinkSpec{},
+		&network.NodeAddress{},
 		&network.RouteStatus{},
 		&network.RouteSpec{},
 	} {

--- a/pkg/resources/network/node_address.go
+++ b/pkg/resources/network/node_address.go
@@ -1,0 +1,99 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"inet.af/netaddr"
+)
+
+// NodeAddressType is type of NodeAddress resource.
+const NodeAddressType = resource.Type("NodeAddresses.net.talos.dev")
+
+// NodeAddress resource holds physical network link status.
+type NodeAddress struct {
+	md   resource.Metadata
+	spec NodeAddressSpec
+}
+
+// NodeAddress well-known IDs.
+const (
+	// Default node address (should be a single address in the spec).
+	//
+	// Used to set for example published etcd peer address.
+	NodeAddressDefaultID = "default"
+	// Current node addresses (as seen at the moment).
+	//
+	// Shows a list of addresses for the node for the UP interfaces.
+	NodeAddressCurrentID = "current"
+	// Accumulative list of the addresses node had over time.
+	//
+	// If some address is no longer present, it will be still kept in the accumulative list.
+	NodeAddressAccumulativeID = "accumulative"
+)
+
+// NodeAddressSpec describes a set of node addresses.
+type NodeAddressSpec struct {
+	Addresses []netaddr.IP `yaml:"addresses"`
+}
+
+// NewNodeAddress initializes a SecretsStatus resource.
+func NewNodeAddress(namespace resource.Namespace, id resource.ID) *NodeAddress {
+	r := &NodeAddress{
+		md:   resource.NewMetadata(namespace, NodeAddressType, id, resource.VersionUndefined),
+		spec: NodeAddressSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *NodeAddress) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *NodeAddress) Spec() interface{} {
+	return r.spec
+}
+
+func (r *NodeAddress) String() string {
+	return fmt.Sprintf("network.NodeAddress(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *NodeAddress) DeepCopy() resource.Resource {
+	return &NodeAddress{
+		md: r.md,
+		spec: NodeAddressSpec{
+			Addresses: append([]netaddr.IP(nil), r.spec.Addresses...),
+		},
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *NodeAddress) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             NodeAddressType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Addresses",
+				JSONPath: `{.addresses}`,
+			},
+		},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *NodeAddress) TypedSpec() *NodeAddressSpec {
+	return &r.spec
+}


### PR DESCRIPTION
This controller provides three important aggregated resources to be
consumed by different interested parties:

* "default" node IP
* "current" addresses (node can be reached on these at the moment)
* "accumulative" addresses (for certSANs)

Example:

```
$ talosctl get nodeaddresses -n 172.20.0.2
NODE         NAMESPACE   TYPE          ID             VERSION   ADDRESSES
172.20.0.2   network     NodeAddress   accumulative   4         ["10.244.0.0","10.244.0.1","172.20.0.2"]
172.20.0.2   network     NodeAddress   current        6         ["10.244.0.0","10.244.0.1","172.20.0.2"]
172.20.0.2   network     NodeAddress   default        1         ["172.20.0.2"]
```

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
