### PR TITLE
feat: add node address filters, filter out k8s addresses for Talos API

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_address_filter.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_address_filter.go
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// K8sAddressFilterController creates NodeAddressFilters based on machine configuration.
+type K8sAddressFilterController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *K8sAddressFilterController) Name() string {
+	return "network.K8sAddressFilterController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *K8sAddressFilterController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineConfigType,
+			ID:        pointer.ToString(config.V1Alpha1ID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *K8sAddressFilterController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: network.NodeAddressFilterType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *K8sAddressFilterController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		cfg, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineConfigType, config.V1Alpha1ID, resource.VersionUndefined))
+		if err != nil && !state.IsNotFoundError(err) {
+			return fmt.Errorf("error getting config: %w", err)
+		}
+
+		touchedIDs := make(map[resource.ID]struct{})
+
+		if cfg != nil {
+			cfgProvider := cfg.(*config.MachineConfig).Config()
+
+			var podCIDR, serviceCIDR netaddr.IPPrefix
+
+			podCIDR, err = netaddr.ParseIPPrefix(cfgProvider.Cluster().Network().PodCIDR())
+			if err != nil {
+				return fmt.Errorf("error parsing podCIDR: %w", err)
+			}
+
+			serviceCIDR, err = netaddr.ParseIPPrefix(cfgProvider.Cluster().Network().ServiceCIDR())
+			if err != nil {
+				return fmt.Errorf("error parsing serviceCIDR: %w", err)
+			}
+
+			if err = r.Modify(ctx, network.NewNodeAddressFilter(network.NamespaceName, k8s.NodeAddressFilterNoK8s), func(r resource.Resource) error {
+				spec := r.(*network.NodeAddressFilter).TypedSpec()
+
+				spec.ExcludeSubnets = []netaddr.IPPrefix{podCIDR, serviceCIDR}
+
+				return nil
+			}); err != nil {
+				return fmt.Errorf("error updating output resource: %w", err)
+			}
+
+			touchedIDs[k8s.NodeAddressFilterNoK8s] = struct{}{}
+
+			if err = r.Modify(ctx, network.NewNodeAddressFilter(network.NamespaceName, k8s.NodeAddressFilterOnlyK8s), func(r resource.Resource) error {
+				spec := r.(*network.NodeAddressFilter).TypedSpec()
+
+				spec.IncludeSubnets = []netaddr.IPPrefix{podCIDR, serviceCIDR}
+
+				return nil
+			}); err != nil {
+				return fmt.Errorf("error updating output resource: %w", err)
+			}
+
+			touchedIDs[k8s.NodeAddressFilterOnlyK8s] = struct{}{}
+		}
+
+		// list keys for cleanup
+		list, err := r.List(ctx, resource.NewMetadata(network.NamespaceName, network.NodeAddressFilterType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range list.Items {
+			if res.Metadata().Owner() != ctrl.Name() {
+				continue
+			}
+
+			if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+				if err = r.Destroy(ctx, res.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up specs: %w", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/config/k8s_address_filter_test.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_address_filter_test.go
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package config_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	configctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/config"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+type K8sAddressFilterSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *K8sAddressFilterSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.Require().NoError(suite.runtime.RegisterController(&configctrl.K8sAddressFilterController{}))
+
+	suite.startRuntime()
+}
+
+func (suite *K8sAddressFilterSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *K8sAddressFilterSuite) assertResource(md resource.Metadata, check func(res resource.Resource) error) func() error {
+	return func() error {
+		r, err := suite.state.Get(suite.ctx, md)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return retry.ExpectedError(err)
+			}
+
+			return err
+		}
+
+		return check(r)
+	}
+}
+
+func (suite *K8sAddressFilterSuite) TestReconcile() {
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+			ClusterNetwork: &v1alpha1.ClusterNetworkConfig{
+				ServiceSubnet: []string{
+					"10.96.0.0/12",
+				},
+				PodSubnet: []string{
+					"10.244.0.0/12",
+				},
+			},
+		},
+	})
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(
+			resource.NewMetadata(network.NamespaceName, network.NodeAddressFilterType, k8s.NodeAddressFilterOnlyK8s, resource.VersionUndefined),
+			func(res resource.Resource) error {
+				spec := res.(*network.NodeAddressFilter).TypedSpec()
+
+				suite.Assert().Equal("[10.244.0.0/12 10.96.0.0/12]", fmt.Sprintf("%s", spec.IncludeSubnets))
+				suite.Assert().Empty(spec.ExcludeSubnets)
+
+				return nil
+			},
+		),
+	))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(
+			resource.NewMetadata(network.NamespaceName, network.NodeAddressFilterType, k8s.NodeAddressFilterNoK8s, resource.VersionUndefined),
+			func(res resource.Resource) error {
+				spec := res.(*network.NodeAddressFilter).TypedSpec()
+
+				suite.Assert().Empty(spec.IncludeSubnets)
+				suite.Assert().Equal("[10.244.0.0/12 10.96.0.0/12]", fmt.Sprintf("%s", spec.ExcludeSubnets))
+
+				return nil
+			},
+		),
+	))
+}
+
+func (suite *K8sAddressFilterSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+}
+
+func TestK8sAddressFilterSuite(t *testing.T) {
+	suite.Run(t, new(K8sAddressFilterSuite))
+}

