### PR TITLE
chore: use etcd client TryLock function on upgrade

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -407,10 +407,7 @@ func (s *Server) Upgrade(ctx context.Context, in *machine.UpgradeRequest) (reply
 			return nil, fmt.Errorf("failed to acquire upgrade mutex: %w", err)
 		}
 
-		// TODO: after we upgrade to v3.4, we can use mu.TryLock() here, to fail
-		// immediately if the lock is not available, instead of blocking here until
-		// the context times out or the upgrade lock comes available.
-		if err = mu.Lock(ctx); err != nil {
+		if err = mu.TryLock(ctx); err != nil {
 			return nil, fmt.Errorf("failed to acquire upgrade lock: %w", err)
 		}
 


### PR DESCRIPTION
We are running etcd 3.4, so it's time to implement the TODO item.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
