### PR TITLE
fix: drop into maintenance mode if config URL is `none` (metal)

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/metal/metal.go
@@ -45,6 +45,10 @@ func (m *Metal) Configuration(ctx context.Context) ([]byte, error) {
 		return nil, errors.ErrNoConfigSource
 	}
 
+	if *option == constants.ConfigNone {
+		return nil, errors.ErrNoConfigSource
+	}
+
 	log.Printf("fetching machine config from: %q", *option)
 
 	u, err := url.Parse(*option)


### PR DESCRIPTION
Installer puts `none` if no URL was present in the cmdline on boot, e.g.
when installing from ISO.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
