### PR TITLE
 chore: drop deprecated `--no-reboot` param and KernelCurrentRoot const

### DIFF
--- a/cmd/talosctl/cmd/talos/apply-config.go
+++ b/cmd/talosctl/cmd/talos/apply-config.go
@@ -176,10 +176,5 @@ func init() {
 	applyConfigCmd.Flags().BoolVar(&applyConfigCmdFlags.interactive, "interactive", false, "apply the config using text based interactive mode")
 	applyConfigCmd.Flags().BoolVar(&applyConfigCmdFlags.onReboot, "on-reboot", false, "apply the config on reboot")
 	applyConfigCmd.Flags().BoolVar(&applyConfigCmdFlags.immediate, "immediate", false, "apply the config immediately (without a reboot)")
-
-	// deprecated, to be removed in 0.12: https://github.com/talos-systems/talos/issues/3909
-	applyConfigCmd.Flags().BoolVar(&applyConfigCmdFlags.onReboot, "no-reboot", false, "apply the config only after the reboot")
-	applyConfigCmd.Flags().MarkHidden("no-reboot") //nolint:errcheck
-
 	addCommand(applyConfigCmd)
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -65,13 +65,6 @@ const (
 	// KernelParamPanic is the kernel parameter name for specifying the time to wait until rebooting after kernel panic (0 disables reboot).
 	KernelParamPanic = "panic"
 
-	// KernelCurrentRoot is the kernel parameter name for specifying the
-	// current root partition.
-	//
-	// Deprecated: Talos now expects to use an entire disk; this constant will be removed in 0.12
-	// (https://github.com/talos-systems/talos/issues/3909).
-	KernelCurrentRoot = "talos.root"
-
 	// NewRoot is the path where the switchroot target is mounted.
 	NewRoot = "/root"
 


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3909

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>