### PR TITLE
feat: update Linux kernel to 5.10.45

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-1-gc8c2a18
-PKGS ?= v0.6.0-alpha.0-8-g2d51360
+PKGS ?= v0.6.0-alpha.0-11-g96072f8
 EXTRAS ?= v0.3.0-1-g4fe2706
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -39,7 +39,9 @@ Added the flag `cluster.coreDNS.disabled` to coreDNS deployment during the clust
         title = "Component Updates"
         description = """\
 * containerd was updated to 1.5.2
-* Linux kernel was updated to 5.10.38
+* Linux kernel was updated to 5.10.45
+* Kubernetes was updated to 1.21.2
+* etcd was updated to 3.4.16
 """
 
     [notes.bootstrap]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.38-talos"
+	DefaultKernelVersion = "5.10.45-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.
@@ -239,7 +239,7 @@ const (
 	KubeletKubeconfig = "/etc/kubernetes/kubeconfig-kubelet"
 
 	// DefaultEtcdVersion is the default target version of etcd.
-	DefaultEtcdVersion = "v3.4.15"
+	DefaultEtcdVersion = "v3.4.16"
 
 	// EtcdRootTalosKey is the root etcd key for Talos-specific storage.
 	EtcdRootTalosKey = "talos:v1"

--- a/website/content/docs/v0.11/Reference/configuration.md
+++ b/website/content/docs/v0.11/Reference/configuration.md
@@ -1086,7 +1086,7 @@ Examples:
 
 ``` yaml
 etcd:
-    image: gcr.io/etcd-development/etcd:v3.4.15 # The container image used to create the etcd service.
+    image: gcr.io/etcd-development/etcd:v3.4.16 # The container image used to create the etcd service.
     # The `ca` is the root certificate authority of the PKI.
     ca:
         crt: TFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSklla05DTUhGLi4u
@@ -2674,7 +2674,7 @@ Appears in:
 
 
 ``` yaml
-image: gcr.io/etcd-development/etcd:v3.4.15 # The container image used to create the etcd service.
+image: gcr.io/etcd-development/etcd:v3.4.16 # The container image used to create the etcd service.
 # The `ca` is the root certificate authority of the PKI.
 ca:
     crt: TFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSklla05DTUhGLi4u
@@ -2701,7 +2701,7 @@ Examples:
 
 
 ``` yaml
-image: gcr.io/etcd-development/etcd:v3.4.15
+image: gcr.io/etcd-development/etcd:v3.4.16
 ```
 
 


### PR DESCRIPTION
This also pulls in HP ILO driver, dmesg restrict mode by default and
dm-crypt options.

See talos-systems/pkgs#289, talos-systems/pkgs#290,
talos-systems/pkgs#287

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3801)
<!-- Reviewable:end -->
