### PR TITLE
feat: provide building of local `Affiliate` structure (for the node)

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/cluster_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/cluster_test.go
@@ -1,0 +1,108 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster_test
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/resources/config"
+)
+
+type ClusterSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *ClusterSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	logger := logging.Wrap(log.Writer())
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logger)
+	suite.Require().NoError(err)
+}
+
+func (suite *ClusterSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *ClusterSuite) assertResource(md resource.Metadata, check func(res resource.Resource) error) func() error {
+	return func() error {
+		r, err := suite.state.Get(suite.ctx, md)
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				return retry.ExpectedError(err)
+			}
+
+			return err
+		}
+
+		return check(r)
+	}
+}
+
+func (suite *ClusterSuite) assertNoResource(md resource.Metadata) func() error {
+	return func() error {
+		_, err := suite.state.Get(suite.ctx, md)
+		if err == nil {
+			return retry.ExpectedErrorf("resource %s still exists", md)
+		}
+
+		if state.IsNotFoundError(err) {
+			return nil
+		}
+
+		return err
+	}
+}
+
+func (suite *ClusterSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	err := suite.state.Create(context.Background(), config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+	}))
+	if state.IsConflictError(err) {
+		err = suite.state.Destroy(context.Background(), config.NewMachineConfig(nil).Metadata())
+	}
+
+	suite.Assert().NoError(err)
+}

