### PR TITLE
feat: implement Kubernetes cluster discovery registry

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/affiliate_merge.go
+++ b/internal/app/machined/pkg/controllers/cluster/affiliate_merge.go
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+// AffiliateMergeController merges raw Affiliates from the RawNamespaceName into final representation in the NamespaceName.
+type AffiliateMergeController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *AffiliateMergeController) Name() string {
+	return "cluster.AffiliateMergeController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *AffiliateMergeController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: cluster.RawNamespaceName,
+			Type:      cluster.AffiliateType,
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *AffiliateMergeController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: cluster.AffiliateType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *AffiliateMergeController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		mergedAffiliates := make(map[resource.ID]*cluster.AffiliateSpec)
+
+		rawAffiliates, err := r.List(ctx, resource.NewMetadata(cluster.RawNamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing affiliates")
+		}
+
+		for _, rawAffiliate := range rawAffiliates.Items {
+			affiliateSpec := rawAffiliate.(*cluster.Affiliate).TypedSpec()
+			id := affiliateSpec.NodeID
+
+			if affiliate, ok := mergedAffiliates[id]; ok {
+				affiliate.Merge(affiliateSpec)
+			} else {
+				mergedAffiliates[id] = affiliateSpec
+			}
+		}
+
+		touchedIDs := make(map[resource.ID]struct{})
+
+		for id, affiliateSpec := range mergedAffiliates {
+			affiliateSpec := affiliateSpec
+
+			if err = r.Modify(ctx, cluster.NewAffiliate(cluster.NamespaceName, id), func(res resource.Resource) error {
+				*res.(*cluster.Affiliate).TypedSpec() = *affiliateSpec
+
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			touchedIDs[id] = struct{}{}
+		}
+
+		// list keys for cleanup
+		list, err := r.List(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range list.Items {
+			if res.Metadata().Owner() != ctrl.Name() {
+				continue
+			}
+
+			if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+				if err = r.Destroy(ctx, res.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up specs: %w", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/cluster/affiliate_merge_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/affiliate_merge_test.go
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+
+	clusterctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+type AffiliateMergeSuite struct {
+	ClusterSuite
+}
+
+func (suite *AffiliateMergeSuite) TestReconcileDefault() {
+	suite.startRuntime()
+
+	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.AffiliateMergeController{}))
+
+	affiliate1 := cluster.NewAffiliate(cluster.RawNamespaceName, "k8s/7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
+	*affiliate1.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Hostname:    "foo.com",
+		Nodename:    "bar",
+		MachineType: machine.TypeControlPlane,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.4")},
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+			Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+		},
+	}
+
+	affiliate2 := cluster.NewAffiliate(cluster.RawNamespaceName, "service/7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
+	*affiliate2.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Hostname:    "foo.com",
+		Nodename:    "bar",
+		MachineType: machine.TypeControlPlane,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.4"), netaddr.MustParseIP("10.5.0.2")},
+	}
+
+	affiliate3 := cluster.NewAffiliate(cluster.RawNamespaceName, "service/9dwHNUViZlPlIervqX9Qo256RUhrfhgO0xBBnKcKl4F")
+	*affiliate3.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "9dwHNUViZlPlIervqX9Qo256RUhrfhgO0xBBnKcKl4F",
+		Hostname:    "worker-1",
+		Nodename:    "worker-1",
+		MachineType: machine.TypeWorker,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.5")},
+	}
+
+	for _, r := range []resource.Resource{affiliate1, affiliate2, affiliate3} {
+		suite.Require().NoError(suite.state.Create(suite.ctx, r))
+	}
+
+	// there should be two merged affiliates: one from affiliate1+affiliate2, and another from affiliate3
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewAffiliate(cluster.NamespaceName, affiliate1.TypedSpec().NodeID).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Affiliate).TypedSpec()
+
+			suite.Assert().Equal(affiliate1.TypedSpec().NodeID, spec.NodeID)
+			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("192.168.3.4"), netaddr.MustParseIP("10.5.0.2")}, spec.Addresses)
+			suite.Assert().Equal("foo.com", spec.Hostname)
+			suite.Assert().Equal("bar", spec.Nodename)
+			suite.Assert().Equal(machine.TypeControlPlane, spec.MachineType)
+			suite.Assert().Equal(netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"), spec.KubeSpan.Address)
+			suite.Assert().Equal("PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=", spec.KubeSpan.PublicKey)
+			suite.Assert().Equal([]netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")}, spec.KubeSpan.AdditionalAddresses)
+			suite.Assert().Equal([]netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")}, spec.KubeSpan.Endpoints)
+
+			return nil
+		}),
+	))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewAffiliate(cluster.NamespaceName, affiliate3.TypedSpec().NodeID).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Affiliate).TypedSpec()
+
+			suite.Assert().Equal(affiliate3.TypedSpec().NodeID, spec.NodeID)
+			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("192.168.3.5")}, spec.Addresses)
+			suite.Assert().Equal("worker-1", spec.Hostname)
+			suite.Assert().Equal("worker-1", spec.Nodename)
+			suite.Assert().Equal(machine.TypeWorker, spec.MachineType)
+			suite.Assert().Zero(spec.KubeSpan.PublicKey)
+
+			return nil
+		}),
+	))
+
+	// remove affiliate2, KubeSpan information should eventually go away
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, affiliate1.Metadata()))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewAffiliate(cluster.NamespaceName, affiliate1.TypedSpec().NodeID).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Affiliate).TypedSpec()
+
+			suite.Assert().Equal(affiliate1.TypedSpec().NodeID, spec.NodeID)
+
+			if spec.KubeSpan.PublicKey != "" {
+				return retry.ExpectedErrorf("not reconciled yet")
+			}
+
+			suite.Assert().Zero(spec.KubeSpan.Address)
+			suite.Assert().Zero(spec.KubeSpan.PublicKey)
+			suite.Assert().Zero(spec.KubeSpan.AdditionalAddresses)
+			suite.Assert().Zero(spec.KubeSpan.Endpoints)
+
+			return nil
+		}),
+	))
+
+	// remove affiliate3, merged affiliate should be removed
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, affiliate3.Metadata()))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertNoResource(*cluster.NewAffiliate(cluster.NamespaceName, affiliate3.TypedSpec().NodeID).Metadata()),
+	))
+}
+
+func TestAffiliateMergeSuite(t *testing.T) {
+	suite.Run(t, new(AffiliateMergeSuite))
+}

