### PR TITLE
backport: chore: ignore tags which don't look like semantic version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REGISTRY ?= ghcr.io
 USERNAME ?= talos-systems
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
-TAG ?= $(shell git describe --tag --always --dirty)
+TAG ?= $(shell git describe --tag --always --dirty --match v[0-9]*)
 IMAGE_REGISTRY ?= $(REGISTRY)
 IMAGE_TAG ?= $(TAG)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
This allows us to use tags for Go submodules `pkg/machinery/v0.11.0` and
still keeps Talos tag follow semantic version `v0.11.0`.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
