### PR TITLE
feat: parse Talos-specific cmdline params

### DIFF
--- a/internal/app/machined/pkg/controllers/network/cmdline_test.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline_test.go
@@ -87,6 +87,31 @@ func (suite *CmdlineSuite) TestParse() {
 
 			expectedError: "cmdline address parse failure: ParseIP(\"xyz\"): unable to parse IP",
 		},
+		{
+			name:    "hostname override",
+			cmdline: "ip=::::master1:eth1 talos.hostname=master2",
+
+			expectedSettings: network.CmdlineNetworking{
+				Hostname: "master2",
+				LinkName: "eth1",
+			},
+		},
+		{
+			name:    "only hostname",
+			cmdline: "talos.hostname=master2",
+
+			expectedSettings: network.CmdlineNetworking{
+				Hostname: "master2",
+			},
+		},
+		{
+			name:    "ignore interfaces",
+			cmdline: "talos.network.interface.ignore=eth2 talos.network.interface.ignore=eth3",
+
+			expectedSettings: network.CmdlineNetworking{
+				IgnoreInterfaces: []string{"eth2", "eth3"},
+			},
+		},
 	} {
 		test := test
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -55,10 +55,6 @@ const (
 	// hostname.
 	KernelParamHostname = "talos.hostname"
 
-	// KernelParamDefaultInterface is the kernel parameter for specifying the
-	// initial interface used to bootstrap the node.
-	KernelParamDefaultInterface = "talos.interface"
-
 	// KernelParamShutdown is the kernel parameter for specifying the
 	// shutdown type (halt/poweroff).
 	KernelParamShutdown = "talos.shutdown"


### PR DESCRIPTION
This parses Talos cmdline args in addition to standard `ip=` cmdline
params.

GC'ed unused constant.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
