### PR TITLE
feat: implement virtual IP (shared IP) network operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/insomniacslk/dhcp v0.0.0-20210528123148-fb4eaaa00ad2
 	github.com/jsimonetti/rtnetlink v0.0.0-20210531051304-b34cb89a106b
 	github.com/mattn/go-isatty v0.0.13
+	github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc
 	github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43
 	github.com/mdlayher/genetlink v1.0.0
 	github.com/mdlayher/netlink v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -876,6 +876,9 @@ github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc h1:m7rJJJeXrYCFpsxXYapkDW53wJCDmf9bsIXUg0HoeQY=
+github.com/mdlayher/arp v0.0.0-20191213142603-f72070a231fc/go.mod h1:eOj1DDj3NAZ6yv+WafaKzY37MFZ58TdfIhQ+8nQbiis=
+github.com/mdlayher/ethernet v0.0.0-20190313224307-5b5fc417d966/go.mod h1:5s5p/sMJ6sNsFl6uCh85lkFGV8kLuIYJCRJLavVJwvg=
 github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 h1:lez6TS6aAau+8wXUP3G9I3TGlmPFEq2CTxBaRqY6AGE=
 github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7/go.mod h1:U6ZQobyTjI/tJyq2HG+i/dfSoFUt8/aZCM+GKtmFk/Y=
 github.com/mdlayher/ethtool v0.0.0-20210210192532-2b88debcdd43 h1:WgyLFv10Ov49JAQI/ZLUkCZ7VJS3r74hwFIGXJsgZlY=
@@ -895,6 +898,7 @@ github.com/mdlayher/netlink v1.3.0/go.mod h1:xK/BssKuwcRXHrtN04UBkwQ6dY9VviGGuri
 github.com/mdlayher/netlink v1.4.0/go.mod h1:dRJi5IABcZpBD2A3D0Mv/AiX8I9uDEu5oGkAVrekmf8=
 github.com/mdlayher/netlink v1.4.1 h1:I154BCU+mKlIf7BgcAJB2r7QjveNPty6uNY1g9ChVfI=
 github.com/mdlayher/netlink v1.4.1/go.mod h1:e4/KuJ+s8UhfUpO9z00/fDZZmhSrs+oxyqAS9cNgn6Q=
+github.com/mdlayher/raw v0.0.0-20190313224157-43dbcdd7739d/go.mod h1:r1fbeITl2xL/zLbVnNHFyOzQJTgr/3fpf1lJX/cjzR8=
 github.com/mdlayher/raw v0.0.0-20190606142536-fef19f00fc18/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065/go.mod h1:7EpbotpCmVZcu+KCX4g9WaRNuu11uyhiW7+Le1dKawg=
 github.com/mdlayher/raw v0.0.0-20210412142147-51b895745faf h1:InctQoB89TIkmgIFQeIL4KXNvWc1iebQXdZggqPSwL8=
