### PR TITLE
fix: cgroup delegate

### DIFF
--- a/internal/pkg/mount/cgroups.go
+++ b/internal/pkg/mount/cgroups.go
@@ -13,7 +13,7 @@ import (
 // CGroupMountPoints returns the cgroup mount points.
 func CGroupMountPoints() (mountpoints *Points, err error) {
 	cgroups := NewMountPoints()
-	cgroups.Set("cgroup2", NewMountPoint("cgroup", constants.CgroupMountPath, "cgroup2", unix.MS_NOSUID|unix.MS_NODEV|unix.MS_NOEXEC|unix.MS_RELATIME, "nsdelegate,memory_recursiveprot"))
+	cgroups.Set("cgroup2", NewMountPoint("cgroup", constants.CgroupMountPath, "cgroup2", unix.MS_NOSUID|unix.MS_NODEV|unix.MS_NOEXEC|unix.MS_RELATIME, "nsdelegate"))
 
 	return cgroups, nil
 }


### PR DESCRIPTION
Fix mount option nsdelegate.
It makes delegation safe (more restrictions in the cgroup namespace).

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>

refs #4108 

result will be:
```bash
cgroup /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate 0 0
```