### PR TITLE
fix: don't panic if the machine config doesn't have network (EM)

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
@@ -76,7 +76,7 @@ func (p *Packet) Name() string {
 }
 
 // Configuration implements the platform.Platform interface.
-//nolint:gocyclo
+//nolint:gocyclo,cyclop
 func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 	// Fetch and unmarshal both the talos machine config and the
 	// metadata about the instance from packet's metadata server
@@ -197,6 +197,14 @@ func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 				})
 			}
 		}
+	}
+
+	if machineConfig.MachineConfig == nil {
+		machineConfig.MachineConfig = &v1alpha1.MachineConfig{}
+	}
+
+	if machineConfig.MachineConfig.MachineNetwork == nil {
+		machineConfig.MachineConfig.MachineNetwork = &v1alpha1.NetworkConfig{}
 	}
 
 	machineConfig.MachineConfig.MachineNetwork.NetworkInterfaces = append(


### PR DESCRIPTION
This handles the case if the machine config doesn't contain
`.machine.network` (I got hit by that today).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
