### PR TITLE
fix: completely prevent editing resources other than mc

### DIFF
--- a/cmd/talosctl/cmd/talos/edit.go
+++ b/cmd/talosctl/cmd/talos/edit.go
@@ -54,11 +54,13 @@ or 'notepad' for Windows.`,
 			var lastError string
 
 			editFn := func(parentCtx context.Context, msg client.ResourceResponse) error {
-				if msg.Resource == nil {
+				if msg.Definition != nil {
 					if msg.Definition.Metadata().ID() != strings.ToLower(config.MachineConfigType) {
 						return fmt.Errorf("only the machineconfig resource can be edited")
 					}
+				}
 
+				if msg.Resource == nil {
 					return nil
 				}
 


### PR DESCRIPTION
The previous check only applied to `talosctl edit <type>`, but failed to
check `talosctl edit <type> <id>`.

Editing didn't work anyways, but this prevents unhelpful error messages.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