--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane_test.go
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+//nolint:dupl
 package config_test
 
 import (

--- a/internal/app/machined/pkg/controllers/network/node_address_test.go
+++ b/internal/app/machined/pkg/controllers/network/node_address_test.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,9 +23,11 @@ import (
 	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
 
 	netctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
 	"github.com/talos-systems/talos/pkg/resources/network"
 )
 
@@ -49,8 +53,6 @@ func (suite *NodeAddressSuite) SetupTest() {
 	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
 	suite.Require().NoError(err)
 
-	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.AddressStatusController{}))
-	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.LinkStatusController{}))
 	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.NodeAddressController{}))
 
 	suite.startRuntime()
@@ -99,7 +101,10 @@ func (suite *NodeAddressSuite) assertAddresses(requiredIDs []string, check func(
 }
 
 func (suite *NodeAddressSuite) TestDefaults() {
-	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.AddressStatusController{}))
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.LinkStatusController{}))
+
+	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		func() error {
 			return suite.assertAddresses([]string{
 				network.NodeAddressDefaultID,
@@ -115,9 +120,100 @@ func (suite *NodeAddressSuite) TestDefaults() {
 				}), "addresses %s", addrs)
 
 				if r.Metadata().ID() == network.NodeAddressDefaultID {
-					suite.Assert().Len(addrs, 1)
+					if len(addrs) != 1 {
+						return fmt.Errorf("there should be only one default address")
+					}
 				} else {
-					suite.Assert().GreaterOrEqual(len(addrs), 1)
+					if len(addrs) == 0 {
+						return fmt.Errorf("there should be some addresses")
+					}
+				}
+
+				return nil
+			})
+		}))
+}
+
+//nolint:gocyclo
+func (suite *NodeAddressSuite) TestFilters() {
+	linkUp := network.NewLinkStatus(network.NamespaceName, "eth0")
+	linkUp.TypedSpec().Type = nethelpers.LinkEther
+	linkUp.TypedSpec().LinkState = true
+	linkUp.TypedSpec().Index = 1
+	suite.Require().NoError(suite.state.Create(suite.ctx, linkUp))
+
+	linkDown := network.NewLinkStatus(network.NamespaceName, "eth1")
+	linkDown.TypedSpec().Type = nethelpers.LinkEther
+	linkDown.TypedSpec().LinkState = false
+	linkDown.TypedSpec().Index = 2
+	suite.Require().NoError(suite.state.Create(suite.ctx, linkDown))
+
+	newAddress := func(addr netaddr.IPPrefix, link *network.LinkStatus) {
+		addressStatus := network.NewAddressStatus(network.NamespaceName, network.AddressID(link.Metadata().ID(), addr))
+		addressStatus.TypedSpec().Address = addr
+		addressStatus.TypedSpec().LinkName = link.Metadata().ID()
+		addressStatus.TypedSpec().LinkIndex = link.TypedSpec().Index
+		suite.Require().NoError(suite.state.Create(suite.ctx, addressStatus))
+	}
+
+	for _, addr := range []string{"10.0.0.1/8", "25.3.7.9/32", "2001:470:6d:30e:4a62:b3ba:180b:b5b8/64", "127.0.0.1/8"} {
+		newAddress(netaddr.MustParseIPPrefix(addr), linkUp)
+	}
+
+	for _, addr := range []string{"10.0.0.2/8", "192.168.3.7/24"} {
+		newAddress(netaddr.MustParseIPPrefix(addr), linkDown)
+	}
+
+	filter1 := network.NewNodeAddressFilter(network.NamespaceName, "no-k8s")
+	filter1.TypedSpec().ExcludeSubnets = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.0.0.0/8")}
+	suite.Require().NoError(suite.state.Create(suite.ctx, filter1))
+
+	filter2 := network.NewNodeAddressFilter(network.NamespaceName, "only-k8s")
+	filter2.TypedSpec().IncludeSubnets = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.0.0.0/8"), netaddr.MustParseIPPrefix("192.168.0.0/16")}
+	suite.Require().NoError(suite.state.Create(suite.ctx, filter2))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertAddresses([]string{
+				network.NodeAddressDefaultID,
+				network.NodeAddressCurrentID,
+				network.NodeAddressAccumulativeID,
+				network.FilteredNodeAddressID(network.NodeAddressCurrentID, filter1.Metadata().ID()),
+				network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, filter1.Metadata().ID()),
+				network.FilteredNodeAddressID(network.NodeAddressCurrentID, filter2.Metadata().ID()),
+				network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, filter2.Metadata().ID()),
+			}, func(r *network.NodeAddress) error {
+				addrs := r.TypedSpec().Addresses
+
+				switch r.Metadata().ID() {
+				case network.NodeAddressDefaultID:
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
+				case network.NodeAddressCurrentID:
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1 25.3.7.9 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
+				case network.NodeAddressAccumulativeID:
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1 10.0.0.2 25.3.7.9 192.168.3.7 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
+				case network.FilteredNodeAddressID(network.NodeAddressCurrentID, filter1.Metadata().ID()):
+					if !reflect.DeepEqual(addrs, ipList("25.3.7.9 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
+				case network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, filter1.Metadata().ID()):
+					if !reflect.DeepEqual(addrs, ipList("25.3.7.9 192.168.3.7 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
+				case network.FilteredNodeAddressID(network.NodeAddressCurrentID, filter2.Metadata().ID()):
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
+				case network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, filter2.Metadata().ID()):
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1 10.0.0.2 192.168.3.7")) {
+						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
+					}
 				}
 
 				return nil
@@ -139,4 +235,14 @@ func (suite *NodeAddressSuite) TearDownTest() {
 
 func TestNodeAddressSuite(t *testing.T) {
 	suite.Run(t, new(NodeAddressSuite))
+}
+
+func ipList(ips string) []netaddr.IP {
+	var result []netaddr.IP //nolint:prealloc
+
+	for _, ip := range strings.Split(ips, " ") {
+		result = append(result, netaddr.MustParseIP(ip))
+	}
+
+	return result
 }

--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -142,7 +142,7 @@ func (ctrl *APIController) reconcile(ctx context.Context, r controller.Runtime, 
 		{
 			Namespace: network.NamespaceName,
 			Type:      network.NodeAddressType,
-			ID:        pointer.ToString(network.NodeAddressAccumulativeID),
+			ID:        pointer.ToString(network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s)),
 			Kind:      controller.InputWeak,
 		},
 		{
@@ -240,7 +240,8 @@ func (ctrl *APIController) reconcile(ctx context.Context, r controller.Runtime, 
 
 		hostnameStatus := hostnameResource.(*network.HostnameStatus).TypedSpec()
 
-		addressesResource, err := r.Get(ctx, resource.NewMetadata(network.NamespaceName, network.NodeAddressType, network.NodeAddressAccumulativeID, resource.VersionUndefined))
+		addressesResource, err := r.Get(ctx,
+			resource.NewMetadata(network.NamespaceName, network.NodeAddressType, network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s), resource.VersionUndefined))
 		if err != nil {
 			if state.IsNotFoundError(err) {
 				continue

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -80,6 +80,7 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
 		&config.MachineTypeController{},
+		&config.K8sAddressFilterController{},
 		&config.K8sControlPlaneController{},
 		&files.EtcFileController{
 			EtcPath:    "/etc",

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -101,6 +101,7 @@ func NewState() (*State, error) {
 		&network.LinkStatus{},
 		&network.LinkSpec{},
 		&network.NodeAddress{},
+		&network.NodeAddressFilter{},
 		&network.OperatorSpec{},
 		&network.ResolverStatus{},
 		&network.ResolverSpec{},

--- a/pkg/resources/k8s/k8s.go
+++ b/pkg/resources/k8s/k8s.go
@@ -9,3 +9,9 @@ import "github.com/cosi-project/runtime/pkg/resource"
 
 // ControlPlaneNamespaceName contains resources supporting Kubernetes control plane.
 const ControlPlaneNamespaceName resource.Namespace = "controlplane"
+
+// NodeAddressFilterOnlyK8s is the ID for the node address filter which leaves only Kubernetes IPs.
+const NodeAddressFilterOnlyK8s = "only-k8s"
+
+// NodeAddressFilterNoK8s is the ID for the node address filter which removes any Kubernetes IPs.
+const NodeAddressFilterNoK8s = "no-k8s"

--- a/pkg/resources/network/network_test.go
+++ b/pkg/resources/network/network_test.go
@@ -34,6 +34,7 @@ func TestRegisterResource(t *testing.T) {
 		&network.LinkStatus{},
 		&network.LinkSpec{},
 		&network.NodeAddress{},
+		&network.NodeAddressFilter{},
 		&network.OperatorSpec{},
 		&network.ResolverStatus{},
 		&network.ResolverSpec{},

--- a/pkg/resources/network/node_address.go
+++ b/pkg/resources/network/node_address.go
@@ -97,3 +97,8 @@ func (r *NodeAddress) ResourceDefinition() meta.ResourceDefinitionSpec {
 func (r *NodeAddress) TypedSpec() *NodeAddressSpec {
 	return &r.spec
 }
+
+// FilteredNodeAddressID returns resource ID for node addresses with filter applied.
+func FilteredNodeAddressID(kind resource.ID, filterID string) resource.ID {
+	return fmt.Sprintf("%s-%s", kind, filterID)
+}

--- a/pkg/resources/network/node_address_filter.go
+++ b/pkg/resources/network/node_address_filter.go
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"inet.af/netaddr"
+)
+
+// NodeAddressFilterType is type of NodeAddressFilter resource.
+const NodeAddressFilterType = resource.Type("NodeAddressFilters.net.talos.dev")
+
+// NodeAddressFilter resource holds filter for NodeAddress resources.
+type NodeAddressFilter struct {
+	md   resource.Metadata
+	spec NodeAddressFilterSpec
+}
+
+// NodeAddressFilterSpec describes a filter for NodeAddresses.
+type NodeAddressFilterSpec struct {
+	// Address is skipped if it doesn't match any of the includeSubnets (if includeSubnets is not empty).
+	IncludeSubnets []netaddr.IPPrefix `yaml:"includeSubnets"`
+	// Address is skipped if it matches any of the includeSubnets.
+	ExcludeSubnets []netaddr.IPPrefix `yaml:"excludeSubnets"`
+}
+
+// NewNodeAddressFilter initializes a NodeAddressFilter resource.
+func NewNodeAddressFilter(namespace resource.Namespace, id resource.ID) *NodeAddressFilter {
+	r := &NodeAddressFilter{
+		md:   resource.NewMetadata(namespace, NodeAddressFilterType, id, resource.VersionUndefined),
+		spec: NodeAddressFilterSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *NodeAddressFilter) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *NodeAddressFilter) Spec() interface{} {
+	return r.spec
+}
+
+func (r *NodeAddressFilter) String() string {
+	return fmt.Sprintf("network.NodeAddressFilter(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *NodeAddressFilter) DeepCopy() resource.Resource {
+	return &NodeAddressFilter{
+		md: r.md,
+		spec: NodeAddressFilterSpec{
+			IncludeSubnets: append([]netaddr.IPPrefix(nil), r.spec.IncludeSubnets...),
+			ExcludeSubnets: append([]netaddr.IPPrefix(nil), r.spec.ExcludeSubnets...),
+		},
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *NodeAddressFilter) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             NodeAddressFilterType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Include Subnets",
+				JSONPath: `{.includeSubnets}`,
+			},
+			{
+				Name:     "Exclude Subnets",
+				JSONPath: `{.excludeSubnets}`,
+			},
+		},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *NodeAddressFilter) TypedSpec() *NodeAddressFilterSpec {
+	return &r.spec
+}


### PR DESCRIPTION
This implements abstract `NodeAddressFilter` which can be attached to
build additional `NodeAddress` resources filtering out some entries from
the complete list.

Kubernetes creates two filters to get all node IPs without Kubernetes
CIDRs and vice versa, only Kubernetes CIDRs.

API certificate generation now considers all addresses minus K8s CIDRs.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
