### PR TITLE
fix: overwrite nodes in the gRPC metadata

### DIFF
--- a/pkg/machinery/client/context.go
+++ b/pkg/machinery/client/context.go
@@ -13,7 +13,10 @@ import (
 // WithNodes wraps the context with metadata to send request to set of nodes.
 func WithNodes(ctx context.Context, nodes ...string) context.Context {
 	md, _ := metadata.FromOutgoingContext(ctx)
-	md = metadata.Join(md, metadata.MD{"nodes": nodes})
+
+	// overwrite any previous nodes in the context metadata with new value
+	md = md.Copy()
+	md.Set("nodes", nodes...)
 
 	return metadata.NewOutgoingContext(ctx, md)
 }


### PR DESCRIPTION
Many places rely on the "replace" semantics, and the change in #3738
broke that assumpion. This was showing up as upgrade test failure when
upgrade code saw a duplicate of config resource (as it saw responses
from two nodes).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
