### PR TITLE
chore: remove bootkube check from cluster health check

### DIFF
--- a/pkg/cluster/check/default.go
+++ b/pkg/cluster/check/default.go
@@ -6,7 +6,6 @@ package check
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/talos-systems/talos/pkg/conditions"
@@ -20,22 +19,6 @@ func DefaultClusterChecks() []ClusterCheck {
 		func(cluster ClusterInfo) conditions.Condition {
 			return conditions.PollingCondition("etcd to be healthy", func(ctx context.Context) error {
 				return ServiceHealthAssertion(ctx, cluster, "etcd", WithNodeTypes(machine.TypeInit, machine.TypeControlPlane))
-			}, 5*time.Minute, 5*time.Second)
-		},
-
-		// wait for bootkube to finish on init node
-		func(cluster ClusterInfo) conditions.Condition {
-			return conditions.PollingCondition("bootkube to finish", func(ctx context.Context) error {
-				err := ServiceStateAssertion(ctx, cluster, "bootkube", "Finished", "Skipped")
-				if err != nil {
-					if errors.Is(err, ErrServiceNotFound) {
-						return nil
-					}
-
-					return err
-				}
-
-				return nil
 			}, 5*time.Minute, 5*time.Second)
 		},
 


### PR DESCRIPTION
We're no longer testing against Talos <= 0.8, so no reason to
run this check (even if it's no-op).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3775)
<!-- Reviewable:end -->
