### PR TITLE
fix: separate healthy and unknown flags in the service resource

### DIFF
--- a/internal/app/machined/pkg/controllers/v1alpha1/service.go
+++ b/internal/app/machined/pkg/controllers/v1alpha1/service.go
@@ -79,7 +79,8 @@ func (ctrl *ServiceController) Run(ctx context.Context, r controller.Runtime, lo
 						svc := r.(*v1alpha1.Service) //nolint:errcheck,forcetypeassert
 
 						svc.SetRunning(true)
-						svc.SetHealthy(msg.GetHealth().GetHealthy() && !msg.GetHealth().GetUnknown())
+						svc.SetHealthy(msg.GetHealth().GetHealthy())
+						svc.SetUnknown(msg.GetHealth().GetUnknown())
 
 						return nil
 					}); err != nil {

--- a/pkg/resources/v1alpha1/service.go
+++ b/pkg/resources/v1alpha1/service.go
@@ -24,6 +24,7 @@ type Service struct {
 type ServiceSpec struct {
 	Running bool `yaml:"running"`
 	Healthy bool `yaml:"healthy"`
+	Unknown bool `yaml:"unknown"`
 }
 
 // NewService initializes a Service resource.
@@ -75,6 +76,10 @@ func (r *Service) ResourceDefinition() meta.ResourceDefinitionSpec {
 				Name:     "Healthy",
 				JSONPath: "{.healthy}",
 			},
+			{
+				Name:     "Health Unknown",
+				JSONPath: "{.unknown}",
+			},
 		},
 	}
 }
@@ -89,6 +94,11 @@ func (r *Service) SetHealthy(healthy bool) {
 	r.spec.Healthy = healthy
 }
 
+// SetUnknown changes .spec.unknown.
+func (r *Service) SetUnknown(unknown bool) {
+	r.spec.Unknown = unknown
+}
+
 // Running returns .spec.running.
 func (r *Service) Running() bool {
 	return r.spec.Running
@@ -97,4 +107,9 @@ func (r *Service) Running() bool {
 // Healthy returns .spec.healthy.
 func (r *Service) Healthy() bool {
 	return r.spec.Healthy
+}
+
+// Unknown returns .spec.unknown.
+func (r *Service) Unknown() bool {
+	return r.spec.Unknown
 }


### PR DESCRIPTION
Otherwise if the service status is unknown it is shown as Unhealthy
which is actually different from what we have for:
`talosctl services` API.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3762)
<!-- Reviewable:end -->
