### PR TITLE
fix: add node address to the list of allowed IPs (kubespan)

### DIFF
--- a/internal/app/machined/pkg/controllers/kubespan/peer_spec.go
+++ b/internal/app/machined/pkg/controllers/kubespan/peer_spec.go
@@ -112,6 +112,10 @@ func (ctrl *PeerSpecController) Run(ctx context.Context, r controller.Runtime, l
 						builder.AddPrefix(ipPrefix)
 					}
 
+					for _, ip := range spec.Addresses {
+						builder.Add(ip)
+					}
+
 					builder.Add(spec.KubeSpan.Address)
 
 					var ipSet *netaddr.IPSet

--- a/internal/app/machined/pkg/controllers/kubespan/peer_spec_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/peer_spec_test.go
@@ -122,7 +122,7 @@ func (suite *PeerSpecSuite) TestReconcile() {
 				spec := res.(*kubespan.PeerSpec).TypedSpec()
 
 				suite.Assert().Equal("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0", spec.Address.String())
-				suite.Assert().Equal("[10.244.3.0/24 fd50:8d60:4238:6302:f857:23ff:fe21:d1e0/128]", fmt.Sprintf("%v", spec.AllowedIPs))
+				suite.Assert().Equal("[10.244.3.0/24 192.168.3.4/32 fd50:8d60:4238:6302:f857:23ff:fe21:d1e0/128]", fmt.Sprintf("%v", spec.AllowedIPs))
 				suite.Assert().Equal([]netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")}, spec.Endpoints)
 				suite.Assert().Equal("bar", spec.Label)
 
@@ -138,7 +138,7 @@ func (suite *PeerSpecSuite) TestReconcile() {
 				spec := res.(*kubespan.PeerSpec).TypedSpec()
 
 				suite.Assert().Equal("fdc8:8aee:4e2d:1202:f073:9cff:fe6c:4d67", spec.Address.String())
-				suite.Assert().Equal("[10.244.4.0/24 fdc8:8aee:4e2d:1202:f073:9cff:fe6c:4d67/128]", fmt.Sprintf("%v", spec.AllowedIPs))
+				suite.Assert().Equal("[10.244.4.0/24 192.168.3.6/32 fdc8:8aee:4e2d:1202:f073:9cff:fe6c:4d67/128]", fmt.Sprintf("%v", spec.AllowedIPs))
 				suite.Assert().Equal([]netaddr.IPPort{netaddr.MustParseIPPort("192.168.3.6:51820")}, spec.Endpoints)
 				suite.Assert().Equal("worker-2", spec.Label)
 


### PR DESCRIPTION
This fixes the bug with host networking pods not being able to reach out
to the Kubernetes services.

This also moves any node-to-node networking over to KubeSpan link as
well.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4246)
<!-- Reviewable:end -->
