### PR TITLE
fix: make route resources ID match closer routing table primary key

### DIFF
--- a/internal/app/machined/pkg/controllers/network/address_config.go
+++ b/internal/app/machined/pkg/controllers/network/address_config.go
@@ -154,7 +154,6 @@ func (ctrl *AddressConfigController) Run(ctx context.Context, r controller.Runti
 	}
 }
 
-//nolint:dupl
 func (ctrl *AddressConfigController) apply(ctx context.Context, r controller.Runtime, addresses []network.AddressSpecSpec) ([]resource.ID, error) {
 	ids := make([]string, 0, len(addresses))
 

--- a/internal/app/machined/pkg/controllers/network/address_merge.go
+++ b/internal/app/machined/pkg/controllers/network/address_merge.go
@@ -3,8 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Package network provides controllers which manage network resources.
-//
-//nolint:dupl
 package network
 
 import (

--- a/internal/app/machined/pkg/controllers/network/operator_spec.go
+++ b/internal/app/machined/pkg/controllers/network/operator_spec.go
@@ -260,7 +260,7 @@ func (ctrl *OperatorSpecController) reconcileOperatorOutputs(ctx context.Context
 			if err := apply(
 				network.NewRouteSpec(
 					network.ConfigNamespaceName,
-					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.RouteID(routeSpec.Destination, routeSpec.Gateway)),
+					fmt.Sprintf("%s/%s", op.Operator.Prefix(), network.RouteID(routeSpec.Table, routeSpec.Family, routeSpec.Destination, routeSpec.Gateway, routeSpec.Priority)),
 				),
 				func(r resource.Resource) {
 					*r.(*network.RouteSpec).TypedSpec() = routeSpec

--- a/internal/app/machined/pkg/controllers/network/route_config.go
+++ b/internal/app/machined/pkg/controllers/network/route_config.go
@@ -142,13 +142,12 @@ func (ctrl *RouteConfigController) Run(ctx context.Context, r controller.Runtime
 	}
 }
 
-//nolint:dupl
 func (ctrl *RouteConfigController) apply(ctx context.Context, r controller.Runtime, routes []network.RouteSpecSpec) ([]resource.ID, error) {
 	ids := make([]string, 0, len(routes))
 
 	for _, route := range routes {
 		route := route
-		id := network.LayeredID(route.ConfigLayer, network.RouteID(route.Destination, route.Gateway))
+		id := network.LayeredID(route.ConfigLayer, network.RouteID(route.Table, route.Family, route.Destination, route.Gateway, route.Priority))
 
 		if err := r.Modify(
 			ctx,

--- a/internal/app/machined/pkg/controllers/network/route_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_config_test.go
@@ -106,7 +106,7 @@ func (suite *RouteConfigSuite) TestCmdline() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertRoutes([]string{
-				"cmdline/172.20.0.1/",
+				"cmdline/inet4/172.20.0.1//1024",
 			}, func(r *network.RouteSpec) error {
 				suite.Assert().Equal("eth1", r.TypedSpec().OutLinkName)
 				suite.Assert().Equal(network.ConfigCmdline, r.TypedSpec().ConfigLayer)
@@ -195,20 +195,20 @@ func (suite *RouteConfigSuite) TestMachineConfiguration() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertRoutes([]string{
-				"configuration/2001:470:6d:30e:8ed2:b60c:9d2f:803b/",
-				"configuration/10.0.3.1/10.0.3.0/24",
-				"configuration/192.168.0.25/192.168.0.0/18",
+				"configuration/inet6/2001:470:6d:30e:8ed2:b60c:9d2f:803b//1024",
+				"configuration/inet4/10.0.3.1/10.0.3.0/24/1024",
+				"configuration/inet4/192.168.0.25/192.168.0.0/18/25",
 			}, func(r *network.RouteSpec) error {
 				switch r.Metadata().ID() {
-				case "configuration/2001:470:6d:30e:8ed2:b60c:9d2f:803b/":
+				case "configuration/inet6/2001:470:6d:30e:8ed2:b60c:9d2f:803b//1024":
 					suite.Assert().Equal("eth2", r.TypedSpec().OutLinkName)
 					suite.Assert().Equal(nethelpers.FamilyInet6, r.TypedSpec().Family)
 					suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
-				case "configuration/10.0.3.1/10.0.3.0/24":
+				case "configuration/inet4/10.0.3.1/10.0.3.0/24/1024":
 					suite.Assert().Equal("eth0.24", r.TypedSpec().OutLinkName)
 					suite.Assert().Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
 					suite.Assert().EqualValues(netctrl.DefaultRouteMetric, r.TypedSpec().Priority)
-				case "configuration/192.168.0.25/192.168.0.0/18":
+				case "configuration/inet4/192.168.0.25/192.168.0.0/18/25":
 					suite.Assert().Equal("eth3", r.TypedSpec().OutLinkName)
 					suite.Assert().Equal(nethelpers.FamilyInet4, r.TypedSpec().Family)
 					suite.Assert().EqualValues(25, r.TypedSpec().Priority)

--- a/internal/app/machined/pkg/controllers/network/route_merge.go
+++ b/internal/app/machined/pkg/controllers/network/route_merge.go
@@ -3,8 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 // Package network provides controllers which manage network resources.
-//
-//nolint:dupl
 package network
 
 import (
@@ -75,7 +73,7 @@ func (ctrl *RouteMergeController) Run(ctx context.Context, r controller.Runtime,
 
 		for _, res := range list.Items {
 			route := res.(*network.RouteSpec) //nolint:errcheck,forcetypeassert
-			id := network.RouteID(route.TypedSpec().Destination, route.TypedSpec().Gateway)
+			id := network.RouteID(route.TypedSpec().Table, route.TypedSpec().Family, route.TypedSpec().Destination, route.TypedSpec().Gateway, route.TypedSpec().Priority)
 
 			existing, ok := routes[id]
 			if ok && existing.TypedSpec().ConfigLayer > route.TypedSpec().ConfigLayer {

--- a/internal/app/machined/pkg/controllers/network/route_status.go
+++ b/internal/app/machined/pkg/controllers/network/route_status.go
@@ -105,7 +105,7 @@ func (ctrl *RouteStatusController) Run(ctx context.Context, r controller.Runtime
 			srcAddr, _ := netaddr.FromStdIPRaw(route.Attributes.Src)
 			srcPrefix := netaddr.IPPrefixFrom(srcAddr, route.SrcLength)
 			gatewayAddr, _ := netaddr.FromStdIPRaw(route.Attributes.Gateway)
-			id := network.RouteID(dstPrefix, gatewayAddr)
+			id := network.RouteID(nethelpers.RoutingTable(route.Table), nethelpers.Family(route.Family), dstPrefix, gatewayAddr, route.Attributes.Priority)
 
 			if err = r.Modify(ctx, network.NewRouteStatus(network.NamespaceName, id), func(r resource.Resource) error {
 				status := r.(*network.RouteStatus).TypedSpec()

--- a/internal/app/machined/pkg/controllers/network/route_status_test.go
+++ b/internal/app/machined/pkg/controllers/network/route_status_test.go
@@ -99,7 +99,7 @@ func (suite *RouteStatusSuite) assertRoutes(requiredIDs []string, check func(*ne
 func (suite *RouteStatusSuite) TestRoutes() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
-			return suite.assertRoutes([]string{"/127.0.0.0/8"}, func(r *network.RouteStatus) error {
+			return suite.assertRoutes([]string{"local/inet4//127.0.0.0/8/0"}, func(r *network.RouteStatus) error {
 				suite.Assert().True(r.TypedSpec().Source.IP().IsLoopback())
 				suite.Assert().Equal("lo", r.TypedSpec().OutLinkName)
 				suite.Assert().Equal(nethelpers.TableLocal, r.TypedSpec().Table)

--- a/pkg/resources/network/network.go
+++ b/pkg/resources/network/network.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
 )
 
 // NamespaceName contains resources related to networking.
@@ -31,11 +33,17 @@ func LinkID(linkName string) string {
 }
 
 // RouteID builds ID (primary key) for the route.
-func RouteID(destination netaddr.IPPrefix, gateway netaddr.IP) string {
+func RouteID(table nethelpers.RoutingTable, family nethelpers.Family, destination netaddr.IPPrefix, gateway netaddr.IP, priority uint32) string {
 	dst, _ := destination.MarshalText() //nolint:errcheck
 	gw, _ := gateway.MarshalText()      //nolint:errcheck
 
-	return fmt.Sprintf("%s/%s", string(gw), string(dst))
+	tablePrefix := ""
+
+	if table != nethelpers.TableMain {
+		tablePrefix = fmt.Sprintf("%s/", table)
+	}
+
+	return fmt.Sprintf("%s%s/%s/%s/%d", tablePrefix, family, string(gw), string(dst), priority)
 }
 
 // OperatorID builds ID (primary key) for the operators.


### PR DESCRIPTION
New primary key is the following:

* table (if `main`, leave it empty)
* family
* gateway
* destination
* metric (priority)

There might be more ways we can improve this (probably gateway should be
removed?), but this should be much better model to represent routes in
the system.

This was discovered in KubeSpan development (@Ulexus).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