--- a/internal/app/machined/pkg/controllers/cluster/config.go
+++ b/internal/app/machined/pkg/controllers/cluster/config.go
@@ -1,0 +1,102 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/config"
+)
+
+// ConfigController watches v1alpha1.Config, updates discovery config.
+type ConfigController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *ConfigController) Name() string {
+	return "cluster.ConfigController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *ConfigController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineConfigType,
+			ID:        pointer.ToString(config.V1Alpha1ID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *ConfigController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: cluster.ConfigType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *ConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+			cfg, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineConfigType, config.V1Alpha1ID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting config: %w", err)
+				}
+			}
+
+			touchedIDs := make(map[resource.ID]struct{})
+
+			if cfg != nil {
+				c := cfg.(*config.MachineConfig).Config()
+
+				if err = r.Modify(ctx, cluster.NewConfig(config.NamespaceName, cluster.ConfigID), func(res resource.Resource) error {
+					res.(*cluster.Config).TypedSpec().DiscoveryEnabled = c.Cluster().Discovery().Enabled()
+
+					return nil
+				}); err != nil {
+					return err
+				}
+
+				touchedIDs[cluster.ConfigID] = struct{}{}
+			}
+
+			// list keys for cleanup
+			list, err := r.List(ctx, resource.NewMetadata(config.NamespaceName, cluster.ConfigType, "", resource.VersionUndefined))
+			if err != nil {
+				return fmt.Errorf("error listing resources: %w", err)
+			}
+
+			for _, res := range list.Items {
+				if res.Metadata().Owner() != ctrl.Name() {
+					continue
+				}
+
+				if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+					if err = r.Destroy(ctx, res.Metadata()); err != nil {
+						return fmt.Errorf("error cleaning up specs: %w", err)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/cluster/config_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/config_test.go
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+
+	clusterctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/config"
+)
+
+type ConfigSuite struct {
+	ClusterSuite
+}
+
+func (suite *ConfigSuite) TestReconcileConfig() {
+	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.ConfigController{}))
+
+	suite.startRuntime()
+
+	cfg := config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ClusterDiscoveryConfig: v1alpha1.ClusterDiscoveryConfig{
+				DiscoveryEnabled: true,
+			},
+		},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	specMD := resource.NewMetadata(config.NamespaceName, cluster.ConfigType, cluster.ConfigID, resource.VersionUndefined)
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(
+			specMD,
+			func(res resource.Resource) error {
+				spec := res.(*cluster.Config).TypedSpec()
+
+				suite.Assert().True(spec.DiscoveryEnabled)
+
+				return nil
+			},
+		),
+	))
+}
+
+func (suite *ConfigSuite) TestReconcileDisabled() {
+	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.ConfigController{}))
+
+	suite.startRuntime()
+
+	cfg := config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+		ClusterConfig: &v1alpha1.ClusterConfig{},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	specMD := resource.NewMetadata(config.NamespaceName, cluster.ConfigType, cluster.ConfigID, resource.VersionUndefined)
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(
+			specMD,
+			func(res resource.Resource) error {
+				spec := res.(*cluster.Config).TypedSpec()
+
+				suite.Assert().False(spec.DiscoveryEnabled)
+
+				return nil
+			},
+		),
+	))
+}
+
+func TestConfigSuite(t *testing.T) {
+	suite.Run(t, new(ConfigSuite))
+}

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -1,0 +1,223 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/kubespan"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+// LocalAffiliateController builds Affiliate resource for the local node.
+type LocalAffiliateController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *LocalAffiliateController) Name() string {
+	return "cluster.LocalAffiliateController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *LocalAffiliateController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      cluster.ConfigType,
+			ID:        pointer.ToString(cluster.ConfigID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: cluster.NamespaceName,
+			Type:      cluster.IdentityType,
+			ID:        pointer.ToString(cluster.LocalIdentity),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.HostnameStatusType,
+			ID:        pointer.ToString(network.HostnameID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: k8s.ControlPlaneNamespaceName,
+			Type:      k8s.NodenameType,
+			ID:        pointer.ToString(k8s.NodenameID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.NodeAddressType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: kubespan.NamespaceName,
+			Type:      kubespan.IdentityType,
+			ID:        pointer.ToString(kubespan.LocalIdentity),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineTypeType,
+			ID:        pointer.ToString(config.MachineTypeID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *LocalAffiliateController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: cluster.AffiliateType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo,cyclop
+func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+			// mandatory resources to be fetched
+			discoveryConfig, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, cluster.ConfigType, cluster.ConfigID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting discovery config: %w", err)
+				}
+
+				continue
+			}
+
+			identity, err := r.Get(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.IdentityType, cluster.LocalIdentity, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting local identity: %w", err)
+				}
+
+				continue
+			}
+
+			hostname, err := r.Get(ctx, resource.NewMetadata(network.NamespaceName, network.HostnameStatusType, network.HostnameID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting hostname: %w", err)
+				}
+
+				continue
+			}
+
+			nodename, err := r.Get(ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.NodenameType, k8s.NodenameID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting nodename: %w", err)
+				}
+
+				continue
+			}
+
+			addresses, err := r.Get(ctx,
+				resource.NewMetadata(network.NamespaceName, network.NodeAddressType, network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterNoK8s), resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting addresses: %w", err)
+				}
+
+				continue
+			}
+
+			machineType, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineTypeType, config.MachineTypeID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting machine type: %w", err)
+				}
+
+				continue
+			}
+
+			// optional resources (kubespan)
+			kubespanIdentity, err := r.Get(ctx, resource.NewMetadata(kubespan.NamespaceName, kubespan.IdentityType, kubespan.LocalIdentity, resource.VersionUndefined))
+			if err != nil && !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting kubespan identity: %w", err)
+			}
+
+			ksAdditionalAddresses, err := r.Get(ctx,
+				resource.NewMetadata(network.NamespaceName, network.NodeAddressType, network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterOnlyK8s), resource.VersionUndefined))
+			if err != nil && !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting kubespan additional addresses: %w", err)
+			}
+
+			localID := identity.(*cluster.Identity).TypedSpec().NodeID
+
+			touchedIDs := make(map[resource.ID]struct{})
+
+			if discoveryConfig.(*cluster.Config).TypedSpec().DiscoveryEnabled {
+				if err = r.Modify(ctx, cluster.NewAffiliate(cluster.NamespaceName, localID), func(res resource.Resource) error {
+					spec := res.(*cluster.Affiliate).TypedSpec()
+
+					spec.Addresses = append([]netaddr.IP(nil), addresses.(*network.NodeAddress).TypedSpec().IPs()...)
+					spec.Hostname = hostname.(*network.HostnameStatus).TypedSpec().FQDN()
+					spec.Nodename = nodename.(*k8s.Nodename).TypedSpec().Nodename
+					spec.MachineType = machineType.(*config.MachineType).MachineType()
+
+					if kubespanIdentity != nil {
+						spec.KubeSpan.Address = kubespanIdentity.(*kubespan.Identity).TypedSpec().Address.IP()
+						spec.KubeSpan.PublicKey = kubespanIdentity.(*kubespan.Identity).TypedSpec().PublicKey
+						spec.KubeSpan.AdditionalAddresses = append([]netaddr.IPPrefix(nil), ksAdditionalAddresses.(*network.NodeAddress).TypedSpec().Addresses...)
+
+						nodeIPs := addresses.(*network.NodeAddress).TypedSpec().IPs()
+						endpoints := make([]netaddr.IPPort, len(nodeIPs))
+
+						for i := range nodeIPs {
+							endpoints[i] = netaddr.IPPortFrom(nodeIPs[i], constants.KubeSpanDefaultPort)
+						}
+
+						spec.KubeSpan.Endpoints = endpoints
+					}
+
+					return nil
+				}); err != nil {
+					return err
+				}
+
+				touchedIDs[localID] = struct{}{}
+			}
+
+			// list keys for cleanup
+			list, err := r.List(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+			if err != nil {
+				return fmt.Errorf("error listing resources: %w", err)
+			}
+
+			for _, res := range list.Items {
+				if res.Metadata().Owner() != ctrl.Name() {
+					continue
+				}
+
+				if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+					if err = r.Destroy(ctx, res.Metadata()); err != nil {
+						return fmt.Errorf("error cleaning up specs: %w", err)
+					}
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+
+	clusterctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+	"github.com/talos-systems/talos/pkg/resources/kubespan"
+	"github.com/talos-systems/talos/pkg/resources/network"
+)
+
+type LocalAffiliateSuite struct {
+	ClusterSuite
+}
+
+func (suite *LocalAffiliateSuite) TestGeneration() {
+	suite.startRuntime()
+
+	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.LocalAffiliateController{}))
+
+	// regular discovery affiliate
+	discoveryConfig := cluster.NewConfig(config.NamespaceName, cluster.ConfigID)
+	discoveryConfig.TypedSpec().DiscoveryEnabled = true
+	suite.Require().NoError(suite.state.Create(suite.ctx, discoveryConfig))
+
+	nodeIdentity := cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity)
+	suite.Require().NoError(nodeIdentity.TypedSpec().Generate())
+	suite.Require().NoError(suite.state.Create(suite.ctx, nodeIdentity))
+
+	hostnameStatus := network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
+	hostnameStatus.TypedSpec().Hostname = "example1"
+	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
+
+	nodename := k8s.NewNodename(k8s.ControlPlaneNamespaceName, k8s.NodenameID)
+	nodename.TypedSpec().Nodename = "example1.com"
+	suite.Require().NoError(suite.state.Create(suite.ctx, nodename))
+
+	nonK8sAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterNoK8s))
+	nonK8sAddresses.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("172.20.0.2/24"), netaddr.MustParseIPPrefix("10.5.0.1/32")}
+	suite.Require().NoError(suite.state.Create(suite.ctx, nonK8sAddresses))
+
+	machineType := config.NewMachineType()
+	machineType.SetMachineType(machine.TypeWorker)
+	suite.Require().NoError(suite.state.Create(suite.ctx, machineType))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewAffiliate(cluster.NamespaceName, nodeIdentity.TypedSpec().NodeID).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Affiliate).TypedSpec()
+
+			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("172.20.0.2"), netaddr.MustParseIP("10.5.0.1")}, spec.Addresses)
+			suite.Assert().Equal("example1", spec.Hostname)
+			suite.Assert().Equal("example1.com", spec.Nodename)
+			suite.Assert().Equal(machine.TypeWorker, spec.MachineType)
+			suite.Assert().Equal(cluster.KubeSpanAffiliateSpec{}, spec.KubeSpan)
+
+			return nil
+		}),
+	))
+
+	// enable kubespan
+	mac, err := net.ParseMAC("ea:71:1b:b2:cc:ee")
+	suite.Require().NoError(err)
+
+	ksIdentity := kubespan.NewIdentity(kubespan.NamespaceName, kubespan.LocalIdentity)
+	suite.Require().NoError(ksIdentity.TypedSpec().GenerateKey())
+	suite.Require().NoError(ksIdentity.TypedSpec().UpdateAddress("8XuV9TZHW08DOk3bVxQjH9ih_TBKjnh-j44tsCLSBzo=", mac))
+	suite.Require().NoError(suite.state.Create(suite.ctx, ksIdentity))
+
+	onlyK8sAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressCurrentID, k8s.NodeAddressFilterOnlyK8s))
+	onlyK8sAddresses.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.1.0/24")}
+	suite.Require().NoError(suite.state.Create(suite.ctx, onlyK8sAddresses))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewAffiliate(cluster.NamespaceName, nodeIdentity.TypedSpec().NodeID).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Affiliate).TypedSpec()
+
+			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("172.20.0.2"), netaddr.MustParseIP("10.5.0.1")}, spec.Addresses)
+			suite.Assert().Equal("example1", spec.Hostname)
+			suite.Assert().Equal("example1.com", spec.Nodename)
+			suite.Assert().Equal(machine.TypeWorker, spec.MachineType)
+
+			if spec.KubeSpan.PublicKey == "" {
+				return retry.ExpectedErrorf("kubespan is not filled in yet")
+			}
+
+			if spec.KubeSpan.AdditionalAddresses == nil {
+				return retry.ExpectedErrorf("kubespan is not filled in yet")
+			}
+
+			suite.Assert().Equal(ksIdentity.TypedSpec().Address.IP(), spec.KubeSpan.Address)
+			suite.Assert().Equal(ksIdentity.TypedSpec().PublicKey, spec.KubeSpan.PublicKey)
+			suite.Assert().Equal([]netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.1.0/24")}, spec.KubeSpan.AdditionalAddresses)
+			suite.Assert().Equal([]netaddr.IPPort{netaddr.MustParseIPPort("172.20.0.2:51820"), netaddr.MustParseIPPort("10.5.0.1:51820")}, spec.KubeSpan.Endpoints)
+
+			return nil
+		}),
+	))
+
+	// disable discovery, local affiliate should be removed
+	oldVersion := discoveryConfig.Metadata().Version()
+	discoveryConfig.TypedSpec().DiscoveryEnabled = false
+	discoveryConfig.Metadata().BumpVersion()
+	suite.Require().NoError(suite.state.Update(suite.ctx, oldVersion, discoveryConfig))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertNoResource(*cluster.NewAffiliate(cluster.NamespaceName, nodeIdentity.TypedSpec().NodeID).Metadata()),
+	))
+}
+
+func TestLocalAffiliateSuite(t *testing.T) {
+	suite.Run(t, new(LocalAffiliateSuite))
+}

