### PR TITLE
fix: update networking stack after Equinix Metal testing

### DIFF
--- a/internal/app/machined/pkg/controllers/network/link_merge.go
+++ b/internal/app/machined/pkg/controllers/network/link_merge.go
@@ -111,6 +111,8 @@ func (ctrl *LinkMergeController) Run(ctx context.Context, r controller.Runtime, 
 			}); err != nil {
 				return fmt.Errorf("error updating resource: %w", err)
 			}
+
+			logger.Debug("merged link spec", zap.String("id", id), zap.Any("spec", link))
 		}
 
 		// list link for cleanup

--- a/internal/app/machined/pkg/controllers/network/link_spec.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec.go
@@ -403,7 +403,7 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 		}
 
 		// sync UP flag
-		existingUp := existing.Attributes.OperationalState == rtnetlink.OperStateUnknown || existing.Attributes.OperationalState == rtnetlink.OperStateUp
+		existingUp := existing.Flags&unix.IFF_UP == unix.IFF_UP
 		if existingUp != link.TypedSpec().Up {
 			flags := uint32(0)
 
@@ -456,6 +456,7 @@ func (ctrl *LinkSpecController) syncLink(ctx context.Context, r controller.Runti
 				Family: existing.Family,
 				Type:   existing.Type,
 				Index:  existing.Index,
+				Change: unix.IFF_UP,
 				Attributes: &rtnetlink.LinkAttributes{
 					Master: pointer.ToUint32(masterIndex),
 				},

--- a/internal/app/machined/pkg/controllers/network/link_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/link_spec_test.go
@@ -339,7 +339,7 @@ func (suite *LinkSpecSuite) TestBond() {
 		Name:        dummy0Name,
 		Type:        nethelpers.LinkEther,
 		Kind:        "dummy",
-		Up:          false,
+		Up:          true,
 		Logical:     true,
 		MasterName:  bondName,
 		ConfigLayer: network.ConfigDefault,
@@ -351,7 +351,7 @@ func (suite *LinkSpecSuite) TestBond() {
 		Name:        dummy1Name,
 		Type:        nethelpers.LinkEther,
 		Kind:        "dummy",
-		Up:          false,
+		Up:          true,
 		Logical:     true,
 		MasterName:  bondName,
 		ConfigLayer: network.ConfigDefault,
@@ -374,8 +374,8 @@ func (suite *LinkSpecSuite) TestBond() {
 				case dummy0Name, dummy1Name:
 					suite.Assert().Equal("dummy", r.TypedSpec().Kind)
 
-					if r.TypedSpec().OperationalState != nethelpers.OperStateDown {
-						return retry.ExpectedErrorf("link is not down: %s", r.TypedSpec().OperationalState)
+					if r.TypedSpec().OperationalState != nethelpers.OperStateUnknown {
+						return retry.ExpectedErrorf("link is not up: %s", r.TypedSpec().OperationalState)
 					}
 
 					if r.TypedSpec().MasterIndex == 0 {

--- a/internal/app/machined/pkg/controllers/network/operator_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config.go
@@ -117,6 +117,12 @@ func (ctrl *OperatorConfigController) Run(ctx context.Context, r controller.Runt
 					continue
 				}
 
+				if device.Bond() != nil {
+					for _, link := range device.Bond().Interfaces() {
+						configuredInterfaces[link] = struct{}{}
+					}
+				}
+
 				if device.DHCP() && device.DHCPOptions().IPv4() {
 					routeMetric := device.DHCPOptions().RouteMetric()
 					if routeMetric == 0 {

--- a/internal/app/machined/pkg/controllers/network/resolver_merge.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_merge.go
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Package network provides controllers which manage network resources.
+//
+//nolint:dupl
 package network
 
 import (

--- a/internal/app/machined/pkg/controllers/network/resolver_spec.go
+++ b/internal/app/machined/pkg/controllers/network/resolver_spec.go
@@ -87,6 +87,14 @@ func (ctrl *ResolverSpecController) Run(ctx context.Context, r controller.Runtim
 					return fmt.Errorf("error removing finalizer: %w", err)
 				}
 			case resource.PhaseRunning:
+				resolvers := make([]string, len(spec.TypedSpec().DNSServers))
+
+				for i := range resolvers {
+					resolvers[i] = spec.TypedSpec().DNSServers[i].String()
+				}
+
+				logger.Info("setting resolvers", zap.Strings("resolvers", resolvers))
+
 				if err = r.Modify(ctx, network.NewResolverStatus(network.NamespaceName, spec.Metadata().ID()), func(r resource.Resource) error {
 					status := r.(*network.ResolverStatus) //nolint:forcetypeassert,errcheck
 

--- a/internal/app/machined/pkg/controllers/network/timeserver_merge.go
+++ b/internal/app/machined/pkg/controllers/network/timeserver_merge.go
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Package network provides controllers which manage network resources.
+//
+//nolint:dupl
 package network
 
 import (

--- a/pkg/machinery/nethelpers/routeflag_string_linux.go
+++ b/pkg/machinery/nethelpers/routeflag_string_linux.go
@@ -12,6 +12,10 @@ func _() {
 	_ = x[RouteCloned-512]
 	_ = x[RouteEqualize-1024]
 	_ = x[RoutePrefix-2048]
+	_ = x[RouteLookupTable-4096]
+	_ = x[RouteFIBMatch-8192]
+	_ = x[RouteOffload-16384]
+	_ = x[RouteTrap-32768]
 }
 
 const (
@@ -19,6 +23,10 @@ const (
 	_RouteFlag_name_1 = "cloned"
 	_RouteFlag_name_2 = "equalize"
 	_RouteFlag_name_3 = "prefix"
+	_RouteFlag_name_4 = "lookup_table"
+	_RouteFlag_name_5 = "fib_match"
+	_RouteFlag_name_6 = "offload"
+	_RouteFlag_name_7 = "trap"
 )
 
 func (i RouteFlag) String() string {
@@ -31,6 +39,14 @@ func (i RouteFlag) String() string {
 		return _RouteFlag_name_2
 	case i == 2048:
 		return _RouteFlag_name_3
+	case i == 4096:
+		return _RouteFlag_name_4
+	case i == 8192:
+		return _RouteFlag_name_5
+	case i == 16384:
+		return _RouteFlag_name_6
+	case i == 32768:
+		return _RouteFlag_name_7
 	default:
 		return "RouteFlag(" + strconv.FormatInt(int64(i), 10) + ")"
 	}

--- a/pkg/machinery/nethelpers/routeflags_linux.go
+++ b/pkg/machinery/nethelpers/routeflags_linux.go
@@ -18,13 +18,18 @@ type RouteFlags uint32
 func (flags RouteFlags) String() string {
 	var values []string
 
-	for flag := RouteNotify; flag <= RoutePrefix; flag <<= 1 {
+	for flag := RouteNotify; flag <= RouteTrap; flag <<= 1 {
 		if (RouteFlag(flags) & flag) == flag {
 			values = append(values, flag.String())
 		}
 	}
 
 	return strings.Join(values, ",")
+}
+
+// Equal tests for RouteFlags equality ignoring flags not managed by this implementation.
+func (flags RouteFlags) Equal(other RouteFlags) bool {
+	return (flags & RouteFlags(RouteFlagsMask)) == (other & RouteFlags(RouteFlagsMask))
 }
 
 // MarshalYAML implements yaml.Marshaler.
@@ -37,8 +42,15 @@ type RouteFlag uint32
 
 // RouteFlag constants.
 const (
-	RouteNotify   RouteFlag = unix.RTM_F_NOTIFY   // notify
-	RouteCloned   RouteFlag = unix.RTM_F_CLONED   // cloned
-	RouteEqualize RouteFlag = unix.RTM_F_EQUALIZE // equalize
-	RoutePrefix   RouteFlag = unix.RTM_F_PREFIX   // prefix
+	RouteNotify      RouteFlag = unix.RTM_F_NOTIFY       // notify
+	RouteCloned      RouteFlag = unix.RTM_F_CLONED       // cloned
+	RouteEqualize    RouteFlag = unix.RTM_F_EQUALIZE     // equalize
+	RoutePrefix      RouteFlag = unix.RTM_F_PREFIX       // prefix
+	RouteLookupTable RouteFlag = unix.RTM_F_LOOKUP_TABLE // lookup_table
+	RouteFIBMatch    RouteFlag = unix.RTM_F_FIB_MATCH    // fib_match
+	RouteOffload     RouteFlag = unix.RTM_F_OFFLOAD      // offload
+	RouteTrap        RouteFlag = unix.RTM_F_TRAP         // trap
 )
+
+// RouteFlagsMask is a supported set of flags to manage.
+const RouteFlagsMask = RouteNotify | RouteCloned | RouteEqualize | RoutePrefix

--- a/pkg/resources/network/link_spec.go
+++ b/pkg/resources/network/link_spec.go
@@ -63,6 +63,8 @@ var (
 )
 
 // Merge with other, overwriting fields from other if set.
+//
+//nolint:gocyclo
 func (spec *LinkSpecSpec) Merge(other *LinkSpecSpec) error {
 	if spec.Logical != other.Logical {
 		return fmt.Errorf("mismatch on logical for %q: %v != %v", spec.Name, spec.Logical, other.Logical)
@@ -82,6 +84,14 @@ func (spec *LinkSpecSpec) Merge(other *LinkSpecSpec) error {
 
 	if other.Type != 0 {
 		spec.Type = 0
+	}
+
+	if other.ParentName != "" {
+		spec.ParentName = other.ParentName
+	}
+
+	if other.MasterName != "" {
+		spec.MasterName = other.MasterName
 	}
 
 	if other.VLAN != zeroVLAN {


### PR DESCRIPTION
This PR contains multiple fixes to the networking controllers and
logging improvements for easier debugging:

* `LinkConfigController` now correctly merges duplicate link definitions
in the machine configuration
* `LinkConfigController` correctly enslaves bond interfaces even if
they're not mentioned explicitly in the config
* bond slaves are no longer brought down forcefully, but they're brought
down before being enslaved (and brought up once they're enslaved)
* route sync code ignores flags which are not managed by Talos

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3771)
<!-- Reviewable:end -->
