### PR TITLE
chore: workaround GitHub new release notes limit

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -201,6 +201,7 @@ local unit_tests = Step("unit-tests", target="unit-tests unit-tests-race", depen
 local e2e_docker = Step("e2e-docker-short", depends_on=[build, unit_tests], target="e2e-docker", environment={"SHORT_INTEGRATION_TEST": "yes", "IMAGE_REGISTRY": local_registry});
 local e2e_qemu = Step("e2e-qemu-short", privileged=true, target="e2e-qemu", depends_on=[build, unit_tests, talosctl_cni_bundle], environment={"IMAGE_REGISTRY": local_registry, "SHORT_INTEGRATION_TEST": "yes"}, when={event: ['pull_request']});
 local e2e_iso = Step("e2e-iso", privileged=true, target="e2e-iso", depends_on=[build, unit_tests, iso, talosctl_cni_bundle], when={event: ['pull_request']}, environment={"IMAGE_REGISTRY": local_registry});
+local release_notes = Step('release-notes', depends_on=[e2e_docker, e2e_qemu]);
 
 local coverage = {
   name: 'coverage',
@@ -311,6 +312,7 @@ local default_steps = [
   e2e_iso,
   e2e_qemu,
   e2e_docker,
+  release_notes,
   push,
   push_latest,
 ];
@@ -494,8 +496,6 @@ local boot = Step('boot', depends_on=[e2e_docker, e2e_qemu]);
 
 local cloud_images = Step("cloud-images", depends_on=[e2e_docker, e2e_qemu], environment=creds_env_vars);
 
-local release_notes = Step('release-notes', depends_on=[e2e_docker, e2e_qemu]);
-
 // TODO(andrewrynhard): We should run E2E tests on a release.
 local release = {
   name: 'release',
@@ -553,7 +553,6 @@ local release = {
 local release_steps = default_steps + [
   boot,
   cloud_images,
-  release_notes,
   release,
 ];
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
 
 function release-tool {
   docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null
-  docker run --rm -w /src -v "${PWD}":/src:ro "${RELEASE_TOOL_IMAGE}" -l -d -n -t "${1}" ./hack/release.toml
+  docker run --rm -w /src -v "${PWD}":/src:ro "${RELEASE_TOOL_IMAGE}" -l -d -n ${2} -t "${1}" ./hack/release.toml
 }
 
 function changelog {
@@ -19,11 +19,18 @@ function changelog {
 }
 
 function release-notes {
-  release-tool "${2}" > "${1}"
+  release-tool "${2}" --gfm > "${1}"
 
   echo -e '\n## Images\n\n```' >> ${1}
   ${ARTIFACTS}/talosctl-linux-amd64 images >> ${1}
   echo -e '```\n' >> ${1}
+
+  size=$(stat -c%s "${1}")
+
+  if (( size > 25000 )); then
+    echo "Release notes size exceeds GitHub limit of 25000 bytes"
+    exit 1
+  fi
 }
 
 function cherry-pick {

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "talos-systems/talos"
 match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v0.10.0"
+previous = "v0.11.4"
 
 pre_release = false
 


### PR DESCRIPTION
GitHub recently introduced limit of 25000 byte for the release notes,
which breaks our release process, as our notes are over the limit.

PR https://github.com/talos-systems/talos/pull/4021 introduced support
for GFM release notes, which are at least 50% smaller.

This PR enables GFM, adds a check for release notes size and pushes
release-notes step to every build so that we known in advance if release
notes are over the limit (vs. the moment we push the release).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>
(cherry picked from commit 571f7db1bb44a0dcb5e373f9c37396d50eb0e8f4)
