### PR TITLE
fix: workaround 'Unauthorized' errors when accessing Kubernetes API

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -214,7 +214,7 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.RootKubernetesS
 	k8sSecrets.APIServer = x509.NewCertificateAndKeyFromKeyPair(apiServer)
 
 	apiServerKubeletClient, err := x509.NewKeyPair(ca,
-		x509.CommonName(constants.KubernetesAdminCertCommonName),
+		x509.CommonName(constants.KubernetesAPIServerKubeletClientCommonName),
 		x509.Organization(constants.KubernetesAdminCertOrganization),
 		x509.NotAfter(time.Now().Add(KubernetesCertificateValidityDuration)),
 		x509.KeyUsage(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment),

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -108,8 +108,9 @@ func NewClientFromPKI(ca, crt, key []byte, endpoint *url.URL) (client *Client, e
 // with a TTL of 10 minutes.
 func NewTemporaryClientFromPKI(ca *x509.PEMEncodedCertificateAndKey, endpoint *url.URL) (client *Client, err error) {
 	opts := []x509.Option{
-		x509.CommonName("admin"),
-		x509.Organization("system:masters"),
+		x509.CommonName(constants.KubernetesAdminCertCommonName),
+		x509.Organization(constants.KubernetesAdminCertOrganization),
+		x509.NotBefore(time.Now().Add(-time.Minute)), // allow for a minute for the time to be not in sync across nodes
 		x509.NotAfter(time.Now().Add(10 * time.Minute)),
 	}
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -163,10 +163,13 @@ const (
 	KubernetesEtcdListenClientPort = "2379"
 
 	// KubernetesAdminCertCommonName defines CN property of Kubernetes admin certificate.
-	KubernetesAdminCertCommonName = "apiserver-kubelet-client"
+	KubernetesAdminCertCommonName = "admin"
 
 	// KubernetesAdminCertOrganization defines Organization values of Kubernetes admin certificate.
 	KubernetesAdminCertOrganization = "system:masters"
+
+	// KubernetesAPIServerKubeletClientCommonName defines CN property of Kubernetes API server certificate to access kubelet API.
+	KubernetesAPIServerKubeletClientCommonName = "apiserver-kubelet-client"
 
 	// KubernetesControllerManagerOrganization defines Organization value of kube-controller-manager client certificate.
 	KubernetesControllerManagerOrganization = "system:kube-controller-manager"


### PR DESCRIPTION
This should fix an error like:

```
failed to create etcd client: error getting kubernetes endpoints: Unauthorized
```

The problem is that the generated cert was used immediately, so even
slight time sync issue across nodes might render the cert not (yet)
usable. Cert is generated on one node, but might be used on any other
node (as it goes via the LB).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
