### PR TITLE
chore: expose WatchRequest in the resources client

### DIFF
--- a/pkg/machinery/client/resources.go
+++ b/pkg/machinery/client/resources.go
@@ -177,11 +177,16 @@ func (client *ResourceWatchClient) Recv() (WatchResponse, error) {
 
 // Watch resources by kind or by kind and ID.
 func (c *ResourcesClient) Watch(ctx context.Context, resourceNamespace, resourceType, resourceID string, callOptions ...grpc.CallOption) (*ResourceWatchClient, error) {
-	client, err := c.client.Watch(ctx, &resourceapi.WatchRequest{
+	return c.WatchRequest(ctx, &resourceapi.WatchRequest{
 		Namespace: resourceNamespace,
 		Type:      resourceType,
 		Id:        resourceID,
 	}, callOptions...)
+}
+
+// WatchRequest resources by watch request.
+func (c *ResourcesClient) WatchRequest(ctx context.Context, request *resourceapi.WatchRequest, callOptions ...grpc.CallOption) (*ResourceWatchClient, error) {
+	client, err := c.client.Watch(ctx, request, callOptions...)
 
 	return &ResourceWatchClient{
 		grpcClient: client,


### PR DESCRIPTION
Current interface does not provide a way to pass `tailEvents` param.
Theila is using this client and it needs to specify `tailEvents`.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>