### PR TITLE
fix: don't marshal clock with SecretsBundle

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -153,7 +153,7 @@ type TrustdInfo struct {
 
 // SecretsBundle holds trustd, kubeadm and certs information.
 type SecretsBundle struct {
-	Clock      Clock
+	Clock      Clock `yaml:"-" json:"-"`
 	Cluster    *Cluster
 	Secrets    *Secrets
 	TrustdInfo *TrustdInfo


### PR DESCRIPTION
This field is not marshalable, as it's technically an interface.

This will be used to save/load SecretsBundle as a whole in the CABPT.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4269)
<!-- Reviewable:end -->
