### PR TITLE
fix: write KubernetesCACert chmodded 0400 instead of 0500

### DIFF
--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -98,7 +98,7 @@ func (k *Kubelet) PreFunc(ctx context.Context, r runtime.Runtime) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(constants.KubernetesCACert, r.Config().Cluster().CA().Crt, 0o500); err != nil {
+	if err := ioutil.WriteFile(constants.KubernetesCACert, r.Config().Cluster().CA().Crt, 0o400); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Looks like this was an error made long ago, fixed similarly for etcd
in b52b20666.

Signed-off-by: Lennard Klein <lennard.klein@eu.equinix.com>
Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

