### PR TITLE
fix: do not require ToVersion to be set when detecting version

### DIFF
--- a/pkg/cluster/kubernetes/detect.go
+++ b/pkg/cluster/kubernetes/detect.go
@@ -33,9 +33,12 @@ func DetectLowestVersion(ctx context.Context, cluster UpgradeProvider, options U
 		return "", err
 	}
 
-	version, err := semver.NewVersion(options.ToVersion)
-	if err != nil {
-		return "", err
+	var version *semver.Version
+	if options.ToVersion != "" {
+		version, err = semver.NewVersion(options.ToVersion)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	for _, pod := range pods.Items {
@@ -61,7 +64,7 @@ func DetectLowestVersion(ctx context.Context, cluster UpgradeProvider, options U
 				continue
 			}
 
-			if v.LessThan(*version) {
+			if version == nil || v.LessThan(*version) {
 				version = v
 			}
 		}


### PR DESCRIPTION
We do not know the upgrade version when checking components' versions in
Theila.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>