### PR TITLE
chore: improve artifacts generation reproducibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -501,6 +501,7 @@ RUN apk add --no-cache --update \
     efibootmgr \
     mtools \
     qemu-img \
+    tar \
     util-linux \
     xfsprogs \
     xorriso \

--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -178,7 +178,18 @@ func finalize(platform runtime.Platform, img, arch string) (err error) {
 }
 
 func tar(filename, src, dir string) error {
-	if _, err := cmd.Run("tar", "-czvf", filepath.Join(outputArg, filename), src, "-C", dir); err != nil {
+	if _, err := cmd.Run("tar",
+		"--sort=name",
+		"--mtime=1970-01-01 00:00Z",
+		"--owner=0",
+		"--group=0",
+		"--numeric-owner",
+		"--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime",
+		"-C", dir,
+		"-czvf",
+		filepath.Join(outputArg, filename),
+		src,
+	); err != nil {
 		return err
 	}
 

--- a/cmd/installer/pkg/raw.go
+++ b/cmd/installer/pkg/raw.go
@@ -6,8 +6,7 @@ package pkg
 
 import (
 	"fmt"
-
-	"github.com/talos-systems/go-cmd/pkg/cmd"
+	"os"
 )
 
 const (
@@ -19,11 +18,18 @@ const (
 func CreateRawDisk() (img string, err error) {
 	img = "/tmp/disk.raw"
 
-	seek := fmt.Sprintf("seek=%d", RAWDiskSize)
+	var f *os.File
 
-	if _, err = cmd.Run("dd", "if=/dev/zero", "of="+img, "bs=1M", "count=0", seek); err != nil {
+	f, err = os.Create(img)
+	if err != nil {
 		return "", fmt.Errorf("failed to create RAW disk: %w", err)
 	}
 
-	return img, nil
+	if err = f.Truncate(RAWDiskSize * 1048576); err != nil {
+		return "", fmt.Errorf("failed to truncate RAW disk: %w", err)
+	}
+
+	err = f.Close()
+
+	return img, err
 }


### PR DESCRIPTION
Sparse file generation replaced with Go native calls.

Final artifact `.tar` reproducible with new tar flags and using GNU tar
instead of busybox one, but as the image itself is not reproducible,
this only helps a bit.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
