### PR TITLE
feat: provide first NIC hardware addr as a resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -384,7 +384,7 @@ COPY --from=machined-build-arm64 /machined /rootfs/sbin/init
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
-COPY hack/containerd.toml /rootfs/etc/cri/containerd.toml
+COPY --chmod=0644 hack/containerd.toml /rootfs/etc/cri/containerd.toml
 RUN touch /rootfs/etc/resolv.conf
 RUN touch /rootfs/etc/hosts
 RUN touch /rootfs/etc/os-release

--- a/internal/app/machined/pkg/controllers/network/hardware_addr.go
+++ b/internal/app/machined/pkg/controllers/network/hardware_addr.go
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// HardwareAddrController manages secrets.Etcd based on configuration.
+type HardwareAddrController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *HardwareAddrController) Name() string {
+	return "network.HardwareAddrController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *HardwareAddrController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.LinkStatusType,
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *HardwareAddrController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: network.HardwareAddrType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *HardwareAddrController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		// list the existing HardwareAddr resources and mark them all to be deleted, as the actual link is discovered via netlink, resource ID is removed from the list
+		list, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.HardwareAddrType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		itemsToDelete := map[resource.ID]struct{}{}
+
+		for _, r := range list.Items {
+			itemsToDelete[r.Metadata().ID()] = struct{}{}
+		}
+
+		// list links and find the first physical link
+		links, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.LinkStatusType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range links.Items {
+			link := res.(*network.LinkStatus) //nolint:errcheck,forcetypeassert
+
+			if !link.Physical() {
+				continue
+			}
+
+			if err = r.Modify(ctx, network.NewHardwareAddr(network.NamespaceName, network.FirstHardwareAddr), func(r resource.Resource) error {
+				spec := r.(*network.HardwareAddr).TypedSpec()
+
+				spec.HardwareAddr = link.TypedSpec().HardwareAddr
+				spec.Name = link.Metadata().ID()
+
+				return nil
+			}); err != nil {
+				return fmt.Errorf("error modifying resource: %w", err)
+			}
+
+			delete(itemsToDelete, network.FirstHardwareAddr)
+
+			// as link status are listed in sorted order, first physical link in the list is the one we need
+			break
+		}
+
+		for id := range itemsToDelete {
+			if err = r.Destroy(ctx, resource.NewMetadata(network.NamespaceName, network.HardwareAddrType, id, resource.VersionUndefined)); err != nil {
+				return fmt.Errorf("error deleting resource %q: %w", id, err)
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/network/hardware_addr_test.go
+++ b/internal/app/machined/pkg/controllers/network/hardware_addr_test.go
@@ -1,0 +1,185 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	netctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+type HardwareAddrSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *HardwareAddrSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.HardwareAddrController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *HardwareAddrSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *HardwareAddrSuite) assertHWAddr(requiredIDs []string, check func(*network.HardwareAddr) error) error {
+	missingIDs := make(map[string]struct{}, len(requiredIDs))
+
+	for _, id := range requiredIDs {
+		missingIDs[id] = struct{}{}
+	}
+
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(network.NamespaceName, network.HardwareAddrType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resources.Items {
+		_, required := missingIDs[res.Metadata().ID()]
+		if !required {
+			continue
+		}
+
+		delete(missingIDs, res.Metadata().ID())
+
+		if err = check(res.(*network.HardwareAddr)); err != nil {
+			return retry.ExpectedError(err)
+		}
+	}
+
+	if len(missingIDs) > 0 {
+		return retry.ExpectedError(fmt.Errorf("some resources are missing: %q", missingIDs))
+	}
+
+	return nil
+}
+
+func (suite *HardwareAddrSuite) assertNoHWAddr(id string) error {
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(network.NamespaceName, network.HardwareAddrType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resources.Items {
+		if res.Metadata().ID() == id {
+			return retry.ExpectedError(fmt.Errorf("interface %q is still there", id))
+		}
+	}
+
+	return nil
+}
+
+func (suite *HardwareAddrSuite) TestFirst() {
+	mustParseMAC := func(addr string) nethelpers.HardwareAddr {
+		mac, err := net.ParseMAC(addr)
+		suite.Require().NoError(err)
+
+		return nethelpers.HardwareAddr(mac)
+	}
+
+	eth0 := network.NewLinkStatus(network.NamespaceName, "eth0")
+	eth0.TypedSpec().Type = nethelpers.LinkEther
+	eth0.TypedSpec().HardwareAddr = mustParseMAC("56:a0:a0:87:1c:fa")
+
+	eth1 := network.NewLinkStatus(network.NamespaceName, "eth1")
+	eth1.TypedSpec().Type = nethelpers.LinkEther
+	eth1.TypedSpec().HardwareAddr = mustParseMAC("6a:2b:bd:b2:fc:e0")
+
+	bond0 := network.NewLinkStatus(network.NamespaceName, "bond0")
+	bond0.TypedSpec().Type = nethelpers.LinkEther
+	bond0.TypedSpec().Kind = "bond"
+	bond0.TypedSpec().HardwareAddr = mustParseMAC("56:a0:a0:87:1c:fb")
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, bond0))
+	suite.Require().NoError(suite.state.Create(suite.ctx, eth1))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertHWAddr([]string{network.FirstHardwareAddr}, func(r *network.HardwareAddr) error {
+				if r.TypedSpec().Name != eth1.Metadata().ID() && net.HardwareAddr(r.TypedSpec().HardwareAddr).String() != "6a:2b:bd:b2:fc:e0" {
+					return retry.ExpectedErrorf("should be eth1")
+				}
+
+				return nil
+			})
+		}))
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, eth0))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertHWAddr([]string{network.FirstHardwareAddr}, func(r *network.HardwareAddr) error {
+				if r.TypedSpec().Name != eth0.Metadata().ID() && net.HardwareAddr(r.TypedSpec().HardwareAddr).String() != "56:a0:a0:87:1c:fa" {
+					return retry.ExpectedErrorf("should be eth0")
+				}
+
+				return nil
+			})
+		}))
+
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, eth0.Metadata()))
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, eth1.Metadata()))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertNoHWAddr(network.FirstHardwareAddr)
+		}))
+}
+
+func (suite *HardwareAddrSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	suite.Assert().NoError(suite.state.Create(context.Background(), network.NewLinkStatus(network.NamespaceName, "bar")))
+}
+
+func TestHardwareAddrSuite(t *testing.T) {
+	suite.Run(t, new(HardwareAddrSuite))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -96,6 +96,7 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&network.AddressSpecController{},
 		&network.AddressStatusController{},
 		&network.EtcFileController{},
+		&network.HardwareAddrController{},
 		&network.HostnameConfigController{
 			Cmdline: procfs.ProcCmdline(),
 		},

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -87,6 +87,7 @@ func NewState() (*State, error) {
 		&k8s.SecretsStatus{},
 		&network.AddressStatus{},
 		&network.AddressSpec{},
+		&network.HardwareAddr{},
 		&network.HostnameStatus{},
 		&network.HostnameSpec{},
 		&network.LinkRefresh{},

--- a/pkg/resources/network/hardrware_addr.go
+++ b/pkg/resources/network/hardrware_addr.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+)
+
+// HardwareAddrType is type of HardwareAddr resource.
+const HardwareAddrType = resource.Type("HardwareAddresses.net.talos.dev")
+
+// FirstHardwareAddr is a resource ID for the first NIC HW addr.
+const FirstHardwareAddr = resource.ID("first")
+
+// HardwareAddr resource describes hardware address of the physical links.
+type HardwareAddr struct {
+	md   resource.Metadata
+	spec HardwareAddrSpec
+}
+
+// HardwareAddrSpec describes spec for the link.
+type HardwareAddrSpec struct {
+	// Name defines link name
+	Name string `yaml:"name"`
+
+	// Hardware address
+	HardwareAddr nethelpers.HardwareAddr `yaml:"hardwareAddr"`
+}
+
+// NewHardwareAddr initializes a HardwareAddr resource.
+func NewHardwareAddr(namespace resource.Namespace, id resource.ID) *HardwareAddr {
+	r := &HardwareAddr{
+		md:   resource.NewMetadata(namespace, HardwareAddrType, id, resource.VersionUndefined),
+		spec: HardwareAddrSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *HardwareAddr) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *HardwareAddr) Spec() interface{} {
+	return r.spec
+}
+
+func (r *HardwareAddr) String() string {
+	return fmt.Sprintf("network.HardwareAddr(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *HardwareAddr) DeepCopy() resource.Resource {
+	return &HardwareAddr{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *HardwareAddr) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             HardwareAddrType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns:     []meta.PrintColumn{},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *HardwareAddr) TypedSpec() *HardwareAddrSpec {
+	return &r.spec
+}

--- a/pkg/resources/network/network_test.go
+++ b/pkg/resources/network/network_test.go
@@ -27,6 +27,7 @@ func TestRegisterResource(t *testing.T) {
 	for _, resource := range []resource.Resource{
 		&network.AddressStatus{},
 		&network.AddressSpec{},
+		&network.HardwareAddr{},
 		&network.HostnameStatus{},
 		&network.HostnameSpec{},
 		&network.LinkRefresh{},


### PR DESCRIPTION
This will be used to derive e.g. KubeSpan address.

Fixes #4132

Example:

```
$ talosctl -n 172.20.0.2 get hardwareaddresses -o yaml
node: 172.20.0.2
metadata:
    namespace: network
    type: HardwareAddresses.net.talos.dev
    id: first
    version: 1
    owner: network.HardwareAddrController
    phase: running
    created: 2021-08-24T20:30:43Z
    updated: 2021-08-24T20:30:43Z
spec:
    name: eth0
    hardwareAddr: 6a:2b:bd:b2:fc:e0
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
