### PR TITLE
fix: multiple fixes for KubeSpan and Wireguard implementation

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
@@ -101,8 +101,6 @@ func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runt
 			continue
 		}
 
-		logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))
-
 		if err = conditions.WaitForFileToExist(constants.KubeletKubeconfig).Wait(ctx); err != nil {
 			return err
 		}

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -185,10 +185,15 @@ func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runt
 						spec.KubeSpan.AdditionalAddresses = append([]netaddr.IPPrefix(nil), ksAdditionalAddresses.(*network.NodeAddress).TypedSpec().Addresses...)
 
 						nodeIPs := addresses.(*network.NodeAddress).TypedSpec().IPs()
-						endpoints := make([]netaddr.IPPort, len(nodeIPs))
+						endpoints := make([]netaddr.IPPort, 0, len(nodeIPs))
 
 						for i := range nodeIPs {
-							endpoints[i] = netaddr.IPPortFrom(nodeIPs[i], constants.KubeSpanDefaultPort)
+							if nodeIPs[i] == spec.KubeSpan.Address {
+								// skip kubespan local address
+								continue
+							}
+
+							endpoints = append(endpoints, netaddr.IPPortFrom(nodeIPs[i], constants.KubeSpanDefaultPort))
 						}
 
 						spec.KubeSpan.Endpoints = endpoints

--- a/internal/app/machined/pkg/controllers/kubespan/peer_spec_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/peer_spec_test.go
@@ -4,6 +4,7 @@
 package kubespan_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -58,7 +59,7 @@ func (suite *PeerSpecSuite) TestReconcile() {
 		KubeSpan: cluster.KubeSpanAffiliateSpec{
 			PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
 			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
-			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24"), netaddr.MustParseIPPrefix("10.244.3.0/32")},
 			Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
 		},
 	}
@@ -121,7 +122,7 @@ func (suite *PeerSpecSuite) TestReconcile() {
 				spec := res.(*kubespan.PeerSpec).TypedSpec()
 
 				suite.Assert().Equal("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0", spec.Address.String())
-				suite.Assert().Equal([]netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")}, spec.AdditionalAddresses)
+				suite.Assert().Equal("[10.244.3.0/24 fd50:8d60:4238:6302:f857:23ff:fe21:d1e0/128]", fmt.Sprintf("%v", spec.AllowedIPs))
 				suite.Assert().Equal([]netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")}, spec.Endpoints)
 				suite.Assert().Equal("bar", spec.Label)
 
@@ -137,7 +138,7 @@ func (suite *PeerSpecSuite) TestReconcile() {
 				spec := res.(*kubespan.PeerSpec).TypedSpec()
 
 				suite.Assert().Equal("fdc8:8aee:4e2d:1202:f073:9cff:fe6c:4d67", spec.Address.String())
-				suite.Assert().Equal([]netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.4.1/24")}, spec.AdditionalAddresses)
+				suite.Assert().Equal("[10.244.4.0/24 fdc8:8aee:4e2d:1202:f073:9cff:fe6c:4d67/128]", fmt.Sprintf("%v", spec.AllowedIPs))
 				suite.Assert().Equal([]netaddr.IPPort{netaddr.MustParseIPPort("192.168.3.6:51820")}, spec.Endpoints)
 				suite.Assert().Equal("worker-2", spec.Label)
 
@@ -161,6 +162,73 @@ func (suite *PeerSpecSuite) TestReconcile() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		suite.assertNoResource(
 			resource.NewMetadata(kubespan.NamespaceName, kubespan.PeerSpecType, affiliate3.TypedSpec().KubeSpan.PublicKey, resource.VersionUndefined),
+		),
+	))
+}
+
+func (suite *PeerSpecSuite) TestIPOverlap() {
+	suite.statePath = suite.T().TempDir()
+
+	suite.Require().NoError(suite.runtime.RegisterController(&kubespanctrl.PeerSpecController{}))
+
+	suite.startRuntime()
+
+	stateMount := runtimeres.NewMountStatus(v1alpha1.NamespaceName, constants.StatePartitionLabel)
+
+	suite.Assert().NoError(suite.state.Create(suite.ctx, stateMount))
+
+	cfg := kubespan.NewConfig(config.NamespaceName, kubespan.ConfigID)
+	cfg.TypedSpec().Enabled = true
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	nodeIdentity := cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity)
+	suite.Require().NoError(nodeIdentity.TypedSpec().Generate())
+	suite.Require().NoError(suite.state.Create(suite.ctx, nodeIdentity))
+
+	affiliate1 := cluster.NewAffiliate(cluster.NamespaceName, "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
+	*affiliate1.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Nodename:    "bar",
+		MachineType: machine.TypeControlPlane,
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24"), netaddr.MustParseIPPrefix("10.244.3.0/32")},
+			Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+		},
+	}
+
+	affiliate2 := cluster.NewAffiliate(cluster.NamespaceName, "9dwHNUViZlPlIervqX9Qo256RUhrfhgO0xBBnKcKl4F")
+	*affiliate2.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "9dwHNUViZlPlIervqX9Qo256RUhrfhgO0xBBnKcKl4F",
+		Hostname:    "worker-1",
+		Nodename:    "worker-1",
+		MachineType: machine.TypeWorker,
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey:           "Zr5ewpUm2Ywo1c+/59WFKIBjZ3c/nVbIWsT5elbjwCU=",
+			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.128/28"), netaddr.MustParseIPPrefix("192.168.3.0/24")},
+			Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+		},
+	}
+
+	for _, r := range []resource.Resource{affiliate1, affiliate2} {
+		suite.Require().NoError(suite.state.Create(suite.ctx, r))
+	}
+
+	// affiliate2 shouldn't be rendered as a peer, as its AdditionalAddresses overlap with affiliate1 addresses
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResourceIDs(resource.NewMetadata(kubespan.NamespaceName, kubespan.PeerSpecType, "", resource.VersionUndefined),
+			[]resource.ID{
+				affiliate1.TypedSpec().KubeSpan.PublicKey,
+			},
+		),
+	))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertNoResource(
+			resource.NewMetadata(kubespan.NamespaceName, kubespan.PeerSpecType, affiliate2.TypedSpec().KubeSpan.PublicKey, resource.VersionUndefined),
 		),
 	))
 }