@@ -1468,6 +1472,7 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190419010253-1f3472d942ba/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/internal/app/machined/pkg/controllers/network/operator/vip.go
+++ b/internal/app/machined/pkg/controllers/network/operator/vip.go
@@ -1,0 +1,298 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package operator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.etcd.io/etcd/client/v3/concurrency"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/internal/pkg/etcd"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+	"github.com/talos-systems/talos/pkg/resources/v1alpha1"
+)
+
+const campaignRetryInterval = time.Second
+
+// VIP implements the Virtual (Shared) IP network operator.
+type VIP struct {
+	logger *zap.Logger
+
+	linkName string
+	sharedIP netaddr.IP
+
+	state state.State
+
+	mu     sync.Mutex
+	leader bool
+}
+
+// NewVIP creates Virtual IP operator.
+func NewVIP(logger *zap.Logger, linkName string, sharedIP netaddr.IP, state state.State) *VIP {
+	return &VIP{
+		logger:   logger,
+		linkName: linkName,
+		sharedIP: sharedIP,
+		state:    state,
+	}
+}
+
+// Prefix returns unique operator prefix which gets prepended to each spec.
+func (vip *VIP) Prefix() string {
+	return fmt.Sprintf("vip/%s", vip.linkName)
+}
+
+// Run the operator loop.
+func (vip *VIP) Run(ctx context.Context, notifyCh chan<- struct{}) {
+	for {
+		err := vip.campaign(ctx, notifyCh)
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				vip.logger.Warn("campaign failure", zap.Error(err), zap.String("link", vip.linkName), zap.Stringer("ip", vip.sharedIP))
+			}
+
+			select {
+			case <-time.After(campaignRetryInterval):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// AddressSpecs implements Operator interface.
+func (vip *VIP) AddressSpecs() []network.AddressSpecSpec {
+	vip.mu.Lock()
+	defer vip.mu.Unlock()
+
+	if !vip.leader {
+		return nil
+	}
+
+	family := nethelpers.FamilyInet6
+	gratuitousARP := false
+
+	if vip.sharedIP.Is4() {
+		family = nethelpers.FamilyInet4
+		gratuitousARP = true
+	}
+
+	return []network.AddressSpecSpec{
+		{
+			Address: netaddr.IPPrefix{
+				IP:   vip.sharedIP,
+				Bits: vip.sharedIP.BitLen(),
+			},
+			LinkName:        vip.linkName,
+			Family:          family,
+			Scope:           nethelpers.ScopeGlobal,
+			Flags:           nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			AnnounceWithARP: gratuitousARP,
+			ConfigLayer:     network.ConfigOperator,
+		},
+	}
+}
+
+// LinkSpecs implements Operator interface.
+func (vip *VIP) LinkSpecs() []network.LinkSpecSpec {
+	return nil
+}
+
+// RouteSpecs implements Operator interface.
+func (vip *VIP) RouteSpecs() []network.RouteSpecSpec {
+	return nil
+}
+
+// HostnameSpecs implements Operator interface.
+func (vip *VIP) HostnameSpecs() []network.HostnameSpecSpec {
+	return nil
+}
+
+// ResolverSpecs implements Operator interface.
+func (vip *VIP) ResolverSpecs() []network.ResolverSpecSpec {
+	return nil
+}
+
+// TimeServerSpecs implements Operator interface.
+func (vip *VIP) TimeServerSpecs() []network.TimeServerSpecSpec {
+	return nil
+}
+
+func (vip *VIP) etcdElectionKey() string {
+	return fmt.Sprintf("%s:vip:election:%s", constants.EtcdRootTalosKey, vip.sharedIP.String())
+}
+
+func (vip *VIP) waitForPreconditions(ctx context.Context) error {
+	//  wait for the etcd to be up
+	_, err := vip.state.WatchFor(ctx, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.ServiceType, "etcd", resource.VersionUndefined),
+		state.WithCondition(func(r resource.Resource) (bool, error) {
+			if resource.IsTombstone(r) {
+				return false, nil
+			}
+
+			svc := r.(*v1alpha1.Service) //nolint:errcheck,forcetypeassert
+
+			return svc.Running() && svc.Healthy(), nil
+		}))
+	if err != nil {
+		return fmt.Errorf("etcd health wait failure: %w", err)
+	}
+
+	return nil
+}
+
+//nolint:gocyclo,cyclop
+func (vip *VIP) campaign(ctx context.Context, notifyCh chan<- struct{}) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	if err := vip.waitForPreconditions(ctx); err != nil {
+		return fmt.Errorf("error waiting for preconditions: %w", err)
+	}
+
+	hostname, err := os.Hostname() // TODO: this should be etcd nodename
+	if err != nil {
+		return fmt.Errorf("refusing to join election without a hostname")
+	}
+
+	ec, err := etcd.NewLocalClient()
+	if err != nil {
+		return fmt.Errorf("failed to create local etcd client: %w", err)
+	}
+
+	defer ec.Close() //nolint:errcheck
+
+	sess, err := concurrency.NewSession(ec.Client)
+	if err != nil {
+		return fmt.Errorf("failed to create concurrency session: %w", err)
+	}
+	defer sess.Close() //nolint:errcheck
+
+	election := concurrency.NewElection(sess, vip.etcdElectionKey())
+
+	node, err := election.Leader(ctx)
+	if err != nil {
+		if err != concurrency.ErrElectionNoLeader {
+			return fmt.Errorf("failed getting current leader: %w", err)
+		}
+	} else if string(node.Kvs[0].Value) == hostname {
+		vip.logger.Info("resigning from previous election")
+
+		// we are still leader from the previous election, attempt to resign to force new election
+		resumedElection := concurrency.ResumeElection(sess, vip.etcdElectionKey(), string(node.Kvs[0].Key), node.Kvs[0].CreateRevision)
+
+		if err = resumedElection.Resign(ctx); err != nil {
+			return fmt.Errorf("failed resigning from previous elections: %w", err)
+		}
+	}
+
+	campaignErrCh := make(chan error)
+
+	go func() {
+		campaignErrCh <- election.Campaign(ctx, hostname)
+	}()
+
+	select {
+	case err = <-campaignErrCh:
+		if err != nil {
+			return fmt.Errorf("failed to conduct campaign: %w", err)
+		}
+	case <-sess.Done():
+		vip.logger.Info("etcd session closed")
+	}
+
+	defer func() {
+		// use a new context to resign, as `ctx` might be canceled
+		resignCtx, resignCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer resignCancel()
+
+		election.Resign(resignCtx) //nolint:errcheck
+	}()
+
+	if err = vip.markAsLeader(ctx, notifyCh, true); err != nil {
+		return err
+	}
+
+	defer func() {
+		vip.markAsLeader(ctx, notifyCh, false) //nolint:errcheck
+
+		vip.logger.Info("removing shared IP", zap.String("link", vip.linkName), zap.Stringer("ip", vip.sharedIP), zap.String("link", vip.linkName))
+	}()
+
+	vip.logger.Info("enabled shared IP", zap.String("link", vip.linkName), zap.Stringer("ip", vip.sharedIP), zap.String("link", vip.linkName))
+
+	watchCh := make(chan state.Event)
+
+	if err = vip.state.Watch(ctx, resource.NewMetadata(v1alpha1.NamespaceName, v1alpha1.ServiceType, "etcd", resource.VersionUndefined), watchCh); err != nil {
+		return fmt.Errorf("error setting up etcd watch: %w", err)
+	}
+
+	err = vip.state.WatchKind(ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.StaticPodStatusType, "", resource.VersionUndefined), watchCh)
+	if err != nil {
+		return fmt.Errorf("kube-apiserver health wait failure: %w", err)
+	}
+
+	observe := election.Observe(ctx)
+
+observeLoop:
+	for {
+		select {
+		case <-sess.Done():
+			vip.logger.Info("etcd session closed")
+
+			break observeLoop
+		case <-ctx.Done():
+			break observeLoop
+		case resp, ok := <-observe:
+			if !ok {
+				break observeLoop
+			}
+
+			if string(resp.Kvs[0].Value) != hostname {
+				vip.logger.Info("detected new leader", zap.ByteString("leader", resp.Kvs[0].Value))
+
+				break observeLoop
+			}
+		case event := <-watchCh:
+			// break the loop when etcd is stoppped or kube-apiserver is stopped
+			if event.Type == state.Destroyed {
+				if event.Resource.Metadata().ID() == "etcd" || strings.HasPrefix(event.Resource.Metadata().ID(), "kube-system/kube-apiserver-") {
+					break observeLoop
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (vip *VIP) markAsLeader(ctx context.Context, notifyCh chan<- struct{}, leader bool) error {
+	{
+		vip.mu.Lock()
+		defer vip.mu.Unlock()
+
+		vip.leader = leader
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case notifyCh <- struct{}{}:
+		return nil
+	}
+}

--- a/pkg/resources/network/address_spec.go
+++ b/pkg/resources/network/address_spec.go
@@ -25,12 +25,13 @@ type AddressSpec struct {
 
 // AddressSpecSpec describes status of rendered secrets.
 type AddressSpecSpec struct {
-	Address     netaddr.IPPrefix        `yaml:"address"`
-	LinkName    string                  `yaml:"linkName"`
-	Family      nethelpers.Family       `yaml:"family"`
-	Scope       nethelpers.Scope        `yaml:"scope"`
-	Flags       nethelpers.AddressFlags `yaml:"flags"`
-	ConfigLayer ConfigLayer             `yaml:"layer"`
+	Address         netaddr.IPPrefix        `yaml:"address"`
+	LinkName        string                  `yaml:"linkName"`
+	Family          nethelpers.Family       `yaml:"family"`
+	Scope           nethelpers.Scope        `yaml:"scope"`
+	Flags           nethelpers.AddressFlags `yaml:"flags"`
+	AnnounceWithARP bool                    `yaml:"announceWithARP,omitempty"`
+	ConfigLayer     ConfigLayer             `yaml:"layer"`
 }
 
 // NewAddressSpec initializes a AddressSpec resource.


### PR DESCRIPTION
Code mostly copy-pasted from the networkd implementation, but adapted to
the resource model:

* watch for etcd state to start/stop activities
* watch for kube-api-server static pod state to give up VIP when
api-server goes down

Gratuitous ARP code re-implemented to drop dependency on kube-vip (once
the old networkd code is removed).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
