### PR TITLE
fix: do not format state partition in the initialize sequence

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -367,6 +367,7 @@ local integration_disk_image = Step("e2e-disk-image", target="e2e-qemu", privile
         "SHORT_INTEGRATION_TEST": "yes",
         "USE_DISK_IMAGE": "true",
         "IMAGE_REGISTRY": local_registry,
+        "WITH_DISK_ENCRYPTION": "true",
 });
 local integration_canal_reset = Step("e2e-canal-reset", target="e2e-qemu", privileged=true, depends_on=[integration_disk_image], environment={
         "INTEGRATION_TEST_RUN": "TestIntegration/api.ResetSuite/TestResetWithSpec",

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -185,6 +185,10 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 
 	phases = phases.AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
+		"saveStateEncryptionConfig",
+		SaveStateEncryptionConfig,
+	).AppendWhen(
+		r.State().Platform().Mode() != runtime.ModeContainer,
 		"mountState",
 		MountStatePartition,
 	).Append(

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1485,7 +1485,13 @@ func MountStatePartition(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 		//nolint:errcheck
 		defer meta.Close()
 
-		opts := []mount.Option{mount.WithFlags(mount.SkipIfMounted)}
+		flags := mount.SkipIfMounted
+
+		if seq == runtime.SequenceInitialize {
+			flags |= mount.SkipIfNoFilesystem
+		}
+
+		opts := []mount.Option{mount.WithFlags(flags)}
 
 		var encryption config.Encryption
 		// first try reading encryption from the config

--- a/internal/pkg/mount/mount.go
+++ b/internal/pkg/mount/mount.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/talos-systems/go-blockdevice/blockdevice"
+	"github.com/talos-systems/go-blockdevice/blockdevice/filesystem"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util"
 	"github.com/talos-systems/go-retry/retry"
 	"golang.org/x/sys/unix"
@@ -44,6 +45,7 @@ func Mount(mountpoints *Points) (err error) {
 	return nil
 }
 
+//nolint:gocyclo
 func mountMountpoint(mountpoint *Point) (err error) {
 	var skipMount bool
 
@@ -59,6 +61,10 @@ func mountMountpoint(mountpoint *Point) (err error) {
 		if err != nil {
 			return fmt.Errorf("mountpoint is set to skip if mounted, but the mount check failed: %w", err)
 		}
+	}
+
+	if mountpoint.MountFlags.Check(SkipIfNoFilesystem) && mountpoint.Fstype() == filesystem.Unknown {
+		skipMount = true
 	}
 
 	if !skipMount {

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -19,6 +19,8 @@ const (
 	Overlay
 	// SkipIfMounted is a flag for skipping mount if the mountpoint is already mounted.
 	SkipIfMounted
+	// SkipIfNoFilesystem is a flag for skipping formatting and mounting if the mountpoint has not filesystem.
+	SkipIfNoFilesystem
 )
 
 // Flags is the mount flags.

--- a/internal/pkg/mount/system.go
+++ b/internal/pkg/mount/system.go
@@ -157,9 +157,13 @@ func SystemMountPointForLabel(device *blockdevice.BlockDevice, label string, opt
 			return fmt.Errorf("failed to determine format options for partition label %s", part.Name)
 		}
 
-		p.fstype = opts.FileSystemType
+		if !o.MountFlags.Check(SkipIfNoFilesystem) {
+			p.fstype = opts.FileSystemType
 
-		return partition.Format(p.source, opts)
+			return partition.Format(p.source, opts)
+		}
+
+		return nil
 	})
 
 	opts = append(opts, WithPreMountHooks(preMountHooks...))


### PR DESCRIPTION
Initialize state should be only reading the config.
So now if it detects that the partition is not even formatted it will
skip it and will consider the state to be empty.

Fixes: https://github.com/talos-systems/talos/issues/3759

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3769)
<!-- Reviewable:end -->
