### PR TITLE
chore: update PKGS version (512 cpus, new ca-certficates)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.7.0-alpha.0-2-g7172a5d
-PKGS ?= v0.7.0-alpha.0-11-g0c011c0
+PKGS ?= v0.7.0-alpha.0-13-g12856ce
 EXTRAS ?= v0.5.0-alpha.0-1-g4957f3c
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0


### PR DESCRIPTION
This pulls in a change to bump number of max CPUs in the kernel to 512
and update ca-certificates.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
