### PR TITLE
feat: add cloud images to releases

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -488,28 +488,11 @@ local conformance_pipelines = [
   Pipeline('cron-conformance-qemu', default_pipeline_steps + [conformance_k8s_qemu], [default_cron_pipeline]) + cron_trigger(['nightly']),
 ];
 
-// Cloud images pipeline.
-
-local cloud_images = Step("cloud-images", depends_on=[load_artifacts], environment=creds_env_vars);
-
-local upload_images_steps = default_pipeline_steps + [
-  cloud_images,
-];
-
-
-local upload_images_trigger = {
-  trigger: {
-    target: {
-      include: ['upload-images'],
-    },
-  },
-};
-
-local upload_images_pipeline = Pipeline('upload-images', upload_images_steps) + upload_images_trigger;
-
 // Release pipeline.
 
 local boot = Step('boot', depends_on=[e2e_docker, e2e_qemu]);
+
+local cloud_images = Step("cloud-images", depends_on=[e2e_docker, e2e_qemu], environment=creds_env_vars);
 
 local release_notes = Step('release-notes', depends_on=[e2e_docker, e2e_qemu]);
 
@@ -528,6 +511,7 @@ local release = {
       '_out/azure-arm64.tar.gz',
       '_out/boot-amd64.tar.gz',
       '_out/boot-arm64.tar.gz',
+      '_out/cloud-images.json',
       '_out/digital-ocean-amd64.tar.gz',
       '_out/digital-ocean-arm64.tar.gz',
       '_out/gcp-amd64.tar.gz',
@@ -563,11 +547,12 @@ local release = {
   when: {
     event: ['tag'],
   },
-  depends_on: [build.name, boot.name, talosctl_cni_bundle.name, images.name, sbcs.name, iso.name, push.name, release_notes.name]
+  depends_on: [build.name, boot.name, cloud_images.name, talosctl_cni_bundle.name, images.name, sbcs.name, iso.name, push.name, release_notes.name]
 };
 
 local release_steps = default_steps + [
   boot,
+  cloud_images,
   release_notes,
   release,
 ];
@@ -617,14 +602,13 @@ local notify_trigger = {
   },
 };
 
-local notify_pipeline = Pipeline('notify', notify_steps, [default_pipeline, upload_images_pipeline, release_pipeline] + integration_pipelines + e2e_pipelines + conformance_pipelines, false, true) + notify_trigger;
+local notify_pipeline = Pipeline('notify', notify_steps, [default_pipeline, release_pipeline] + integration_pipelines + e2e_pipelines + conformance_pipelines, false, true) + notify_trigger;
 
 // Final configuration file definition.
 
 [
   default_pipeline,
   default_cron_pipeline,
-  upload_images_pipeline,
   release_pipeline,
 ] + integration_pipelines + e2e_pipelines + conformance_pipelines + [
   notify_pipeline,

--- a/hack/cloud-image-uploader/main.go
+++ b/hack/cloud-image-uploader/main.go
@@ -9,9 +9,11 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/binary"
 	"encoding/json"
+	"io"
 	"log"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"github.com/spf13/pflag"
@@ -85,7 +87,14 @@ func main() {
 		log.Fatalf("failed: %s", err)
 	}
 
-	e := json.NewEncoder(os.Stdout)
+	f, err := os.Create(filepath.Join(DefaultOptions.ArtifactsPath, "cloud-images.json"))
+	if err != nil {
+		log.Fatalf("failed: %s", err)
+	}
+
+	defer f.Close()
+
+	e := json.NewEncoder(io.MultiWriter(os.Stdout, f))
 	e.SetIndent("", "  ")
 	e.Encode(&result) //nolint:errcheck
 }


### PR DESCRIPTION
This PR updates our CI so that when we release talos, a json file
containing our cloud images for AWS will be published as a release
asset.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3820)
<!-- Reviewable:end -->
