### PR TITLE
fix: mark kube-proxy as system critical priority

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -161,6 +161,7 @@ spec:
           mountPath: /etc/kubernetes
           readOnly: true
       hostNetwork: true
+      priorityClassName: system-cluster-critical
       serviceAccountName: kube-proxy
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
This makes sure control plane components are evicted last in case of
resource shortage.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3800)
<!-- Reviewable:end -->