--- a/internal/app/machined/pkg/controllers/cluster/config.go
+++ b/internal/app/machined/pkg/controllers/cluster/config.go
@@ -72,6 +72,10 @@ func (ctrl *ConfigController) Run(ctx context.Context, r controller.Runtime, log
 				if err = r.Modify(ctx, cluster.NewConfig(config.NamespaceName, cluster.ConfigID), func(res resource.Resource) error {
 					res.(*cluster.Config).TypedSpec().DiscoveryEnabled = c.Cluster().Discovery().Enabled()
 
+					if c.Cluster().Discovery().Enabled() {
+						res.(*cluster.Config).TypedSpec().RegistryKubernetesEnabled = c.Cluster().Discovery().Registries().Kubernetes().Enabled()
+					}
+
 					return nil
 				}); err != nil {
 					return err

--- a/internal/app/machined/pkg/controllers/cluster/config_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/config_test.go
@@ -46,6 +46,7 @@ func (suite *ConfigSuite) TestReconcileConfig() {
 				spec := res.(*cluster.Config).TypedSpec()
 
 				suite.Assert().True(spec.DiscoveryEnabled)
+				suite.Assert().True(spec.RegistryKubernetesEnabled)
 
 				return nil
 			},
@@ -75,6 +76,7 @@ func (suite *ConfigSuite) TestReconcileDisabled() {
 				spec := res.(*cluster.Config).TypedSpec()
 
 				suite.Assert().False(spec.DiscoveryEnabled)
+				suite.Assert().False(spec.RegistryKubernetesEnabled)
 
 				return nil
 			},

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
@@ -1,0 +1,182 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/internal/pkg/discovery/registry"
+	"github.com/talos-systems/talos/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/kubernetes"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/config"
+	"github.com/talos-systems/talos/pkg/resources/k8s"
+)
+
+// KubernetesPullController pulls list of Affiliate resource from the Kubernetes registry.
+type KubernetesPullController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *KubernetesPullController) Name() string {
+	return "cluster.KubernetesPullController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *KubernetesPullController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      cluster.ConfigType,
+			ID:        pointer.ToString(cluster.ConfigID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: k8s.ControlPlaneNamespaceName,
+			Type:      k8s.NodenameType,
+			ID:        pointer.ToString(k8s.NodenameID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *KubernetesPullController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: cluster.AffiliateType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo,cyclop
+func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	var (
+		kubernetesClient   *kubernetes.Client
+		kubernetesRegistry *registry.Kubernetes
+		watchCtxCancel     context.CancelFunc
+		notifyCh           <-chan struct{}
+	)
+
+	defer func() {
+		if watchCtxCancel != nil {
+			watchCtxCancel()
+		}
+
+		if kubernetesClient != nil {
+			kubernetesClient.Close() //nolint:errcheck
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		case <-notifyCh:
+		}
+
+		discoveryConfig, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, cluster.ConfigType, cluster.ConfigID, resource.VersionUndefined))
+		if err != nil {
+			if !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting discovery config: %w", err)
+			}
+
+			continue
+		}
+
+		if !discoveryConfig.(*cluster.Config).TypedSpec().RegistryKubernetesEnabled {
+			continue
+		}
+
+		logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))
+
+		if err = conditions.WaitForFileToExist(constants.KubeletKubeconfig).Wait(ctx); err != nil {
+			return err
+		}
+
+		nodename, err := r.Get(ctx, resource.NewMetadata(k8s.ControlPlaneNamespaceName, k8s.NodenameType, k8s.NodenameID, resource.VersionUndefined))
+		if err != nil {
+			if !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting nodename: %w", err)
+			}
+
+			continue
+		}
+
+		if kubernetesClient == nil {
+			kubernetesClient, err = kubernetes.NewClientFromKubeletKubeconfig()
+			if err != nil {
+				return fmt.Errorf("error building kubernetes client: %w", err)
+			}
+		}
+
+		if kubernetesRegistry == nil {
+			kubernetesRegistry = registry.NewKubernetes(kubernetesClient)
+		}
+
+		if notifyCh == nil {
+			var watchCtx context.Context
+
+			watchCtx, watchCtxCancel = context.WithCancel(ctx) //nolint:govet
+
+			notifyCh, err = kubernetesRegistry.Watch(watchCtx, logger)
+			if err != nil {
+				return fmt.Errorf("error setting up registry watcher: %w", err) //nolint:govet
+			}
+		}
+
+		affiliateSpecs, err := kubernetesRegistry.List(nodename.(*k8s.Nodename).TypedSpec().Nodename)
+		if err != nil {
+			return fmt.Errorf("error listing affiliates: %w", err)
+		}
+
+		touchedIDs := make(map[resource.ID]struct{})
+
+		for _, affilateSpec := range affiliateSpecs {
+			id := fmt.Sprintf("k8s/%s", affilateSpec.NodeID)
+
+			affilateSpec := affilateSpec
+
+			if err = r.Modify(ctx, cluster.NewAffiliate(cluster.RawNamespaceName, id), func(res resource.Resource) error {
+				*res.(*cluster.Affiliate).TypedSpec() = *affilateSpec
+
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			touchedIDs[id] = struct{}{}
+		}
+
+		// list keys for cleanup
+		list, err := r.List(ctx, resource.NewMetadata(cluster.RawNamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range list.Items {
+			if res.Metadata().Owner() != ctrl.Name() {
+				continue
+			}
+
+			if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+				if err = r.Destroy(ctx, res.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up specs: %w", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/internal/pkg/discovery/registry"
+	"github.com/talos-systems/talos/pkg/conditions"
+	"github.com/talos-systems/talos/pkg/kubernetes"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/config"
+)
+
+// KubernetesPushController pushes Affiliate resource to the Kubernetes registry.
+type KubernetesPushController struct {
+	localAffiliateID resource.ID
+	kubernetesClient *kubernetes.Client
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *KubernetesPushController) Name() string {
+	return "cluster.KubernetesPushController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *KubernetesPushController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      cluster.ConfigType,
+			ID:        pointer.ToString(cluster.ConfigID),
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: cluster.NamespaceName,
+			Type:      cluster.IdentityType,
+			ID:        pointer.ToString(cluster.LocalIdentity),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *KubernetesPushController) Outputs() []controller.Output {
+	return nil
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	defer func() {
+		if ctrl.kubernetesClient != nil {
+			ctrl.kubernetesClient.Close() //nolint:errcheck
+		}
+
+		ctrl.kubernetesClient = nil
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+			discoveryConfig, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, cluster.ConfigType, cluster.ConfigID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting discovery config: %w", err)
+				}
+
+				continue
+			}
+
+			if !discoveryConfig.(*cluster.Config).TypedSpec().RegistryKubernetesEnabled {
+				continue
+			}
+
+			if err = conditions.WaitForFileToExist(constants.KubeletKubeconfig).Wait(ctx); err != nil {
+				return err
+			}
+
+			identity, err := r.Get(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.IdentityType, cluster.LocalIdentity, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting local identity: %w", err)
+				}
+
+				continue
+			}
+
+			localAffiliateID := identity.(*cluster.Identity).TypedSpec().NodeID
+
+			if ctrl.localAffiliateID != localAffiliateID {
+				ctrl.localAffiliateID = localAffiliateID
+
+				if err = r.UpdateInputs(append(ctrl.Inputs(),
+					controller.Input{
+						Namespace: cluster.NamespaceName,
+						Type:      cluster.AffiliateType,
+						ID:        pointer.ToString(ctrl.localAffiliateID),
+						Kind:      controller.InputWeak,
+					},
+				)); err != nil {
+					return err
+				}
+			}
+
+			affiliate, err := r.Get(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.AffiliateType, ctrl.localAffiliateID, resource.VersionUndefined))
+			if err != nil {
+				if !state.IsNotFoundError(err) {
+					return fmt.Errorf("error getting local affiliate: %w", err)
+				}
+
+				continue
+			}
+
+			if ctrl.kubernetesClient == nil {
+				ctrl.kubernetesClient, err = kubernetes.NewClientFromKubeletKubeconfig()
+				if err != nil {
+					return fmt.Errorf("error building kubernetes client: %w", err)
+				}
+			}
+
+			if err = registry.NewKubernetes(ctrl.kubernetesClient).Push(ctx, affiliate.(*cluster.Affiliate)); err != nil {
+				// reset client connection
+				ctrl.kubernetesClient.Close() //nolint:errcheck
+				ctrl.kubernetesClient = nil
+
+				return fmt.Errorf("error pushing to Kubernetes registry: %w", err)
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -173,6 +173,7 @@ func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runt
 				if err = r.Modify(ctx, cluster.NewAffiliate(cluster.NamespaceName, localID), func(res resource.Resource) error {
 					spec := res.(*cluster.Affiliate).TypedSpec()
 
+					spec.NodeID = localID
 					spec.Addresses = append([]netaddr.IP(nil), addresses.(*network.NodeAddress).TypedSpec().IPs()...)
 					spec.Hostname = hostname.(*network.HostnameStatus).TypedSpec().FQDN()
 					spec.Nodename = nodename.(*k8s.Nodename).TypedSpec().Nodename

--- a/internal/app/machined/pkg/controllers/cluster/member.go
+++ b/internal/app/machined/pkg/controllers/cluster/member.go
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+// MemberController converts Affiliates which have Nodename set into Members.
+type MemberController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *MemberController) Name() string {
+	return "cluster.MemberController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *MemberController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: cluster.NamespaceName,
+			Type:      cluster.AffiliateType,
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *MemberController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: cluster.MemberType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *MemberController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		affiliates, err := r.List(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing affiliates")
+		}
+
+		touchedIDs := make(map[resource.ID]struct{})
+
+		for _, affiliate := range affiliates.Items {
+			affiliateSpec := affiliate.(*cluster.Affiliate).TypedSpec()
+			if affiliateSpec.Nodename == "" {
+				// not a cluster member
+				continue
+			}
+
+			if err = r.Modify(ctx, cluster.NewMember(cluster.NamespaceName, affiliateSpec.Nodename), func(res resource.Resource) error {
+				spec := res.(*cluster.Member).TypedSpec()
+
+				spec.Addresses = append([]netaddr.IP(nil), affiliateSpec.Addresses...)
+				spec.Hostname = affiliateSpec.Hostname
+				spec.MachineType = affiliateSpec.MachineType
+				spec.NodeID = affiliateSpec.NodeID
+
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			touchedIDs[affiliateSpec.Nodename] = struct{}{}
+		}
+
+		// list keys for cleanup
+		list, err := r.List(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.MemberType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range list.Items {
+			if res.Metadata().Owner() != ctrl.Name() {
+				continue
+			}
+
+			if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+				if err = r.Destroy(ctx, res.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up specs: %w", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/cluster/member_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/member_test.go
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package cluster_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+
+	clusterctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+type MemberSuite struct {
+	ClusterSuite
+}
+
+func (suite *MemberSuite) TestReconcileDefault() {
+	suite.startRuntime()
+
+	suite.Require().NoError(suite.runtime.RegisterController(&clusterctrl.MemberController{}))
+
+	affiliate1 := cluster.NewAffiliate(cluster.NamespaceName, "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
+	*affiliate1.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Hostname:    "foo.com",
+		Nodename:    "bar",
+		MachineType: machine.TypeControlPlane,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.4")},
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+			Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+		},
+	}
+
+	affiliate2 := cluster.NewAffiliate(cluster.NamespaceName, "9dwHNUViZlPlIervqX9Qo256RUhrfhgO0xBBnKcKl4F")
+	*affiliate2.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "9dwHNUViZlPlIervqX9Qo256RUhrfhgO0xBBnKcKl4F",
+		Hostname:    "worker-1",
+		Nodename:    "worker-1",
+		MachineType: machine.TypeWorker,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.5")},
+	}
+
+	affiliate3 := cluster.NewAffiliate(cluster.NamespaceName, "xCnFFfxylOf9i5ynhAkt6ZbfcqaLDGKfIa3gwpuaxe7F")
+	*affiliate3.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "xCnFFfxylOf9i5ynhAkt6ZbfcqaLDGKfIa3gwpuaxe7F",
+		MachineType: machine.TypeWorker,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.6")},
+	}
+
+	for _, r := range []resource.Resource{affiliate1, affiliate2, affiliate3} {
+		suite.Require().NoError(suite.state.Create(suite.ctx, r))
+	}
+
+	// affiliates with non-empty Nodename should be translated to Members
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewMember(cluster.NamespaceName, affiliate1.TypedSpec().Nodename).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Member).TypedSpec()
+
+			suite.Assert().Equal(affiliate1.TypedSpec().NodeID, spec.NodeID)
+			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("192.168.3.4")}, spec.Addresses)
+			suite.Assert().Equal("foo.com", spec.Hostname)
+			suite.Assert().Equal(machine.TypeControlPlane, spec.MachineType)
+
+			return nil
+		}),
+	))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*cluster.NewMember(cluster.NamespaceName, affiliate2.TypedSpec().Nodename).Metadata(), func(r resource.Resource) error {
+			spec := r.(*cluster.Member).TypedSpec()
+
+			suite.Assert().Equal(affiliate2.TypedSpec().NodeID, spec.NodeID)
+			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("192.168.3.5")}, spec.Addresses)
+			suite.Assert().Equal("worker-1", spec.Hostname)
+			suite.Assert().Equal(machine.TypeWorker, spec.MachineType)
+
+			return nil
+		}),
+	))
+
+	// remove affiliate2, member information should eventually go away
+	suite.Require().NoError(suite.state.Destroy(suite.ctx, affiliate2.Metadata()))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertNoResource(*cluster.NewMember(cluster.NamespaceName, affiliate2.TypedSpec().Nodename).Metadata()),
+	))
+}
+
+func TestMemberSuite(t *testing.T) {
+	suite.Run(t, new(MemberSuite))
+}

