### PR TITLE
feat: update pkgs version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.6.0
-PKGS ?= v0.6.0
+PKGS ?= v0.6.0-1-g7b2e126
 EXTRAS ?= v0.4.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0


### PR DESCRIPTION
This PR bumps pkgs to v0.6.0-1-g7b2e126, so that we gain a fix for
hotplugging of nvme drives.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
