### PR TITLE
fix: properly case the VMware name

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vmware/vmware_amd64.go
@@ -118,7 +118,7 @@ func (v *VMware) Configuration(context.Context) ([]byte, error) {
 	}
 
 	if *option == constants.ConfigGuestInfo {
-		log.Printf("fetching machine config from VMWare extraConfig or OVF env")
+		log.Printf("fetching machine config from VMware extraConfig or OVF env")
 
 		ok, err := vmcheck.IsVirtualWorld()
 		if err != nil {

--- a/website/content/docs/v0.12/Introduction/support-matrix.md
+++ b/website/content/docs/v0.12/Introduction/support-matrix.md
@@ -13,7 +13,7 @@ weight: 6
 | **Platforms**                                                                                                  |                                    |                                    |
 | - cloud                                                                                                        | AWS, GCP, Azure, Digital Ocean, OpenStack                               |
 | - bare metal                                                                                                   | x86: BIOS, UEFI; arm64: UEFI; boot: ISO, PXE, disk image                |
-| - virtualized                                                                                                  | VMWare, Hyper-V, KVM, Proxmox, Xen                                      |
+| - virtualized                                                                                                  | VMware, Hyper-V, KVM, Proxmox, Xen                                      |
 | - SBCs                                                                                                         | Raspberry Pi4, Banana Pi M64, Pine64, and other                         |
 | - local                                                                                                        | Docker, QEMU                                                            |
 | **Cluster API**                                                                                                |                                    |                                    |


### PR DESCRIPTION
# Pull Request

## What? (description)

Fix the casing of the `VMware` name.

## Why? (reasoning)

Its name is `VMware` instead of `VMWare`.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
