### PR TITLE
feat: add subnet filter for etcd address

### DIFF
--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -362,6 +362,7 @@ type Etcd interface {
 	Image() string
 	CA() *x509.PEMEncodedCertificateAndKey
 	ExtraArgs() map[string]string
+	Subnet() string
 }
 
 // Token defines the requirements for a config that pertains to Kubernetes

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_etcdconfig.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_etcdconfig.go
@@ -42,3 +42,8 @@ func (e *EtcdConfig) ExtraArgs() map[string]string {
 
 	return e.EtcdExtraArgs
 }
+
+// Subnet implements the config.Etcd interface.
+func (e *EtcdConfig) Subnet() string {
+	return e.EtcdSubnet
+}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -330,6 +330,8 @@ var (
 
 	clusterEtcdImageExample = (&EtcdConfig{}).Image()
 
+	clusterEtcdSubnetExample = (&EtcdConfig{EtcdSubnet: "10.0.0.0/8"}).Subnet()
+
 	clusterCoreDNSExample = &CoreDNS{
 		CoreDNSImage: (&CoreDNS{}).Image(),
 	}
@@ -1278,6 +1280,12 @@ type EtcdConfig struct {
 	//           "advertise-client-urls": "https://1.2.3.4:2379",
 	//         }
 	EtcdExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
+	//   description: |
+	//     The subnet from which the advertise URL should be.
+	//
+	//   examples:
+	//     - value: clusterEtcdSubnetExample
+	EtcdSubnet string `yaml:"subnet,omitempty"`
 }
 
 // ClusterNetworkConfig represents kube networking configuration options.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -945,7 +945,7 @@ func init() {
 			FieldName: "etcd",
 		},
 	}
-	EtcdConfigDoc.Fields = make([]encoder.Doc, 3)
+	EtcdConfigDoc.Fields = make([]encoder.Doc, 4)
 	EtcdConfigDoc.Fields[0].Name = "image"
 	EtcdConfigDoc.Fields[0].Type = "string"
 	EtcdConfigDoc.Fields[0].Note = ""
@@ -965,6 +965,14 @@ func init() {
 	EtcdConfigDoc.Fields[2].Note = ""
 	EtcdConfigDoc.Fields[2].Description = "Extra arguments to supply to etcd.\nNote that the following args are not allowed:\n\n- `name`\n- `data-dir`\n- `initial-cluster-state`\n- `listen-peer-urls`\n- `listen-client-urls`\n- `cert-file`\n- `key-file`\n- `trusted-ca-file`\n- `peer-client-cert-auth`\n- `peer-cert-file`\n- `peer-trusted-ca-file`\n- `peer-key-file`"
 	EtcdConfigDoc.Fields[2].Comments[encoder.LineComment] = "Extra arguments to supply to etcd."
+
+	EtcdConfigDoc.Fields[3].Name = "subnet"
+	EtcdConfigDoc.Fields[3].Type = "string"
+	EtcdConfigDoc.Fields[3].Note = ""
+	EtcdConfigDoc.Fields[3].Description = "The subnet from which the advertise URL should be."
+	EtcdConfigDoc.Fields[3].Comments[encoder.LineComment] = "The subnet from which the advertise URL should be."
+
+	EtcdConfigDoc.Fields[3].AddExample("", clusterEtcdSubnetExample)
 
 	ClusterNetworkConfigDoc.Type = "ClusterNetworkConfig"
 	ClusterNetworkConfigDoc.Comments[encoder.LineComment] = "ClusterNetworkConfig represents kube networking configuration options."

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -202,6 +202,8 @@ func (c *Config) Validate(mode config.RuntimeMode, options ...config.ValidationO
 }
 
 // Validate validates the config.
+//
+//nolint:gocyclo
 func (c *ClusterConfig) Validate() error {
 	var result *multierror.Error
 
@@ -223,6 +225,12 @@ func (c *ClusterConfig) Validate() error {
 
 	if ecp := c.ExternalCloudProviderConfig; ecp != nil {
 		result = multierror.Append(result, ecp.Validate())
+	}
+
+	if c.EtcdConfig != nil && c.EtcdConfig.EtcdSubnet != "" {
+		if _, _, err := net.ParseCIDR(c.EtcdConfig.EtcdSubnet); err != nil {
+			result = multierror.Append(result, fmt.Errorf("%q is not a valid subnet", c.EtcdConfig.EtcdSubnet))
+		}
 	}
 
 	result = multierror.Append(result, c.ClusterInlineManifests.Validate(), c.ClusterDiscoveryConfig.Validate(c))

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -795,6 +795,46 @@ func TestValidate(t *testing.T) {
 			},
 			expectedError: "2 errors occurred:\n\t* cluster discovery service requires .cluster.id\n\t* cluster discovery service requires .cluster.secret\n\n",
 		},
+		{
+			name: "GoodEtcdSubnet",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					EtcdConfig: &v1alpha1.EtcdConfig{
+						EtcdSubnet: "10.0.0.0/8",
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "BadEtcdSubnet",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "controlplane",
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+					EtcdConfig: &v1alpha1.EtcdConfig{
+						EtcdSubnet: "10.0.0.0",
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* \"10.0.0.0\" is not a valid subnet\n\n",
+		},
 	} {
 		test := test
 

--- a/website/content/docs/v0.13/Reference/configuration.md
+++ b/website/content/docs/v0.13/Reference/configuration.md
@@ -1136,6 +1136,9 @@ etcd:
     # Extra arguments to supply to etcd.
     extraArgs:
         election-timeout: "5000"
+
+    # # The subnet from which the advertise URL should be.
+    # subnet: 10.0.0.0/8
 ```
 
 
@@ -2714,6 +2717,9 @@ ca:
 # Extra arguments to supply to etcd.
 extraArgs:
     election-timeout: "5000"
+
+# # The subnet from which the advertise URL should be.
+# subnet: 10.0.0.0/8
 ```
 
 <hr />
@@ -2787,6 +2793,28 @@ Note that the following args are not allowed:
 - `peer-cert-file`
 - `peer-trusted-ca-file`
 - `peer-key-file`
+
+</div>
+
+<hr />
+<div class="dd">
+
+<code>subnet</code>  <i>string</i>
+
+</div>
+<div class="dt">
+
+The subnet from which the advertise URL should be.
+
+
+
+Examples:
+
+
+``` yaml
+subnet: 10.0.0.0/8
+```
+
 
 </div>
 


### PR DESCRIPTION
This adds the ability to specify the subnet that `etcd`'s listen address
should be in. This allows users to ensure that `etcd` is on a private
subnet.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>