--- a/pkg/resources/kubespan/peer_spec.go
+++ b/pkg/resources/kubespan/peer_spec.go
@@ -25,10 +25,10 @@ type PeerSpec struct {
 
 // PeerSpecSpec describes PeerSpec state.
 type PeerSpecSpec struct {
-	Address             netaddr.IP         `yaml:"address"`
-	AdditionalAddresses []netaddr.IPPrefix `yaml:"additionalAddresses"`
-	Endpoints           []netaddr.IPPort   `yaml:"endpoints"`
-	Label               string             `yaml:"label"`
+	Address    netaddr.IP         `yaml:"address"`
+	AllowedIPs []netaddr.IPPrefix `yaml:"allowedIPs"`
+	Endpoints  []netaddr.IPPort   `yaml:"endpoints"`
+	Label      string             `yaml:"label"`
 }
 
 // NewPeerSpec initializes a PeerSpec resource.
@@ -62,10 +62,10 @@ func (r *PeerSpec) DeepCopy() resource.Resource {
 	return &PeerSpec{
 		md: r.md,
 		spec: PeerSpecSpec{
-			Address:             r.spec.Address,
-			AdditionalAddresses: append([]netaddr.IPPrefix(nil), r.spec.AdditionalAddresses...),
-			Endpoints:           append([]netaddr.IPPort(nil), r.spec.Endpoints...),
-			Label:               r.spec.Label,
+			Address:    r.spec.Address,
+			AllowedIPs: append([]netaddr.IPPrefix(nil), r.spec.AllowedIPs...),
+			Endpoints:  append([]netaddr.IPPort(nil), r.spec.Endpoints...),
+			Label:      r.spec.Label,
 		},
 	}
 }

--- a/pkg/resources/network/link_spec.go
+++ b/pkg/resources/network/link_spec.go
@@ -158,6 +158,7 @@ func (r *LinkSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 		Aliases:          []resource.Type{},
 		DefaultNamespace: NamespaceName,
 		PrintColumns:     []meta.PrintColumn{},
+		Sensitivity:      meta.Sensitive,
 	}
 }
 

--- a/pkg/resources/network/link_status.go
+++ b/pkg/resources/network/link_status.go
@@ -110,6 +110,7 @@ func (r *LinkStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 				JSONPath: `{.linkState}`,
 			},
 		},
