### PR TITLE
feat: default to bootstrap workflow

### DIFF
--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -237,7 +237,7 @@ func writeV1Alpha1Config(args []string) error {
 		return err
 	}
 
-	if err = configBundle.Write(genConfigCmdFlags.outputDir, commentsFlags, machine.TypeInit, machine.TypeControlPlane, machine.TypeJoin); err != nil {
+	if err = configBundle.Write(genConfigCmdFlags.outputDir, commentsFlags, machine.TypeControlPlane, machine.TypeJoin); err != nil {
 		return err
 	}
 

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -42,6 +42,18 @@ Added the flag `cluster.coreDNS.disabled` to coreDNS deployment during the clust
 * Linux kernel was updated to 5.10.29
 """
 
+    [notes.bootstrap]
+        title = "Default to Bootstrap workflow"
+        description = """\
+The `init.yaml` is no longer an output of `talosctl gen config`.
+We now encourage using the bootstrap API, instead it `init` node types, as we
+intend on deprecating this machine type in the future.
+The `init.yaml` and `controlplane.yaml` machine configs are identical with the
+exception of the machine type.
+Users can use a modified `controlplane.yaml` with the machine type set to
+`init` if they would like to avoid using the bootstrap API.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -153,7 +153,6 @@ func (suite *GenSuite) TestGenConfigPatch() {
 		{
 			flag: "config-patch",
 			shouldAffect: map[string]bool{
-				"init.yaml":         true,
 				"controlplane.yaml": true,
 				"join.yaml":         true,
 			},
@@ -161,7 +160,6 @@ func (suite *GenSuite) TestGenConfigPatch() {
 		{
 			flag: "config-patch-control-plane",
 			shouldAffect: map[string]bool{
-				"init.yaml":         true,
 				"controlplane.yaml": true,
 			},
 		},
@@ -177,7 +175,7 @@ func (suite *GenSuite) TestGenConfigPatch() {
 		suite.Run(tt.flag, func() {
 			suite.RunCLI([]string{"gen", "config", "foo", "https://192.168.0.1:6443", "--" + tt.flag, string(patch)})
 
-			for _, configName := range []string{"init.yaml", "controlplane.yaml", "join.yaml"} {
+			for _, configName := range []string{"controlplane.yaml", "join.yaml"} {
 				cfg, err := configloader.NewFromFile(configName)
 
 				suite.Assert().NoError(err)

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -54,7 +54,7 @@ func (suite *ValidateSuite) TearDownTest() {
 func (suite *ValidateSuite) TestValidate() {
 	suite.RunCLI([]string{"gen", "config", "foobar", "https://10.0.0.1"})
 
-	for _, configFile := range []string{"init.yaml", "controlplane.yaml", "join.yaml"} {
+	for _, configFile := range []string{"controlplane.yaml", "join.yaml"} {
 		configFile := configFile
 
 		for _, mode := range []string{"cloud", "container"} {

--- a/website/content/docs/v0.11/Bare Metal Platforms/digital-rebar.md
+++ b/website/content/docs/v0.11/Bare Metal Platforms/digital-rebar.md
@@ -26,7 +26,6 @@ Using the DNS name of the load balancer, generate the base configuration files f
 
 ```bash
 $ talosctl gen config talos-k8s-metal-tutorial https://<load balancer IP or DNS>:<port>
-created init.yaml
 created controlplane.yaml
 created join.yaml
 created talosconfig
@@ -42,8 +41,6 @@ Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will b
 #### Validate the Configuration Files
 
 ```bash
-$ talosctl validate --config init.yaml --mode metal
-init.yaml is valid for metal mode
 $ talosctl validate --config controlplane.yaml --mode metal
 controlplane.yaml is valid for metal mode
 $ talosctl validate --config join.yaml --mode metal
@@ -53,7 +50,7 @@ join.yaml is valid for metal mode
 #### Publishing the Machine Configuration Files
 
 Digital Rebar has a build-in fileserver, which means we can use this feature to expose the talos configuration files.
-We will place `init.yaml`, `controlplane.yaml`, and `worker.yaml` into Digital Rebar file server by using the `drpcli` tools.
+We will place `controlplane.yaml`, and `worker.yaml` into Digital Rebar file server by using the `drpcli` tools.
 
 Copy the generated files from the step above into your Digital Rebar installation.
 
@@ -61,7 +58,7 @@ Copy the generated files from the step above into your Digital Rebar installatio
 drpcli file upload <file>.yaml as <file>.yaml
 ```
 
-Replacing `<file>` with init, controlplane or worker.
+Replacing `<file>` with controlplane or worker.
 
 ### Download the boot files
 
@@ -132,7 +129,6 @@ We're using some of Digital Rebar build in templating to make sure the machine g
 This is why we also include a `params.yaml` in the example directory to make sure the role is set to one of the following:
 
 - controlplane
-- init
 - worker
 
 The `{{.Param \"talos/role\"}}` then gets populated with one of the above roles.
@@ -150,12 +146,27 @@ Once this is done, you can boot the machine.
 
 To understand the boot process, we have a higher level overview located at [metal overview.](/v0.11/en/guides/metal/overview)
 
-### Retrieve the `kubeconfig`
+### Bootstrap Etcd
 
-Once everything is running we can retrieve the admin `kubeconfig` by running:
+To configure `talosctl` we will need the first control plane node's IP:
+
+Set the `endpoints` and `nodes`:
 
 ```bash
 talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
 talosctl --talosconfig talosconfig config node <control plane 1 IP>
+```
+
+Bootstrap `etcd`:
+
+```bash
+talosctl --talosconfig talosconfig bootstrap
+```
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.11/Bare Metal Platforms/equinix-metal.md
+++ b/website/content/docs/v0.11/Bare Metal Platforms/equinix-metal.md
@@ -54,20 +54,18 @@ Using the DNS name of the loadbalancer created earlier, generate the base config
 
 ```bash
 $ talosctl gen config talos-k8s-aws-tutorial https://<load balancer IP or DNS>:<port>
-created init.yaml
 created controlplane.yaml
 created join.yaml
 created talosconfig
 ```
 
-Now add the required shebang (e.g. `#!talos`) at the top of `init.yaml`, `controlplane.yaml`, and `join.yaml`
+Now add the required shebang (e.g. `#!talos`) at the top of `controlplane.yaml`, and `join.yaml`
 At this point, you can modify the generated configs to your liking.
 Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will be applied during the config generation.
 
 #### Validate the Configuration Files
 
 ```bash
-talosctl validate --config init.yaml --mode metal
 talosctl validate --config controlplane.yaml --mode metal
 talosctl validate --config join.yaml --mode metal
 ```
@@ -75,20 +73,7 @@ talosctl validate --config join.yaml --mode metal
 > Note: Validation of the install disk could potentially fail as the validation
 > is performed on you local machine and the specified disk may not exist.
 
-#### Create the Bootstrap Node
-
-```bash
-packet device create \
-  --project-id $PROJECT_ID \
-  --facility $FACILITY \
-  --ipxe-script-url $PXE_SERVER \
-  --operating-system "custom_ipxe" \
-  --plan $PLAN\
-  --hostname $HOSTNAME\
-  --userdata-file init.yaml
-```
-
-#### Create the Remaining Control Plane Nodes
+#### Create the Control Plane Nodes
 
 ```bash
 packet device create \
@@ -116,12 +101,25 @@ packet device create \
   --userdata-file join.yaml
 ```
 
+### Bootstrap Etcd
+
+Set the `endpoints` and `nodes`:
+
+```bash
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
+```
+
+Bootstrap `etcd`:
+
+```bash
+talosctl --talosconfig talosconfig bootstrap
+```
+
 ### Retrieve the `kubeconfig`
 
 At this point we can retrieve the admin `kubeconfig` by running:
 
 ```bash
-talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
-talosctl --talosconfig talosconfig config node <control plane 1 IP>
 talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.11/Cloud Platforms/openstack.md
+++ b/website/content/docs/v0.11/Cloud Platforms/openstack.md
@@ -103,11 +103,8 @@ We are now ready to create our Openstack nodes.
 Create control plane:
 
 ```bash
-# Create control plane 1. Substitute the correct path to configuration files and the desired flavor.
-openstack server create talos-control-plane-1 --flavor m1.small --nic port-id=talos-control-plane-1 --image talos --user-data /path/to/init.yaml
-
 # Create control planes 2 and 3, substituting the same info.
-for i in $( seq 2 3 ); do
+for i in $( seq 1 3 ); do
   openstack server create talos-control-plane-$i --flavor m1.small --nic port-id=talos-control-plane-$i --image talos --user-data /path/to/controlplane.yaml
 done
 ```
@@ -121,15 +118,29 @@ openstack server create talos-worker-1 --flavor m1.small --network shared --imag
 
 > Note: This step can be repeated to add more workers.
 
-### Retrieve the `kubeconfig`
+### Bootstrap Etcd
 
 You should now be able to interact with your cluster with `talosctl`.
 We will use one of the floating IPs we allocated earlier.
 It does not matter which one.
 
+Set the `endpoints` and `nodes`:
+
 ```bash
-talosctl --talosconfig ./talosconfig config endpoint <FLOATING_IP>
-talosctl --talosconfig ./talosconfig config node <FLOATING_IP>
-talosctl --talosconfig ./talosconfig kubeconfig
-kubectl --kubeconfig ./kubeconfig get nodes
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
+```
+
+Bootstrap `etcd`:
+
+```bash
+talosctl --talosconfig talosconfig bootstrap
+```
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig kubeconfig .
 ```

--- a/website/content/docs/v0.11/Guides/configuring-the-cluster-endpoint.md
+++ b/website/content/docs/v0.11/Guides/configuring-the-cluster-endpoint.md
@@ -30,7 +30,7 @@ The configuration can either be done on a Loadbalancer, or simply trough DNS.
 
 For example:
 
-> This is in the config file for the cluster e.g. init.yaml, controlplane.yaml and join.yaml.
+> This is in the config file for the cluster e.g. controlplane.yaml and join.yaml.
 > for more details, please see: [v1alpha1 endpoint configuration](../../reference/configuration/#controlplaneconfig)
 
 ```yaml

--- a/website/content/docs/v0.11/Introduction/getting-started.md
+++ b/website/content/docs/v0.11/Introduction/getting-started.md
@@ -207,7 +207,6 @@ When you run this command, you will receive a number of files in your current
 directory:
 
 - `controlplane.yaml`
-- `init.yaml`
 - `join.yaml`
 - `talosconfig`
 
@@ -215,7 +214,7 @@ The three `.yaml` files are what we call Machine Configs.
 They are installed onto the Talos servers to act as their complete configuration,
 describing everything from what disk Talos should be installed to, to what
 sysctls to set, to what network settings it should have.
-In the case of the `controlplane.yaml` and `init.yaml`, it even describes how Talos should form its Kubernetes cluster.
+In the case of the `controlplane.yaml`, it even describes how Talos should form its Kubernetes cluster.
 
 The `talosconfig` file (which is also YAML) is your local client configuration
 file.

--- a/website/content/docs/v0.11/Local Platforms/virtualbox.md
+++ b/website/content/docs/v0.11/Local Platforms/virtualbox.md
@@ -112,22 +112,21 @@ Issue the following command, updating the output directory, cluster name, and co
 talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out
 ```
 
-This will create several files in the \_out directory: init.yaml, controlplane.yaml, join.yaml, and talosconfig.
+This will create several files in the `_out` directory: controlplane.yaml, join.yaml, and talosconfig.
 
 ## Create Control Plane Node
 
-Using the `init.yaml` generated above, you can now apply this config using talosctl.
+Using the `controlplane.yaml` generated above, you can now apply this config using talosctl.
 Issue:
 
 ```bash
-talosctl apply-config --insecure --nodes $CONTROL_PLANE_IP --file _out/init.yaml
+talosctl apply-config --insecure --nodes $CONTROL_PLANE_IP --file _out/controlplane.yaml
 ```
 
 You should now see some action in the VirtualBox console for this VM.
 Talos will be installed to disk, the VM will reboot, and then Talos will configure the Kubernetes control plane on this VM.
 
 > Note: This process can be repeated multiple times to create an HA control plane.
-> Simply apply `controlplane.yaml` instead of `init.yaml` for subsequent nodes.
 
 ## Create Worker Node
 
@@ -157,12 +156,27 @@ talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP
 ```
 
-## Retrieve and Configure the `kubeconfig`
+### Bootstrap Etcd
 
-Fetch the kubeconfig file from the control plane node by issuing:
+Set the `endpoints` and `nodes`:
 
 ```bash
-talosctl kubeconfig
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
+```
+
+Bootstrap `etcd`:
+
+```bash
+talosctl --talosconfig talosconfig bootstrap
+```
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig kubeconfig .
 ```
 
 You can then use kubectl in this fashion:

--- a/website/content/docs/v0.11/Virtualized Platforms/proxmox.md
+++ b/website/content/docs/v0.11/Virtualized Platforms/proxmox.md
@@ -146,22 +146,21 @@ Issue the following command, updating the output directory, cluster name, and co
 talosctl gen config talos-vbox-cluster https://$CONTROL_PLANE_IP:6443 --output-dir _out
 ```
 
-This will create several files in the \_out directory: init.yaml, controlplane.yaml, join.yaml, and talosconfig.
+This will create several files in the `_out` directory: controlplane.yaml, join.yaml, and talosconfig.
 
 ## Create Control Plane Node
 
-Using the `init.yaml` generated above, you can now apply this config using talosctl.
+Using the `controlplane.yaml` generated above, you can now apply this config using talosctl.
 Issue:
 
 ```bash
-talosctl apply-config --insecure --nodes $CONTROL_PLANE_IP --file _out/init.yaml
+talosctl apply-config --insecure --nodes $CONTROL_PLANE_IP --file _out/controlplan.yaml
 ```
 
 You should now see some action in the Proxmox console for this VM.
 Talos will be installed to disk, the VM will reboot, and then Talos will configure the Kubernetes control plane on this VM.
 
 > Note: This process can be repeated multiple times to create an HA control plane.
-> Simply apply `controlplane.yaml` instead of `init.yaml` for subsequent nodes.
 
 ## Create Worker Node
 
@@ -191,18 +190,27 @@ talosctl config endpoint $CONTROL_PLANE_IP
 talosctl config node $CONTROL_PLANE_IP
 ```
 
-## Retrieve and Configure the `kubeconfig`
+### Bootstrap Etcd
 
-Fetch the kubeconfig file from the control plane node by issuing:
+Set the `endpoints` and `nodes`:
 
 ```bash
-talosctl kubeconfig
+talosctl --talosconfig talosconfig config endpoint <control plane 1 IP>
+talosctl --talosconfig talosconfig config node <control plane 1 IP>
 ```
 
-You can then use kubectl in this fashion:
+Bootstrap `etcd`:
 
 ```bash
-kubectl get nodes
+talosctl --talosconfig talosconfig bootstrap
+```
+
+### Retrieve the `kubeconfig`
+
+At this point we can retrieve the admin `kubeconfig` by running:
+
+```bash
+talosctl --talosconfig talosconfig kubeconfig .
 ```
 
 ## Cleaning Up

--- a/website/content/docs/v0.11/Virtualized Platforms/vmware.md
+++ b/website/content/docs/v0.11/Virtualized Platforms/vmware.md
@@ -25,7 +25,6 @@ Using the DNS name or name of the loadbalancer used in the prereq steps, generat
 
 ```bash
 $ talosctl gen config talos-k8s-vmware-tutorial https://<load balancer IP or DNS>:<port>
-created init.yaml
 created controlplane.yaml
 created join.yaml
 created talosconfig
@@ -33,7 +32,6 @@ created talosconfig
 
 ```bash
 $ talosctl gen config talos-k8s-vmware-tutorial https://<DNS name>:6443
-created init.yaml
 created controlplane.yaml
 created join.yaml
 created talosconfig
@@ -45,8 +43,6 @@ Optionally, you can specify `--config-patch` with RFC6902 jsonpatch which will b
 #### Validate the Configuration Files
 
 ```bash
-$ talosctl validate --config init.yaml --mode cloud
-init.yaml is valid for cloud mode
 $ talosctl validate --config controlplane.yaml --mode cloud
 controlplane.yaml is valid for cloud mode
 $ talosctl validate --config join.yaml --mode cloud
@@ -108,7 +104,7 @@ To facilitate persistent storage using the vSphere cloud provider integration wi
 
 ```bash
 govc vm.change \
-  -e "guestinfo.talos.config=$(cat init.yaml | base64)" \
+  -e "guestinfo.talos.config=$(cat controlplane.yaml | base64)" \
   -e "disk.enableUUID=1" \
   -vm /ha-datacenter/vm/control-plane-1
 ```


### PR DESCRIPTION
Changes `gen config` to output `controlplane` and `join` machine config
types only. Users can manually set the `type` to `init` if they need to.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>