### PR TITLE
chore: use Go 1.16.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0
-PKGS ?= v0.6.0-alpha.0-5-ga3a6650
-EXTRAS ?= v0.3.0
+TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-1-gc8c2a18
+PKGS ?= v0.6.0-alpha.0-7-ge63e4e9
+EXTRAS ?= v0.3.0-1-g4fe2706
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0
 STRINGER_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.29-talos"
+	DefaultKernelVersion = "5.10.38-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump tools, pkgs, extras.
