### PR TITLE
chore: require GPG signatures

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -2,7 +2,7 @@ policies:
   - type: commit
     spec:
       dco: true
-      gpg: false
+      gpg: true
       spellcheck:
         locale: US
       maximumOfOneCommit: true


### PR DESCRIPTION
GPG signatures are now required.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>