### PR TITLE
backport: fix: correctly define example for `extraMounts`

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -354,14 +354,16 @@ var (
 		mustParseURL("https://cluster1.internal:6443"),
 	}
 
-	kubeletExtraMountsExample = []specs.Mount{
+	kubeletExtraMountsExample = []ExtraMount{
 		{
-			Source:      "/var/lib/example",
-			Destination: "/var/lib/example",
-			Type:        "bind",
-			Options: []string{
-				"rshared",
-				"rw",
+			specs.Mount{
+				Source:      "/var/lib/example",
+				Destination: "/var/lib/example",
+				Type:        "bind",
+				Options: []string{
+					"rshared",
+					"rw",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
The type was changed, but the example wasn't updated accordingly.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>
(cherry picked from commit bd5b9c96e2563249a5633433703493b292b83ee9)

PR: #4184 