### PR TITLE
feat: improve security of Kubernetes control plane components

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -406,6 +406,7 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 		"/usr/local/bin/kube-scheduler",
 		fmt.Sprintf("--kubeconfig=%s", filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig")),
 		"--bind-address=127.0.0.1",
+		"--port=0",
 		"--leader-elect=true",
 		"--profiling=false",
 	}


### PR DESCRIPTION
Fix of fixes #3765

disable kube-scheduler insecure port too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3785)
<!-- Reviewable:end -->
