### PR TITLE
chore: use tagged versions of bldr dependencies for 0.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.5.0-1-gc8c2a18
-PKGS ?= v0.6.0-alpha.0-12-g41d6ccc
-EXTRAS ?= v0.3.0-1-g4fe2706
+TOOLS ?= ghcr.io/talos-systems/tools:v0.6.0
+PKGS ?= v0.6.0
+EXTRAS ?= v0.4.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0
 STRINGER_VERSION ?= v0.1.0


### PR DESCRIPTION
No actual changes, just tag updates.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3829)
<!-- Reviewable:end -->
