### PR TITLE
chore: add a special condition to check for kubeconfig readiness

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_pull.go
@@ -101,7 +101,7 @@ func (ctrl *KubernetesPullController) Run(ctx context.Context, r controller.Runt
 			continue
 		}
 
-		if err = conditions.WaitForFileToExist(constants.KubeletKubeconfig).Wait(ctx); err != nil {
+		if err = conditions.WaitForKubeconfigReady(constants.KubeletKubeconfig).Wait(ctx); err != nil {
 			return err
 		}
 

--- a/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
+++ b/internal/app/machined/pkg/controllers/cluster/kubernetes_push.go
@@ -86,7 +86,7 @@ func (ctrl *KubernetesPushController) Run(ctx context.Context, r controller.Runt
 				continue
 			}
 
-			if err = conditions.WaitForFileToExist(constants.KubeletKubeconfig).Wait(ctx); err != nil {
+			if err = conditions.WaitForKubeconfigReady(constants.KubeletKubeconfig).Wait(ctx); err != nil {
 				return err
 			}
 

--- a/internal/app/machined/pkg/controllers/k8s/endpoint.go
+++ b/internal/app/machined/pkg/controllers/k8s/endpoint.go
@@ -85,7 +85,7 @@ func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, l
 
 		logger.Debug("waiting for kubelet client config", zap.String("file", constants.KubeletKubeconfig))
 
-		if err = conditions.WaitForFileToExist(constants.KubeletKubeconfig).Wait(ctx); err != nil {
+		if err = conditions.WaitForKubeconfigReady(constants.KubeletKubeconfig).Wait(ctx); err != nil {
 			return err
 		}
 

--- a/pkg/conditions/files.go
+++ b/pkg/conditions/files.go
@@ -14,6 +14,9 @@ import (
 type file string
 
 func (filename file) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
 	for {
 		_, err := os.Stat(string(filename))
 		if err == nil {
@@ -27,7 +30,7 @@ func (filename file) Wait(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(1 * time.Second):
+		case <-ticker.C:
 		}
 	}
 }

--- a/pkg/conditions/kubeconfig.go
+++ b/pkg/conditions/kubeconfig.go
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package conditions
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type kubeconfig string
+
+func (filename kubeconfig) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		_, err := os.Stat(string(filename))
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+
+		_, err = clientcmd.BuildConfigFromFlags("", string(filename))
+		if err == nil {
+			return nil
+		}
+
+		// TODO: we can't check for specific error here (looking for file not found for client key/cert):
+		//       https://github.com/kubernetes/kubernetes/pull/105080
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (filename kubeconfig) String() string {
+	return fmt.Sprintf("kubeconfig %q to be ready", string(filename))
+}
+
+// WaitForKubeconfigReady is a condition that will wait for the kubeconfig to be ready.
+func WaitForKubeconfigReady(filename string) Condition {
+	return kubeconfig(filename)
+}


### PR DESCRIPTION
The problem is that the kubelet kubeconfig gets created early, but the
actual client key and cert files are not written, so controllers spam
with scary errors that the config is not valid. This PR removes those
scary messages as we wait for the kubeconfig to be usable.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4247)
<!-- Reviewable:end -->
