### PR TITLE
fix: wait for the network to be ready in mainteancne mode

### DIFF
--- a/pkg/resources/network/hostname_status.go
+++ b/pkg/resources/network/hostname_status.go
@@ -35,6 +35,17 @@ func (spec *HostnameStatusSpec) FQDN() string {
 	return spec.Hostname + "." + spec.Domainname
 }
 
+// DNSNames returns DNS names to be added to the certificate based on the hostname and fqdn.
+func (spec *HostnameStatusSpec) DNSNames() []string {
+	result := []string{spec.Hostname}
+
+	if spec.Domainname != "" {
+		result = append(result, spec.FQDN())
+	}
+
+	return result
+}
+
 // NewHostnameStatus initializes a HostnameStatus resource.
 func NewHostnameStatus(namespace resource.Namespace, id resource.ID) *HostnameStatus {
 	r := &HostnameStatus{


### PR DESCRIPTION
This got "broken" as part of the change to the new networking
implementation, so that maintenance service is launched before the
network is ready.

Fetch DNS names and IPs for the certificate from the resources.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3768)
<!-- Reviewable:end -->
