### PR TITLE
fix: don't allow bootstrap if etcd data directory is not empty

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -324,6 +324,10 @@ func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (r
 		return nil, status.Error(codes.FailedPrecondition, "time is not in sync yet")
 	}
 
+	if entries, _ := os.ReadDir(constants.EtcdDataPath); len(entries) > 0 { //nolint:errcheck
+		return nil, status.Error(codes.AlreadyExists, "etcd data directory is not empty")
+	}
+
 	go func() {
 		if err := s.Controller.Run(context.Background(), runtime.SequenceBootstrap, in); err != nil {
 			log.Println("bootstrap failed:", err)


### PR DESCRIPTION
If etcd data directory is not empty, it means that `etcd` is already
running (or etcd has run), so removing data directory might lead to data
loss. Under normal circumstances `etcd` is not started before either
node joins existing etcd cluster or it gets bootstrapped.

Most importantly, with this change it's not possible to nuke etcd member
by issuing `talosctl bootstrap` on already running Talos node.

Plus nag user about doing bootstrap if the node is waiting to join.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
