### PR TITLE
fix: ignore 'not a leader' error on forfeit leadership

### DIFF
--- a/internal/pkg/etcd/etcd.go
+++ b/internal/pkg/etcd/etcd.go
@@ -6,6 +6,7 @@ package etcd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -259,6 +260,11 @@ func (c *Client) ForfeitLeadership(ctx context.Context) (string, error) {
 
 				_, err = c.MoveLeader(ctx, m.GetID())
 				if err != nil {
+					if errors.Is(err, rpctypes.ErrNotLeader) {
+						// this member is not a leader anymore, so nothing to be done for the forfeit leadership
+						return "", nil
+					}
+
 					return "", err
 				}
 


### PR DESCRIPTION
When forfeiting etcd leadership, it might be that the node still reports
leadership status while not being a leader once the actual API call is
used. We should ignore such an error as the node is not a leader.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
