### PR TITLE
fix: bump pkgs for new kernel 5.10.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.7.0-alpha.0-2-g7172a5d
-PKGS ?= v0.7.0-alpha.0-6-g65159fb
+PKGS ?= v0.7.0-alpha.0-7-g7b6cc05
 EXTRAS ?= v0.5.0-alpha.0-1-g4957f3c
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.45-talos"
+	DefaultKernelVersion = "5.10.52-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This PR pulls in new pkgs to ensure we're patched against CVE-2021-33909

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>