### PR TITLE
fix: controlplane keyusage

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -7,6 +7,7 @@ package secrets
 import (
 	"bytes"
 	"context"
+	stdlibx509 "crypto/x509"
 	"fmt"
 	"net"
 	"net/url"
@@ -201,6 +202,10 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.RootKubernetesS
 		x509.CommonName("kube-apiserver"),
 		x509.Organization("kube-master"),
 		x509.NotAfter(time.Now().Add(KubernetesCertificateValidityDuration)),
+		x509.KeyUsage(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment),
+		x509.ExtKeyUsage([]stdlibx509.ExtKeyUsage{
+			stdlibx509.ExtKeyUsageServerAuth,
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate api-server cert: %w", err)
@@ -212,6 +217,10 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.RootKubernetesS
 		x509.CommonName(constants.KubernetesAdminCertCommonName),
 		x509.Organization(constants.KubernetesAdminCertOrganization),
 		x509.NotAfter(time.Now().Add(KubernetesCertificateValidityDuration)),
+		x509.KeyUsage(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment),
+		x509.ExtKeyUsage([]stdlibx509.ExtKeyUsage{
+			stdlibx509.ExtKeyUsageClientAuth,
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate api-server cert: %w", err)
@@ -227,6 +236,10 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.RootKubernetesS
 	frontProxy, err := x509.NewKeyPair(aggregatorCA,
 		x509.CommonName("front-proxy-client"),
 		x509.NotAfter(time.Now().Add(KubernetesCertificateValidityDuration)),
+		x509.KeyUsage(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment),
+		x509.ExtKeyUsage([]stdlibx509.ExtKeyUsage{
+			stdlibx509.ExtKeyUsageClientAuth,
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate aggregator cert: %w", err)

--- a/internal/pkg/kubeconfig/generate.go
+++ b/internal/pkg/kubeconfig/generate.go
@@ -5,6 +5,7 @@
 package kubeconfig
 
 import (
+	stdlibx509 "crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -100,7 +101,12 @@ func Generate(in *GenerateInput, out io.Writer) error {
 	clientCert, err := x509.NewKeyPair(k8sCA,
 		x509.CommonName(in.CommonName),
 		x509.Organization(in.Organization),
-		x509.NotAfter(time.Now().Add(in.CertificateLifetime)))
+		x509.NotAfter(time.Now().Add(in.CertificateLifetime)),
+		x509.KeyUsage(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment),
+		x509.ExtKeyUsage([]stdlibx509.ExtKeyUsage{
+			stdlibx509.ExtKeyUsageClientAuth,
+		}),
+	)
 	if err != nil {
 		return fmt.Errorf("error generating Kubernetes client certificate: %w", err)
 	}


### PR DESCRIPTION
* kube-apiserver keyusage serverAuth
* kube-scheduler keyusage clientAuth
* kube-controller-manager keyusage clientAuth
* kubeconfig keyusage clientAuth

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
