### PR TITLE
feat: use dynamic NodeAddresses/HostnameStatus in Kubernetes certs

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -414,7 +414,9 @@ func create(ctx context.Context) (err error) {
 			fallthrough
 		case forceEndpoint != "":
 			endpointList = []string{forceEndpoint}
+			// using non-default endpoints, provision additional cert SANs and fix endpoint list
 			provisionOptions = append(provisionOptions, provision.WithEndpoint(forceEndpoint))
+			genOptions = append(genOptions, generate.WithAdditionalSubjectAltNames(endpointList))
 		case forceInitNodeAsEndpoint:
 			endpointList = []string{ips[0][0].String()}
 		default:

--- a/internal/app/machined/pkg/controllers/secrets/altnames.go
+++ b/internal/app/machined/pkg/controllers/secrets/altnames.go
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets
+
+import "net"
+
+// AltNames defines certificate alternative names.
+type AltNames struct {
+	IPs      []net.IP
+	DNSNames []string
+}
+
+// Append list of SANs splitting into IPs/DNS names.
+func (altNames *AltNames) Append(sans ...string) {
+	for _, san := range sans {
+		if ip := net.ParseIP(san); ip != nil {
+			altNames.AppendIPs(ip)
+		} else {
+			altNames.AppendDNSNames(san)
+		}
+	}
+}
+
+// AppendIPs skipping duplicates.
+func (altNames *AltNames) AppendIPs(ips ...net.IP) {
+	for _, ip := range ips {
+		found := false
+
+		for _, addr := range altNames.IPs {
+			if addr.Equal(ip) {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			altNames.IPs = append(altNames.IPs, ip)
+		}
+	}
+}
+
+// AppendDNSNames skipping duplicates.
+func (altNames *AltNames) AppendDNSNames(dnsNames ...string) {
+	for _, dnsName := range dnsNames {
+		found := false
+
+		for _, name := range altNames.DNSNames {
+			if name == dnsName {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			altNames.DNSNames = append(altNames.DNSNames, dnsName)
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/secrets/api_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/api_test.go
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package secrets_test
+
+import (
+	"context"
+	stdlibx509 "crypto/x509"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/crypto/x509"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+
+	secretsctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/secrets"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/machinery/role"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+	"github.com/talos-systems/talos/pkg/resources/secrets"
+)
+
+type APISuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *APISuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&secretsctrl.APIController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *APISuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *APISuite) TestReconcileControlPlane() {
+	rootSecrets := secrets.NewRoot(secrets.RootOSID)
+
+	talosCA, err := x509.NewSelfSignedCertificateAuthority(
+		x509.Organization("talos"),
+	)
+	suite.Require().NoError(err)
+
+	rootSecrets.OSSpec().CA = &x509.PEMEncodedCertificateAndKey{
+		Crt: talosCA.CrtPEM,
+		Key: talosCA.KeyPEM,
+	}
+	rootSecrets.OSSpec().CertSANDNSNames = []string{"example.com"}
+	rootSecrets.OSSpec().CertSANIPs = []netaddr.IP{netaddr.MustParseIP("10.4.3.2"), netaddr.MustParseIP("10.2.1.3")}
+	rootSecrets.OSSpec().Token = "something"
+	suite.Require().NoError(suite.state.Create(suite.ctx, rootSecrets))
+
+	machineType := config.NewMachineType()
+	machineType.SetMachineType(machine.TypeControlPlane)
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineType))
+
+	networkStatus := network.NewStatus(network.NamespaceName, network.StatusID)
+	networkStatus.TypedSpec().AddressReady = true
+	networkStatus.TypedSpec().HostnameReady = true
+	suite.Require().NoError(suite.state.Create(suite.ctx, networkStatus))
+
+	hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostnameStatus.TypedSpec().Hostname = "foo"
+	hostnameStatus.TypedSpec().Domainname = "example.com"
+	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
+
+	nodeAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s))
+	nodeAddresses.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("10.2.1.3"), netaddr.MustParseIP("172.16.0.1")}
+	suite.Require().NoError(suite.state.Create(suite.ctx, nodeAddresses))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			certs, err := suite.state.Get(suite.ctx, resource.NewMetadata(secrets.NamespaceName, secrets.APIType, secrets.APIID, resource.VersionUndefined))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					return retry.ExpectedError(err)
+				}
+
+				return err
+			}
+
+			apiCerts := certs.(*secrets.API).TypedSpec()
+
+			suite.Assert().Equal(talosCA.CrtPEM, apiCerts.CA.Crt)
+			suite.Assert().Nil(apiCerts.CA.Key)
+
+			serverCert, err := apiCerts.Server.GetCert()
+			suite.Require().NoError(err)
+
+			suite.Assert().Equal([]string{"example.com", "foo", "foo.example.com"}, serverCert.DNSNames)
+			suite.Assert().Equal([]net.IP{net.ParseIP("10.4.3.2").To4(), net.ParseIP("10.2.1.3").To4(), net.ParseIP("172.16.0.1").To4()}, serverCert.IPAddresses)
+
+			suite.Assert().Equal("foo.example.com", serverCert.Subject.CommonName)
+			suite.Assert().Empty(serverCert.Subject.Organization)
+
+			suite.Assert().Equal(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment, serverCert.KeyUsage)
+			suite.Assert().Equal([]stdlibx509.ExtKeyUsage{stdlibx509.ExtKeyUsageServerAuth}, serverCert.ExtKeyUsage)
+
+			clientCert, err := apiCerts.Client.GetCert()
+			suite.Require().NoError(err)
+
+			suite.Assert().Empty(clientCert.DNSNames)
+			suite.Assert().Empty(clientCert.IPAddresses)
+
+			suite.Assert().Equal("foo.example.com", clientCert.Subject.CommonName)
+			suite.Assert().Equal([]string{string(role.Impersonator)}, clientCert.Subject.Organization)
+
+			suite.Assert().Equal(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment, clientCert.KeyUsage)
+			suite.Assert().Equal([]stdlibx509.ExtKeyUsage{stdlibx509.ExtKeyUsageClientAuth}, clientCert.ExtKeyUsage)
+
+			return nil
+		},
+	))
+}
+
+func (suite *APISuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+}
+
+func TestAPISuite(t *testing.T) {
+	suite.Run(t, new(APISuite))
+}

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
@@ -1,0 +1,221 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package secrets_test
+
+import (
+	"context"
+	stdlibx509 "crypto/x509"
+	"log"
+	"net"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/crypto/x509"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+	"k8s.io/client-go/tools/clientcmd"
+
+	secretsctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/secrets"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+	"github.com/talos-systems/talos/pkg/resources/secrets"
+	timeresource "github.com/talos-systems/talos/pkg/resources/time"
+)
+
+type KubernetesSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *KubernetesSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&secretsctrl.KubernetesController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *KubernetesSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *KubernetesSuite) TestReconcile() {
+	rootSecrets := secrets.NewRoot(secrets.RootKubernetesID)
+
+	k8sCA, err := x509.NewSelfSignedCertificateAuthority(
+		x509.Organization("kubernetes"),
+		x509.ECDSA(true),
+	)
+	suite.Require().NoError(err)
+
+	aggregatorCA, err := x509.NewSelfSignedCertificateAuthority(
+		x509.Organization("kubernetes"),
+		x509.ECDSA(true),
+	)
+	suite.Require().NoError(err)
+
+	serviceAccount, err := x509.NewECDSAKey()
+	suite.Require().NoError(err)
+
+	rootSecrets.KubernetesSpec().Name = "cluster1"
+	rootSecrets.KubernetesSpec().Endpoint, err = url.Parse("https://some.url:6443/")
+	suite.Require().NoError(err)
+
+	rootSecrets.KubernetesSpec().CA = &x509.PEMEncodedCertificateAndKey{
+		Crt: k8sCA.CrtPEM,
+		Key: k8sCA.KeyPEM,
+	}
+	rootSecrets.KubernetesSpec().AggregatorCA = &x509.PEMEncodedCertificateAndKey{
+		Crt: aggregatorCA.CrtPEM,
+		Key: aggregatorCA.KeyPEM,
+	}
+	rootSecrets.KubernetesSpec().ServiceAccount = &x509.PEMEncodedKey{
+		Key: serviceAccount.KeyPEM,
+	}
+	rootSecrets.KubernetesSpec().CertSANs = []string{"example.com"}
+	rootSecrets.KubernetesSpec().APIServerIPs = []net.IP{net.ParseIP("10.4.3.2"), net.ParseIP("10.2.1.3")}
+	rootSecrets.KubernetesSpec().DNSDomain = "cluster.remote"
+	suite.Require().NoError(suite.state.Create(suite.ctx, rootSecrets))
+
+	machineType := config.NewMachineType()
+	machineType.SetMachineType(machine.TypeControlPlane)
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineType))
+
+	networkStatus := network.NewStatus(network.NamespaceName, network.StatusID)
+	networkStatus.TypedSpec().AddressReady = true
+	networkStatus.TypedSpec().HostnameReady = true
+	suite.Require().NoError(suite.state.Create(suite.ctx, networkStatus))
+
+	hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostnameStatus.TypedSpec().Hostname = "foo"
+	hostnameStatus.TypedSpec().Domainname = "example.com"
+	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
+
+	nodeAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s))
+	nodeAddresses.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("10.2.1.3"), netaddr.MustParseIP("172.16.0.1")}
+	suite.Require().NoError(suite.state.Create(suite.ctx, nodeAddresses))
+
+	timeSync := timeresource.NewStatus()
+	timeSync.SetStatus(timeresource.StatusSpec{
+		Synced: true,
+	})
+	suite.Require().NoError(suite.state.Create(suite.ctx, timeSync))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			certs, err := suite.state.Get(suite.ctx, resource.NewMetadata(secrets.NamespaceName, secrets.KubernetesType, secrets.KubernetesID, resource.VersionUndefined))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					return retry.ExpectedError(err)
+				}
+
+				return err
+			}
+
+			kubernetesCerts := certs.(*secrets.Kubernetes).Certs()
+
+			apiCert, err := kubernetesCerts.APIServer.GetCert()
+			suite.Require().NoError(err)
+
+			suite.Assert().Equal(
+				[]string{
+					"some.url",
+					"example.com",
+					"kubernetes",
+					"kubernetes.default",
+					"kubernetes.default.svc",
+					"kubernetes.default.svc.cluster.remote",
+					"localhost",
+					"foo",
+					"foo.example.com",
+				}, apiCert.DNSNames)
+			suite.Assert().Equal([]net.IP{net.ParseIP("10.4.3.2").To4(), net.ParseIP("10.2.1.3").To4(), net.ParseIP("172.16.0.1").To4()}, apiCert.IPAddresses)
+
+			suite.Assert().Equal("kube-apiserver", apiCert.Subject.CommonName)
+			suite.Assert().Equal([]string{"kube-master"}, apiCert.Subject.Organization)
+
+			suite.Assert().Equal(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment, apiCert.KeyUsage)
+			suite.Assert().Equal([]stdlibx509.ExtKeyUsage{stdlibx509.ExtKeyUsageServerAuth}, apiCert.ExtKeyUsage)
+
+			clientCert, err := kubernetesCerts.APIServerKubeletClient.GetCert()
+			suite.Require().NoError(err)
+
+			suite.Assert().Empty(clientCert.DNSNames)
+			suite.Assert().Empty(clientCert.IPAddresses)
+
+			suite.Assert().Equal(constants.KubernetesAPIServerKubeletClientCommonName, clientCert.Subject.CommonName)
+			suite.Assert().Equal([]string{constants.KubernetesAdminCertOrganization}, clientCert.Subject.Organization)
+
+			suite.Assert().Equal(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment, clientCert.KeyUsage)
+			suite.Assert().Equal([]stdlibx509.ExtKeyUsage{stdlibx509.ExtKeyUsageClientAuth}, clientCert.ExtKeyUsage)
+
+			frontProxyCert, err := kubernetesCerts.FrontProxy.GetCert()
+			suite.Require().NoError(err)
+
+			suite.Assert().Empty(frontProxyCert.DNSNames)
+			suite.Assert().Empty(frontProxyCert.IPAddresses)
+
+			suite.Assert().Equal("front-proxy-client", frontProxyCert.Subject.CommonName)
+			suite.Assert().Empty(frontProxyCert.Subject.Organization)
+
+			suite.Assert().Equal(stdlibx509.KeyUsageDigitalSignature|stdlibx509.KeyUsageKeyEncipherment, frontProxyCert.KeyUsage)
+			suite.Assert().Equal([]stdlibx509.ExtKeyUsage{stdlibx509.ExtKeyUsageClientAuth}, frontProxyCert.ExtKeyUsage)
+
+			for _, kubeconfig := range []string{kubernetesCerts.ControllerManagerKubeconfig, kubernetesCerts.SchedulerKubeconfig, kubernetesCerts.AdminKubeconfig} {
+				config, err := clientcmd.Load([]byte(kubeconfig))
+				suite.Require().NoError(err)
+
+				suite.Assert().NoError(clientcmd.ConfirmUsable(*config, config.CurrentContext))
+			}
+
+			return nil
+		},
+	))
+}
+
+func (suite *KubernetesSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+}
+
+func TestKubernetesSuite(t *testing.T) {
+	suite.Run(t, new(KubernetesSuite))
+}

