### PR TITLE
fix: make sure file mode is same (reproducibility issue)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -342,7 +342,7 @@ COPY --from=machined-build-amd64 /machined /rootfs/sbin/init
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
-COPY hack/containerd.toml /rootfs/etc/cri/containerd.toml
+COPY --chmod=0644 hack/containerd.toml /rootfs/etc/cri/containerd.toml
 RUN touch /rootfs/etc/resolv.conf
 RUN touch /rootfs/etc/hosts
 RUN touch /rootfs/etc/os-release


### PR DESCRIPTION
This fixes the diff between local and CI builds, apparently different
`umask` for the file checked out on the host:

```
--- initramfs-amd64.xz
+++ initramfs-amd64.ci.xz
│   --- initramfs-amd64
├── +++ initramfs-amd64.ci
│ ├── rootfs.sqsh
│ │ ├── unsquashfs -d  -lls {}
│ │ │ @@ -9,15 +9,15 @@
│ │ │  -rwxr-xr-x root/root          11441016 2021-08-17 16:57 /bin/runc
│ │ │  drwxr-xr-x root/root                 3 2021-08-17 16:57 /boot
│ │ │  drwxr-xr-x root/root                 3 2021-08-17 16:57 /dev
│ │ │  drwxr-xr-x root/root               186 2021-08-17 16:57 /etc
│ │ │  lrwxrwxrwx root/root                 8 2021-08-17 16:57 /etc/ca-certificates -> /etc/ssl
│ │ │  drwxr-xr-x root/root                 3 2021-08-17 16:57 /etc/cni
│ │ │  drwxr-xr-x root/root                38 2021-08-17 16:57 /etc/cri
│ │ │ --rw-rw-r-- root/root               385 2021-08-17 16:57 /etc/cri/containerd.toml
│ │ │ +-rw-r--r-- root/root               385 2021-08-17 16:57 /etc/cri/containerd.toml
│ │ │  -rw-r--r-- root/root                 0 2021-08-17 16:57 /etc/hosts
│ │ │  drwxr-xr-x root/root                75 2021-08-17 16:57 /etc/iscsi
│ │ │  drwxr-xr-x root/root                36 2021-08-17 16:57 /etc/iscsi/ifaces
│ │ │  -rw-r--r-- root/root              5984 2021-08-17 16:57 /etc/iscsi/ifaces/iface.example
│ │ │  -rw-r--r-- root/root                54 2021-08-17 16:57 /etc/iscsi/initiatorname.iscsi
│ │ │  -rw-r--r-- root/root             13338 2021-08-17 16:57 /etc/iscsi/iscsid.conf
│ │ │  drwxr-xr-x root/root                72 2021-08-17 16:57 /etc/isns
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
