### PR TITLE
fix: correctly define example for `extraMounts`

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "talos-systems/talos"
 match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v0.11.0"
+previous = "v0.12.0"
 
 pre_release = true
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -356,14 +356,16 @@ var (
 		mustParseURL("https://cluster1.internal:6443"),
 	}
 
-	kubeletExtraMountsExample = []specs.Mount{
+	kubeletExtraMountsExample = []ExtraMount{
 		{
-			Source:      "/var/lib/example",
-			Destination: "/var/lib/example",
-			Type:        "bind",
-			Options: []string{
-				"rshared",
-				"rw",
+			specs.Mount{
+				Source:      "/var/lib/example",
+				Destination: "/var/lib/example",
+				Type:        "bind",
+				Options: []string{
+					"rshared",
+					"rw",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The type was changed, but the example wasn't updated accordingly.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>