--- a/internal/app/machined/pkg/controllers/secrets/utils.go
+++ b/internal/app/machined/pkg/controllers/secrets/utils.go
@@ -1,0 +1,69 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets
+
+import (
+	"context"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"golang.org/x/time/rate"
+)
+
+// RateLimitEvents to reduce the rate of reconcile events.
+//
+// RateLimitEvents makes sure that reconcile events are not coming faster than interval.
+// Any reconcile events which come during the waiting delay are coalesced with the original events.
+//
+//nolint:gocyclo
+func RateLimitEvents(ctx context.Context, in <-chan controller.ReconcileEvent, interval time.Duration) <-chan controller.ReconcileEvent {
+	limiter := rate.NewLimiter(rate.Every(interval), 1)
+	ch := make(chan controller.ReconcileEvent)
+
+	go func() {
+		for {
+			var event controller.ReconcileEvent
+
+			// wait for an actual reconcile event
+			select {
+			case <-ctx.Done():
+				return
+			case event = <-in:
+			}
+
+			// figure out if the event can be delivered immediately
+			reservation := limiter.Reserve()
+			delay := reservation.Delay()
+
+			if delay != 0 {
+				timer := time.NewTimer(delay)
+				defer timer.Stop()
+
+			WAIT:
+				for {
+					select {
+					case <-ctx.Done():
+						reservation.Cancel()
+
+						return
+					case <-in:
+						// coalesce extra events while waiting
+					case <-timer.C:
+						break WAIT
+					}
+				}
+			}
+
+			// deliver rate-limited coalesced event
+			select {
+			case <-ctx.Done():
+				return
+			case ch <- event:
+			}
+		}
+	}()
+
+	return ch
+}

