### PR TITLE
feat: add a method to get gRPC connection from the client

### DIFF
--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -147,7 +147,7 @@ func New(ctx context.Context, opts ...OptionFunc) (c *Client, err error) {
 		return nil, errors.New("failed to determine endpoints")
 	}
 
-	c.conn, err = c.getConn(ctx)
+	c.conn, err = c.GetConn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client connection: %w", err)
 	}
@@ -166,7 +166,8 @@ func New(ctx context.Context, opts ...OptionFunc) (c *Client, err error) {
 	return c, nil
 }
 
-func (c *Client) getConn(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+// GetConn creates new gRPC connection.
+func (c *Client) GetConn(ctx context.Context, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	endpoints := c.getEndpoints()
 
 	var target string


### PR DESCRIPTION
This change is for Theila which is going to use gRPC proxy to forward
requests from TS frontend right to the node's apid.
`gRPC` proxy operates on top of `grpc.ClientConn` objects, so getting
this connection from the clients which are already being created is the
easiest path.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/3834)
<!-- Reviewable:end -->