--- a/internal/app/machined/pkg/controllers/secrets/kubernetes.go
+++ b/internal/app/machined/pkg/controllers/secrets/kubernetes.go
@@ -124,8 +124,6 @@ func (ctrl *KubernetesController) Run(ctx context.Context, r controller.Runtime,
 
 	r.QueueReconcile()
 
-	rateLimitedEventCh := RateLimitEvents(ctx, r.EventCh(), time.Minute)
-
 	refreshTicker := time.NewTicker(KubernetesCertificateValidityDuration / 2)
 	defer refreshTicker.Stop()
 
@@ -133,7 +131,7 @@ func (ctrl *KubernetesController) Run(ctx context.Context, r controller.Runtime,
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-rateLimitedEventCh:
+		case <-r.EventCh():
 		case <-refreshTicker.C:
 		}
 

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -76,8 +76,12 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&time.SyncController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},
+		&cluster.AffiliateMergeController{},
 		&cluster.ConfigController{},
 		&cluster.LocalAffiliateController{},
+		&cluster.MemberController{},
+		&cluster.KubernetesPullController{},
+		&cluster.KubernetesPushController{},
 		&cluster.NodeIdentityController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
 		},

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -60,6 +60,7 @@ func NewState() (*State, error) {
 	}{
 		{v1alpha1.NamespaceName, "Talos v1alpha1 subsystems glue resources."},
 		{cluster.NamespaceName, "Cluster configuration and discovery resources."},
+		{cluster.RawNamespaceName, "Cluster unmerged raw resources."},
 		{config.NamespaceName, "Talos node configuration."},
 		{files.NamespaceName, "Files and file-like resources."},
 		{k8s.ControlPlaneNamespaceName, "Kubernetes control plane resources."},
@@ -80,6 +81,7 @@ func NewState() (*State, error) {
 		&cluster.Affiliate{},
 		&cluster.Config{},
 		&cluster.Identity{},
+		&cluster.Member{},
 		&config.MachineConfig{},
 		&config.MachineType{},
 		&config.K8sControlPlane{},

--- a/internal/pkg/discovery/registry/kubernetes.go
+++ b/internal/pkg/discovery/registry/kubernetes.go
@@ -1,0 +1,290 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/informers"
+	informersv1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/talos-systems/talos/pkg/kubernetes"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+// Kubernetes defines a Kubernetes-based node discoverer.
+type Kubernetes struct {
+	client *kubernetes.Client
+
+	nodes informersv1.NodeInformer
+}
+
+// NewKubernetes creates new Kubernetes registry.
+func NewKubernetes(client *kubernetes.Client) *Kubernetes {
+	return &Kubernetes{
+		client: client,
+	}
+}
+
+// AnnotationsFromAffiliate generates Kubernetes Node annotations from the Affiliate spec.
+func AnnotationsFromAffiliate(affiliate *cluster.Affiliate) map[string]string {
+	var kubeSpanAddress string
+
+	if !affiliate.TypedSpec().KubeSpan.Address.IsZero() {
+		kubeSpanAddress = affiliate.TypedSpec().KubeSpan.Address.String()
+	}
+
+	return map[string]string{
+		constants.ClusterNodeIDAnnotation:            affiliate.Metadata().ID(),
+		constants.NetworkSelfIPsAnnotation:           ipsToString(affiliate.TypedSpec().Addresses),
+		constants.KubeSpanIPAnnotation:               kubeSpanAddress,
+		constants.KubeSpanPublicKeyAnnotation:        affiliate.TypedSpec().KubeSpan.PublicKey,
+		constants.KubeSpanAssignedPrefixesAnnotation: ipPrefixesToString(affiliate.TypedSpec().KubeSpan.AdditionalAddresses),
+		constants.KubeSpanKnownEndpointsAnnotation:   ipPortsToString(affiliate.TypedSpec().KubeSpan.Endpoints),
+	}
+}
+
+// AffiliateFromNode converts Kubernetes Node resource to Affiliate.
+//
+// If the Node resource doesn't have cluster discovery annotations, nil is returned.
+//
+//nolint:gocyclo
+func AffiliateFromNode(node *v1.Node) *cluster.AffiliateSpec {
+	nodeID, ok := node.Annotations[constants.ClusterNodeIDAnnotation]
+	if !ok {
+		// skip the node, not part of the cluster discovery process
+		return nil
+	}
+
+	affiliate := &cluster.AffiliateSpec{
+		NodeID: nodeID,
+	}
+
+	if selfIPs, ok := node.Annotations[constants.NetworkSelfIPsAnnotation]; ok {
+		affiliate.Addresses = parseIPs(selfIPs)
+	}
+
+	// Nodename and hostname are pulled from native Kubernetes fields.
+	affiliate.Nodename = node.Name
+
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == v1.NodeHostName {
+			affiliate.Hostname = addr.Address
+
+			break
+		}
+	}
+
+	// Machine type is derived from node roles.
+	_, labelMaster := node.Labels[constants.LabelNodeRoleMaster]
+	_, labelControlPlane := node.Labels[constants.LabelNodeRoleControlPlane]
+
+	affiliate.MachineType = machine.TypeWorker
+
+	if labelMaster || labelControlPlane {
+		affiliate.MachineType = machine.TypeControlPlane
+	}
+
+	// Every other field is pulled from node annotations.
+	if publicKey, ok := node.Annotations[constants.KubeSpanPublicKeyAnnotation]; ok {
+		affiliate.KubeSpan.PublicKey = publicKey
+	}
+
+	if ksIP, ok := node.Annotations[constants.KubeSpanIPAnnotation]; ok {
+		affiliate.KubeSpan.Address, _ = netaddr.ParseIP(ksIP) //nolint:errcheck
+	}
+
+	if additionalAddresses, ok := node.Annotations[constants.KubeSpanAssignedPrefixesAnnotation]; ok {
+		affiliate.KubeSpan.AdditionalAddresses = parseIPPrefixes(additionalAddresses)
+	}
+
+	if endpoints, ok := node.Annotations[constants.KubeSpanKnownEndpointsAnnotation]; ok {
+		affiliate.KubeSpan.Endpoints = parseIPPorts(endpoints)
+	}
+
+	return affiliate
+}
+
+func ipsToString(in []netaddr.IP) string {
+	items := make([]string, len(in))
+
+	for i := range in {
+		items[i] = in[i].String()
+	}
+
+	return strings.Join(items, ",")
+}
+
+func ipPrefixesToString(in []netaddr.IPPrefix) string {
+	items := make([]string, len(in))
+
+	for i := range in {
+		items[i] = in[i].String()
+	}
+
+	return strings.Join(items, ",")
+}
+
+func ipPortsToString(in []netaddr.IPPort) string {
+	items := make([]string, len(in))
+
+	for i := range in {
+		items[i] = in[i].String()
+	}
+
+	return strings.Join(items, ",")
+}
+
+func parseIPs(in string) []netaddr.IP {
+	var result []netaddr.IP
+
+	for _, item := range strings.Split(in, ",") {
+		if ip, err := netaddr.ParseIP(item); err == nil {
+			result = append(result, ip)
+		}
+	}
+
+	return result
+}
+
+func parseIPPrefixes(in string) []netaddr.IPPrefix {
+	var result []netaddr.IPPrefix
+
+	for _, item := range strings.Split(in, ",") {
+		if ip, err := netaddr.ParseIPPrefix(item); err == nil {
+			result = append(result, ip)
+		}
+	}
+
+	return result
+}
+
+func parseIPPorts(in string) []netaddr.IPPort {
+	var result []netaddr.IPPort
+
+	for _, item := range strings.Split(in, ",") {
+		if ip, err := netaddr.ParseIPPort(item); err == nil {
+			result = append(result, ip)
+		}
+	}
+
+	return result
+}
+
+// Push updates Kubernetes Node resource to track Affiliate state.
+func (r *Kubernetes) Push(ctx context.Context, affiliate *cluster.Affiliate) error {
+	node, err := r.client.CoreV1().Nodes().Get(ctx, affiliate.TypedSpec().Nodename, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get node %q: %w", affiliate.TypedSpec().Nodename, err)
+	}
+
+	oldData, err := json.Marshal(node)
+	if err != nil {
+		return fmt.Errorf("failed to marshal existing node data: %w", err)
+	}
+
+	for key, value := range AnnotationsFromAffiliate(affiliate) {
+		if value == "" {
+			delete(node.Annotations, key)
+		} else {
+			node.Annotations[key] = value
+		}
+	}
+
+	newData, err := json.Marshal(node)
+	if err != nil {
+		return fmt.Errorf("failed to marshal new data for node %q: %w", node.Name, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	if err != nil {
+		return fmt.Errorf("failed to create two way merge patch: %w", err)
+	}
+
+	if _, err := r.client.CoreV1().Nodes().Patch(ctx, affiliate.TypedSpec().Nodename, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			return fmt.Errorf("unable to update node %q due to conflict: %w", affiliate.TypedSpec().Nodename, err)
+		}
+
+		return fmt.Errorf("error patching node %q: %w", affiliate.TypedSpec().Nodename, err)
+	}
+
+	return nil
+}
+
+// List returns list of Affiliates coming from the registry.
+//
+// Watch should be called first for the List to return data.
+func (r *Kubernetes) List(localNodeName string) ([]*cluster.AffiliateSpec, error) {
+	if r.nodes == nil {
+		return nil, fmt.Errorf("List() called without Watch() first")
+	}
+
+	nodes, err := r.nodes.Lister().List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*cluster.AffiliateSpec, 0, len(nodes))
+
+	for _, node := range nodes {
+		// skip this node, no need to pull itself
+		if node.Name == localNodeName {
+			continue
+		}
+
+		affiliate := AffiliateFromNode(node)
+		if affiliate == nil {
+			continue
+		}
+
+		result = append(result, affiliate)
+	}
+
+	return result, nil
+}
+
+// Watch starts watching Node state and notifies on updates via notify channel.
+func (r *Kubernetes) Watch(ctx context.Context, logger *zap.Logger) (<-chan struct{}, error) {
+	informerFactory := informers.NewSharedInformerFactory(r.client.Clientset, 30*time.Second)
+
+	notifyCh := make(chan struct{}, 1)
+
+	notify := func(_ interface{}) {
+		select {
+		case notifyCh <- struct{}{}:
+		default:
+		}
+	}
+
+	r.nodes = informerFactory.Core().V1().Nodes()
+	r.nodes.Informer().SetWatchErrorHandler(func(r *cache.Reflector, err error) { //nolint:errcheck
+		logger.Error("kubernetes registry node watch error", zap.Error(err))
+	})
+	r.nodes.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    notify,
+		DeleteFunc: notify,
+		UpdateFunc: func(_, _ interface{}) { notify(nil) },
+	})
+
+	informerFactory.Start(ctx.Done())
+
+	return notifyCh, nil
+}