--- a/internal/app/machined/pkg/controllers/cluster/node_identity_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/node_identity_test.go
@@ -5,27 +5,18 @@
 package cluster_test
 
 import (
-	"context"
-	"fmt"
-	"log"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/cosi-project/runtime/pkg/controller/runtime"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/state"
-	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
-	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-retry/retry"
 
 	clusterctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/cluster"
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
-	"github.com/talos-systems/talos/pkg/logging"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/resources/cluster"
 	runtimeres "github.com/talos-systems/talos/pkg/resources/runtime"
@@ -33,77 +24,31 @@ import (
 )
 
 type NodeIdentitySuite struct {
-	suite.Suite
-
-	state state.State
-
-	runtime *runtime.Runtime
-	wg      sync.WaitGroup
-
-	ctx       context.Context
-	ctxCancel context.CancelFunc
+	ClusterSuite
 
 	statePath string
 }
 
-func (suite *NodeIdentitySuite) SetupTest() {
-	suite.statePath = suite.T().TempDir()
-
-	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
-
-	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
-
-	var err error
-
-	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
-	suite.Require().NoError(err)
-
-	suite.startRuntime()
-}
-
-func (suite *NodeIdentitySuite) startRuntime() {
-	suite.wg.Add(1)
-
-	go func() {
-		defer suite.wg.Done()
-
-		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
-	}()
-}
-
-func (suite *NodeIdentitySuite) assertNodeIdentities(expected []string) error {
-	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(cluster.NamespaceName, cluster.IdentityType, "", resource.VersionUndefined))
-	if err != nil {
-		return err
-	}
-
-	ids := make([]string, 0, len(resources.Items))
-
-	for _, res := range resources.Items {
-		ids = append(ids, res.Metadata().ID())
-	}
-
-	if !reflect.DeepEqual(expected, ids) {
-		return retry.ExpectedError(fmt.Errorf("expected %q, got %q", expected, ids))
-	}
-
-	return nil
-}
-
 func (suite *NodeIdentitySuite) TestContainerMode() {
+	suite.statePath = suite.T().TempDir()
+	suite.startRuntime()
+
 	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.NodeIdentityController{
 		StatePath:    suite.statePath,
 		V1Alpha1Mode: v1alpha1runtime.ModeContainer,
 	}))
 
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-		func() error {
-			return suite.assertNodeIdentities([]string{cluster.LocalIdentity})
-		},
+		suite.assertResource(*cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity).Metadata(), func(_ resource.Resource) error {
+			return nil
+		}),
 	))
 }
 
 func (suite *NodeIdentitySuite) TestDefault() {
+	suite.statePath = suite.T().TempDir()
+	suite.startRuntime()
+
 	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.NodeIdentityController{
 		StatePath:    suite.statePath,
 		V1Alpha1Mode: v1alpha1runtime.ModeMetal,
@@ -119,13 +64,16 @@ func (suite *NodeIdentitySuite) TestDefault() {
 	suite.Assert().NoError(suite.state.Create(suite.ctx, stateMount))
 
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-		func() error {
-			return suite.assertNodeIdentities([]string{cluster.LocalIdentity})
-		},
+		suite.assertResource(*cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity).Metadata(), func(_ resource.Resource) error {
+			return nil
+		}),
 	))
 }
 
 func (suite *NodeIdentitySuite) TestLoad() {
+	suite.statePath = suite.T().TempDir()
+	suite.startRuntime()
+
 	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.NodeIdentityController{
 		StatePath:    suite.statePath,
 		V1Alpha1Mode: v1alpha1runtime.ModeMetal,
@@ -139,26 +87,12 @@ func (suite *NodeIdentitySuite) TestLoad() {
 	suite.Assert().NoError(suite.state.Create(suite.ctx, stateMount))
 
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-		func() error {
-			return suite.assertNodeIdentities([]string{cluster.LocalIdentity})
-		},
+		suite.assertResource(*cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity).Metadata(), func(r resource.Resource) error {
+			suite.Assert().Equal("gvqfS27LxD58lPlASmpaueeRVzuof16iXoieRgEvBWaE", r.(*cluster.Identity).TypedSpec().NodeID)
+
+			return nil
+		}),
 	))
