### PR TITLE
fix: workaround issues when IPv6 is fully or partially disabled

### DIFF
--- a/internal/app/machined/pkg/controllers/network/address_config.go
+++ b/internal/app/machined/pkg/controllers/network/address_config.go
@@ -195,14 +195,6 @@ func (ctrl *AddressConfigController) loopbackDefaults() []network.AddressSpecSpe
 			LinkName:    "lo",
 			ConfigLayer: network.ConfigDefault,
 		},
-		{
-			Address:     netaddr.IPPrefixFrom(netaddr.IPFrom16([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}), 128),
-			Family:      nethelpers.FamilyInet6,
-			Scope:       nethelpers.ScopeHost,
-			Flags:       nethelpers.AddressFlags(nethelpers.AddressPermanent),
-			LinkName:    "lo",
-			ConfigLayer: network.ConfigDefault,
-		},
 	}
 }
 

--- a/internal/app/machined/pkg/controllers/network/address_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/address_config_test.go
@@ -107,7 +107,6 @@ func (suite *AddressConfigSuite) TestLoopback() {
 		func() error {
 			return suite.assertAddresses([]string{
 				"default/lo/127.0.0.1/8",
-				"default/lo/::1/128",
 			}, func(r *network.AddressSpec) error {
 				suite.Assert().Equal("lo", r.TypedSpec().LinkName)
 				suite.Assert().Equal(nethelpers.ScopeHost, r.TypedSpec().Scope)

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -199,7 +199,9 @@ func WriteRequiredSysctlsForContainer(seq runtime.Sequence, data interface{}) (r
 		}
 
 		if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "net.ipv6.conf.default.forwarding", Value: "1"}); err != nil {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set net.ipv6.conf.default.forwarding: %w", err))
+			if !errors.Is(err, os.ErrNotExist) { // ignore error if ipv6 is disabled
+				multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set net.ipv6.conf.default.forwarding: %w", err))
+			}
 		}
 
 		if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "kernel.pid_max", Value: "262144"}); err != nil {
@@ -228,7 +230,9 @@ func WriteRequiredSysctls(seq runtime.Sequence, data interface{}) (runtime.TaskE
 		}
 
 		if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "net.ipv6.conf.default.forwarding", Value: "1"}); err != nil {
-			multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set net.ipv6.conf.default.forwarding: %w", err))
+			if !errors.Is(err, os.ErrNotExist) { // ignore error if ipv6 is disabled
+				multiErr = multierror.Append(multiErr, fmt.Errorf("failed to set net.ipv6.conf.default.forwarding: %w", err))
+			}
 		}
 
 		if err := sysctl.WriteSystemProperty(&sysctl.SystemProperty{Key: "kernel.pid_max", Value: "262144"}); err != nil {


### PR DESCRIPTION
Fixes #3847

Fixes #3919

1. Looks like `::1/128` is assigned to `lo` interface by the kernel
without our help, and kernel does it properly whether IPv6 is enabled
for not (including particular interface).

2. If IPv6 is disabled completely with command line, we should ignore
failures to write ipv6 sysctls (as these are not security-related,
skipping them isn't a risk).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