--- a/internal/pkg/discovery/registry/kubernetes_test.go
+++ b/internal/pkg/discovery/registry/kubernetes_test.go
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package registry_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"inet.af/netaddr"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/talos-systems/talos/internal/pkg/discovery/registry"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+func TestAnnotationsFromAffiliate(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		affiliate cluster.AffiliateSpec
+		expected  map[string]string
+	}{
+		{
+			name: "zero",
+			expected: map[string]string{
+				"cluster.talos.dev/node-id":                "",
+				"networking.talos.dev/assigned-prefixes":   "",
+				"networking.talos.dev/kubespan-endpoints":  "",
+				"networking.talos.dev/kubespan-ip":         "",
+				"networking.talos.dev/kubespan-public-key": "",
+				"networking.talos.dev/self-ips":            "",
+			},
+		},
+		{
+			name: "mixed",
+			affiliate: cluster.AffiliateSpec{
+				NodeID:      "29QQTc97U5ZyFTIX33Dp9NqtwxqQI8QI13scCLzffrZ",
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+					Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+				},
+			},
+			expected: map[string]string{
+				"cluster.talos.dev/node-id":                "29QQTc97U5ZyFTIX33Dp9NqtwxqQI8QI13scCLzffrZ",
+				"networking.talos.dev/assigned-prefixes":   "10.244.3.1/24",
+				"networking.talos.dev/kubespan-endpoints":  "10.0.0.2:51820,192.168.3.4:51820",
+				"networking.talos.dev/kubespan-ip":         "fd50:8d60:4238:6302:f857:23ff:fe21:d1e0",
+				"networking.talos.dev/kubespan-public-key": "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+				"networking.talos.dev/self-ips":            "10.0.0.2,192.168.3.4",
+			},
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			affiliate := cluster.NewAffiliate(cluster.NamespaceName, tt.affiliate.NodeID)
+			*affiliate.TypedSpec() = tt.affiliate
+
+			assert.Equal(t, tt.expected, registry.AnnotationsFromAffiliate(affiliate))
+		})
+	}
+}
+
+func TestAffiliateFromNode(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		node     v1.Node
+		expected *cluster.AffiliateSpec
+	}{
+		{
+			name: "no annotations",
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "worker-1",
+					Annotations: map[string]string{},
+				},
+				Spec: v1.NodeSpec{},
+			},
+			expected: nil,
+		},
+		{
+			name: "discovered",
+			node: v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar",
+					Annotations: map[string]string{
+						"cluster.talos.dev/node-id":                "29QQTc97U5ZyFTIX33Dp9NqtwxqQI8QI13scCLzffrZ",
+						"networking.talos.dev/assigned-prefixes":   "10.244.3.1/24",
+						"networking.talos.dev/kubespan-endpoints":  "10.0.0.2:51820,192.168.3.4:51820",
+						"networking.talos.dev/kubespan-ip":         "fd50:8d60:4238:6302:f857:23ff:fe21:d1e0",
+						"networking.talos.dev/kubespan-public-key": "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+						"networking.talos.dev/self-ips":            "10.0.0.2,192.168.3.4",
+					},
+					Labels: map[string]string{
+						constants.LabelNodeRoleControlPlane: "",
+					},
+				},
+				Spec: v1.NodeSpec{},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeHostName,
+							Address: "foo.com",
+						},
+					},
+				},
+			},
+			expected: &cluster.AffiliateSpec{
+				NodeID:      "29QQTc97U5ZyFTIX33Dp9NqtwxqQI8QI13scCLzffrZ",
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+					Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+				},
+			},
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, registry.AffiliateFromNode(&tt.node))
+		})
+	}
+}

