### PR TITLE
chore: use parallel xz with higher compression level

### DIFF
--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -186,7 +186,7 @@ func tar(filename, src, dir string) error {
 }
 
 func xz(filename string) error {
-	if _, err := cmd.Run("xz", "-0", filename); err != nil {
+	if _, err := cmd.Run("xz", "-6", "-T", "0", filename); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Preset `-0` for xz means fast compression but low compression level.
Changing this to `-6` (default) means that result is 10% smaller (tested
with RPi4 image).

Enable parallel compression with number of threads equal to number of
CPUs to make it compress even faster then with `-0`:

* `-0`: 15s
* `-6`: 60s
* `-6 -T 0`: 10s (on my machine, depends on number of cores)

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