--- a/internal/app/machined/pkg/controllers/secrets/utils_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/utils_test.go
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package secrets_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/secrets"
+)
+
+func TestRateLimitEvents(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	inCh := make(chan controller.ReconcileEvent)
+	outCh := secrets.RateLimitEvents(ctx, inCh, time.Second)
+
+	inputs := 0
+	outputs := 0
+
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+
+LOOP:
+	for {
+		select {
+		case <-timer.C:
+			break LOOP
+		case <-outCh:
+			outputs++
+		case inCh <- controller.ReconcileEvent{}:
+			inputs++
+		}
+	}
+
+	assert.Less(t, outputs, 5)
+	assert.Greater(t, inputs, 15)
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -309,7 +309,7 @@ func (h *Client) WaitUntilReady(ctx context.Context, name string) error {
 					return retry.ExpectedError(err)
 				}
 
-				if apierrors.ReasonForError(err) == metav1.StatusReasonUnknown {
+				if apierrors.ReasonForError(err) == metav1.StatusReasonUnknown || IsRetryableError(err) {
 					// non-API error, e.g. networking error
 					return retry.ExpectedError(err)
 				}

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,8 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion0_13    = &VersionContract{0, 13}
+	TalosVersion0_12    = &VersionContract{0, 12}
 	TalosVersion0_11    = &VersionContract{0, 11}
 	TalosVersion0_10    = &VersionContract{0, 10}
 	TalosVersion0_9     = &VersionContract{0, 9}
@@ -78,4 +80,9 @@ func (contract *VersionContract) SupportsServiceAccount() bool {
 // SupportsRBACFeature returns true if version of Talos supports RBAC feature gate.
 func (contract *VersionContract) SupportsRBACFeature() bool {
 	return contract.Greater(TalosVersion0_10)
+}
+
+// SupportsDynamicCertSANs returns true if version of Talos supports dynamic certificate generation with SANs provided from resources.
+func (contract *VersionContract) SupportsDynamicCertSANs() bool {
+	return contract.Greater(TalosVersion0_12)
 }

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -48,6 +48,23 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, config.TalosVersionCurrent.SupportsECDSAKeys())
 	assert.True(t, config.TalosVersionCurrent.SupportsServiceAccount())
 	assert.True(t, config.TalosVersionCurrent.SupportsRBACFeature())
+	assert.True(t, config.TalosVersionCurrent.SupportsDynamicCertSANs())
+}
+
+func TestContract0_13(t *testing.T) {
+	assert.True(t, config.TalosVersion0_13.SupportsAggregatorCA())
+	assert.True(t, config.TalosVersion0_13.SupportsECDSAKeys())
+	assert.True(t, config.TalosVersion0_13.SupportsServiceAccount())
+	assert.True(t, config.TalosVersion0_13.SupportsRBACFeature())
+	assert.True(t, config.TalosVersion0_13.SupportsDynamicCertSANs())
+}
+
+func TestContract0_12(t *testing.T) {
+	assert.True(t, config.TalosVersion0_12.SupportsAggregatorCA())
+	assert.True(t, config.TalosVersion0_12.SupportsECDSAKeys())
+	assert.True(t, config.TalosVersion0_12.SupportsServiceAccount())
+	assert.True(t, config.TalosVersion0_12.SupportsRBACFeature())
+	assert.False(t, config.TalosVersion0_12.SupportsDynamicCertSANs())
 }
 
 func TestContract0_11(t *testing.T) {
@@ -55,6 +72,7 @@ func TestContract0_11(t *testing.T) {
 	assert.True(t, config.TalosVersion0_11.SupportsECDSAKeys())
 	assert.True(t, config.TalosVersion0_11.SupportsServiceAccount())
 	assert.True(t, config.TalosVersion0_11.SupportsRBACFeature())
+	assert.False(t, config.TalosVersion0_11.SupportsDynamicCertSANs())
 }
 
 func TestContract0_10(t *testing.T) {
@@ -62,6 +80,7 @@ func TestContract0_10(t *testing.T) {
 	assert.True(t, config.TalosVersion0_10.SupportsECDSAKeys())
 	assert.True(t, config.TalosVersion0_10.SupportsServiceAccount())
 	assert.False(t, config.TalosVersion0_10.SupportsRBACFeature())
+	assert.False(t, config.TalosVersion0_10.SupportsDynamicCertSANs())
 }
 
 func TestContract0_9(t *testing.T) {
@@ -69,11 +88,13 @@ func TestContract0_9(t *testing.T) {
 	assert.True(t, config.TalosVersion0_9.SupportsECDSAKeys())
 	assert.True(t, config.TalosVersion0_9.SupportsServiceAccount())
 	assert.False(t, config.TalosVersion0_9.SupportsRBACFeature())
+	assert.False(t, config.TalosVersion0_9.SupportsDynamicCertSANs())
 }
 
 func TestContract0_8(t *testing.T) {
 	assert.False(t, config.TalosVersion0_8.SupportsAggregatorCA())
 	assert.False(t, config.TalosVersion0_8.SupportsECDSAKeys())
 	assert.False(t, config.TalosVersion0_8.SupportsServiceAccount())
-	assert.False(t, config.TalosVersion0_9.SupportsRBACFeature())
+	assert.False(t, config.TalosVersion0_8.SupportsRBACFeature())
+	assert.False(t, config.TalosVersion0_8.SupportsDynamicCertSANs())
 }

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -460,16 +460,11 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		return nil, err
 	}
 
-	var additionalSubjectAltNames []string
+	additionalSubjectAltNames := append([]string(nil), options.AdditionalSubjectAltNames...)
 
-	var additionalMachineCertSANs []string
-
-	if len(options.EndpointList) > 0 {
-		additionalSubjectAltNames = options.EndpointList
-		additionalMachineCertSANs = options.EndpointList
+	if !options.VersionContract.SupportsDynamicCertSANs() {
+		additionalSubjectAltNames = append(additionalSubjectAltNames, options.EndpointList...)
 	}
-
-	additionalSubjectAltNames = append(additionalSubjectAltNames, options.AdditionalSubjectAltNames...)
 
 	input = &Input{
 		Certs:                      secrets.Certs,
@@ -485,7 +480,7 @@ func NewInput(clustername, endpoint, kubernetesVersion string, secrets *SecretsB
 		Secrets:                    secrets.Secrets,
 		TrustdInfo:                 secrets.TrustdInfo,
 		AdditionalSubjectAltNames:  additionalSubjectAltNames,
-		AdditionalMachineCertSANs:  additionalMachineCertSANs,
+		AdditionalMachineCertSANs:  additionalSubjectAltNames,
 		InstallDisk:                options.InstallDisk,
 		InstallImage:               options.InstallImage,
 		InstallExtraKernelArgs:     options.InstallExtraKernelArgs,


### PR DESCRIPTION
This is a PR on a path towards removing `ApplyDynamicConfig`.

This fixes Kubernetes API server certificate generation to use dynamic
data to generate cert with proper SANs for IPs of the node.

As part of that refactored a bit apid certificate generation (without
any changes).

Added two unit-tests for apid and Kubernetes certificate generation.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
