### PR TITLE
chore: enable GPG identity check for Talos

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -2,7 +2,10 @@ policies:
   - type: commit
     spec:
       dco: true
-      gpg: true
+      gpg:
+        required: true
+        identity:
+          gitHubOrganization: talos-systems
       spellcheck:
         locale: US
       maximumOfOneCommit: true

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ release-artifacts:
 
 .PHONY: conformance
 conformance: ## Performs policy checks against the commit and source code.
-	docker run --rm -it -v $(PWD):/src -w /src docker.io/autonomy/conform:v0.1.0-alpha.20
+	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/talos-systems/conform:v0.1.0-alpha.22 enforce
 
 .PHONY: release-notes
 release-notes:


### PR DESCRIPTION
This check enforces that commit should not only be signed by GPG
signature, but also signature identity should be one of the
`talos-systems` organization members.

Talos welcomes all external contributions, this check just means that
the commit will be signed with one of the org members before merge.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
