### PR TITLE
fix: update go-blockdevice

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.3.2-0.20210707205149-deec8d47700e
-	github.com/talos-systems/go-blockdevice v0.2.2-0.20210804205442-2ec0c3cc0ff5
+	github.com/talos-systems/go-blockdevice v0.2.3
 	github.com/talos-systems/go-cmd v0.1.0
 	github.com/talos-systems/go-debug v0.2.1
 	github.com/talos-systems/go-kmsg v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1164,8 +1164,9 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.3.2-0.20210707205149-deec8d47700e h1:7mNVNvTTRA7mqflb/34iSJrimISfRErruMyptRAGWkg=
 github.com/talos-systems/crypto v0.3.2-0.20210707205149-deec8d47700e/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
-github.com/talos-systems/go-blockdevice v0.2.2-0.20210804205442-2ec0c3cc0ff5 h1:2w2J85ONVHGNs07HiMLd80mw4RtcYPP6V//oXY3nFak=
 github.com/talos-systems/go-blockdevice v0.2.2-0.20210804205442-2ec0c3cc0ff5/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.3 h1:THqjUboZfTVth3R9+75vtBXYWollr5bVg3wLGpB4C6I=
+github.com/talos-systems/go-blockdevice v0.2.3/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-cmd v0.1.0 h1:bqPeL0ksproFyTOlvMisdUXc7uAf0aqJ5Q6waSGv32s=
 github.com/talos-systems/go-cmd v0.1.0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=


### PR DESCRIPTION
Brings in the latest version of go-blockdevice to fix and issues with
the PMBR.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>