### PR TITLE
chore: revert "improve artifacts generation reproducibility"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -504,7 +504,6 @@ RUN apk add --no-cache --update \
     efibootmgr \
     mtools \
     qemu-img \
-    tar \
     util-linux \
     xfsprogs \
     xorriso \

--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -178,18 +178,7 @@ func finalize(platform runtime.Platform, img, arch string) (err error) {
 }
 
 func tar(filename, src, dir string) error {
-	if _, err := cmd.Run("tar",
-		"--sort=name",
-		"--mtime=1970-01-01 00:00Z",
-		"--owner=0",
-		"--group=0",
-		"--numeric-owner",
-		"--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime",
-		"-C", dir,
-		"-czvf",
-		filepath.Join(outputArg, filename),
-		src,
-	); err != nil {
+	if _, err := cmd.Run("tar", "-czvf", filepath.Join(outputArg, filename), src, "-C", dir); err != nil {
 		return err
 	}
 

--- a/cmd/installer/pkg/raw.go
+++ b/cmd/installer/pkg/raw.go
@@ -6,7 +6,8 @@ package pkg
 
 import (
 	"fmt"
-	"os"
+
+	"github.com/talos-systems/go-cmd/pkg/cmd"
 )
 
 const (
@@ -18,18 +19,11 @@ const (
 func CreateRawDisk() (img string, err error) {
 	img = "/tmp/disk.raw"
 
-	var f *os.File
+	seek := fmt.Sprintf("seek=%d", RAWDiskSize)
 
-	f, err = os.Create(img)
-	if err != nil {
+	if _, err = cmd.Run("dd", "if=/dev/zero", "of="+img, "bs=1M", "count=0", seek); err != nil {
 		return "", fmt.Errorf("failed to create RAW disk: %w", err)
 	}
 
-	if err = f.Truncate(RAWDiskSize * 1048576); err != nil {
-		return "", fmt.Errorf("failed to truncate RAW disk: %w", err)
-	}
-
-	err = f.Close()
-
-	return img, err
+	return img, nil
 }


### PR DESCRIPTION
GCP does not consider generated .tar file to be valid.

This reverts commit b2507b41d250b989b9c13ad23e16202cd53a18d2.
Refs #4023.