+		Sensitivity: meta.Sensitive,
 	}
 }
 

--- a/pkg/resources/network/link_test.go
+++ b/pkg/resources/network/link_test.go
@@ -89,9 +89,19 @@ func TestWireguardPeer(t *testing.T) {
 		},
 	}
 
+	peer1_2 := network.WireguardPeer{
+		PublicKey:                   key1.PublicKey().String(),
+		PersistentKeepaliveInterval: 10 * time.Second,
+		AllowedIPs: []netaddr.IPPrefix{
+			netaddr.MustParseIPPrefix("10.2.0.0/16"),
+			netaddr.MustParseIPPrefix("10.2.0.0/24"),
+		},
+	}
+
 	assert.True(t, peer1.Equal(&peer1))
 	assert.False(t, peer1.Equal(&peer2))
 	assert.False(t, peer1.Equal(&peer1_1))
+	assert.True(t, peer1.Equal(&peer1_2))
 }
 
 func TestWireguardSpecZero(t *testing.T) {
@@ -118,7 +128,8 @@ func TestWireguardSpecDecode(t *testing.T) {
 		FirewallMark: 1,
 		Peers: []wgtypes.Peer{
 			{
-				PublicKey: pub1.PublicKey(),
+				PublicKey:    pub1.PublicKey(),
+				PresharedKey: priv,
 				Endpoint: &net.UDPAddr{
 					IP:   net.ParseIP("10.2.0.3"),
 					Port: 20000,
@@ -148,8 +159,9 @@ func TestWireguardSpecDecode(t *testing.T) {
 		FirewallMark: 1,
 		Peers: []network.WireguardPeer{
 			{
-				PublicKey: pub1.PublicKey().String(),
-				Endpoint:  "10.2.0.3:20000",
+				PublicKey:    pub1.PublicKey().String(),
+				PresharedKey: priv.String(),
+				Endpoint:     "10.2.0.3:20000",
 				AllowedIPs: []netaddr.IPPrefix{
 					netaddr.MustParseIPPrefix("172.24.0.0/16"),
 				},
@@ -239,6 +251,7 @@ func TestWireguardSpecEncode(t *testing.T) {
 					Port: 20000,
 				},
 				PersistentKeepaliveInterval: pointer.ToDuration(0),
+				ReplaceAllowedIPs:           true,
 				AllowedIPs: []net.IPNet{
 					{
 						IP:   net.ParseIP("172.24.0.0").To4(),
@@ -249,6 +262,7 @@ func TestWireguardSpecEncode(t *testing.T) {
 			{
 				PublicKey:                   pub2.PublicKey(),
 				PersistentKeepaliveInterval: pointer.ToDuration(0),
+				ReplaceAllowedIPs:           true,
 				AllowedIPs: []net.IPNet{
 					{
 						IP:   net.ParseIP("172.25.0.0").To4(),
@@ -300,7 +314,8 @@ func TestWireguardSpecEncode(t *testing.T) {
 		FirewallMark: 2,
 		Peers: []network.WireguardPeer{
 			{
-				PublicKey: pub1.PublicKey().String(),
+				PublicKey:    pub1.PublicKey().String(),
+				PresharedKey: priv.String(),
 				AllowedIPs: []netaddr.IPPrefix{
 					netaddr.MustParseIPPrefix("172.24.0.0/16"),
 				},
@@ -316,7 +331,9 @@ func TestWireguardSpecEncode(t *testing.T) {
 		Peers: []wgtypes.PeerConfig{
 			{
 				PublicKey:                   pub1.PublicKey(),
+				PresharedKey:                &priv,
 				PersistentKeepaliveInterval: pointer.ToDuration(0),
+				ReplaceAllowedIPs:           true,
 				AllowedIPs: []net.IPNet{
 					{
 						IP:   net.ParseIP("172.24.0.0").To4(),


### PR DESCRIPTION
* calculate covering IPPrefixes for the KubeSpan peer `AllowedIPs`,
check for overlap
* don't use KubeSpan IP as potential node endpoint (inception!)
* allow Wireguard config to be applied which doesn't change peer
endpoint
* support for pre-shared Wireguard peer keys

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
Signed-off-by: Seán C McCord <ulexus@gmail.com>
Co-authored-by: Seán C McCord <ulexus@gmail.com>
