### PR TITLE
chore: ignore future pkg/machinery/vX.Y.Z tags

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -562,6 +562,11 @@ local release_trigger = {
     event: [
       'tag',
     ],
+    ref: {
+      exclude: [
+        "refs/tags/pkg/**",
+      ],
+    },
   },
 };
 


### PR DESCRIPTION
Drone shouldn't build releases for `pkg/machinery/vX.Y.Z` tags.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