--- a/internal/pkg/discovery/registry/registry.go
+++ b/internal/pkg/discovery/registry/registry.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package registry provides code to push and pull Affiliates to different registries.
+package registry

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -473,6 +473,24 @@ const (
 
 	// KubeSpanDefaultPort is the default Wireguard listening port for incoming connections.
 	KubeSpanDefaultPort = 51820
+
+	// NetworkSelfIPsAnnotation is the node annotation used to list the (comma-separated) IP addresses of the host, as discovered by Talos tooling.
+	NetworkSelfIPsAnnotation = "networking.talos.dev/self-ips"
+
+	// ClusterNodeIDAnnotation is the node annotation used to represent node ID.
+	ClusterNodeIDAnnotation = "cluster.talos.dev/node-id"
+
+	// KubeSpanIPAnnotation is the node annotation to be used for indicating the Wireguard IP of the node.
+	KubeSpanIPAnnotation = "networking.talos.dev/kubespan-ip"
+
+	// KubeSpanPublicKeyAnnotation is the node annotation to be used for indicating the Wireguard Public Key of the node.
+	KubeSpanPublicKeyAnnotation = "networking.talos.dev/kubespan-public-key"
+
+	// KubeSpanAssignedPrefixesAnnotation is the node annotation use to list the (comma-separated) set of IP prefixes for which the annotated node should be responsible.
+	KubeSpanAssignedPrefixesAnnotation = "networking.talos.dev/assigned-prefixes"
+
+	// KubeSpanKnownEndpointsAnnotation is the node annotation used to list the (comma-separated) known-good Wireguard endpoints for the node, as seen by other peers.
+	KubeSpanKnownEndpointsAnnotation = "networking.talos.dev/kubespan-endpoints"
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/resources/cluster/affiliate_test.go
+++ b/pkg/resources/cluster/affiliate_test.go
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+)
+
+func TestAffiliateSpec_Merge(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		a, b, expected cluster.AffiliateSpec
+	}{
+		{
+			name: "zero",
+		},
+		{
+			name: "merge kubespan",
+			a: cluster.AffiliateSpec{
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2")},
+			},
+			b: cluster.AffiliateSpec{
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+					Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+				},
+			},
+			expected: cluster.AffiliateSpec{
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+					Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+				},
+			},
+		},
+		{
+			name: "merge mixed",
+			a: cluster.AffiliateSpec{
+				Addresses: []netaddr.IP{netaddr.MustParseIP("10.0.0.2")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey: "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:   netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					Endpoints: []netaddr.IPPort{netaddr.MustParseIPPort("192.168.3.4:51820")},
+				},
+			},
+			b: cluster.AffiliateSpec{
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.4")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+					Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+				},
+			},
+			expected: cluster.AffiliateSpec{
+				Hostname:    "foo.com",
+				Nodename:    "bar",
+				MachineType: machine.TypeControlPlane,
+				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				KubeSpan: cluster.KubeSpanAffiliateSpec{
+					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+					AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+					Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("192.168.3.4:51820"), netaddr.MustParseIPPort("10.0.0.2:51820")},
+				},
+			},
+		},
+	} {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			spec := tt.a
+			spec.Merge(&tt.b)
+
+			assert.Equal(t, tt.expected, spec)
+		})
+	}
+}

