### PR TITLE
docs: ensure azure VMs are 0 indexed

### DIFF
--- a/website/content/docs/v0.11/Cloud Platforms/azure.md
+++ b/website/content/docs/v0.11/Cloud Platforms/azure.md
@@ -209,7 +209,7 @@ az vm availability-set create \
   -g $GROUP
 
 # Create the controlplane nodes
-for i in $( seq 1 3 ); do
+for i in $( seq 0 1 2 ); do
   az vm create \
     --name talos-controlplane-$i \
     --image talos \

--- a/website/content/docs/v0.12/Cloud Platforms/azure.md
+++ b/website/content/docs/v0.12/Cloud Platforms/azure.md
@@ -209,7 +209,7 @@ az vm availability-set create \
   -g $GROUP
 
 # Create the controlplane nodes
-for i in $( seq 1 3 ); do
+for i in $( seq 0 1 2 ); do
   az vm create \
     --name talos-controlplane-$i \
     --image talos \


### PR DESCRIPTION
This PR makes sure that azure VMs are zero indexed for consistency with
the way that NICs and IPs are generated earlier in the docs. I'm not
quite sure why we went with `seq( 0 1 2 )` instead of `seq( 0 2 )`, but
I kept the sequences the same for consistency.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

