### PR TITLE
fix: do not set KSPP kernel params in container mode

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -48,12 +48,12 @@ func (ctrl *KernelParamDefaultsController) Run(ctx context.Context, r controller
 	case <-ctx.Done():
 		return nil
 	case <-r.EventCh():
-		kernels := append(
-			kspp.GetKernelParams(),
-			ctrl.getKernelParams()...,
-		)
+		kernelParams := ctrl.getKernelParams()
+		if ctrl.V1Alpha1Mode != v1alpha1runtime.ModeContainer {
+			kernelParams = append(kernelParams, kspp.GetKernelParams()...)
+		}
 
-		for _, prop := range kernels {
+		for _, prop := range kernelParams {
 			value := prop.Value
 			item := runtime.NewKernelParamSpec(runtime.NamespaceName, prop.Key)
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -109,11 +109,11 @@ func SetupLogger(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionF
 // EnforceKSPPRequirements represents the EnforceKSPPRequirements task.
 func EnforceKSPPRequirements(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		if err = kspp.EnforceKSPPKernelParameters(); err != nil {
+		if err = resourceruntime.NewKernelParamsSetCondition(r.State().V1Alpha2().Resources(), kspp.GetKernelParams()...).Wait(ctx); err != nil {
 			return err
 		}
 
-		return resourceruntime.NewKernelParamsSetCondition(r.State().V1Alpha2().Resources(), kspp.GetKernelParams()...).Wait(ctx)
+		return kspp.EnforceKSPPKernelParameters()
 	}, "enforceKSPPRequirements"
 }
 


### PR DESCRIPTION
That was accidentally changed after migration to kernel params
controller.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>