### PR TITLE
chore: run etcd as non-root user

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -93,7 +93,7 @@ Talos can be configued to use Kubernetes 1.21 or CAPI v0.4.x components can be u
 * etcd PKI moved to `/system/secrets`
 * kubelet bootstrap CSR auto-signing scoped to kubelet bootstrap tokens only
 * enforce default seccomp profile on all system containers
-* run system services apid and trustd as non-root users
+* run system services apid, trustd, and etcd as non-root users
 """
 
     [notes.equinixmetal]

--- a/internal/app/machined/pkg/system/services/utils.go
+++ b/internal/app/machined/pkg/system/services/utils.go
@@ -6,9 +6,11 @@ package services
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 
@@ -34,4 +36,19 @@ func prepareRootfs(id string) error {
 	}
 
 	return nil
+}
+
+// chownRecursive changes file ownership recursively from the specified root.
+func chownRecursive(root string, uid, gid uint32) error {
+	return filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.Sys().(*syscall.Stat_t).Uid != uid || info.Sys().(*syscall.Stat_t).Gid != gid {
+			return os.Chown(path, int(uid), int(gid))
+		}
+
+		return nil
+	})
 }

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -268,6 +268,9 @@ const (
 	// EtcdRecoverySnapshotPath is the path where etcd snapshot is uploaded for recovery.
 	EtcdRecoverySnapshotPath = "/var/lib/etcd.snapshot"
 
+	// EtcdUserID is the user ID for the etcd process.
+	EtcdUserID = 60
+
 	// ConfigPath is the path to the downloaded config.
 	ConfigPath = StateMountPoint + "/config.yaml"
 


### PR DESCRIPTION
etcd has two mounts from the host, both of them are chowned to be
accessible by the etcd user:

* data directory
* secrets directory

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
