### PR TITLE
fix: correctly pick route scope for link-local destination

### DIFF
--- a/internal/app/machined/pkg/controllers/network/route_spec_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_spec_test.go
@@ -370,6 +370,91 @@ func (suite *RouteSpecSuite) TestDefaultAndInterfaceRoutes() {
 	suite.Require().NoError(suite.state.Destroy(suite.ctx, def.Metadata()))
 }
 
+func (suite *RouteSpecSuite) TestLinkLocalRoute() {
+	dummyInterface := suite.uniqueDummyInterface()
+
+	conn, err := rtnetlink.Dial(nil)
+	suite.Require().NoError(err)
+
+	defer conn.Close() //nolint:errcheck
+
+	suite.Require().NoError(conn.Link.New(&rtnetlink.LinkMessage{
+		Type:   unix.ARPHRD_ETHER,
+		Flags:  unix.IFF_UP,
+		Change: unix.IFF_UP,
+		Attributes: &rtnetlink.LinkAttributes{
+			Name: dummyInterface,
+			MTU:  1500,
+			Info: &rtnetlink.LinkInfo{
+				Kind: "dummy",
+			},
+		},
+	}))
+
+	iface, err := net.InterfaceByName(dummyInterface)
+	suite.Require().NoError(err)
+
+	defer conn.Link.Delete(uint32(iface.Index)) //nolint:errcheck
+
+	localIP := net.ParseIP("10.28.0.27").To4()
+
+	suite.Require().NoError(conn.Address.New(&rtnetlink.AddressMessage{
+		Family:       unix.AF_INET,
+		PrefixLength: 24,
+		Scope:        unix.RT_SCOPE_UNIVERSE,
+		Index:        uint32(iface.Index),
+		Attributes: rtnetlink.AddressAttributes{
+			Address: localIP,
+			Local:   localIP,
+		},
+	}))
+
+	ll := network.NewRouteSpec(network.NamespaceName, "ll")
+	*ll.TypedSpec() = network.RouteSpecSpec{
+		Family:      nethelpers.FamilyInet4,
+		Destination: netaddr.MustParseIPPrefix("169.254.169.254/32"),
+		Gateway:     netaddr.MustParseIP("10.28.0.1"),
+		Source:      netaddr.MustParseIPPrefix("10.28.0.27/24"),
+		Table:       nethelpers.TableMain,
+		OutLinkName: dummyInterface,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		Priority:    1048576,
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+	ll.TypedSpec().Normalize()
+
+	for _, res := range []resource.Resource{ll} {
+		suite.Require().NoError(suite.state.Create(suite.ctx, res), "%v", res.Spec())
+	}
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertRoute(netaddr.MustParseIPPrefix("169.254.169.254/32"), netaddr.MustParseIP("10.28.0.1"), func(route rtnetlink.RouteMessage) error {
+				suite.Assert().EqualValues(1048576, route.Attributes.Priority)
+
+				return nil
+			})
+		}))
+
+	// teardown the routes
+	for {
+		ready, err := suite.state.Teardown(suite.ctx, ll.Metadata())
+		suite.Require().NoError(err)
+
+		if ready {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// torn down route should be removed immediately
+	suite.Assert().NoError(suite.assertNoRoute(netaddr.MustParseIPPrefix("169.254.169.254/32"), netaddr.MustParseIP("10.28.0.1")))
+
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, ll.Metadata()))
+}
+
 func (suite *RouteSpecSuite) TearDownTest() {
 	suite.T().Log("tear down")
 

--- a/pkg/resources/network/route_spec.go
+++ b/pkg/resources/network/route_spec.go
@@ -64,8 +64,6 @@ func (route *RouteSpecSpec) Normalize() {
 	switch {
 	case route.Gateway.IsZero():
 		route.Scope = nethelpers.ScopeLink
-	case route.Destination.IP().IsLinkLocalUnicast() || route.Destination.IP().IsLinkLocalMulticast():
-		route.Scope = nethelpers.ScopeLink
 	case route.Destination.IP().IsLoopback():
 		route.Scope = nethelpers.ScopeHost
 	default:


### PR DESCRIPTION
Route scope doesn't depend on destination IP type being link-local, e.g.
in Azure route to link local address is create with gateway, and that
should be global (universe) scope route.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
