### PR TITLE
chore: update references to old protobuf package

### DIFF
--- a/cmd/talosctl/cmd/talos/dashboard/source.go
+++ b/cmd/talosctl/cmd/talos/dashboard/source.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/talos-systems/talos/cmd/talosctl/cmd/talos/dashboard/data"
 	"github.com/talos-systems/talos/pkg/machinery/client"
@@ -86,7 +86,7 @@ func (source *APISource) gather() *data.Data {
 
 	gatherFuncs := []func() error{
 		func() error {
-			resp, err := source.MachineClient.Hostname(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.Hostname(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -107,7 +107,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.LoadAvg(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.LoadAvg(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -128,7 +128,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.Version(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.Version(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -149,7 +149,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.Memory(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.Memory(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -170,7 +170,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.SystemStat(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.SystemStat(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -191,7 +191,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.CPUInfo(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.CPUInfo(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -212,7 +212,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.NetworkDeviceStats(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.NetworkDeviceStats(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -233,7 +233,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.DiskStats(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.DiskStats(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}
@@ -254,7 +254,7 @@ func (source *APISource) gather() *data.Data {
 			return nil
 		},
 		func() error {
-			resp, err := source.MachineClient.Processes(source.ctx, &empty.Empty{})
+			resp, err := source.MachineClient.Processes(source.ctx, &emptypb.Empty{})
 			if err != nil {
 				return err
 			}

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/gdamore/tcell/v2 v2.3.11
 	github.com/gizak/termui/v3 v3.1.0
-	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_inspect.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_inspect.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
-	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	inspectapi "github.com/talos-systems/talos/pkg/machinery/api/inspect"
 )
@@ -22,7 +22,7 @@ type InspectServer struct {
 }
 
 // ControllerRuntimeDependencies implements inspect.InspectService interface.
-func (s *InspectServer) ControllerRuntimeDependencies(ctx context.Context, in *empty.Empty) (*inspectapi.ControllerRuntimeDependenciesResponse, error) {
+func (s *InspectServer) ControllerRuntimeDependencies(ctx context.Context, in *emptypb.Empty) (*inspectapi.ControllerRuntimeDependenciesResponse, error) {
 	graph, err := s.server.Controller.V1Alpha2().DependencyGraph()
 	if err != nil {
 		return nil, fmt.Errorf("error fetching dependency graph: %w", err)

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_monitoring.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_monitoring.go
@@ -11,14 +11,14 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/prometheus/procfs"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 )
 
 // Hostname implements the machine.MachineServer interface.
-func (s *Server) Hostname(ctx context.Context, in *empty.Empty) (*machine.HostnameResponse, error) {
+func (s *Server) Hostname(ctx context.Context, in *emptypb.Empty) (*machine.HostnameResponse, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (s *Server) Hostname(ctx context.Context, in *empty.Empty) (*machine.Hostna
 }
 
 // LoadAvg implements the machine.MachineServer interface.
-func (s *Server) LoadAvg(ctx context.Context, in *empty.Empty) (*machine.LoadAvgResponse, error) {
+func (s *Server) LoadAvg(ctx context.Context, in *emptypb.Empty) (*machine.LoadAvgResponse, error) {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func (s *Server) LoadAvg(ctx context.Context, in *empty.Empty) (*machine.LoadAvg
 }
 
 // SystemStat implements the machine.MachineServer interface.
-func (s *Server) SystemStat(ctx context.Context, in *empty.Empty) (*machine.SystemStatResponse, error) {
+func (s *Server) SystemStat(ctx context.Context, in *emptypb.Empty) (*machine.SystemStatResponse, error) {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ func (s *Server) SystemStat(ctx context.Context, in *empty.Empty) (*machine.Syst
 }
 
 // CPUInfo implements the machine.MachineServer interface.
-func (s *Server) CPUInfo(ctx context.Context, in *empty.Empty) (*machine.CPUInfoResponse, error) {
+func (s *Server) CPUInfo(ctx context.Context, in *emptypb.Empty) (*machine.CPUInfoResponse, error) {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil, err
@@ -193,7 +193,7 @@ func (s *Server) CPUInfo(ctx context.Context, in *empty.Empty) (*machine.CPUInfo
 }
 
 // NetworkDeviceStats implements the machine.MachineServer interface.
-func (s *Server) NetworkDeviceStats(ctx context.Context, in *empty.Empty) (*machine.NetworkDeviceStatsResponse, error) {
+func (s *Server) NetworkDeviceStats(ctx context.Context, in *emptypb.Empty) (*machine.NetworkDeviceStatsResponse, error) {
 	fs, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (s *Server) NetworkDeviceStats(ctx context.Context, in *empty.Empty) (*mach
 }
 
 // DiskStats implements the machine.MachineServer interface.
-func (s *Server) DiskStats(ctx context.Context, in *empty.Empty) (*machine.DiskStatsResponse, error) {
+func (s *Server) DiskStats(ctx context.Context, in *emptypb.Empty) (*machine.DiskStatsResponse, error) {
 	f, err := os.Open("/proc/diskstats")
 	if err != nil {
 		return nil, err

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 	criconstants "github.com/containerd/cri/pkg/constants"
-	"github.com/golang/protobuf/ptypes/empty"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/prometheus/procfs"
 	"github.com/rs/xid"
@@ -40,6 +39,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	installer "github.com/talos-systems/talos/cmd/installer/pkg/install"
 	"github.com/talos-systems/talos/internal/app/machined/internal/install"
@@ -210,7 +210,7 @@ func (s *Server) GenerateConfiguration(ctx context.Context, in *machine.Generate
 // Reboot implements the machine.MachineServer interface.
 //
 //nolint:dupl
-func (s *Server) Reboot(ctx context.Context, in *empty.Empty) (reply *machine.RebootResponse, err error) {
+func (s *Server) Reboot(ctx context.Context, in *emptypb.Empty) (reply *machine.RebootResponse, err error) {
 	log.Printf("reboot via API received")
 
 	if err := s.checkSupported(runtime.Reboot); err != nil {
@@ -348,7 +348,7 @@ func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (r
 // Shutdown implements the machine.MachineServer interface.
 //
 //nolint:dupl
-func (s *Server) Shutdown(ctx context.Context, in *empty.Empty) (reply *machine.ShutdownResponse, err error) {
+func (s *Server) Shutdown(ctx context.Context, in *emptypb.Empty) (reply *machine.ShutdownResponse, err error) {
 	log.Printf("shutdown via API received")
 
 	if err = s.checkSupported(runtime.Shutdown); err != nil {
@@ -596,7 +596,7 @@ func (s *Server) Reset(ctx context.Context, in *machine.ResetRequest) (reply *ma
 }
 
 // ServiceList returns list of the registered services and their status.
-func (s *Server) ServiceList(ctx context.Context, in *empty.Empty) (result *machine.ServiceListResponse, err error) {
+func (s *Server) ServiceList(ctx context.Context, in *emptypb.Empty) (result *machine.ServiceListResponse, err error) {
 	services := system.Services(s.Controller.Runtime()).List()
 
 	result = &machine.ServiceListResponse{
@@ -976,7 +976,7 @@ func (s *Server) DiskUsage(req *machine.DiskUsageRequest, obj machine.MachineSer
 }
 
 // Mounts implements the machine.MachineServer interface.
-func (s *Server) Mounts(ctx context.Context, in *empty.Empty) (reply *machine.MountsResponse, err error) {
+func (s *Server) Mounts(ctx context.Context, in *emptypb.Empty) (reply *machine.MountsResponse, err error) {
 	file, err := os.Open("/proc/mounts")
 	if err != nil {
 		return nil, err
@@ -1048,7 +1048,7 @@ func (s *Server) Mounts(ctx context.Context, in *empty.Empty) (reply *machine.Mo
 }
 
 // Version implements the machine.MachineServer interface.
-func (s *Server) Version(ctx context.Context, in *empty.Empty) (reply *machine.VersionResponse, err error) {
+func (s *Server) Version(ctx context.Context, in *emptypb.Empty) (reply *machine.VersionResponse, err error) {
 	var platform *machine.PlatformInfo
 
 	if s.Controller.Runtime().State().Platform() != nil {
@@ -1074,7 +1074,7 @@ func (s *Server) Version(ctx context.Context, in *empty.Empty) (reply *machine.V
 }
 
 // Kubeconfig implements the machine.MachineServer interface.
-func (s *Server) Kubeconfig(empty *empty.Empty, obj machine.MachineService_KubeconfigServer) error {
+func (s *Server) Kubeconfig(empty *emptypb.Empty, obj machine.MachineService_KubeconfigServer) error {
 	var b bytes.Buffer
 
 	if err := kubeconfig.GenerateAdmin(s.Controller.Runtime().Config().Cluster(), &b); err != nil {
@@ -1543,7 +1543,7 @@ func (s *Server) Dmesg(req *machine.DmesgRequest, srv machine.MachineService_Dme
 }
 
 // Processes implements the machine.MachineServer interface.
-func (s *Server) Processes(ctx context.Context, in *empty.Empty) (reply *machine.ProcessesResponse, err error) {
+func (s *Server) Processes(ctx context.Context, in *emptypb.Empty) (reply *machine.ProcessesResponse, err error) {
 	procs, err := procfs.AllProcs()
 	if err != nil {
 		return nil, err
@@ -1608,7 +1608,7 @@ func (s *Server) Processes(ctx context.Context, in *empty.Empty) (reply *machine
 }
 
 // Memory implements the machine.MachineServer interface.
-func (s *Server) Memory(ctx context.Context, in *empty.Empty) (reply *machine.MemoryResponse, err error) {
+func (s *Server) Memory(ctx context.Context, in *emptypb.Empty) (reply *machine.MemoryResponse, err error) {
 	proc, err := procfs.NewDefaultFS()
 	if err != nil {
 		return nil, err
@@ -1900,7 +1900,7 @@ func (s *Server) EtcdRecover(srv machine.MachineService_EtcdRecoverServer) error
 //
 // Temporary API only used when converting from self-hosted to Talos-managed control plane.
 // This API can be removed once the conversion process is no longer needed (Talos 0.11?).
-func (s *Server) RemoveBootkubeInitializedKey(ctx context.Context, in *empty.Empty) (*machine.RemoveBootkubeInitializedKeyResponse, error) {
+func (s *Server) RemoveBootkubeInitializedKey(ctx context.Context, in *emptypb.Empty) (*machine.RemoveBootkubeInitializedKeyResponse, error) {
 	client, err := etcd.NewLocalClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create etcd client: %w", err)

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_time.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_time.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/beevik/ntp"
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	timeapi "github.com/talos-systems/talos/pkg/machinery/api/time"
@@ -36,7 +36,7 @@ func (r *TimeServer) Register(s *grpc.Server) {
 }
 
 // Time issues a query to the configured ntp server and displays the results.
-func (r *TimeServer) Time(ctx context.Context, in *empty.Empty) (reply *timeapi.TimeResponse, err error) {
+func (r *TimeServer) Time(ctx context.Context, in *emptypb.Empty) (reply *timeapi.TimeResponse, err error) {
 	timeServers := r.ConfigProvider.Config().Machine().Time().Servers()
 
 	if len(timeServers) == 0 {

--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_time_test.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_time_test.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	runtime "github.com/talos-systems/talos/internal/app/machined/internal/server/v1alpha1"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
@@ -75,7 +75,7 @@ func (suite *TimedSuite) TestTime() {
 	suite.Require().NoError(err)
 
 	nClient := timeapi.NewTimeServiceClient(conn)
-	reply, err := nClient.Time(context.Background(), &empty.Empty{})
+	reply, err := nClient.Time(context.Background(), &emptypb.Empty{})
 	suite.Require().NoError(err)
 	suite.Assert().Equal(reply.Messages[0].Server, testServer)
 }

--- a/internal/app/machined/pkg/runtime/events.go
+++ b/internal/app/machined/pkg/runtime/events.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/rs/xid"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/talos-systems/talos/pkg/machinery/api/machine"
 )
@@ -107,7 +107,7 @@ func (event *Event) ToMachineEvent() (*machine.Event, error) {
 	}
 
 	return &machine.Event{
-		Data: &any.Any{
+		Data: &anypb.Any{
 			TypeUrl: event.TypeURL,
 			Value:   value,
 		},

--- a/internal/app/networkd/pkg/server/server.go
+++ b/internal/app/networkd/pkg/server/server.go
@@ -10,10 +10,10 @@ import (
 	"log"
 	"net"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/jsimonetti/rtnetlink"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	networkapi "github.com/talos-systems/talos/pkg/machinery/api/network"
 )
@@ -29,7 +29,7 @@ func (r *NetworkServer) Register(s *grpc.Server) {
 }
 
 // Routes returns the hosts routing table.
-func (r *NetworkServer) Routes(ctx context.Context, in *empty.Empty) (reply *networkapi.RoutesResponse, err error) {
+func (r *NetworkServer) Routes(ctx context.Context, in *emptypb.Empty) (reply *networkapi.RoutesResponse, err error) {
 	conn, err := rtnetlink.Dial(nil)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (r *NetworkServer) Routes(ctx context.Context, in *empty.Empty) (reply *net
 }
 
 // Interfaces returns the hosts network interfaces and addresses.
-func (r *NetworkServer) Interfaces(ctx context.Context, in *empty.Empty) (reply *networkapi.InterfacesResponse, err error) {
+func (r *NetworkServer) Interfaces(ctx context.Context, in *emptypb.Empty) (reply *networkapi.InterfacesResponse, err error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
 		return reply, err

--- a/internal/app/networkd/pkg/server/server_test.go
+++ b/internal/app/networkd/pkg/server/server_test.go
@@ -12,10 +12,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/talos-systems/talos/internal/app/networkd/pkg/server"
 	"github.com/talos-systems/talos/pkg/grpc/dialer"
@@ -51,7 +51,7 @@ func (suite *NetworkSuite) TestRoutes() {
 	suite.Assert().NoError(err)
 
 	nClient := networkapi.NewNetworkServiceClient(conn)
-	resp, err := nClient.Routes(context.Background(), &empty.Empty{})
+	resp, err := nClient.Routes(context.Background(), &emptypb.Empty{})
 	suite.Assert().NoError(err)
 	suite.Assert().Greater(len(resp.Messages[0].Routes), 0)
 }
@@ -76,7 +76,7 @@ func (suite *NetworkSuite) TestInterfaces() {
 	suite.Assert().NoError(err)
 
 	nClient := networkapi.NewNetworkServiceClient(conn)
-	resp, err := nClient.Interfaces(context.Background(), &empty.Empty{})
+	resp, err := nClient.Interfaces(context.Background(), &emptypb.Empty{})
 	suite.Assert().NoError(err)
 	suite.Assert().Greater(len(resp.Messages[0].Interfaces), 0)
 }

--- a/internal/app/storaged/server.go
+++ b/internal/app/storaged/server.go
@@ -7,8 +7,8 @@ package internal
 import (
 	"context"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util/disk"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/talos-systems/talos/pkg/machinery/api/storage"
 )
@@ -20,7 +20,7 @@ type Server struct {
 }
 
 // Disks implements storage.StorageService.
-func (s *Server) Disks(ctx context.Context, in *empty.Empty) (reply *storage.DisksResponse, err error) {
+func (s *Server) Disks(ctx context.Context, in *emptypb.Empty) (reply *storage.DisksResponse, err error) {
 	disks, err := disk.List()
 	if err != nil {
 		return nil, err

--- a/internal/integration/api/etcd.go
+++ b/internal/integration/api/etcd.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/talos-systems/talos/internal/integration/base"
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
@@ -136,7 +136,7 @@ func (suite *EtcdSuite) TestEtcdLeaveCluster() {
 	// NB: Reboot the node so that it can rejoin the etcd cluster. This allows us
 	// to check the cluster health and catch any issues in rejoining.
 	suite.AssertRebooted(suite.ctx, node, func(nodeCtx context.Context) error {
-		_, err = suite.Client.MachineClient.Reboot(nodeCtx, &empty.Empty{})
+		_, err = suite.Client.MachineClient.Reboot(nodeCtx, &emptypb.Empty{})
 
 		return err
 	}, 10*time.Minute)

--- a/pkg/machinery/client/client.go
+++ b/pkg/machinery/client/client.go
@@ -18,13 +18,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	grpctls "github.com/talos-systems/crypto/tls"
 	"github.com/talos-systems/net"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	clusterapi "github.com/talos-systems/talos/pkg/machinery/api/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/api/common"
@@ -322,7 +322,7 @@ func (c *Client) Close() error {
 
 // KubeconfigRaw returns K8s client config (kubeconfig).
 func (c *Client) KubeconfigRaw(ctx context.Context) (io.ReadCloser, <-chan error, error) {
-	stream, err := c.MachineClient.Kubeconfig(ctx, &empty.Empty{})
+	stream, err := c.MachineClient.Kubeconfig(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -408,7 +408,7 @@ func (c *Client) GenerateConfiguration(ctx context.Context, req *machineapi.Gene
 
 // Disks returns the list of block devices.
 func (c *Client) Disks(ctx context.Context, callOptions ...grpc.CallOption) (resp *storageapi.DisksResponse, err error) {
-	resp, err = c.StorageClient.Disks(ctx, &empty.Empty{}, callOptions...)
+	resp, err = c.StorageClient.Disks(ctx, &emptypb.Empty{}, callOptions...)
 
 	var filtered interface{}
 	filtered, err = FilterMessages(resp, err)
@@ -491,7 +491,7 @@ func (c *Client) ResetGeneric(ctx context.Context, req *machineapi.ResetRequest)
 
 // Reboot implements the proto.MachineServiceClient interface.
 func (c *Client) Reboot(ctx context.Context) (err error) {
-	resp, err := c.MachineClient.Reboot(ctx, &empty.Empty{})
+	resp, err := c.MachineClient.Reboot(ctx, &emptypb.Empty{})
 
 	if err == nil {
 		_, err = FilterMessages(resp, err)
@@ -524,7 +524,7 @@ func (c *Client) Bootstrap(ctx context.Context, req *machineapi.BootstrapRequest
 
 // Shutdown implements the proto.MachineServiceClient interface.
 func (c *Client) Shutdown(ctx context.Context) (err error) {
-	resp, err := c.MachineClient.Shutdown(ctx, &empty.Empty{})
+	resp, err := c.MachineClient.Shutdown(ctx, &emptypb.Empty{})
 
 	if err == nil {
 		_, err = FilterMessages(resp, err)
@@ -558,7 +558,7 @@ func (c *Client) Logs(ctx context.Context, namespace string, driver common.Conta
 func (c *Client) Version(ctx context.Context, callOptions ...grpc.CallOption) (resp *machineapi.VersionResponse, err error) {
 	resp, err = c.MachineClient.Version(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -573,7 +573,7 @@ func (c *Client) Version(ctx context.Context, callOptions ...grpc.CallOption) (r
 func (c *Client) Routes(ctx context.Context, callOptions ...grpc.CallOption) (resp *networkapi.RoutesResponse, err error) {
 	resp, err = c.NetworkClient.Routes(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -588,7 +588,7 @@ func (c *Client) Routes(ctx context.Context, callOptions ...grpc.CallOption) (re
 func (c *Client) Interfaces(ctx context.Context, callOptions ...grpc.CallOption) (resp *networkapi.InterfacesResponse, err error) {
 	resp, err = c.NetworkClient.Interfaces(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -603,7 +603,7 @@ func (c *Client) Interfaces(ctx context.Context, callOptions ...grpc.CallOption)
 func (c *Client) Processes(ctx context.Context, callOptions ...grpc.CallOption) (resp *machineapi.ProcessesResponse, err error) {
 	resp, err = c.MachineClient.Processes(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -618,7 +618,7 @@ func (c *Client) Processes(ctx context.Context, callOptions ...grpc.CallOption) 
 func (c *Client) Memory(ctx context.Context, callOptions ...grpc.CallOption) (resp *machineapi.MemoryResponse, err error) {
 	resp, err = c.MachineClient.Memory(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -633,7 +633,7 @@ func (c *Client) Memory(ctx context.Context, callOptions ...grpc.CallOption) (re
 func (c *Client) Mounts(ctx context.Context, callOptions ...grpc.CallOption) (resp *machineapi.MountsResponse, err error) {
 	resp, err = c.MachineClient.Mounts(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -691,7 +691,7 @@ func (c *Client) Upgrade(ctx context.Context, image string, preserve, stage, for
 func (c *Client) ServiceList(ctx context.Context, callOptions ...grpc.CallOption) (resp *machineapi.ServiceListResponse, err error) {
 	resp, err = c.MachineClient.ServiceList(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -717,7 +717,7 @@ func (c *Client) ServiceInfo(ctx context.Context, id string, callOptions ...grpc
 
 	resp, err = c.MachineClient.ServiceList(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 
@@ -798,7 +798,7 @@ func (c *Client) ServiceRestart(ctx context.Context, id string, callOptions ...g
 func (c *Client) Time(ctx context.Context, callOptions ...grpc.CallOption) (resp *timeapi.TimeResponse, err error) {
 	resp, err = c.TimeClient.Time(
 		ctx,
-		&empty.Empty{},
+		&emptypb.Empty{},
 		callOptions...,
 	)
 

--- a/pkg/machinery/client/inspect.go
+++ b/pkg/machinery/client/inspect.go
@@ -7,8 +7,8 @@ package client
 import (
 	"context"
 
-	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	inspectapi "github.com/talos-systems/talos/pkg/machinery/api/inspect"
 )
@@ -20,7 +20,7 @@ type InspectClient struct {
 
 // ControllerRuntimeDependencies returns graph describing dependencies between controllers.
 func (c *InspectClient) ControllerRuntimeDependencies(ctx context.Context, callOptions ...grpc.CallOption) (*inspectapi.ControllerRuntimeDependenciesResponse, error) {
-	resp, err := c.client.ControllerRuntimeDependencies(ctx, &empty.Empty{}, callOptions...)
+	resp, err := c.client.ControllerRuntimeDependencies(ctx, &emptypb.Empty{}, callOptions...)
 
 	var filtered interface{}
 	filtered, err = FilterMessages(resp, err)


### PR DESCRIPTION
This simply uses new protobuf package instead of old one.

Old protobuf package is still in use by Talos dependencies.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
