### PR TITLE
fix: assign source address to the DHCP default gateway routes

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp4.go
@@ -213,6 +213,7 @@ func (d *DHCP4) parseAck(ack *dhcpv4.DHCPv4) {
 			d.routes = append(d.routes, network.RouteSpecSpec{
 				Family:      nethelpers.FamilyInet4,
 				Gateway:     gw,
+				Source:      addr,
 				OutLinkName: d.linkName,
 				Table:       nethelpers.TableMain,
 				Priority:    d.routeMetric,


### PR DESCRIPTION
This isn't strictly require, but it should be backwards compatible with
Talos 0.10 (networkd).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3808)
<!-- Reviewable:end -->
