### PR TITLE
fix: cache etcd client used for healthchecks

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -55,7 +55,8 @@ type Etcd struct {
 	RecoverFromSnapshot  bool
 	RecoverSkipHashCheck bool
 
-	args []string
+	args   []string
+	client *etcd.Client
 }
 
 // ID implements the Service interface.
@@ -113,6 +114,12 @@ func (e *Etcd) PreFunc(ctx context.Context, r runtime.Runtime) (err error) {
 
 // PostFunc implements the Service interface.
 func (e *Etcd) PostFunc(r runtime.Runtime, state events.ServiceState) (err error) {
+	if e.client != nil {
+		e.client.Close() //nolint:errcheck
+	}
+
+	e.client = nil
+
 	return nil
 }
 
@@ -173,14 +180,16 @@ func (e *Etcd) Runner(r runtime.Runtime) (runner.Runner, error) {
 // HealthFunc implements the HealthcheckedService interface.
 func (e *Etcd) HealthFunc(runtime.Runtime) health.Check {
 	return func(ctx context.Context) error {
-		client, err := etcd.NewClient([]string{"127.0.0.1:2379"})
-		if err != nil {
-			return err
+		if e.client == nil {
+			var err error
+
+			e.client, err = etcd.NewLocalClient()
+			if err != nil {
+				return err
+			}
 		}
 
-		defer client.Close() //nolint:errcheck
-
-		return client.ValidateQuorum(ctx)
+		return e.client.ValidateQuorum(ctx)
 	}
 }
 


### PR DESCRIPTION
We run etcd health check every 30s, and create/destroy client every 30s.
This puts a lot of pressure on etcd itself and machined.

There's protobuf overhead, TLS connection overhead, etc.

As we don't support changing etcd PKI (yet), client created once is good
enough for the lifetime of the node.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