-
-	r, err := suite.state.Get(suite.ctx, cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity).Metadata())
-	suite.Require().NoError(err)
-
-	suite.Assert().Equal("gvqfS27LxD58lPlASmpaueeRVzuof16iXoieRgEvBWaE", r.(*cluster.Identity).TypedSpec().NodeID)
-}
-
-func (suite *NodeIdentitySuite) TearDownTest() {
-	suite.T().Log("tear down")
-
-	suite.ctxCancel()
-
-	suite.wg.Wait()
-
-	// trigger updates in resources to stop watch loops
-	suite.Assert().NoError(suite.state.Create(context.Background(), runtimeres.NewMountStatus(v1alpha1.NamespaceName, "-")))
 }
 
 func TestNodeIdentitySuite(t *testing.T) {

--- a/internal/app/machined/pkg/controllers/network/etcfile.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile.go
@@ -200,7 +200,7 @@ func (ctrl *EtcFileController) renderHosts(hostnameStatus *network.HostnameStatu
 		Alias      string
 		ExtraHosts []talosconfig.ExtraHost
 	}{
-		IP:         nodeAddressStatus.Addresses[0].String(),
+		IP:         nodeAddressStatus.Addresses[0].IP().String(),
 		Hostname:   hostnameStatus.FQDN(),
 		Alias:      hostnameStatus.Hostname,
 		ExtraHosts: extraHosts,

--- a/internal/app/machined/pkg/controllers/network/etcfile_test.go
+++ b/internal/app/machined/pkg/controllers/network/etcfile_test.go
@@ -91,7 +91,7 @@ func (suite *EtcFileConfigSuite) SetupTest() {
 	})
 
 	suite.defaultAddress = network.NewNodeAddress(network.NamespaceName, network.NodeAddressDefaultID)
-	suite.defaultAddress.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("33.11.22.44")}
+	suite.defaultAddress.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("33.11.22.44/32")}
 
 	suite.hostnameStatus = network.NewHostnameStatus(network.NamespaceName, network.HostnameID)
 	suite.hostnameStatus.TypedSpec().Hostname = "foo"

