### PR TITLE
fix: set the /etc/os-release HOME_URL parameter

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -306,7 +306,7 @@ NAME="{{ .Name }}"
 ID={{ .ID }}
 VERSION_ID={{ .Version }}
 PRETTY_NAME="{{ .Name }} ({{ .Version }})"
-HOME_URL="https://docs.talos-systems.com/"
+HOME_URL="https://www.talos.dev/"
 BUG_REPORT_URL="https://github.com/talos-systems/talos/issues"
 `
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What?

Set the /etc/os-release HOME_URL parameter.

## Why?

It was using a non-functional url as described in https://github.com/talos-systems/talos/issues/3968

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