--- a/pkg/resources/cluster/cluster.go
+++ b/pkg/resources/cluster/cluster.go
@@ -8,3 +8,6 @@ import "github.com/cosi-project/runtime/pkg/resource"
 
 // NamespaceName contains resources related to cluster as a whole.
 const NamespaceName resource.Namespace = "cluster"
+
+// RawNamespaceName contains raw resources which haven't gone through the merge phase yet.
+const RawNamespaceName resource.Namespace = "cluster-raw"

--- a/pkg/resources/cluster/cluster_test.go
+++ b/pkg/resources/cluster/cluster_test.go
@@ -28,6 +28,7 @@ func TestRegisterResource(t *testing.T) {
 		&cluster.Affiliate{},
 		&cluster.Config{},
 		&cluster.Identity{},
+		&cluster.Member{},
 	} {
 		assert.NoError(t, resourceRegistry.Register(ctx, resource))
 	}

--- a/pkg/resources/cluster/config.go
+++ b/pkg/resources/cluster/config.go
@@ -27,7 +27,8 @@ type Config struct {
 
 // ConfigSpec describes KubeSpan configuration..
 type ConfigSpec struct {
-	DiscoveryEnabled bool `yaml:"discoveryEnabled"`
+	DiscoveryEnabled          bool `yaml:"discoveryEnabled"`
+	RegistryKubernetesEnabled bool `yaml:"registryKubernetesEnabled"`
 }
 
 // NewConfig initializes a Config resource.

--- a/pkg/resources/cluster/member.go
+++ b/pkg/resources/cluster/member.go
@@ -1,0 +1,101 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+)
+
+// MemberType is type of Member resource.
+const MemberType = resource.Type("Members.cluster.talos.dev")
+
+// Member resource contains information about discovered cluster members.
+//
+// Members are usually derived from Affiliates.
+type Member struct {
+	md   resource.Metadata
+	spec MemberSpec
+}
+
+// MemberSpec describes Member state.
+type MemberSpec struct {
+	NodeID      string       `yaml:"nodeId"`
+	Addresses   []netaddr.IP `yaml:"addresses"`
+	Hostname    string       `yaml:"hostname"`
+	MachineType machine.Type `yaml:"machineType"`
+}
+
+// NewMember initializes a Member resource.
+func NewMember(namespace resource.Namespace, id resource.ID) *Member {
+	r := &Member{
+		md:   resource.NewMetadata(namespace, MemberType, id, resource.VersionUndefined),
+		spec: MemberSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Member) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Member) Spec() interface{} {
+	return r.spec
+}
+
+func (r *Member) String() string {
+	return fmt.Sprintf("cluster.Member(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Member) DeepCopy() resource.Resource {
+	return &Member{
+		md: r.md,
+		spec: MemberSpec{
+			NodeID:      r.spec.NodeID,
+			Addresses:   append([]netaddr.IP(nil), r.spec.Addresses...),
+			Hostname:    r.spec.Hostname,
+			MachineType: r.spec.MachineType,
+		},
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *Member) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             MemberType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Hostname",
+				JSONPath: `{.hostname}`,
+			},
+			{
+				Name:     "Machine Type",
+				JSONPath: `{.machineType}`,
+			},
+			{
+				Name:     "Addresses",
+				JSONPath: `{.addresses}`,
+			},
+		},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *Member) TypedSpec() *MemberSpec {
+	return &r.spec
+}


### PR DESCRIPTION
This implements pushing to and pulling from Kubernetes cluster discovery
registry which is simply using extra Talos annotations on the Node
resources.

Note: cluster discovery is still disabled by default.

This means that each Talos node is going to push data from its own local
`Affiliate` structure to the `Node` resource, and also watches the other
`Node`s to scrape data to build `Affiliate`s from each other cluster
member.

Further down the pipeline, `Affiliate` is converted to a cluster
`Member` which is an easy way to see the cluster membership.

In its current form, `talosctl get members` is mostly equivalent to
`kubectl get nodes`, but as we add more registries, it will become more
powerful.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
