### PR TITLE
fix: handle cases when merged resource re-appears before being destroyed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/containernetworking/plugins v0.9.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/cosi-project/runtime v0.0.0-20210624153826-3e48f565450e
+	github.com/cosi-project/runtime v0.0.0-20210625174835-93ead370bf57
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosi-project/runtime v0.0.0-20210624153826-3e48f565450e h1:XhgJOruZ+dN6MGTzQKlzZlNxEt4jHETPjzuUa2mqX0c=
-github.com/cosi-project/runtime v0.0.0-20210624153826-3e48f565450e/go.mod h1:v/3MIWNuuOSdXXMl3QgCSwZrAk1fTOmQHEnTAfvDqP4=
+github.com/cosi-project/runtime v0.0.0-20210625174835-93ead370bf57 h1:gZQEGt1L56dirY59z8gtiqacfLoDPdmOhyGEXqTSRvo=
+github.com/cosi-project/runtime v0.0.0-20210625174835-93ead370bf57/go.mod h1:v/3MIWNuuOSdXXMl3QgCSwZrAk1fTOmQHEnTAfvDqP4=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/internal/app/machined/pkg/controllers/network/address_merge.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/controller"
 	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
 	"go.uber.org/zap"
 
 	"github.com/talos-systems/talos/pkg/resources/network"
@@ -95,7 +96,16 @@ func (ctrl *AddressMergeController) Run(ctx context.Context, r controller.Runtim
 
 				return nil
 			}); err != nil {
-				return fmt.Errorf("error updating resource: %w", err)
+				if state.IsPhaseConflictError(err) {
+					logger.Debug("conflict detected", zap.String("id", id))
+
+					delete(addresses, id)
+
+					// trigger another reconcile
+					r.QueueReconcile()
+				} else {
+					return fmt.Errorf("error updating resource: %w", err)
+				}
 			}
 		}
 

--- a/internal/app/machined/pkg/controllers/network/hostname_merge.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_merge.go
@@ -90,9 +90,18 @@ func (ctrl *HostnameMergeController) Run(ctx context.Context, r controller.Runti
 
 				return nil
 			}); err != nil {
-				return fmt.Errorf("error updating resource: %w", err)
+				if state.IsPhaseConflictError(err) {
+					// conflict
+					final.Hostname = ""
+
+					r.QueueReconcile()
+				} else {
+					return fmt.Errorf("error updating resource: %w", err)
+				}
 			}
-		} else {
+		}
+
+		if final.Hostname == "" {
 			// remove existing
 			var okToDestroy bool
 

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
 	github.com/containerd/go-cni v1.0.2
 	github.com/containernetworking/cni v0.8.1 // indirect; security fix in 0.8.1
-	github.com/cosi-project/runtime v0.0.0-20210624153826-3e48f565450e
+	github.com/cosi-project/runtime v0.0.0-20210625174835-93ead370bf57
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -17,8 +17,8 @@ github.com/containerd/go-cni v1.0.2/go.mod h1:nrNABBHzu0ZwCug9Ije8hL2xBCYh/pjfMb
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/cosi-project/runtime v0.0.0-20210624153826-3e48f565450e h1:XhgJOruZ+dN6MGTzQKlzZlNxEt4jHETPjzuUa2mqX0c=
-github.com/cosi-project/runtime v0.0.0-20210624153826-3e48f565450e/go.mod h1:v/3MIWNuuOSdXXMl3QgCSwZrAk1fTOmQHEnTAfvDqP4=
+github.com/cosi-project/runtime v0.0.0-20210625174835-93ead370bf57 h1:gZQEGt1L56dirY59z8gtiqacfLoDPdmOhyGEXqTSRvo=
+github.com/cosi-project/runtime v0.0.0-20210625174835-93ead370bf57/go.mod h1:v/3MIWNuuOSdXXMl3QgCSwZrAk1fTOmQHEnTAfvDqP4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
The sequence of events to reproduce the problem:

* some resource was merged as final representation with ID `x`
* underlying source resource gets destroyed
* merge controller marks final resource `x` for teardown and waits
for the finalizers to be empty
* another source resource appears which gets merged to same final `x`
* as `x` is in the teardown phase, spec controller will ignore it
* merge controller doesn't see the problem as well, as `x` spec is
correct, but the phase is wrong (which merge controller ignores)

This pulls in COSI fix to return an error if a resource in teardown
phase is modified. This way merge controller knows that the resource `x`
is in the teardown phase, so it should be first fully torn down, and
then new representation should be re-created as new resource with same ID
`x`.

Regression unit-tests included (they don't reproduce the sequence of
events always reliably, but they do with 10% probability).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
