### PR TITLE
chore: Update containerd config version 2

### DIFF
--- a/hack/containerd.toml
+++ b/hack/containerd.toml
@@ -1,4 +1,8 @@
+version = 2
+
+disabled_plugins = ["io.containerd.snapshotter.v1.aufs", "io.containerd.v1.zfs", "io.containerd.snapshotter.v1.zfs", "io.containerd.v1.devmapper", "io.containerd.snapshotter.v1.devmapper", "io.containerd.snapshotter.v1.btrfs"]
+
 imports = ["/var/cri/conf.d/*.toml"]
 
-[plugins.cri.containerd.runtimes.runc]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"

--- a/internal/pkg/containers/cri/containerd/config.go
+++ b/internal/pkg/containers/cri/containerd/config.go
@@ -44,7 +44,7 @@ type CRIConfig struct {
 
 // PluginsConfig represents the CRI plugins config.
 type PluginsConfig struct {
-	CRI CRIConfig `toml:"cri"`
+	CRI CRIConfig `toml:"io.containerd.grpc.v1.cri"`
 }
 
 // Config represnts the containerd config.

--- a/internal/pkg/containers/cri/containerd/config_test.go
+++ b/internal/pkg/containers/cri/containerd/config_test.go
@@ -97,19 +97,19 @@ func (suite *ConfigSuite) TestGenerateRegistriesConfig() {
 		},
 		&v1alpha1.MachineFile{
 			FileContent: `[plugins]
-  [plugins.cri]
-    [plugins.cri.registry]
-      [plugins.cri.registry.mirrors]
-        [plugins.cri.registry.mirrors."docker.io"]
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
           endpoint = ["https://registry-1.docker.io", "https://registry-2.docker.io"]
-      [plugins.cri.registry.configs]
-        [plugins.cri.registry.configs."some.host:123"]
-          [plugins.cri.registry.configs."some.host:123".auth]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."some.host:123"]
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."some.host:123".auth]
             username = "root"
             password = "secret"
             auth = "auth"
             identitytoken = "token"
-          [plugins.cri.registry.configs."some.host:123".tls]
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."some.host:123".tls]
             insecure_skip_verify = true
             ca_file = "/var/etc/cri/ca/some.host:123.crt"
             cert_file = "/var/etc/cri/client/some.host:123.crt"


### PR DESCRIPTION
Fixes #3816

* Rename key cri -> io.containerd.grpc.v1.cri
* Disable plugins aufs,zfs,devmapper,btrfs (less warning messages on
  boot time)

