### PR TITLE
feat: update Linux to 5.10.58 and many pkgs updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.7.0-alpha.0-3-g2368154
-PKGS ?= v0.7.0-alpha.0-16-gda4ac04
+PKGS ?= v0.7.0-alpha.0-24-g35b7e68
 EXTRAS ?= v0.5.0-alpha.0-2-g8ce17e5
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.10.57-talos"
+	DefaultKernelVersion = "5.10.58-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
* util-linux: 2.37
* LibreSSL: 3.2.5
* linux-firmware: 20210716
* eudev: 3.2.10
* u-boot: 2021.07
* raspberrypi-firmware: 1.20210805

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
