### PR TITLE
fix: don't enable RBAC feature in the config for Talos < 0.11

### DIFF
--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,8 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion0_11    = &VersionContract{0, 11}
+	TalosVersion0_10    = &VersionContract{0, 10}
 	TalosVersion0_9     = &VersionContract{0, 9}
 	TalosVersion0_8     = &VersionContract{0, 8}
 )
@@ -71,4 +73,9 @@ func (contract *VersionContract) SupportsAggregatorCA() bool {
 // SupportsServiceAccount returns true if version of Talos supports ServiceAccount in the config.
 func (contract *VersionContract) SupportsServiceAccount() bool {
 	return contract.Greater(TalosVersion0_8)
+}
+
+// SupportsRBACFeature returns true if version of Talos supports RBAC feature gate.
+func (contract *VersionContract) SupportsRBACFeature() bool {
+	return contract.Greater(TalosVersion0_10)
 }

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -47,16 +47,33 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, config.TalosVersionCurrent.SupportsAggregatorCA())
 	assert.True(t, config.TalosVersionCurrent.SupportsECDSAKeys())
 	assert.True(t, config.TalosVersionCurrent.SupportsServiceAccount())
+	assert.True(t, config.TalosVersionCurrent.SupportsRBACFeature())
+}
+
+func TestContract0_11(t *testing.T) {
+	assert.True(t, config.TalosVersion0_11.SupportsAggregatorCA())
+	assert.True(t, config.TalosVersion0_11.SupportsECDSAKeys())
+	assert.True(t, config.TalosVersion0_11.SupportsServiceAccount())
+	assert.True(t, config.TalosVersion0_11.SupportsRBACFeature())
+}
+
+func TestContract0_10(t *testing.T) {
+	assert.True(t, config.TalosVersion0_10.SupportsAggregatorCA())
+	assert.True(t, config.TalosVersion0_10.SupportsECDSAKeys())
+	assert.True(t, config.TalosVersion0_10.SupportsServiceAccount())
+	assert.False(t, config.TalosVersion0_10.SupportsRBACFeature())
 }
 
 func TestContract0_9(t *testing.T) {
 	assert.True(t, config.TalosVersion0_9.SupportsAggregatorCA())
 	assert.True(t, config.TalosVersion0_9.SupportsECDSAKeys())
 	assert.True(t, config.TalosVersion0_9.SupportsServiceAccount())
+	assert.False(t, config.TalosVersion0_9.SupportsRBACFeature())
 }
 
 func TestContract0_8(t *testing.T) {
 	assert.False(t, config.TalosVersion0_8.SupportsAggregatorCA())
 	assert.False(t, config.TalosVersion0_8.SupportsECDSAKeys())
 	assert.False(t, config.TalosVersion0_8.SupportsServiceAccount())
+	assert.False(t, config.TalosVersion0_9.SupportsRBACFeature())
 }

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -52,7 +52,8 @@ func Config(t machine.Type, in *Input) (c *v1alpha1.Config, err error) {
 //
 //nolint:maligned
 type Input struct {
-	Certs *Certs
+	Certs           *Certs
+	VersionContract *config.VersionContract
 
 	// ControlplaneEndpoint is the canonical address of the kubernetes control
 	// plane.  It can be a DNS name, the IP address of a load balancer, or
@@ -453,6 +454,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 
 	input = &Input{
 		Certs:                      secrets.Certs,
+		VersionContract:            options.VersionContract,
 		ControlPlaneEndpoint:       endpoint,
 		PodNet:                     []string{podNet},
 		ServiceNet:                 []string{serviceNet},

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -51,9 +51,11 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 		},
 		MachineDisks:                in.MachineDisks,
 		MachineSystemDiskEncryption: in.SystemDiskEncryptionConfig,
-		MachineFeatures: &v1alpha1.FeaturesConfig{
-			RBAC: pointer.ToBool(true),
-		},
+		MachineFeatures:             &v1alpha1.FeaturesConfig{},
+	}
+
+	if in.VersionContract.SupportsRBACFeature() {
+		machine.MachineFeatures.RBAC = pointer.ToBool(true)
 	}
 
 	certSANs := in.GetAPIServerSANs()

--- a/pkg/machinery/config/types/v1alpha1/generate/join.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/join.go
@@ -51,9 +51,11 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 		},
 		MachineDisks:                in.MachineDisks,
 		MachineSystemDiskEncryption: in.SystemDiskEncryptionConfig,
-		MachineFeatures: &v1alpha1.FeaturesConfig{
-			RBAC: pointer.ToBool(true),
-		},
+		MachineFeatures:             &v1alpha1.FeaturesConfig{},
+	}
+
+	if in.VersionContract.SupportsRBACFeature() {
+		machine.MachineFeatures.RBAC = pointer.ToBool(true)
 	}
 
 	controlPlaneURL, err := url.Parse(in.ControlPlaneEndpoint)


### PR DESCRIPTION
This makes sure that if config is generated for older version of Talos,
RBAC feature is not enabled by default.

We do this to ensure that there's no surprise if Talos 0.10 is upgraded
to 0.11 and RBAC is enabled while the user is not ready for that.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3772)
<!-- Reviewable:end -->
