### PR TITLE
docs: document required options for extraMounts

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -363,6 +363,7 @@ var (
 				Destination: "/var/lib/example",
 				Type:        "bind",
 				Options: []string{
+					"bind",
 					"rshared",
 					"rw",
 				},
@@ -828,6 +829,7 @@ type KubeletConfig struct {
 	KubeletExtraArgs map[string]string `yaml:"extraArgs,omitempty"`
 	//   description: |
 	//     The `extraMounts` field is used to add additional mounts to the kubelet container.
+	//     Note that either `bind` or `rbind` are required in the `options`.
 	//   examples:
 	//     - value: kubeletExtraMountsExample
 	KubeletExtraMounts []ExtraMount `yaml:"extraMounts,omitempty"`

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -475,7 +475,7 @@ func init() {
 	KubeletConfigDoc.Fields[3].Name = "extraMounts"
 	KubeletConfigDoc.Fields[3].Type = "[]ExtraMount"
 	KubeletConfigDoc.Fields[3].Note = ""
-	KubeletConfigDoc.Fields[3].Description = "The `extraMounts` field is used to add additional mounts to the kubelet container."
+	KubeletConfigDoc.Fields[3].Description = "The `extraMounts` field is used to add additional mounts to the kubelet container.\nNote that either `bind` or `rbind` are required in the `options`."
 	KubeletConfigDoc.Fields[3].Comments[encoder.LineComment] = "The `extraMounts` field is used to add additional mounts to the kubelet container."
 
 	KubeletConfigDoc.Fields[3].AddExample("", kubeletExtraMountsExample)

--- a/website/content/docs/v0.13/Reference/configuration.md
+++ b/website/content/docs/v0.13/Reference/configuration.md
@@ -300,6 +300,7 @@ kubelet:
     #       type: bind
     #       source: /var/lib/example
     #       options:
+    #         - bind
     #         - rshared
     #         - rw
 ```
@@ -1336,6 +1337,7 @@ Appears in:
   type: bind
   source: /var/lib/example
   options:
+    - bind
     - rshared
     - rw
 ```
@@ -1368,6 +1370,7 @@ extraArgs:
 #       type: bind
 #       source: /var/lib/example
 #       options:
+#         - bind
 #         - rshared
 #         - rw
 ```
@@ -1451,6 +1454,7 @@ extraArgs:
 <div class="dt">
 
 The `extraMounts` field is used to add additional mounts to the kubelet container.
+Note that either `bind` or `rbind` are required in the `options`.
 
 
 
@@ -1463,6 +1467,7 @@ extraMounts:
       type: bind
       source: /var/lib/example
       options:
+        - bind
         - rshared
         - rw
 ```


### PR DESCRIPTION
Clarifies that either `bind` or `rbind` are required in the Kubelet's
`extraMounts`.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
