### PR TITLE
feat: update controller-runtime logs to console level on config.debug

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -101,9 +101,11 @@ func (r *Runtime) CanApplyImmediate(b []byte) error {
 
 	// the config changes allowed to be applied immediately are:
 	// * cluster config
+	// * .machine.debug
 	// * .machine.time
 	// * .machine.network
 	newConfig.ClusterConfig = currentConfig.ClusterConfig
+	newConfig.ConfigDebug = currentConfig.ConfigDebug
 
 	if newConfig.MachineConfig != nil && currentConfig.MachineConfig != nil {
 		newConfig.MachineConfig.MachineTime = currentConfig.MachineConfig.MachineTime

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -34,6 +34,7 @@ import (
 	"github.com/talos-systems/talos/internal/pkg/containers/image"
 	"github.com/talos-systems/talos/pkg/argsbuilder"
 	"github.com/talos-systems/talos/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/resources/network"
 	timeresource "github.com/talos-systems/talos/pkg/resources/time"
@@ -185,7 +186,7 @@ func (k *Kubelet) Runner(r runtime.Runtime) (runner.Runner, error) {
 	}
 
 	return restart.New(containerd.NewRunner(
-		r.Config().Debug(),
+		r.Config().Debug() && r.Config().Machine().Type() == machine.TypeJoin, // enable debug logs only for the worker nodes
 		&args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithNamespace(constants.SystemContainerdNamespace),

--- a/pkg/logging/zap.go
+++ b/pkg/logging/zap.go
@@ -61,7 +61,7 @@ var StdWriter = &LogWrapper{nil}
 // LogDestination defines logging destination Config.
 type LogDestination struct {
 	// Level log level.
-	Level  zap.AtomicLevel
+	Level  zapcore.LevelEnabler
 	writer io.Writer
 	config zapcore.EncoderConfig
 }
@@ -91,7 +91,7 @@ func WithColoredLevels() EncoderOption {
 }
 
 // NewLogDestination creates new log destination.
-func NewLogDestination(writer io.Writer, logLevel zapcore.Level, options ...EncoderOption) *LogDestination {
+func NewLogDestination(writer io.Writer, logLevel zapcore.LevelEnabler, options ...EncoderOption) *LogDestination {
 	config := zap.NewDevelopmentEncoderConfig()
 	config.ConsoleSeparator = " "
 	config.StacktraceKey = "error"
@@ -101,7 +101,7 @@ func NewLogDestination(writer io.Writer, logLevel zapcore.Level, options ...Enco
 	}
 
 	return &LogDestination{
-		Level:  zap.NewAtomicLevelAt(logLevel),
+		Level:  logLevel,
 		config: config,
 		writer: writer,
 	}


### PR DESCRIPTION
This PR enables debug logging of controller-runtime to the server
console if the machine configuration .debug field is set to true (log
verbosity can be also changed on the fly).

For control plane nodes, don't send kubelet logs to the console (as they
tend to flood the console with messages), this leaves reasonable amount
of logging for early boot troubleshooting.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3767)
<!-- Reviewable:end -->