--- a/internal/app/machined/pkg/controllers/network/hostname_config.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config.go
@@ -177,7 +177,7 @@ func (ctrl *HostnameConfigController) getDefault(defaultAddr *network.NodeAddres
 		return
 	}
 
-	spec.Hostname = fmt.Sprintf("talos-%s", strings.ReplaceAll(strings.ReplaceAll(defaultAddr.TypedSpec().Addresses[0].String(), ":", ""), ".", "-"))
+	spec.Hostname = fmt.Sprintf("talos-%s", strings.ReplaceAll(strings.ReplaceAll(defaultAddr.TypedSpec().Addresses[0].IP().String(), ":", ""), ".", "-"))
 	spec.ConfigLayer = network.ConfigDefault
 
 	return spec

--- a/internal/app/machined/pkg/controllers/network/hostname_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/hostname_config_test.go
@@ -118,7 +118,7 @@ func (suite *HostnameConfigSuite) TestDefaults() {
 	suite.startRuntime()
 
 	defaultAddress := network.NewNodeAddress(network.NamespaceName, network.NodeAddressDefaultID)
-	defaultAddress.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("33.11.22.44")}
+	defaultAddress.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("33.11.22.44/32")}
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, defaultAddress))
 

--- a/internal/app/machined/pkg/controllers/network/node_address_test.go
+++ b/internal/app/machined/pkg/controllers/network/node_address_test.go
@@ -116,7 +116,7 @@ func (suite *NodeAddressSuite) TestDefaults() {
 				suite.T().Logf("id %q val %s", r.Metadata().ID(), addrs)
 
 				suite.Assert().True(sort.SliceIsSorted(addrs, func(i, j int) bool {
-					return addrs[i].Compare(addrs[j]) < 0
+					return addrs[i].IP().Compare(addrs[j].IP()) < 0
 				}), "addresses %s", addrs)
 
 				if r.Metadata().ID() == network.NodeAddressDefaultID {
@@ -187,31 +187,31 @@ func (suite *NodeAddressSuite) TestFilters() {
 
 				switch r.Metadata().ID() {
 				case network.NodeAddressDefaultID:
-					if !reflect.DeepEqual(addrs, ipList("10.0.0.1")) {
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1/8")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				case network.NodeAddressCurrentID:
-					if !reflect.DeepEqual(addrs, ipList("10.0.0.1 25.3.7.9 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1/8 25.3.7.9/32 2001:470:6d:30e:4a62:b3ba:180b:b5b8/64")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				case network.NodeAddressAccumulativeID:
-					if !reflect.DeepEqual(addrs, ipList("10.0.0.1 10.0.0.2 25.3.7.9 192.168.3.7 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1/8 10.0.0.2/8 25.3.7.9/32 192.168.3.7/24 2001:470:6d:30e:4a62:b3ba:180b:b5b8/64")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				case network.FilteredNodeAddressID(network.NodeAddressCurrentID, filter1.Metadata().ID()):
-					if !reflect.DeepEqual(addrs, ipList("25.3.7.9 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+					if !reflect.DeepEqual(addrs, ipList("25.3.7.9/32 2001:470:6d:30e:4a62:b3ba:180b:b5b8/64")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				case network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, filter1.Metadata().ID()):
-					if !reflect.DeepEqual(addrs, ipList("25.3.7.9 192.168.3.7 2001:470:6d:30e:4a62:b3ba:180b:b5b8")) {
+					if !reflect.DeepEqual(addrs, ipList("25.3.7.9/32 192.168.3.7/24 2001:470:6d:30e:4a62:b3ba:180b:b5b8/64")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				case network.FilteredNodeAddressID(network.NodeAddressCurrentID, filter2.Metadata().ID()):
-					if !reflect.DeepEqual(addrs, ipList("10.0.0.1")) {
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1/8")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				case network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, filter2.Metadata().ID()):
-					if !reflect.DeepEqual(addrs, ipList("10.0.0.1 10.0.0.2 192.168.3.7")) {
+					if !reflect.DeepEqual(addrs, ipList("10.0.0.1/8 10.0.0.2/8 192.168.3.7/24")) {
 						return fmt.Errorf("unexpected %q: %s", r.Metadata().ID(), addrs)
 					}
 				}
@@ -237,11 +237,11 @@ func TestNodeAddressSuite(t *testing.T) {
 	suite.Run(t, new(NodeAddressSuite))
 }
 
-func ipList(ips string) []netaddr.IP {
-	var result []netaddr.IP //nolint:prealloc
+func ipList(ips string) []netaddr.IPPrefix {
+	var result []netaddr.IPPrefix //nolint:prealloc
 
 	for _, ip := range strings.Split(ips, " ") {
-		result = append(result, netaddr.MustParseIP(ip))
+		result = append(result, netaddr.MustParseIPPrefix(ip))
 	}
 
 	return result

--- a/internal/app/machined/pkg/controllers/network/status_test.go
+++ b/internal/app/machined/pkg/controllers/network/status_test.go
@@ -90,7 +90,7 @@ func (suite *StatusSuite) TestNone() {
 
 func (suite *StatusSuite) TestAddresses() {
 	nodeAddress := network.NewNodeAddress(network.NamespaceName, network.NodeAddressCurrentID)
-	nodeAddress.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("10.0.0.1")}
+	nodeAddress.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.0.0.1/24")}
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, nodeAddress))
 

--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -279,7 +279,7 @@ func (ctrl *APIController) reconcile(ctx context.Context, r controller.Runtime, 
 
 		var altNames AltNames
 
-		for _, ip := range append(rootSpec.CertSANIPs, nodeAddresses.Addresses...) {
+		for _, ip := range append(rootSpec.CertSANIPs, nodeAddresses.IPs()...) {
 			altNames.AppendIPs(ip.IPAddr().IP)
 		}
 

--- a/internal/app/machined/pkg/controllers/secrets/api_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/api_test.go
@@ -103,7 +103,7 @@ func (suite *APISuite) TestReconcileControlPlane() {
 	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
 
 	nodeAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s))
-	nodeAddresses.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("10.2.1.3"), netaddr.MustParseIP("172.16.0.1")}
+	nodeAddresses.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.2.1.3/24"), netaddr.MustParseIPPrefix("172.16.0.1/32")}
 	suite.Require().NoError(suite.state.Create(suite.ctx, nodeAddresses))
 
 	suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -219,7 +219,7 @@ func (ctrl *KubernetesController) updateSecrets(k8sRoot *secrets.RootKubernetesS
 
 	altNames.AppendIPs(k8sRoot.APIServerIPs...)
 
-	for _, addr := range nodeAddresses.Addresses {
+	for _, addr := range nodeAddresses.IPs() {
 		altNames.AppendIPs(addr.IPAddr().IP)
 	}
 

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes_test.go
@@ -127,7 +127,7 @@ func (suite *KubernetesSuite) TestReconcile() {
 	suite.Require().NoError(suite.state.Create(suite.ctx, hostnameStatus))
 
 	nodeAddresses := network.NewNodeAddress(network.NamespaceName, network.FilteredNodeAddressID(network.NodeAddressAccumulativeID, k8s.NodeAddressFilterNoK8s))
-	nodeAddresses.TypedSpec().Addresses = []netaddr.IP{netaddr.MustParseIP("10.2.1.3"), netaddr.MustParseIP("172.16.0.1")}
+	nodeAddresses.TypedSpec().Addresses = []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.2.1.3/24"), netaddr.MustParseIPPrefix("172.16.0.1/32")}
 	suite.Require().NoError(suite.state.Create(suite.ctx, nodeAddresses))
 
 	timeSync := timeresource.NewStatus()

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -76,6 +76,8 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&time.SyncController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
+		&cluster.ConfigController{},
+		&cluster.LocalAffiliateController{},
 		&cluster.NodeIdentityController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -77,6 +77,8 @@ func NewState() (*State, error) {
 	// register Talos resources
 	for _, r := range []resource.Resource{
 		&v1alpha1.Service{},
+		&cluster.Affiliate{},
+		&cluster.Config{},
 		&cluster.Identity{},
 		&config.MachineConfig{},
 		&config.MachineType{},

--- a/internal/app/maintenance/main.go
+++ b/internal/app/maintenance/main.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, logger *log.Logger, r runtime.Runtime) ([]byte, er
 		return nil, fmt.Errorf("error getting node addresses: %w", err)
 	}
 
-	ips := currentAddresses.(*network.NodeAddress).TypedSpec().Addresses
+	ips := currentAddresses.(*network.NodeAddress).TypedSpec().IPs()
 
 	hostnameStatus, err := r.State().V1Alpha2().Resources().Get(ctx, resource.NewMetadata(network.NamespaceName, network.HostnameStatusType, network.HostnameID, resource.VersionUndefined))
 	if err != nil {

--- a/pkg/machinery/config/types/v1alpha1/machine/machine.go
+++ b/pkg/machinery/config/types/v1alpha1/machine/machine.go
@@ -49,3 +49,17 @@ func ParseType(s string) (Type, error) {
 		return TypeUnknown, fmt.Errorf("invalid machine type: %q", s)
 	}
 }
+
+// MarshalText implements encoding.TextMarshaler.
+func (t Type) MarshalText() (text []byte, err error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (t *Type) UnmarshalText(text []byte) error {
+	var err error
+
+	*t, err = ParseType(string(text))
+
+	return err
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -470,6 +470,9 @@ const (
 
 	// KubeSpanIdentityFilename is the filename to cache KubeSpan identity across reboots.
 	KubeSpanIdentityFilename = "kubespan-identity.yaml"
+
+	// KubeSpanDefaultPort is the default Wireguard listening port for incoming connections.
+	KubeSpanDefaultPort = 51820
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/resources/cluster/affiliate.go
+++ b/pkg/resources/cluster/affiliate.go
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+)
+
+// AffiliateType is type of Affiliate resource.
+const AffiliateType = resource.Type("Affiliates.cluster.talos.dev")
+
+// Affiliate resource holds information about cluster affiliate: it is discovered potential cluster member and/or KubeSpan peer.
+//
+// Controller builds local Affiliate structure for the node itself, other Affiliates are pulled from the registry during the discovery process.
+type Affiliate struct {
+	md   resource.Metadata
+	spec AffiliateSpec
+}
+
+// AffiliateSpec describes Affiliate state.
+type AffiliateSpec struct {
+	Addresses   []netaddr.IP          `yaml:"addresses"`
+	Hostname    string                `yaml:"hostname"`
+	Nodename    string                `yaml:"nodename,omitempty"`
+	MachineType machine.Type          `yaml:"machineType,omitempty"`
+	KubeSpan    KubeSpanAffiliateSpec `yaml:"kubespan,omitempty"`
+}
+
+// KubeSpanAffiliateSpec describes additional information specific for the KubeSpan.
+type KubeSpanAffiliateSpec struct {
+	PublicKey           string             `yaml:"publicKey"`
+	Address             netaddr.IP         `yaml:"address"`
+	AdditionalAddresses []netaddr.IPPrefix `yaml:"additionalAddresses"`
+	Endpoints           []netaddr.IPPort   `yaml:"endpoints"`
+}
+
+// NewAffiliate initializes a Affiliate resource.
+func NewAffiliate(namespace resource.Namespace, id resource.ID) *Affiliate {
+	r := &Affiliate{
+		md:   resource.NewMetadata(namespace, AffiliateType, id, resource.VersionUndefined),
+		spec: AffiliateSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Affiliate) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Affiliate) Spec() interface{} {
+	return r.spec
+}
+
+func (r *Affiliate) String() string {
+	return fmt.Sprintf("cluster.Affiliate(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Affiliate) DeepCopy() resource.Resource {
+	return &Affiliate{
+		md: r.md,
+		spec: AffiliateSpec{
+			Addresses:   append([]netaddr.IP(nil), r.spec.Addresses...),
+			Hostname:    r.spec.Hostname,
+			Nodename:    r.spec.Nodename,
+			MachineType: r.spec.MachineType,
+			KubeSpan: KubeSpanAffiliateSpec{
+				PublicKey:           r.spec.KubeSpan.PublicKey,
+				Address:             r.spec.KubeSpan.Address,
+				AdditionalAddresses: append([]netaddr.IPPrefix(nil), r.spec.KubeSpan.AdditionalAddresses...),
+				Endpoints:           append([]netaddr.IPPort(nil), r.spec.KubeSpan.Endpoints...),
+			},
+		},
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *Affiliate) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             AffiliateType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Hostname",
+				JSONPath: `{.hostname}`,
+			},
+			{
+				Name:     "Addresses",
+				JSONPath: `{.addresses}`,
+			},
+		},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *Affiliate) TypedSpec() *AffiliateSpec {
+	return &r.spec
+}

--- a/pkg/resources/cluster/cluster_test.go
+++ b/pkg/resources/cluster/cluster_test.go
@@ -25,6 +25,8 @@ func TestRegisterResource(t *testing.T) {
 	resourceRegistry := registry.NewResourceRegistry(resources)
 
 	for _, resource := range []resource.Resource{
+		&cluster.Affiliate{},
+		&cluster.Config{},
 		&cluster.Identity{},
 	} {
 		assert.NoError(t, resourceRegistry.Register(ctx, resource))

--- a/pkg/resources/cluster/config.go
+++ b/pkg/resources/cluster/config.go
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package kubespan
+package cluster
 
 import (
 	"fmt"
@@ -14,10 +14,10 @@ import (
 )
 
 // ConfigType is type of Config resource.
-const ConfigType = resource.Type("KubeSpanConfigs.kubespan.talos.dev")
+const ConfigType = resource.Type("DiscoveryConfigs.cluster.talos.dev")
 
 // ConfigID the singleton config resource ID.
-const ConfigID = resource.ID("kubespan")
+const ConfigID = resource.ID("cluster")
 
 // Config resource holds KubeSpan configuration.
 type Config struct {
@@ -27,8 +27,7 @@ type Config struct {
 
 // ConfigSpec describes KubeSpan configuration..
 type ConfigSpec struct {
-	Enabled   bool   `yaml:"enabled"`
-	ClusterID string `yaml:"clusterId"`
+	DiscoveryEnabled bool `yaml:"discoveryEnabled"`
 }
 
 // NewConfig initializes a Config resource.
@@ -54,7 +53,7 @@ func (r *Config) Spec() interface{} {
 }
 
 func (r *Config) String() string {
-	return fmt.Sprintf("kubespan.Config(%q)", r.md.ID())
+	return fmt.Sprintf("cluster.Config(%q)", r.md.ID())
 }
 
 // DeepCopy implements resource.Resource.

--- a/pkg/resources/network/node_address.go
+++ b/pkg/resources/network/node_address.go
@@ -39,7 +39,7 @@ const (
 
 // NodeAddressSpec describes a set of node addresses.
 type NodeAddressSpec struct {
-	Addresses []netaddr.IP `yaml:"addresses"`
+	Addresses []netaddr.IPPrefix `yaml:"addresses"`
 }
 
 // NewNodeAddress initializes a NodeAddress resource.
@@ -73,7 +73,7 @@ func (r *NodeAddress) DeepCopy() resource.Resource {
 	return &NodeAddress{
 		md: r.md,
 		spec: NodeAddressSpec{
-			Addresses: append([]netaddr.IP(nil), r.spec.Addresses...),
+			Addresses: append([]netaddr.IPPrefix(nil), r.spec.Addresses...),
 		},
 	}
 }
@@ -96,6 +96,17 @@ func (r *NodeAddress) ResourceDefinition() meta.ResourceDefinitionSpec {
 // TypedSpec allows to access the Spec with the proper type.
 func (r *NodeAddress) TypedSpec() *NodeAddressSpec {
 	return &r.spec
+}
+
+// IPs returns IP without prefix.
+func (spec *NodeAddressSpec) IPs() []netaddr.IP {
+	result := make([]netaddr.IP, len(spec.Addresses))
+
+	for i := range spec.Addresses {
+		result[i] = spec.Addresses[i].IP()
+	}
+
+	return result
 }
 
 // FilteredNodeAddressID returns resource ID for node addresses with filter applied.


### PR DESCRIPTION
Fixes #4139

This builds the local (for the node) `Affiliate` structure which
describes node for the cluster discovery. Dependending on the
configuration, KubeSpan information might be included as well.

`NodeAddresses` were updated to hold CIDRs instead of simple IPs.

The `Affiliate` will be pushed to the registries, while `Affiliate`s for
other nodes will be fetched back from the registries.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
