### PR TITLE
fix: stop etcd client logs from going to the server console

### DIFF
--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -18,6 +18,7 @@ import (
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system"
@@ -54,6 +55,7 @@ func NewClient(endpoints []string) (client *Client, err error) {
 		DialTimeout: 5 * time.Second,
 		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 		TLS:         tlsConfig,
+		Logger:      zap.NewNop(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error building etcd client: %w", err)


### PR DESCRIPTION
When etcd calls start failing, these log messages start spamming the
console a lot. Disable the client log until we figure out a better
destination for them.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3774)
<!-- Reviewable:end -->
