### PR TITLE
feat: implement controller which runs network operators

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator_spec.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec.go
@@ -1,0 +1,398 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator"
+	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// OperatorSpecController applies network.OperatorSpec to the actual interfaces.
+type OperatorSpecController struct {
+	V1alpha1Platform v1alpha1runtime.Platform
+	State            state.State
+
+	// Factory can be overridden for unit-testing.
+	Factory OperatorFactory
+
+	operators map[string]*operatorRunState
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *OperatorSpecController) Name() string {
+	return "network.OperatorSpecController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *OperatorSpecController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.OperatorSpecType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.LinkStatusType,
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *OperatorSpecController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: network.AddressSpecType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: network.LinkSpecType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: network.RouteSpecType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: network.HostnameSpecType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: network.ResolverSpecType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: network.TimeServerSpecType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// operatorRunState describes a state of running operator.
+type operatorRunState struct {
+	Operator operator.Operator
+	Spec     network.OperatorSpecSpec
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func (state *operatorRunState) Start(ctx context.Context, notifyCh chan<- struct{}) {
+	state.wg.Add(1)
+
+	ctx, state.cancel = context.WithCancel(ctx)
+
+	go func() {
+		defer state.wg.Done()
+
+		state.Operator.Run(ctx, notifyCh)
+	}()
+}
+
+func (state *operatorRunState) Stop() {
+	state.cancel()
+
+	state.wg.Wait()
+}
+
+// Run implements controller.Controller interface.
+func (ctrl *OperatorSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	notifyCh := make(chan struct{})
+
+	ctrl.operators = make(map[string]*operatorRunState)
+
+	defer func() {
+		for _, operator := range ctrl.operators {
+			operator.Stop()
+		}
+	}()
+
+	if ctrl.Factory == nil {
+		ctrl.Factory = ctrl.newOperator
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+			if err := ctrl.reconcileOperators(ctx, r, logger, notifyCh); err != nil {
+				return err
+			}
+		case <-notifyCh:
+			if err := ctrl.reconcileOperatorOutputs(ctx, r); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+//nolint:gocyclo
+func (ctrl *OperatorSpecController) reconcileOperators(ctx context.Context, r controller.Runtime, logger *zap.Logger, notifyCh chan<- struct{}) error {
+	// build link up statuses
+	linkStatuses := make(map[string]bool)
+
+	list, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.LinkStatusType, "", resource.VersionUndefined))
+	if err != nil {
+		return fmt.Errorf("error listing source network addresses: %w", err)
+	}
+
+	for _, item := range list.Items {
+		linkStatus := item.(*network.LinkStatus) //nolint:errcheck,forcetypeassert
+
+		linkStatuses[linkStatus.Metadata().ID()] = linkStatus.TypedSpec().OperationalState == nethelpers.OperStateUnknown || linkStatus.TypedSpec().OperationalState == nethelpers.OperStateUp
+	}
+
+	// list operator specs
+	list, err = r.List(ctx, resource.NewMetadata(network.NamespaceName, network.OperatorSpecType, "", resource.VersionUndefined))
+	if err != nil {
+		return fmt.Errorf("error listing source network addresses: %w", err)
+	}
+
+	// figure out which operators should run
+	shouldRun := make(map[string]*network.OperatorSpecSpec)
+
+	for _, item := range list.Items {
+		operatorSpec := item.(*network.OperatorSpec) //nolint:errcheck,forcetypeassert
+
+		up, exists := linkStatuses[operatorSpec.TypedSpec().LinkName]
+
+		// link doesn't exist, skip operator
+		if !exists {
+			continue
+		}
+
+		// link is down and operator requires link to be up, skip it
+		if operatorSpec.TypedSpec().RequireUp && !up {
+			continue
+		}
+
+		shouldRun[operatorSpec.Metadata().ID()] = operatorSpec.TypedSpec()
+	}
+
+	// stop running operators which shouldn't run
+	for id := range ctrl.operators {
+		if _, exists := shouldRun[id]; !exists {
+			logger.Debug("stopping operator", zap.String("operator", id))
+
+			// stop operator
+			ctrl.operators[id].Stop()
+			delete(ctrl.operators, id)
+		} else if *shouldRun[id] != ctrl.operators[id].Spec {
+			logger.Debug("replacing operator", zap.String("operator", id))
+
+			// stop operator
+			ctrl.operators[id].Stop()
+			delete(ctrl.operators, id)
+		}
+	}
+
+	// start operators which aren't running
+	for id := range shouldRun {
+		if _, exists := ctrl.operators[id]; !exists {
+			ctrl.operators[id] = &operatorRunState{
+				Operator: ctrl.Factory(logger, shouldRun[id]),
+				Spec:     *shouldRun[id],
+			}
+
+			logger.Debug("starting operator", zap.String("operator", id))
+			ctrl.operators[id].Start(ctx, notifyCh)
+		}
+	}
+
+	// now reconcile outputs as the operators might have changed
+	return ctrl.reconcileOperatorOutputs(ctx, r)
+}
+
+//nolint:gocyclo,cyclop
+func (ctrl *OperatorSpecController) reconcileOperatorOutputs(ctx context.Context, r controller.Runtime) error {
+	// query specs from all operators and update outputs
+	touchedIDs := map[string]map[string]struct{}{}
+
+	apply := func(res resource.Resource, fn func(resource.Resource)) error {
+		if touchedIDs[res.Metadata().Type()] == nil {
+			touchedIDs[res.Metadata().Type()] = map[string]struct{}{}
+		}
+
+		touchedIDs[res.Metadata().Type()][res.Metadata().ID()] = struct{}{}
+
+		return r.Modify(ctx, res, func(r resource.Resource) error {
+			fn(r)
+
+			return nil
+		})
+	}
+
+	for _, op := range ctrl.operators {
+		for _, addressSpec := range op.Operator.AddressSpecs() {
+			addressSpec := addressSpec
+
+			if err := apply(
+				network.NewAddressSpec(
+					network.ConfigNamespaceName,
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.AddressID(addressSpec.LinkName, addressSpec.Address)),
+				),
+				func(r resource.Resource) {
+					*r.(*network.AddressSpec).TypedSpec() = addressSpec
+				},
+			); err != nil {
+				return fmt.Errorf("error applying spec: %w", err)
+			}
+		}
+
+		for _, routeSpec := range op.Operator.RouteSpecs() {
+			routeSpec := routeSpec
+
+			if err := apply(
+				network.NewRouteSpec(
+					network.ConfigNamespaceName,
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.RouteID(routeSpec.Destination, routeSpec.Gateway)),
+				),
+				func(r resource.Resource) {
+					*r.(*network.RouteSpec).TypedSpec() = routeSpec
+				},
+			); err != nil {
+				return fmt.Errorf("error applying spec: %w", err)
+			}
+		}
+
+		for _, linkSpec := range op.Operator.LinkSpecs() {
+			linkSpec := linkSpec
+
+			if err := apply(
+				network.NewLinkSpec(
+					network.ConfigNamespaceName,
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.LinkID(linkSpec.Name)),
+				),
+				func(r resource.Resource) {
+					*r.(*network.LinkSpec).TypedSpec() = linkSpec
+				},
+			); err != nil {
+				return fmt.Errorf("error applying spec: %w", err)
+			}
+		}
+
+		for _, hostnameSpec := range op.Operator.HostnameSpecs() {
+			hostnameSpec := hostnameSpec
+
+			if err := apply(
+				network.NewHostnameSpec(
+					network.ConfigNamespaceName,
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.HostnameID),
+				),
+				func(r resource.Resource) {
+					*r.(*network.HostnameSpec).TypedSpec() = hostnameSpec
+				},
+			); err != nil {
+				return fmt.Errorf("error applying spec: %w", err)
+			}
+		}
+
+		for _, resolverSpec := range op.Operator.ResolverSpecs() {
+			resolverSpec := resolverSpec
+
+			if err := apply(
+				network.NewResolverSpec(
+					network.ConfigNamespaceName,
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.ResolverID),
+				),
+				func(r resource.Resource) {
+					*r.(*network.ResolverSpec).TypedSpec() = resolverSpec
+				},
+			); err != nil {
+				return fmt.Errorf("error applying spec: %w", err)
+			}
+		}
+
+		for _, timeserverSpec := range op.Operator.TimeServerSpecs() {
+			timeserverSpec := timeserverSpec
+
+			if err := apply(
+				network.NewTimeServerSpec(
+					network.ConfigNamespaceName,
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.TimeServerID),
+				),
+				func(r resource.Resource) {
+					*r.(*network.TimeServerSpec).TypedSpec() = timeserverSpec
+				},
+			); err != nil {
+				return fmt.Errorf("error applying spec: %w", err)
+			}
+		}
+	}
+
+	// clean up not touched specs
+	for _, resourceType := range []resource.Type{
+		network.AddressSpecType,
+		network.LinkSpecType,
+		network.RouteSpecType,
+		network.HostnameSpecType,
+		network.ResolverSpecType,
+		network.TimeServerSpecType,
+	} {
+		list, err := r.List(ctx, resource.NewMetadata(network.ConfigNamespaceName, resourceType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing specs: %w", err)
+		}
+
+		for _, item := range list.Items {
+			if item.Metadata().Owner() != ctrl.Name() {
+				continue
+			}
+
+			touched := false
+
+			if touchedIDs[resourceType] != nil {
+				if _, exists := touchedIDs[resourceType][item.Metadata().ID()]; exists {
+					touched = true
+				}
+			}
+
+			if !touched {
+				if err = r.Destroy(ctx, item.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up untouched spec: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// OperatorFactory creates operator based on the spec.
+type OperatorFactory func(*zap.Logger, *network.OperatorSpecSpec) operator.Operator
+
+func (ctrl *OperatorSpecController) newOperator(logger *zap.Logger, spec *network.OperatorSpecSpec) operator.Operator {
+	switch spec.Operator {
+	case network.OperatorDHCP4:
+		logger = logger.With(zap.String("operator", "dhcp4"))
+
+		return operator.NewDHCP4(logger, spec.LinkName, spec.DHCP4.RouteMetric, ctrl.V1alpha1Platform)
+	case network.OperatorDHCP6:
+		logger = logger.With(zap.String("operator", "dhcp6"))
+
+		return operator.NewDHCP6(logger, spec.LinkName)
+	case network.OperatorVIP:
+		logger = logger.With(zap.String("operator", "vip"))
+
+		return operator.NewVIP(logger, spec.LinkName, spec.VIP.IP, ctrl.State)
+	case network.OperatorWgLAN:
+		panic("not implemented")
+	default:
+		panic(fmt.Sprintf("unexpected operator %s", spec.Operator))
+	}
+}

--- a/internal/app/machined/pkg/controllers/network/operator_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec_test.go
@@ -1,0 +1,446 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	netctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+type OperatorSpecSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+type mockOperator struct {
+	spec     network.OperatorSpecSpec
+	notifyCh chan<- struct{}
+
+	mu          sync.Mutex
+	addresses   []network.AddressSpecSpec
+	links       []network.LinkSpecSpec
+	routes      []network.RouteSpecSpec
+	hostname    []network.HostnameSpecSpec
+	resolvers   []network.ResolverSpecSpec
+	timeservers []network.TimeServerSpecSpec
+}
+
+var (
+	runningOperators   = map[string]*mockOperator{}
+	runningOperatorsMu sync.Mutex
+)
+
+func (mock *mockOperator) Prefix() string {
+	return fmt.Sprintf("%s/%s", mock.spec.Operator, mock.spec.LinkName)
+}
+
+func (mock *mockOperator) Run(ctx context.Context, notifyCh chan<- struct{}) {
+	mock.notifyCh = notifyCh
+
+	{
+		runningOperatorsMu.Lock()
+		runningOperators[mock.Prefix()] = mock
+		runningOperatorsMu.Unlock()
+	}
+
+	<-ctx.Done()
+
+	{
+		runningOperatorsMu.Lock()
+		delete(runningOperators, mock.Prefix())
+		runningOperatorsMu.Unlock()
+	}
+}
+
+func (mock *mockOperator) notify() {
+	mock.notifyCh <- struct{}{}
+}
+
+func (mock *mockOperator) AddressSpecs() []network.AddressSpecSpec {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.addresses
+}
+
+func (mock *mockOperator) LinkSpecs() []network.LinkSpecSpec {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.links
+}
+
+func (mock *mockOperator) RouteSpecs() []network.RouteSpecSpec {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.routes
+}
+
+func (mock *mockOperator) HostnameSpecs() []network.HostnameSpecSpec {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.hostname
+}
+
+func (mock *mockOperator) ResolverSpecs() []network.ResolverSpecSpec {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.resolvers
+}
+
+func (mock *mockOperator) TimeServerSpecs() []network.TimeServerSpecSpec {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+
+	return mock.timeservers
+}
+
+func (suite *OperatorSpecSuite) newOperator(logger *zap.Logger, spec *network.OperatorSpecSpec) operator.Operator {
+	return &mockOperator{
+		spec: *spec,
+	}
+}
+
+func (suite *OperatorSpecSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	runningOperators = map[string]*mockOperator{}
+
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.OperatorSpecController{
+		Factory: suite.newOperator,
+	}))
+
+	suite.startRuntime()
+}
+
+func (suite *OperatorSpecSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *OperatorSpecSuite) assertRunning(runningIDs []string, assertFunc func(*mockOperator) error) error {
+	runningOperatorsMu.Lock()
+	defer runningOperatorsMu.Unlock()
+
+	for _, id := range runningIDs {
+		op, exists := runningOperators[id]
+
+		if !exists {
+			return retry.ExpectedErrorf("operator %q is not running", id)
+		}
+
+		if err := assertFunc(op); err != nil {
+			return retry.ExpectedError(err)
+		}
+	}
+
+	for id := range runningOperators {
+		found := false
+
+		for _, expectedID := range runningIDs {
+			if expectedID == id {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return retry.ExpectedErrorf("operator %s should not be running", id)
+		}
+	}
+
+	return nil
+}
+
+func (suite *OperatorSpecSuite) assertResources(resourceType resource.Type, requiredIDs []string) error {
+	missingIDs := make(map[string]struct{}, len(requiredIDs))
+
+	for _, id := range requiredIDs {
+		missingIDs[id] = struct{}{}
+	}
+
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(network.ConfigNamespaceName, resourceType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resources.Items {
+		delete(missingIDs, res.Metadata().ID())
+	}
+
+	if len(missingIDs) > 0 {
+		return retry.ExpectedError(fmt.Errorf("some resources are missing: %q", missingIDs))
+	}
+
+	return nil
+}
+
+func (suite *OperatorSpecSuite) TestScheduling() {
+	specDHCP := network.NewOperatorSpec(network.NamespaceName, "dhcp4/eth0")
+	*specDHCP.TypedSpec() = network.OperatorSpecSpec{
+		Operator:  network.OperatorDHCP4,
+		LinkName:  "eth0",
+		RequireUp: true,
+		DHCP4: network.DHCP4OperatorSpec{
+			RouteMetric: 1024,
+		},
+	}
+
+	specVIP := network.NewOperatorSpec(network.NamespaceName, "vip/eth0")
+	*specVIP.TypedSpec() = network.OperatorSpecSpec{
+		Operator:  network.OperatorVIP,
+		LinkName:  "eth0",
+		RequireUp: false,
+		VIP: network.VIPOperatorSpec{
+			IP: netaddr.MustParseIP("1.2.3.4"),
+		},
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, specDHCP))
+	suite.Require().NoError(suite.state.Create(suite.ctx, specVIP))
+
+	// operators shouldn't be running yet, as link state is not known yet
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRunning(nil, func(op *mockOperator) error {
+				return nil
+			})
+		}))
+
+	linkState := network.NewLinkStatus(network.NamespaceName, "eth0")
+	*linkState.TypedSpec() = network.LinkStatusSpec{
+		OperationalState: nethelpers.OperStateDown,
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, linkState))
+
+	// vip operator should be scheduled now, as VIP operator doesn't require link to be up
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRunning([]string{"vip/eth0"}, func(op *mockOperator) error {
+				suite.Assert().Equal(netaddr.MustParseIP("1.2.3.4"), op.spec.VIP.IP)
+
+				return nil
+			})
+		}))
+
+	_, err := suite.state.UpdateWithConflicts(suite.ctx, linkState.Metadata(), func(r resource.Resource) error {
+		r.(*network.LinkStatus).TypedSpec().OperationalState = nethelpers.OperStateUp
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	// now all operators should be scheduled
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRunning([]string{"dhcp4/eth0", "vip/eth0"}, func(op *mockOperator) error {
+				switch op.spec.Operator { //nolint:exhaustive
+				case network.OperatorDHCP4:
+					suite.Assert().EqualValues(1024, op.spec.DHCP4.RouteMetric)
+				case network.OperatorVIP:
+					suite.Assert().Equal(netaddr.MustParseIP("1.2.3.4"), op.spec.VIP.IP)
+				default:
+					panic("unreachable")
+				}
+
+				return nil
+			})
+		}))
+
+	// change the spec, operator should be rescheduled
+	_, err = suite.state.UpdateWithConflicts(suite.ctx, specVIP.Metadata(), func(r resource.Resource) error {
+		r.(*network.OperatorSpec).TypedSpec().VIP.IP = netaddr.MustParseIP("3.4.5.6")
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRunning([]string{"dhcp4/eth0", "vip/eth0"}, func(op *mockOperator) error {
+				switch op.spec.Operator { //nolint:exhaustive
+				case network.OperatorDHCP4:
+					suite.Assert().EqualValues(1024, op.spec.DHCP4.RouteMetric)
+				case network.OperatorVIP:
+					if op.spec.VIP.IP.Compare(netaddr.MustParseIP("3.4.5.6")) != 0 {
+						return retry.ExpectedErrorf("unexpected vip: %s", op.spec.VIP.IP)
+					}
+				default:
+					panic("unreachable")
+				}
+
+				return nil
+			})
+		}))
+
+	// bring down the interface, operator should be stopped
+	_, err = suite.state.UpdateWithConflicts(suite.ctx, linkState.Metadata(), func(r resource.Resource) error {
+		r.(*network.LinkStatus).TypedSpec().OperationalState = nethelpers.OperStateDown
+
+		return nil
+	})
+	suite.Require().NoError(err)
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRunning([]string{"vip/eth0"}, func(op *mockOperator) error {
+				return nil
+			})
+		}))
+}
+
+func (suite *OperatorSpecSuite) TestOperatorOutputs() {
+	specDHCP := network.NewOperatorSpec(network.NamespaceName, "dhcp4/eth0")
+	*specDHCP.TypedSpec() = network.OperatorSpecSpec{
+		Operator:  network.OperatorDHCP4,
+		LinkName:  "eth0",
+		RequireUp: true,
+		DHCP4: network.DHCP4OperatorSpec{
+			RouteMetric: 1024,
+		},
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, specDHCP))
+
+	linkState := network.NewLinkStatus(network.NamespaceName, "eth0")
+	*linkState.TypedSpec() = network.LinkStatusSpec{
+		OperationalState: nethelpers.OperStateUp,
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, linkState))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRunning([]string{"dhcp4/eth0"}, func(op *mockOperator) error {
+				return nil
+			})
+		}))
+
+	// pretend dhcp has some specs ready
+	runningOperatorsMu.Lock()
+	dhcpMock := runningOperators["dhcp4/eth0"]
+	runningOperatorsMu.Unlock()
+
+	dhcpMock.mu.Lock()
+	dhcpMock.addresses = []network.AddressSpecSpec{
+		{
+			Address:     netaddr.MustParseIPPrefix("10.5.0.2/24"),
+			LinkName:    "eth0",
+			Family:      nethelpers.FamilyInet4,
+			Scope:       nethelpers.ScopeGlobal,
+			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			ConfigLayer: network.ConfigOperator,
+		},
+	}
+	dhcpMock.links = []network.LinkSpecSpec{
+		{
+			Name:        "eth0",
+			Up:          true,
+			ConfigLayer: network.ConfigOperator,
+		},
+	}
+	dhcpMock.hostname = []network.HostnameSpecSpec{
+		{
+			Hostname:    "foo",
+			ConfigLayer: network.ConfigOperator,
+		},
+	}
+	dhcpMock.mu.Unlock()
+
+	dhcpMock.notify()
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertResources(network.AddressSpecType, []string{"dhcp4/eth0/eth0/10.5.0.2/24"})
+		}))
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertResources(network.LinkSpecType, []string{"dhcp4/eth0/eth0"})
+		}))
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertResources(network.HostnameSpecType, []string{"dhcp4/eth0/hostname"})
+		}))
+
+	// update specs
+	dhcpMock.mu.Lock()
+	dhcpMock.addresses = []network.AddressSpecSpec{
+		{
+			Address:     netaddr.MustParseIPPrefix("10.5.0.3/24"),
+			LinkName:    "eth0",
+			Family:      nethelpers.FamilyInet4,
+			Scope:       nethelpers.ScopeGlobal,
+			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
+			ConfigLayer: network.ConfigOperator,
+		},
+	}
+	dhcpMock.mu.Unlock()
+
+	dhcpMock.notify()
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertResources(network.AddressSpecType, []string{"dhcp4/eth0/eth0/10.5.0.3/24"})
+		}))
+}
+
+func (suite *OperatorSpecSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	suite.Assert().NoError(suite.state.Create(context.Background(), network.NewOperatorSpec(network.NamespaceName, "bar")))
+}
+
+func TestOperatorSpecSuite(t *testing.T) {
+	suite.Run(t, new(OperatorSpecSuite))
+}


### PR DESCRIPTION
Controller operates on `OperatorSpec` resources generated by
`OperatorSpecController` from the machine configuration.

`OperatorSpecControllers` figures out whether operator should run based
on link status, restarts operators on configuration changes.
The controller also scrapes operators for the specs and syncs them as
resources.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
