### PR TITLE
fix: remove admission plugins enabled by default from the list

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -193,7 +193,7 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 
 	args := []string{
 		"/usr/local/bin/kube-apiserver",
-		"--enable-admission-plugins=PodSecurityPolicy,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeClaimResize,DefaultStorageClass,DefaultTolerationSeconds,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,Priority,NodeRestriction", //nolint:lll
+		"--enable-admission-plugins=PodSecurityPolicy,NodeRestriction",
 		"--advertise-address=$(POD_IP)",
 		"--allow-privileged=true",
 		fmt.Sprintf("--api-audiences=%s", cfg.ControlPlaneEndpoint),


### PR DESCRIPTION
This allows to disable these plugins via `extraArgs` and shortens
argument list for the `kube-apiserver`.

There are no functional changes, as these plugins are enabled by default
anyways.

Based on #3971

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
