### PR TITLE
feat: add an option to disable PSP

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -141,14 +141,15 @@ func (ctrl *K8sControlPlaneController) manageAPIServerConfig(ctx context.Context
 
 	return r.Modify(ctx, config.NewK8sControlPlaneAPIServer(), func(r resource.Resource) error {
 		r.(*config.K8sControlPlane).SetAPIServer(config.K8sControlPlaneAPIServerSpec{
-			Image:                cfgProvider.Cluster().APIServer().Image(),
-			CloudProvider:        cloudProvider,
-			ControlPlaneEndpoint: cfgProvider.Cluster().Endpoint().String(),
-			EtcdServers:          []string{"https://127.0.0.1:2379"},
-			LocalPort:            cfgProvider.Cluster().LocalAPIServerPort(),
-			ServiceCIDR:          cfgProvider.Cluster().Network().ServiceCIDR(),
-			ExtraArgs:            cfgProvider.Cluster().APIServer().ExtraArgs(),
-			ExtraVolumes:         convertVolumes(cfgProvider.Cluster().APIServer().ExtraVolumes()),
+			Image:                    cfgProvider.Cluster().APIServer().Image(),
+			CloudProvider:            cloudProvider,
+			ControlPlaneEndpoint:     cfgProvider.Cluster().Endpoint().String(),
+			EtcdServers:              []string{"https://127.0.0.1:2379"},
+			LocalPort:                cfgProvider.Cluster().LocalAPIServerPort(),
+			ServiceCIDR:              cfgProvider.Cluster().Network().ServiceCIDR(),
+			ExtraArgs:                cfgProvider.Cluster().APIServer().ExtraArgs(),
+			ExtraVolumes:             convertVolumes(cfgProvider.Cluster().APIServer().ExtraVolumes()),
+			PodSecurityPolicyEnabled: !cfgProvider.Cluster().APIServer().DisablePodSecurityPolicy(),
 		})
 
 		return nil
@@ -234,6 +235,8 @@ func (ctrl *K8sControlPlaneController) manageManifestsConfig(ctx context.Context
 			FlannelEnabled:  cfgProvider.Cluster().Network().CNI().Name() == constants.FlannelCNI,
 			FlannelImage:    images.Flannel,
 			FlannelCNIImage: images.FlannelCNI,
+
+			PodSecurityPolicyEnabled: !cfgProvider.Cluster().APIServer().DisablePodSecurityPolicy(),
 		})
 
 		return nil

--- a/internal/app/machined/pkg/controllers/k8s/manifest.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest.go
@@ -175,7 +175,6 @@ func (ctrl *ManifestController) render(cfg config.K8sManifestsSpec, scrt *secret
 		{"01-csr-approver-role-binding", csrApproverRoleBindingTemplate},
 		{"01-csr-renewal-role-binding", csrRenewalRoleBindingTemplate},
 		{"02-kube-system-sa-role-binding", kubeSystemSARoleBindingTemplate},
-		{"03-default-pod-security-policy", podSecurityPolicy},
 		{"11-kube-config-in-cluster", kubeConfigInClusterTemplate},
 	}
 
@@ -208,6 +207,14 @@ func (ctrl *ManifestController) render(cfg config.K8sManifestsSpec, scrt *secret
 		defaultManifests = append(defaultManifests,
 			[]manifestDesc{
 				{"10-kube-proxy", kubeProxyTemplate},
+			}...,
+		)
+	}
+
+	if cfg.PodSecurityPolicyEnabled {
+		defaultManifests = append(defaultManifests,
+			[]manifestDesc{
+				{"03-default-pod-security-policy", podSecurityPolicy},
 			}...,
 		)
 	}

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -473,10 +473,6 @@ kind: ClusterRole
 metadata:
   name: flannel
 rules:
-  - apiGroups: ['extensions']
-    resources: ['podsecuritypolicies']
-    verbs: ['use']
-    resourceNames: ['psp.flannel.unprivileged']
   - apiGroups:
       - ""
     resources:

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -307,6 +307,7 @@ type APIServer interface {
 	Image() string
 	ExtraArgs() map[string]string
 	ExtraVolumes() []VolumeMount
+	DisablePodSecurityPolicy() bool
 }
 
 // ControllerManager defines the requirements for a config that pertains to controller manager related

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_apiserverconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_apiserverconfig.go
@@ -37,3 +37,8 @@ func (a *APIServerConfig) ExtraVolumes() []config.VolumeMount {
 
 	return volumes
 }
+
+// DisablePodSecurityPolicy implements the config.APIServer interface.
+func (a *APIServerConfig) DisablePodSecurityPolicy() bool {
+	return a.DisablePodSecurityPolicyConfig
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -1157,6 +1157,9 @@ type APIServerConfig struct {
 	//   description: |
 	//     Extra certificate subject alternative names for the API server's certificate.
 	CertSANs []string `yaml:"certSANs,omitempty"`
+	//   description: |
+	//     Disable PodSecurityPolicy in the API server and default manifests.
+	DisablePodSecurityPolicyConfig bool `yaml:"disablePodSecurityPolicy,omitempty"`
 }
 
 // ControllerManagerConfig represents the kube controller manager configuration options.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -796,7 +796,7 @@ func init() {
 			FieldName: "apiServer",
 		},
 	}
-	APIServerConfigDoc.Fields = make([]encoder.Doc, 4)
+	APIServerConfigDoc.Fields = make([]encoder.Doc, 5)
 	APIServerConfigDoc.Fields[0].Name = "image"
 	APIServerConfigDoc.Fields[0].Type = "string"
 	APIServerConfigDoc.Fields[0].Note = ""
@@ -819,6 +819,11 @@ func init() {
 	APIServerConfigDoc.Fields[3].Note = ""
 	APIServerConfigDoc.Fields[3].Description = "Extra certificate subject alternative names for the API server's certificate."
 	APIServerConfigDoc.Fields[3].Comments[encoder.LineComment] = "Extra certificate subject alternative names for the API server's certificate."
+	APIServerConfigDoc.Fields[4].Name = "disablePodSecurityPolicy"
+	APIServerConfigDoc.Fields[4].Type = "bool"
+	APIServerConfigDoc.Fields[4].Note = ""
+	APIServerConfigDoc.Fields[4].Description = "Disable PodSecurityPolicy in the API server and default manifests."
+	APIServerConfigDoc.Fields[4].Comments[encoder.LineComment] = "Disable PodSecurityPolicy in the API server and default manifests."
 
 	ControllerManagerConfigDoc.Type = "ControllerManagerConfig"
 	ControllerManagerConfigDoc.Comments[encoder.LineComment] = "ControllerManagerConfig represents the kube controller manager configuration options."

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -46,14 +46,15 @@ type K8sExtraVolume struct {
 
 // K8sControlPlaneAPIServerSpec is configuration for kube-apiserver.
 type K8sControlPlaneAPIServerSpec struct {
-	Image                string            `yaml:"image"`
-	CloudProvider        string            `yaml:"cloudProvider"`
-	ControlPlaneEndpoint string            `yaml:"controlPlaneEndpoint"`
-	EtcdServers          []string          `yaml:"etcdServers"`
-	LocalPort            int               `yaml:"localPort"`
-	ServiceCIDR          string            `yaml:"serviceCIDR"`
-	ExtraArgs            map[string]string `yaml:"extraArgs"`
-	ExtraVolumes         []K8sExtraVolume  `yaml:"extraVolumes"`
+	Image                    string            `yaml:"image"`
+	CloudProvider            string            `yaml:"cloudProvider"`
+	ControlPlaneEndpoint     string            `yaml:"controlPlaneEndpoint"`
+	EtcdServers              []string          `yaml:"etcdServers"`
+	LocalPort                int               `yaml:"localPort"`
+	ServiceCIDR              string            `yaml:"serviceCIDR"`
+	ExtraArgs                map[string]string `yaml:"extraArgs"`
+	ExtraVolumes             []K8sExtraVolume  `yaml:"extraVolumes"`
+	PodSecurityPolicyEnabled bool              `yaml:"podSecurityPolicyEnabled"`
 }
 
 // K8sControlPlaneControllerManagerSpec is configuration for kube-controller-manager.
@@ -97,6 +98,8 @@ type K8sManifestsSpec struct {
 	FlannelEnabled  bool   `yaml:"flannelEnabled"`
 	FlannelImage    string `yaml:"flannelImage"`
 	FlannelCNIImage string `yaml:"flannelCNIImage"`
+
+	PodSecurityPolicyEnabled bool `yaml:"podSecurityPolicyEnabled"`
 }
 
 // ExtraManifest defines a single extra manifest to download.

--- a/website/content/docs/v0.12/Reference/configuration.md
+++ b/website/content/docs/v0.12/Reference/configuration.md
@@ -2489,6 +2489,19 @@ Extra certificate subject alternative names for the API server's certificate.
 
 <hr />
 
+<div class="dd">
+
+<code>disablePodSecurityPolicy</code>  <i>bool</i>
+
+</div>
+<div class="dt">
+
+Disable PodSecurityPolicy in the API server and default manifests.
+
+</div>
+
+<hr />
+
 
 
 


### PR DESCRIPTION
This feature comes as PSP is deprecated and going to be removed in 1.25.
In preparation for that, add an option to disable PSP which was always
enabled in Talos by default.

To keep backwards compatibility, PSP is still enabled by default.

See also #3971

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
Co-authored-by: Adam Szucs-Matyas <szucsitg@gmail.com>
