### PR TITLE
chore: add an option to launch cluster with bad RTC state

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -107,6 +107,7 @@ var (
 	configPatch               string
 	configPatchControlPlane   string
 	configPatchJoin           string
+	badRTC                    bool
 )
 
 // createCmd represents the cluster up command.
@@ -491,6 +492,7 @@ func create(ctx context.Context) (err error) {
 			NanoCPUs:            nanoCPUs,
 			Disks:               disks,
 			SkipInjectingConfig: skipInjectingConfig,
+			BadRTC:              badRTC,
 		}
 
 		if i == 0 {
@@ -542,6 +544,7 @@ func create(ctx context.Context) (err error) {
 				Disks:               disks,
 				Config:              cfg,
 				SkipInjectingConfig: skipInjectingConfig,
+				BadRTC:              badRTC,
 			})
 	}
 
@@ -809,5 +812,6 @@ func init() {
 	createCmd.Flags().StringVar(&configPatch, "config-patch", "", "patch generated machineconfigs (applied to all node types)")
 	createCmd.Flags().StringVar(&configPatchControlPlane, "config-patch-control-plane", "", "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")
 	createCmd.Flags().StringVar(&configPatchJoin, "config-patch-join", "", "patch generated machineconfigs (applied to 'join' type)")
+	createCmd.Flags().BoolVar(&badRTC, "bad-rtc", false, "launch VM with bad RTC state (QEMU only)")
 	Cmd.AddCommand(createCmd)
 }

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -115,6 +115,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 		PFlashImages:      pflashImages,
 		MonitorPath:       state.GetRelativePath(fmt.Sprintf("%s.monitor", nodeReq.Name)),
 		EnableKVM:         opts.TargetArch == runtime.GOARCH,
+		BadRTC:            nodeReq.BadRTC,
 		DefaultBootOrder:  defaultBootOrder,
 		BootloaderEnabled: opts.BootloaderEnabled,
 		NodeUUID:          nodeUUID,

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -148,6 +148,11 @@ type NodeRequest struct {
 	// BootOrder can be forced to be "nc" (PXE boot) via the API in QEMU provisioner.
 	DefaultBootOrder string
 
+	// Testing features
+
+	// BadRTC resets RTC to well known time in the past (QEMU provisioner).
+	BadRTC bool
+
 	// PXE-booted VMs
 	PXEBooted        bool
 	TFTPServer       string

--- a/website/content/docs/v0.11/Reference/cli.md
+++ b/website/content/docs/v0.11/Reference/cli.md
@@ -90,6 +90,7 @@ talosctl cluster create [flags]
 
 ```
       --arch string                             cluster architecture (default "amd64")
+      --bad-rtc                                 launch VM with bad RTC state (QEMU only)
       --cidr string                             CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
       --cni-bin-path strings                    search path for CNI binaries (VM only) (default [/home/user/.talos/cni/bin])
       --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.11.0-alpha.1/talosctl-cni-bundle-${ARCH}.tar.gz")


### PR DESCRIPTION
This is useful for time sync testing.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3819)
<!-- Reviewable:end -->
