### PR TITLE
fix: enable seccomp default profile by default

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -92,6 +92,7 @@ Talos can be configued to use Kubernetes 1.21 or CAPI v0.4.x components can be u
         description = """\
 * etcd PKI moved to `/system/secrets`
 * kubelet bootstrap CSR auto-signing scoped to kubelet bootstrap tokens only
+* enforce default seccomp profile on all system containers
 """
 
     [notes.equinixmetal]

--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
@@ -275,6 +276,8 @@ func (c *containerdRunner) newOCISpecOpts(image oci.Image) []oci.SpecOpts {
 		oci.WithEnv(c.opts.Env),
 		oci.WithHostHostsFile,
 		oci.WithHostResolvconf,
+		oci.WithNoNewPrivileges,
+		seccomp.WithDefaultProfile(),
 	)
 
 	specOpts = append(specOpts,


### PR DESCRIPTION
This enable seccomp profile for all contianers launched by Talos: apid,
trustd, etcd and kubelet.

Also by default disallow gaining more priveleges in the container
(basically disables setuid). As contianers are running as root this is
no-op, but soon we'll have running as non-root users and this becomes
important.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
