### PR TITLE
fix: don't set bond delay options if miimon is not enabled

### DIFF
--- a/pkg/resources/network/link.go
+++ b/pkg/resources/network/link.go
@@ -141,8 +141,11 @@ func (bond *BondMasterSpec) Encode() ([]byte, error) {
 	encoder.Uint8(unix.IFLA_BOND_FAIL_OVER_MAC, uint8(bond.FailOverMac))
 	encoder.Uint8(unix.IFLA_BOND_AD_SELECT, uint8(bond.ADSelect))
 	encoder.Uint32(unix.IFLA_BOND_MIIMON, bond.MIIMon)
-	encoder.Uint32(unix.IFLA_BOND_UPDELAY, bond.UpDelay)
-	encoder.Uint32(unix.IFLA_BOND_DOWNDELAY, bond.DownDelay)
+
+	if bond.MIIMon != 0 {
+		encoder.Uint32(unix.IFLA_BOND_UPDELAY, bond.UpDelay)
+		encoder.Uint32(unix.IFLA_BOND_DOWNDELAY, bond.DownDelay)
+	}
 
 	if bond.Mode != nethelpers.BondMode8023AD && bond.Mode != nethelpers.BondModeALB && bond.Mode != nethelpers.BondModeTLB {
 		encoder.Uint32(unix.IFLA_BOND_ARP_INTERVAL, bond.ARPInterval)
@@ -177,7 +180,9 @@ func (bond *BondMasterSpec) Encode() ([]byte, error) {
 		encoder.Uint16(unix.IFLA_BOND_AD_USER_PORT_KEY, bond.ADUserPortKey)
 	}
 
-	encoder.Uint32(unix.IFLA_BOND_PEER_NOTIF_DELAY, bond.PeerNotifyDelay)
+	if bond.MIIMon != 0 {
+		encoder.Uint32(unix.IFLA_BOND_PEER_NOTIF_DELAY, bond.PeerNotifyDelay)
+	}
 
 	return encoder.Encode()
 }


### PR DESCRIPTION
Basically all delay options are interlocked with `miimon`: if `miimon`
is zero, all delays are set to zero, and kernel complains even if zero
delay attribute is sent while miimon is zero.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
