### PR TITLE
chore: refactor CLI tests

### DIFF
--- a/internal/integration/base/run.go
+++ b/internal/integration/base/run.go
@@ -135,10 +135,10 @@ func runAndWait(suite *suite.Suite, cmd *exec.Cmd) (stdoutBuf, stderrBuf *bytes.
 	return &stdout, &stderr, err
 }
 
-// Run executes command, asserts on its exit status/output, and returns stdout.
+// run executes command, asserts on its exit status/output, and returns stdout.
 //
 //nolint:gocyclo,nakedret
-func Run(suite *suite.Suite, cmd *exec.Cmd, options ...RunOption) (stdout string) {
+func run(suite *suite.Suite, cmd *exec.Cmd, options ...RunOption) (stdout string) {
 	var opts runOptions
 
 	for _, o := range options {

--- a/internal/integration/cli/config.go
+++ b/internal/integration/cli/config.go
@@ -7,8 +7,6 @@
 package cli
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 
@@ -34,10 +32,7 @@ func (suite *TalosconfigSuite) TestList() {
 
 // TestMerge checks how talosctl config merge.
 func (suite *TalosconfigSuite) TestMerge() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	defer os.RemoveAll(tempDir) //nolint:errcheck
-
-	suite.Require().NoError(err)
+	tempDir := suite.T().TempDir()
 
 	suite.RunCLI([]string{"gen", "config", "-o", tempDir, "foo", "https://192.168.0.1:6443"})
 

--- a/internal/integration/cli/copy.go
+++ b/internal/integration/cli/copy.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -27,15 +26,12 @@ func (suite *CopySuite) SuiteName() string {
 
 // TestSuccess runs comand with success.
 func (suite *CopySuite) TestSuccess() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := suite.T().TempDir()
 
 	suite.RunCLI([]string{"copy", "--nodes", suite.RandomDiscoveredNode(), "/etc/os-release", tempDir},
 		base.StdoutEmpty())
 
-	_, err = os.Stat(filepath.Join(tempDir, "os-release"))
+	_, err := os.Stat(filepath.Join(tempDir, "os-release"))
 	suite.Require().NoError(err)
 }
 

--- a/internal/integration/cli/etcd.go
+++ b/internal/integration/cli/etcd.go
@@ -7,8 +7,6 @@
 package cli
 
 import (
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 
@@ -46,12 +44,7 @@ func (suite *EtcdSuite) TestForfeitLeadership() {
 
 // TestSnapshot tests etcd snapshot (backup).
 func (suite *EtcdSuite) TestSnapshot() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer func() {
-		suite.Assert().NoError(os.RemoveAll(tempDir))
-	}()
+	tempDir := suite.T().TempDir()
 
 	dbPath := filepath.Join(tempDir, "snapshot.db")
 

--- a/internal/integration/cli/gen.go
+++ b/internal/integration/cli/gen.go
@@ -8,7 +8,6 @@ package cli
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"regexp"
 
@@ -31,10 +30,9 @@ func (suite *GenSuite) SuiteName() string {
 
 // SetupTest ...
 func (suite *GenSuite) SetupTest() {
-	var err error
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
+	var err error
 	suite.savedCwd, err = os.Getwd()
 	suite.Require().NoError(err)
 
@@ -45,10 +43,6 @@ func (suite *GenSuite) SetupTest() {
 func (suite *GenSuite) TearDownTest() {
 	if suite.savedCwd != "" {
 		suite.Require().NoError(os.Chdir(suite.savedCwd))
-	}
-
-	if suite.tmpDir != "" {
-		suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 	}
 }
 

--- a/internal/integration/cli/kubeconfig.go
+++ b/internal/integration/cli/kubeconfig.go
@@ -7,7 +7,6 @@
 package cli
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,10 +29,7 @@ func (suite *KubeconfigSuite) SuiteName() string {
 
 // TestDirectory generates kubeconfig in specified directory.
 func (suite *KubeconfigSuite) TestDirectory() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := suite.T().TempDir()
 
 	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), tempDir},
 		base.StdoutEmpty())
@@ -41,16 +37,13 @@ func (suite *KubeconfigSuite) TestDirectory() {
 	path := filepath.Join(tempDir, "kubeconfig")
 	suite.Require().FileExists(path)
 
-	_, err = clientcmd.LoadFromFile(path)
+	_, err := clientcmd.LoadFromFile(path)
 	suite.Require().NoError(err)
 }
 
 // TestCwd generates kubeconfig in cwd.
 func (suite *KubeconfigSuite) TestCwd() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := suite.T().TempDir()
 
 	savedCwd, err := os.Getwd()
 	suite.Require().NoError(err)
@@ -67,10 +60,7 @@ func (suite *KubeconfigSuite) TestCwd() {
 
 // TestCustomName generates kubeconfig with custom name.
 func (suite *KubeconfigSuite) TestCustomName() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := suite.T().TempDir()
 
 	suite.RunCLI([]string{"kubeconfig", "--merge=false", "--nodes", suite.RandomDiscoveredNode(machine.TypeControlPlane), filepath.Join(tempDir, "k8sconfig")},
 		base.StdoutEmpty())
@@ -89,10 +79,7 @@ func (suite *KubeconfigSuite) TestMultiNodeFail() {
 
 // TestMergeRename tests merge config into existing kubeconfig with default rename conflict resolution.
 func (suite *KubeconfigSuite) TestMergeRename() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := suite.T().TempDir()
 
 	path := filepath.Join(tempDir, "config")
 
@@ -108,10 +95,7 @@ func (suite *KubeconfigSuite) TestMergeRename() {
 
 // TestMergeOverwrite test merge config into existing kubeconfig with overwrite conflict resolution.
 func (suite *KubeconfigSuite) TestMergeOverwrite() {
-	tempDir, err := ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
-
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	tempDir := suite.T().TempDir()
 
 	path := filepath.Join(tempDir, "config")
 

--- a/internal/integration/cli/validate.go
+++ b/internal/integration/cli/validate.go
@@ -8,7 +8,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/talos-systems/talos/internal/integration/base"
@@ -29,10 +28,9 @@ func (suite *ValidateSuite) SuiteName() string {
 
 // SetupTest ...
 func (suite *ValidateSuite) SetupTest() {
-	var err error
-	suite.tmpDir, err = ioutil.TempDir("", "talos")
-	suite.Require().NoError(err)
+	suite.tmpDir = suite.T().TempDir()
 
+	var err error
 	suite.savedCwd, err = os.Getwd()
 	suite.Require().NoError(err)
 
@@ -43,10 +41,6 @@ func (suite *ValidateSuite) SetupTest() {
 func (suite *ValidateSuite) TearDownTest() {
 	if suite.savedCwd != "" {
 		suite.Require().NoError(os.Chdir(suite.savedCwd))
-	}
-
-	if suite.tmpDir != "" {
-		suite.Require().NoError(os.RemoveAll(suite.tmpDir))
 	}
 }
 


### PR DESCRIPTION
Use testing.T.TempDir.
Add support for `talosctl --endpoints`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3810)
<!-- Reviewable:end -->
