### PR TITLE
fix: write upgrade logs only to the LogOutput if it's defined

### DIFF
--- a/pkg/cluster/kubernetes/upgrade.go
+++ b/pkg/cluster/kubernetes/upgrade.go
@@ -53,6 +53,8 @@ func (options *UpgradeOptions) Path() string {
 func (options *UpgradeOptions) Log(line string, args ...interface{}) {
 	if options.LogOutput != nil {
 		options.LogOutput.Write([]byte(fmt.Sprintf(line, args...))) //nolint:errcheck
+
+		return
 	}
 
 	fmt.Printf(line+"\n", args...)


### PR DESCRIPTION
No need to print them to stdout in that case.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>