### PR TITLE
feat: provide Kubernetes nodename as a COSI resource

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint:dupl
 package k8s_test
 
 import (

--- a/internal/app/machined/pkg/controllers/k8s/extra_manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/extra_manifest_test.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint:dupl
 package k8s_test
 
 import (

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint:dupl
 package k8s_test
 
 import (

--- a/internal/app/machined/pkg/controllers/k8s/nodename.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodename.go
@@ -1,0 +1,109 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// NodenameController renders manifests based on templates and config/secrets.
+type NodenameController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *NodenameController) Name() string {
+	return "k8s.NodenameController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *NodenameController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineConfigType,
+			ID:        pointer.ToString(config.V1Alpha1ID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.HostnameStatusType,
+			ID:        pointer.ToString(network.HostnameID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *NodenameController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: k8s.NodenameType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+func (ctrl *NodenameController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		cfg, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineConfigType, config.V1Alpha1ID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return fmt.Errorf("error getting config: %w", err)
+		}
+
+		cfgProvider := cfg.(*config.MachineConfig).Config()
+
+		hostnameResource, err := r.Get(ctx, resource.NewMetadata(network.NamespaceName, network.HostnameStatusType, network.HostnameID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				continue
+			}
+
+			return err
+		}
+
+		hostnameStatus := hostnameResource.(*network.HostnameStatus).TypedSpec()
+
+		if err = r.Modify(
+			ctx,
+			k8s.NewNodename(k8s.ControlPlaneNamespaceName, k8s.NodenameID),
+			func(r resource.Resource) error {
+				nodename := r.(*k8s.Nodename) //nolint:errcheck,forcetypeassert
+
+				if cfgProvider.Machine().Kubelet().RegisterWithFQDN() {
+					nodename.TypedSpec().Nodename = hostnameStatus.FQDN()
+				} else {
+					nodename.TypedSpec().Nodename = hostnameStatus.Hostname
+				}
+
+				nodename.TypedSpec().HostnameVersion = hostnameResource.Metadata().Version().String()
+
+				return nil
+			},
+		); err != nil {
+			return fmt.Errorf("error modifying nodename resource: %w", err)
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/k8s/nodename_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodename_test.go
@@ -1,0 +1,181 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package k8s_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	k8sctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/k8s"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+type NodenameSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *NodenameSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&k8sctrl.NodenameController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *NodenameSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+//nolint:dupl
+func (suite *NodenameSuite) assertNodename(expected string) error {
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.NodenameType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	if len(resources.Items) != 1 {
+		return retry.ExpectedErrorf("expected 1 item, got %d", len(resources.Items))
+	}
+
+	if resources.Items[0].Metadata().ID() != k8s.NodenameID {
+		return fmt.Errorf("unexpected ID")
+	}
+
+	if resources.Items[0].(*k8s.Nodename).TypedSpec().Nodename != expected {
+		return retry.ExpectedErrorf("expected %q, got %q", expected, resources.Items[0].(*k8s.Nodename).TypedSpec().Nodename)
+	}
+
+	return nil
+}
+
+func (suite *NodenameSuite) TestDefault() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+		},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostnameStatus.TypedSpec().Hostname = "foo"
+	hostnameStatus.TypedSpec().Domainname = "bar.ltd"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertNodename("foo")
+		},
+	))
+}
+
+func (suite *NodenameSuite) TestFQDN() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineKubelet: &v1alpha1.KubeletConfig{
+				KubeletRegisterWithFQDN: true,
+			},
+		},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+		},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostnameStatus.TypedSpec().Hostname = "foo"
+	hostnameStatus.TypedSpec().Domainname = "bar.ltd"
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertNodename("foo.bar.ltd")
+		},
+	))
+}
+
+func (suite *NodenameSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	err := suite.state.Create(context.Background(), config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+	}))
+	if state.IsConflictError(err) {
+		err = suite.state.Destroy(context.Background(), config.NewMachineConfig(nil).Metadata())
+	}
+
+	suite.Require().NoError(err)
+
+	suite.Assert().NoError(suite.state.Create(context.Background(), network.NewHostnameStatus(network.NamespaceName, "bar")))
+}
+
+func TestNodenameSuite(t *testing.T) {
+	suite.Run(t, new(NodenameSuite))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -85,6 +85,7 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&k8s.KubeletStaticPodController{},
 		&k8s.ManifestController{},
 		&k8s.ManifestApplyController{},
+		&k8s.NodenameController{},
 		&k8s.RenderSecretsStaticPodController{},
 		&network.AddressConfigController{
 			Cmdline:      procfs.ProcCmdline(),

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -80,6 +80,7 @@ func NewState() (*State, error) {
 		&files.EtcFileStatus{},
 		&k8s.Manifest{},
 		&k8s.ManifestStatus{},
+		&k8s.Nodename{},
 		&k8s.StaticPod{},
 		&k8s.StaticPodStatus{},
 		&k8s.SecretsStatus{},

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -36,6 +36,7 @@ import (
 	"github.com/talos-systems/talos/pkg/conditions"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
 	"github.com/talos-systems/talos/pkg/resources/network"
 	timeresource "github.com/talos-systems/talos/pkg/resources/time"
 )
@@ -132,6 +133,7 @@ func (k *Kubelet) Condition(r runtime.Runtime) conditions.Condition {
 	return conditions.WaitForAll(
 		timeresource.NewSyncCondition(r.State().V1Alpha2().Resources()),
 		network.NewReadyCondition(r.State().V1Alpha2().Resources(), network.AddressReady, network.HostnameReady, network.EtcFilesReady),
+		k8s.NewNodenameReadyCondition(r.State().V1Alpha2().Resources()),
 	)
 }
 

--- a/pkg/kubernetes/kubelet/kubelet.go
+++ b/pkg/kubernetes/kubelet/kubelet.go
@@ -29,12 +29,7 @@ type Client struct {
 }
 
 // NewClient creates new kubelet API client.
-func NewClient(clientCert, clientKey, caPEM []byte) (*Client, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
-	}
-
+func NewClient(nodename string, clientCert, clientKey, caPEM []byte) (*Client, error) {
 	config := &rest.Config{
 		Host: fmt.Sprintf("https://127.0.0.1:%d/", constants.KubeletPort),
 		ContentConfig: rest.ContentConfig{
@@ -45,7 +40,7 @@ func NewClient(clientCert, clientKey, caPEM []byte) (*Client, error) {
 			CertData:   clientCert,
 			KeyData:    clientKey,
 			CAData:     caPEM,
-			ServerName: hostname,
+			ServerName: nodename,
 		},
 	}
 

--- a/pkg/resources/k8s/condition.go
+++ b/pkg/resources/k8s/condition.go
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build linux
+
+package k8s
+
+import (
+	"context"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// NodenameReadyCondition implements condition which waits for the nodename to be ready.
+type NodenameReadyCondition struct {
+	state state.State
+}
+
+// NewNodenameReadyCondition builds a coondition which waits for the network to be ready.
+func NewNodenameReadyCondition(state state.State) *NodenameReadyCondition {
+	return &NodenameReadyCondition{
+		state: state,
+	}
+}
+
+func (condition *NodenameReadyCondition) String() string {
+	return "nodename"
+}
+
+// Wait implements condition interface.
+func (condition *NodenameReadyCondition) Wait(ctx context.Context) error {
+	_, err := condition.state.WatchFor(
+		ctx,
+		resource.NewMetadata(ControlPlaneNamespaceName, NodenameType, NodenameID, resource.VersionUndefined),
+		state.WithCondition(func(r resource.Resource) (bool, error) {
+			if resource.IsTombstone(r) {
+				return false, nil
+			}
+
+			nodename := r.(*Nodename).TypedSpec()
+
+			// check that hostname status version matches one recorded in the nodename
+			hostnameStatus, err := condition.state.Get(ctx, resource.NewMetadata(network.NamespaceName, network.HostnameStatusType, network.HostnameID, resource.VersionUndefined))
+			if err != nil {
+				return false, err
+			}
+
+			if hostnameStatus.Metadata().Version().String() != nodename.HostnameVersion {
+				return false, nil
+			}
+
+			return true, nil
+		}),
+	)
+
+	return err
+}

--- a/pkg/resources/k8s/condition_test.go
+++ b/pkg/resources/k8s/condition_test.go
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+func TestCondition(t *testing.T) {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(ctxCancel)
+
+	t.Parallel()
+
+	for _, tt := range []struct {
+		Name           string
+		NodenameExists bool
+		VersionMatches bool
+		Succeeds       bool
+	}{
+		{
+			Name:     "no nodename",
+			Succeeds: false,
+		},
+		{
+			Name:           "version mismatch",
+			NodenameExists: true,
+			VersionMatches: false,
+			Succeeds:       false,
+		},
+		{
+			Name:           "success",
+			NodenameExists: true,
+			VersionMatches: true,
+			Succeeds:       true,
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			state := state.WrapCore(namespaced.NewState(inmem.Build))
+
+			hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+			hostnameStatus.TypedSpec().Hostname = "foo"
+
+			require.NoError(t, state.Create(ctx, hostnameStatus))
+
+			if tt.NodenameExists {
+				nodename := k8s.NewNodename(k8s.ControlPlaneNamespaceName, k8s.NodenameID)
+				nodename.TypedSpec().Nodename = "foo"
+
+				md := hostnameStatus.Metadata()
+
+				if !tt.VersionMatches {
+					md.BumpVersion()
+				}
+
+				nodename.TypedSpec().HostnameVersion = md.Version().String()
+
+				require.NoError(t, state.Create(ctx, nodename))
+			}
+
+			err := k8s.NewNodenameReadyCondition(state).Wait(ctx)
+
+			if tt.Succeeds {
+				assert.NoError(t, err)
+			} else {
+				assert.True(t, errors.Is(err, context.DeadlineExceeded), "error is %v", err)
+			}
+		})
+	}
+}

--- a/pkg/resources/k8s/k8s_test.go
+++ b/pkg/resources/k8s/k8s_test.go
@@ -27,6 +27,7 @@ func TestRegisterResource(t *testing.T) {
 	for _, resource := range []resource.Resource{
 		&k8s.ManifestStatus{},
 		&k8s.Manifest{},
+		&k8s.Nodename{},
 		&k8s.SecretsStatus{},
 		&k8s.StaticPodStatus{},
 		&k8s.StaticPod{},

--- a/pkg/resources/k8s/nodename.go
+++ b/pkg/resources/k8s/nodename.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+)
+
+// NodenameType is type of Nodename resource.
+const NodenameType = resource.Type("Nodenames.kubernetes.talos.dev")
+
+// NodenameID is a singleton resource ID for Nodename.
+const NodenameID = resource.ID("nodename")
+
+// Nodename resource holds Kubernetes nodename.
+type Nodename struct {
+	md   resource.Metadata
+	spec NodenameSpec
+}
+
+// NodenameSpec describes Kubernetes nodename.
+type NodenameSpec struct {
+	Nodename        string `yaml:"nodename"`
+	HostnameVersion string `yaml:"hostnameVersion"`
+}
+
+// NewNodename initializes a Nodename resource.
+func NewNodename(namespace resource.Namespace, id resource.ID) *Nodename {
+	r := &Nodename{
+		md:   resource.NewMetadata(namespace, NodenameType, id, resource.VersionUndefined),
+		spec: NodenameSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Nodename) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Nodename) Spec() interface{} {
+	return r.spec
+}
+
+func (r *Nodename) String() string {
+	return fmt.Sprintf("k8s.Nodename(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Nodename) DeepCopy() resource.Resource {
+	return &Nodename{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *Nodename) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             NodenameType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: ControlPlaneNamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Nodename",
+				JSONPath: "{.nodename}",
+			},
+		},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *Nodename) TypedSpec() *NodenameSpec {
+	return &r.spec
+}


### PR DESCRIPTION
This changes the way Kubernetes nodename is computed: it is set by the
controller based on the hostname and machine configuration, and pulled
from the resource when needed.

Kubelet client now also uses nodename to fix the certifcate mismatch
issue on AWS.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3776)
<!-- Reviewable:end -->
