### PR TITLE
docs: Updated Kubelet extraMounts

### DIFF
--- a/pkg/machinery/config/decoder/decoder_test.go
+++ b/pkg/machinery/config/decoder/decoder_test.go
@@ -238,12 +238,13 @@ kind: kubelet
 version: v1alpha1
 spec:
   extraMounts:
-   - destination: /var/local
-     options:
-       - rbind
-       - rshared
-       - rw
-     source: /var/local
+	- mount:
+			destination: /var/local
+			options:
+			- rbind
+			- rshared
+			- rw
+			source: /var/local
 `),
 			},
 		},

--- a/website/content/docs/v0.12/Guides/storage.md
+++ b/website/content/docs/v0.12/Guides/storage.md
@@ -86,13 +86,14 @@ This can be done with `talosctl edit machineconfig` or via config patches during
 ```yaml
 ...
 extraMounts:
-  - destination: /var/local
-    type: bind
-    source: /var/local
-    options:
-    - rbind
-    - rshared
-    - rw
+  - mount:
+      destination: /var/local
+      type: bind
+      source: /var/local
+      options:
+      - rbind
+      - rshared
+      - rw
 ...
 ```
 

--- a/website/content/docs/v0.12/Reference/configuration.md
+++ b/website/content/docs/v0.12/Reference/configuration.md
@@ -296,10 +296,11 @@ kubelet:
 
     # # The `extraMounts` field is used to add additional mounts to the kubelet container.
     # extraMounts:
-    #     - destination: /var/lib/example
-    #       type: bind
-    #       source: /var/lib/example
-    #       options:
+    #     - mount:
+    #         destination: /var/lib/example
+    #         type: bind
+    #         source: /var/lib/example
+    #         options:
     #         - rshared
     #         - rw
 ```
@@ -1295,10 +1296,11 @@ Appears in:
 
 
 ``` yaml
-- destination: /var/lib/example
-  type: bind
-  source: /var/lib/example
-  options:
+- mount:
+    destination: /var/lib/example
+    type: bind
+    source: /var/lib/example
+    options:
     - rshared
     - rw
 ```
@@ -1327,10 +1329,11 @@ extraArgs:
 
 # # The `extraMounts` field is used to add additional mounts to the kubelet container.
 # extraMounts:
-#     - destination: /var/lib/example
-#       type: bind
-#       source: /var/lib/example
-#       options:
+#     - mount:
+#         destination: /var/lib/example
+#         type: bind
+#         source: /var/lib/example
+#         options:
 #         - rshared
 #         - rw
 ```
@@ -1422,10 +1425,11 @@ Examples:
 
 ``` yaml
 extraMounts:
-    - destination: /var/lib/example
-      type: bind
-      source: /var/lib/example
-      options:
+    - mount:
+        destination: /var/lib/example
+        type: bind
+        source: /var/lib/example
+        options:
         - rshared
         - rw
 ```


### PR DESCRIPTION
Signed-off-by: masoudbahar <masoudbahar@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What?
Updated Kubelet extraMounts in documentation and decoder_test.go

## Why?
In v0.12 the Kubelet extraMounts specification has changed, but documentation hasn't reflected this. This PR make them match.
