### PR TITLE
chore: update tools/pkgs/extras to the new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.7.0
-PKGS ?= v0.7.0
-EXTRAS ?= v0.5.0
+TOOLS ?= ghcr.io/talos-systems/tools:v0.8.0-alpha.0
+PKGS ?= v0.8.0-alpha.0
+EXTRAS ?= v0.6.0-alpha.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0
 STRINGER_VERSION ?= v0.1.3


### PR DESCRIPTION
This pulls in latest master versions of tools/pkgs/extras:

* new reproducible toolchain with GCC 11.2
* fix for the `strip` to be multi-arch
* new reproducible tools
* updated pkgs with fixes for GCC 11.2
* updated extras

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
