### PR TITLE
feat: add operating system version field to discovery

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/talos-systems/talos/pkg/resources/k8s"
 	"github.com/talos-systems/talos/pkg/resources/kubespan"
 	"github.com/talos-systems/talos/pkg/resources/network"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 // LocalAffiliateController builds Affiliate resource for the local node.
@@ -178,6 +179,7 @@ func (ctrl *LocalAffiliateController) Run(ctx context.Context, r controller.Runt
 					spec.Hostname = hostname.(*network.HostnameStatus).TypedSpec().FQDN()
 					spec.Nodename = nodename.(*k8s.Nodename).TypedSpec().Nodename
 					spec.MachineType = machineType.(*config.MachineType).MachineType()
+					spec.OperatingSystem = fmt.Sprintf("%s (%s)", version.Name, version.Tag)
 
 					spec.KubeSpan = cluster.KubeSpanAffiliateSpec{}
 

--- a/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/local_affiliate_test.go
@@ -65,6 +65,7 @@ func (suite *LocalAffiliateSuite) TestGeneration() {
 			suite.Assert().Equal("example1", spec.Hostname)
 			suite.Assert().Equal("example1.com", spec.Nodename)
 			suite.Assert().Equal(machine.TypeWorker, spec.MachineType)
+			suite.Assert().Equal(" ()", spec.OperatingSystem) // build tags are not set for unit-tests
 			suite.Assert().Equal(cluster.KubeSpanAffiliateSpec{}, spec.KubeSpan)
 
 			return nil

--- a/internal/app/machined/pkg/controllers/cluster/member.go
+++ b/internal/app/machined/pkg/controllers/cluster/member.go
@@ -76,6 +76,7 @@ func (ctrl *MemberController) Run(ctx context.Context, r controller.Runtime, log
 				spec.Addresses = append([]netaddr.IP(nil), affiliateSpec.Addresses...)
 				spec.Hostname = affiliateSpec.Hostname
 				spec.MachineType = affiliateSpec.MachineType
+				spec.OperatingSystem = affiliateSpec.OperatingSystem
 				spec.NodeID = affiliateSpec.NodeID
 
 				return nil

--- a/internal/app/machined/pkg/controllers/cluster/member_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/member_test.go
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint:dupl
 package cluster_test
 
 import (
@@ -30,11 +29,12 @@ func (suite *MemberSuite) TestReconcileDefault() {
 
 	affiliate1 := cluster.NewAffiliate(cluster.NamespaceName, "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
 	*affiliate1.TypedSpec() = cluster.AffiliateSpec{
-		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
-		Hostname:    "foo.com",
-		Nodename:    "bar",
-		MachineType: machine.TypeControlPlane,
-		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.4")},
+		NodeID:          "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Hostname:        "foo.com",
+		Nodename:        "bar",
+		MachineType:     machine.TypeControlPlane,
+		OperatingSystem: "Talos (v1.0.0)",
+		Addresses:       []netaddr.IP{netaddr.MustParseIP("192.168.3.4")},
 		KubeSpan: cluster.KubeSpanAffiliateSpec{
 			PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
 			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
@@ -72,6 +72,7 @@ func (suite *MemberSuite) TestReconcileDefault() {
 			suite.Assert().Equal([]netaddr.IP{netaddr.MustParseIP("192.168.3.4")}, spec.Addresses)
 			suite.Assert().Equal("foo.com", spec.Hostname)
 			suite.Assert().Equal(machine.TypeControlPlane, spec.MachineType)
+			suite.Assert().Equal("Talos (v1.0.0)", spec.OperatingSystem)
 
 			return nil
 		}),

--- a/internal/pkg/discovery/registry/kubernetes.go
+++ b/internal/pkg/discovery/registry/kubernetes.go
@@ -102,6 +102,8 @@ func AffiliateFromNode(node *v1.Node) *cluster.AffiliateSpec {
 		affiliate.MachineType = machine.TypeControlPlane
 	}
 
+	affiliate.OperatingSystem = node.Status.NodeInfo.OSImage
+
 	// Every other field is pulled from node annotations.
 	if publicKey, ok := node.Annotations[constants.KubeSpanPublicKeyAnnotation]; ok {
 		affiliate.KubeSpan.PublicKey = publicKey

--- a/internal/pkg/discovery/registry/kubernetes_test.go
+++ b/internal/pkg/discovery/registry/kubernetes_test.go
@@ -113,14 +113,18 @@ func TestAffiliateFromNode(t *testing.T) {
 							Address: "foo.com",
 						},
 					},
+					NodeInfo: v1.NodeSystemInfo{
+						OSImage: "Talos (v1.0.0)",
+					},
 				},
 			},
 			expected: &cluster.AffiliateSpec{
-				NodeID:      "29QQTc97U5ZyFTIX33Dp9NqtwxqQI8QI13scCLzffrZ",
-				Hostname:    "foo.com",
-				Nodename:    "bar",
-				MachineType: machine.TypeControlPlane,
-				Addresses:   []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				NodeID:          "29QQTc97U5ZyFTIX33Dp9NqtwxqQI8QI13scCLzffrZ",
+				Hostname:        "foo.com",
+				Nodename:        "bar",
+				MachineType:     machine.TypeControlPlane,
+				Addresses:       []netaddr.IP{netaddr.MustParseIP("10.0.0.2"), netaddr.MustParseIP("192.168.3.4")},
+				OperatingSystem: "Talos (v1.0.0)",
 				KubeSpan: cluster.KubeSpanAffiliateSpec{
 					PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
 					Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),

--- a/pkg/resources/cluster/affiliate.go
+++ b/pkg/resources/cluster/affiliate.go
@@ -27,12 +27,13 @@ type Affiliate struct {
 
 // AffiliateSpec describes Affiliate state.
 type AffiliateSpec struct {
-	NodeID      string                `yaml:"nodeId"`
-	Addresses   []netaddr.IP          `yaml:"addresses"`
-	Hostname    string                `yaml:"hostname"`
-	Nodename    string                `yaml:"nodename,omitempty"`
-	MachineType machine.Type          `yaml:"machineType"`
-	KubeSpan    KubeSpanAffiliateSpec `yaml:"kubespan,omitempty"`
+	NodeID          string                `yaml:"nodeId"`
+	Addresses       []netaddr.IP          `yaml:"addresses"`
+	Hostname        string                `yaml:"hostname"`
+	Nodename        string                `yaml:"nodename,omitempty"`
+	OperatingSystem string                `yaml:"operatingSystem"`
+	MachineType     machine.Type          `yaml:"machineType"`
+	KubeSpan        KubeSpanAffiliateSpec `yaml:"kubespan,omitempty"`
 }
 
 // KubeSpanAffiliateSpec describes additional information specific for the KubeSpan.
@@ -74,11 +75,12 @@ func (r *Affiliate) DeepCopy() resource.Resource {
 	return &Affiliate{
 		md: r.md,
 		spec: AffiliateSpec{
-			NodeID:      r.spec.NodeID,
-			Addresses:   append([]netaddr.IP(nil), r.spec.Addresses...),
-			Hostname:    r.spec.Hostname,
-			Nodename:    r.spec.Nodename,
-			MachineType: r.spec.MachineType,
+			NodeID:          r.spec.NodeID,
+			Addresses:       append([]netaddr.IP(nil), r.spec.Addresses...),
+			Hostname:        r.spec.Hostname,
+			Nodename:        r.spec.Nodename,
+			OperatingSystem: r.spec.OperatingSystem,
+			MachineType:     r.spec.MachineType,
 			KubeSpan: KubeSpanAffiliateSpec{
 				PublicKey:           r.spec.KubeSpan.PublicKey,
 				Address:             r.spec.KubeSpan.Address,

--- a/pkg/resources/cluster/member.go
+++ b/pkg/resources/cluster/member.go
@@ -27,10 +27,11 @@ type Member struct {
 
 // MemberSpec describes Member state.
 type MemberSpec struct {
-	NodeID      string       `yaml:"nodeId"`
-	Addresses   []netaddr.IP `yaml:"addresses"`
-	Hostname    string       `yaml:"hostname"`
-	MachineType machine.Type `yaml:"machineType"`
+	NodeID          string       `yaml:"nodeId"`
+	Addresses       []netaddr.IP `yaml:"addresses"`
+	Hostname        string       `yaml:"hostname"`
+	MachineType     machine.Type `yaml:"machineType"`
+	OperatingSystem string       `yaml:"operatingSystem"`
 }
 
 // NewMember initializes a Member resource.
@@ -64,10 +65,11 @@ func (r *Member) DeepCopy() resource.Resource {
 	return &Member{
 		md: r.md,
 		spec: MemberSpec{
-			NodeID:      r.spec.NodeID,
-			Addresses:   append([]netaddr.IP(nil), r.spec.Addresses...),
-			Hostname:    r.spec.Hostname,
-			MachineType: r.spec.MachineType,
+			NodeID:          r.spec.NodeID,
+			Addresses:       append([]netaddr.IP(nil), r.spec.Addresses...),
+			Hostname:        r.spec.Hostname,
+			MachineType:     r.spec.MachineType,
+			OperatingSystem: r.spec.OperatingSystem,
 		},
 	}
 }
@@ -86,6 +88,10 @@ func (r *Member) ResourceDefinition() meta.ResourceDefinitionSpec {
 			{
 				Name:     "Machine Type",
 				JSONPath: `{.machineType}`,
+			},
+			{
+				Name:     "OS",
+				JSONPath: `{.operatingSystem}`,
 			},
 			{
 				Name:     "Addresses",


### PR DESCRIPTION
Fixes #4232

The result:

```
talosctl -n 172.20.0.2 get members
NODE         NAMESPACE   TYPE     ID                       VERSION   HOSTNAME                 MACHINE TYPE   OS                                           ADDRESSES
172.20.0.2   cluster     Member   talos-default-master-1   2         talos-default-master-1   controlplane   Talos (v0.13.0-alpha.0-13-gfdd80a12-dirty)   ["172.20.0.2","fdd1:f54:2697:3902:44f8:92ff:fe2e:1aea"]
172.20.0.2   cluster     Member   talos-default-worker-1   1         talos-default-worker-1   worker         Talos (v0.13.0-alpha.0-13-gfdd80a12-dirty)   ["172.20.0.3","fdd1:f54:2697:3902:d4ba:55ff:fe8a:f551"]
172.20.0.2   cluster     Member   talos-default-worker-2   1         talos-default-worker-2   worker         Talos (v0.13.0-alpha.0-13-gfdd80a12-dirty)   ["172.20.0.4","fdd1:f54:2697:3902:e00d:f4ff:fecf:51c8"]
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4249)
<!-- Reviewable:end -->
