### PR TITLE
fix: bump pkgs for new kernel 5.10.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.6.0-1-g545d839
-PKGS ?= v0.6.0-2-gf8d83b4
+PKGS ?= v0.6.0-3-g5e6def3
 EXTRAS ?= v0.4.0-1-g0f96c53
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.45-talos"
+	DefaultKernelVersion = "5.10.52-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
This PR pulls in new pkgs to ensure we're patched against CVE-2021-33909

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>
