### PR TITLE
feat: set oom score for main processes

### DIFF
--- a/internal/app/machined/pkg/system/runner/process/process.go
+++ b/internal/app/machined/pkg/system/runner/process/process.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containerd/containerd/sys"
 	"github.com/talos-systems/go-cmd/pkg/cmd/proc/reaper"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/system/events"
@@ -120,6 +121,12 @@ func (p *processRunner) run(eventSink events.Recorder) error {
 
 	if err = cmd.Start(); err != nil {
 		return fmt.Errorf("error starting process: %w", err)
+	}
+
+	if p.opts.OOMScoreAdj != 0 {
+		if err = sys.AdjustOOMScore(cmd.Process.Pid, p.opts.OOMScoreAdj); err != nil {
+			eventSink(events.StateRunning, "Failed to change OOMScoreAdj to process %s", p)
+		}
 	}
 
 	eventSink(events.StateRunning, "Process %s started with PID %d", p, cmd.Process.Pid)

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -56,6 +56,8 @@ type Options struct {
 	GracefulShutdownTimeout time.Duration
 	// Stdin is the process standard input.
 	Stdin io.ReadSeeker
+	// Specify an oom_score_adj for the process.
+	OOMScoreAdj int
 }
 
 // Option is the functional option func.
@@ -70,6 +72,7 @@ func DefaultOptions() *Options {
 		GracefulShutdownTimeout: 10 * time.Second,
 		ContainerdAddress:       constants.CRIContainerdAddress,
 		Stdin:                   nil,
+		OOMScoreAdj:             0,
 	}
 }
 
@@ -133,5 +136,12 @@ func WithGracefulShutdownTimeout(timeout time.Duration) Option {
 func WithStdin(stdin io.ReadSeeker) Option {
 	return func(args *Options) {
 		args.Stdin = stdin
+	}
+}
+
+// WithOOMScoreAdj sets the oom_score_adj.
+func WithOOMScoreAdj(score int) Option {
+	return func(args *Options) {
+		args.OOMScoreAdj = score
 	}
 }

--- a/internal/app/machined/pkg/system/services/apid.go
+++ b/internal/app/machined/pkg/system/services/apid.go
@@ -156,6 +156,7 @@ func (o *APID) Runner(r runtime.Runtime) (runner.Runner, error) {
 			oci.WithRootFSPath(filepath.Join(constants.SystemLibexecPath, o.ID(r))),
 			oci.WithRootFSReadonly(),
 		),
+		runner.WithOOMScoreAdj(-998),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -74,6 +74,7 @@ func (c *Containerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithEnv(env),
+		runner.WithOOMScoreAdj(-999),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -77,6 +77,7 @@ func (c *CRI) Runner(r runtime.Runtime) (runner.Runner, error) {
 		args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithEnv(env),
+		runner.WithOOMScoreAdj(-100),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -170,6 +170,7 @@ func (e *Etcd) Runner(r runtime.Runtime) (runner.Runner, error) {
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithMounts(mounts),
 		),
+		runner.WithOOMScoreAdj(-998),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/app/machined/pkg/system/services/trustd.go
+++ b/internal/app/machined/pkg/system/services/trustd.go
@@ -104,6 +104,7 @@ func (t *Trustd) Runner(r runtime.Runtime) (runner.Runner, error) {
 			oci.WithRootFSPath(filepath.Join(constants.SystemLibexecPath, t.ID(r))),
 			oci.WithRootFSReadonly(),
 		),
+		runner.WithOOMScoreAdj(-998),
 	),
 		restart.WithType(restart.Forever),
 	), nil


### PR DESCRIPTION
# Pull Request

#3846 #1849

This PR change oom-score:
* containerd to -999
* apid, trustd to -998
* cri to -100
* etcd to -998


Result:

```bash
4804	1334		1000	bash
4816	1333		1000	bash
4817	1333		1000	sort
4745	1332		1000	sleep
1814	666		0	udevd
2220	628		-100	containerd
2373	604		-99	containerd-shim
2442	604		-99	containerd-shim
2572	604		-99	containerd-shim
2601	604		-99	containerd-shim
2602	604		-99	containerd-shim
3102	604		-99	containerd-shim
3128	604		-99	containerd-shim
4213	604		-99	containerd-shim
4262	604		-99	containerd-shim
4530	604		-99	containerd-shim
4619	603		-99	containerd-shim
4621	603		-99	containerd-shim
2787	167		-997	kube-apiserver
3068	38		-997	kube-controller
2464	35		-999	kubelet
3419	33		-997	cilium-agent
3231	22		-997	cilium-operator
3030	19		-997	kube-scheduler
2287	18		-998	trustd
2288	18		-998	apid
2393	17		-998	etcd
1793	16		-999	containerd
4361	16		-997	coredns
4370	16		-997	coredns
2245	4		-998	containerd-shim
2246	4		-998	containerd-shim
4022	4		-997	cilium-health-r
2651	2		-998	pause
2652	2		-998	pause
2667	2		-998	pause
3154	2		-998	pause
3160	2		-998	pause
4235	2		-998	pause
4282	2		-998	pause
4563	2		-998	pause
4660	2		-998	pause
4668	2		-998	pause
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
