### PR TITLE
fix: ignore DeadlineExceeded error correctly on bootstrap

### DIFF
--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -14,7 +14,6 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
@@ -70,7 +69,7 @@ var duCmd = &cobra.Command{
 			for {
 				info, err := stream.Recv()
 				if err != nil {
-					if err == io.EOF || status.Code(err) == codes.Canceled {
+					if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 						return w.Flush()
 					}
 

--- a/cmd/talosctl/cmd/talos/dmesg.go
+++ b/cmd/talosctl/cmd/talos/dmesg.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
@@ -37,7 +36,7 @@ var dmesgCmd = &cobra.Command{
 			for {
 				resp, err := stream.Recv()
 				if err != nil {
-					if err == io.EOF || status.Code(err) == codes.Canceled {
+					if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 						break
 					}
 

--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/cmd/talosctl/cmd/talos/output"
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
@@ -62,7 +61,7 @@ var getCmd = &cobra.Command{
 				for {
 					msg, err := watchClient.Recv()
 					if err != nil {
-						if err == io.EOF || status.Code(err) == codes.Canceled {
+						if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 							return nil
 						}
 

--- a/cmd/talosctl/cmd/talos/inspect.go
+++ b/cmd/talosctl/cmd/talos/inspect.go
@@ -14,7 +14,6 @@ import (
 	"github.com/emicklei/dot"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/cmd/talosctl/pkg/talos/helpers"
 	"github.com/talos-systems/talos/pkg/cli"
@@ -89,7 +88,7 @@ to render the graph:
 						for {
 							resp, err := listClient.Recv()
 							if err != nil {
-								if err == io.EOF || status.Code(err) == codes.Canceled {
+								if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 									break
 								}
 

--- a/cmd/talosctl/cmd/talos/list.go
+++ b/cmd/talosctl/cmd/talos/list.go
@@ -16,7 +16,6 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
@@ -87,7 +86,7 @@ var lsCmd = &cobra.Command{
 				for {
 					info, err := stream.Recv()
 					if err != nil {
-						if err == io.EOF || status.Code(err) == codes.Canceled {
+						if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 							if multipleNodes {
 								return w.Flush()
 							}
@@ -132,7 +131,7 @@ var lsCmd = &cobra.Command{
 			for {
 				info, err := stream.Recv()
 				if err != nil {
-					if err == io.EOF || status.Code(err) == codes.Canceled {
+					if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 						return w.Flush()
 					}
 

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -15,7 +15,6 @@ import (
 	criconstants "github.com/containerd/cri/pkg/constants"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/pkg/cli"
 	"github.com/talos-systems/talos/pkg/machinery/api/common"
@@ -158,7 +157,7 @@ func (slicer *lineSlicer) run(stream machine.MachineService_LogsClient) {
 	for {
 		data, err := stream.Recv()
 		if err != nil {
-			if err == io.EOF || status.Code(err) == codes.Canceled {
+			if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 				return
 			}
 			slicer.errCh <- err

--- a/cmd/talosctl/pkg/talos/helpers/resources.go
+++ b/cmd/talosctl/pkg/talos/helpers/resources.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/pkg/machinery/client"
 )
@@ -51,7 +50,7 @@ func ForEachResource(ctx context.Context, c *client.Client, callback func(ctx co
 		for {
 			msg, err := listClient.Recv()
 			if err != nil {
-				if err == io.EOF || status.Code(err) == codes.Canceled {
+				if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 					return nil
 				}
 

--- a/internal/integration/api/diskusage.go
+++ b/internal/integration/api/diskusage.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/internal/integration/base"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -115,7 +114,7 @@ func (suite *DiskUsageSuite) TestDiskUsageRequests() {
 			responseCount++
 
 			if err != nil {
-				if err == io.EOF || status.Code(err) == codes.Canceled {
+				if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 					break
 				}
 

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/talos-systems/talos/internal/integration/base"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -126,7 +125,7 @@ func (suite *EtcdSuite) TestEtcdLeaveCluster() {
 
 		info, err = stream.Recv()
 		if err != nil {
-			if err == io.EOF || status.Code(err) == codes.Canceled {
+			if err == io.EOF || client.StatusCode(err) == codes.Canceled {
 				break
 			}
 		}

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	clusterapi "github.com/talos-systems/talos/pkg/machinery/api/cluster"
@@ -962,7 +961,7 @@ func ReadStream(stream MachineStream) (io.ReadCloser, <-chan error, error) {
 		for {
 			data, err := stream.Recv()
 			if err != nil {
-				if err == io.EOF || status.Code(err) == codes.Canceled {
+				if err == io.EOF || StatusCode(err) == codes.Canceled {
 					return
 				}
 				//nolint:errcheck

--- a/pkg/machinery/client/events.go
+++ b/pkg/machinery/client/events.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -97,7 +96,7 @@ func (c *Client) EventsWatch(ctx context.Context, watchFunc func(<-chan Event), 
 	for {
 		event, err := stream.Recv()
 		if err != nil {
-			if err == io.EOF || status.Code(err) == codes.Canceled {
+			if err == io.EOF || StatusCode(err) == codes.Canceled {
 				return nil
 			}
 

--- a/pkg/machinery/client/status.go
+++ b/pkg/machinery/client/status.go
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client
+
+import (
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// StatusCode returns the Code of the error if it is a Status error, codes.OK if err
+// is nil, or codes.Unknown otherwise correctly unwrapping wrapped errors.
+//
+// StatusCode is mostly equivalent to grpc `status.Code` method, but it correctly unwraps wrapped errors
+// including `multierror.Error` used when parsing multi-node responses.
+func StatusCode(err error) codes.Code {
+	type grpcStatus interface {
+		GRPCStatus() *status.Status
+	}
+
+	// Don't use FromError to avoid allocation of OK status.
+	if err == nil {
+		return codes.OK
+	}
+
+	var se grpcStatus
+
+	if errors.As(err, &se) {
+		return se.GRPCStatus().Code()
+	}
+
+	return codes.Unknown
+}

--- a/pkg/machinery/client/status_test.go
+++ b/pkg/machinery/client/status_test.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package client_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/talos-systems/talos/pkg/machinery/client"
+)
+
+func TestStatusCode(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+		code codes.Code
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			code: codes.OK,
+		},
+		{
+			name: "not status",
+			err:  errors.New("some error"),
+			code: codes.Unknown,
+		},
+		{
+			name: "status",
+			err:  status.Error(codes.AlreadyExists, "file already exists"),
+			code: codes.AlreadyExists,
+		},
+		{
+			name: "status wrapped",
+			err:  multierror.Append(nil, status.Error(codes.AlreadyExists, "file already exists")).ErrorOrNil(),
+			code: codes.AlreadyExists,
+		},
+		{
+			name: "multiple wrapped",
+			err:  multierror.Append(nil, status.Error(codes.FailedPrecondition, "can't be zero"), status.Error(codes.AlreadyExists, "file already exists")).ErrorOrNil(),
+			code: codes.FailedPrecondition,
+		},
+		{
+			name: "double wrapped",
+			err:  multierror.Append(nil, fmt.Errorf("127.0.0.1: %w", status.Error(codes.AlreadyExists, "file already exists"))).ErrorOrNil(),
+			code: codes.AlreadyExists,
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, client.StatusCode(tt.err), tt.code)
+		})
+	}
+}


### PR DESCRIPTION
The problem was that gRPC method `status.Code(err)` doesn't unwrap
errors, while Talos client returns errors wrapped with
`multierror.Error` and `fmt.Errrorf`, so `status.Code` doesn't return
error code correctly.

Fix that by introducing our own client method which correctly goes over
the chain of wrapped errors.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
