### PR TITLE
fix: use readonly mode when probing devices with `All` lookup

### DIFF
--- a/cmd/installer/cmd/image.go
+++ b/cmd/installer/cmd/image.go
@@ -68,7 +68,7 @@ func runImageCmd() (err error) {
 		return err
 	}
 
-	log.Print("attaching loopback device ")
+	log.Print("attaching loopback device")
 
 	if options.Disk, err = pkg.Loattach(img); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
 	github.com/talos-systems/crypto v0.3.2
-	github.com/talos-systems/go-blockdevice v0.2.4-0.20210922122752-e367f9dc7fa9
+	github.com/talos-systems/go-blockdevice v0.2.4-0.20210922213318-33afba347c0d
 	github.com/talos-systems/go-cmd v0.1.0
 	github.com/talos-systems/go-debug v0.2.1
 	github.com/talos-systems/go-kmsg v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1039,8 +1039,8 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/talos-systems/crypto v0.3.2 h1:I+MC9ql6K29EMlbPzdSeHZInSRWdze1FX1qGGrlom8Q=
 github.com/talos-systems/crypto v0.3.2/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/talos-systems/go-blockdevice v0.2.3/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
-github.com/talos-systems/go-blockdevice v0.2.4-0.20210922122752-e367f9dc7fa9 h1:youTpqU4Pi6cX0naqXM42oHrZT4zhvfLoV2mXIEXHdk=
-github.com/talos-systems/go-blockdevice v0.2.4-0.20210922122752-e367f9dc7fa9/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.2.4-0.20210922213318-33afba347c0d h1:vxXTelbHH1NTI/VE2TsWHDzVamTbbf3a3uRPvyXps/k=
+github.com/talos-systems/go-blockdevice v0.2.4-0.20210922213318-33afba347c0d/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-cmd v0.1.0 h1:bqPeL0ksproFyTOlvMisdUXc7uAf0aqJ5Q6waSGv32s=
 github.com/talos-systems/go-cmd v0.1.0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1235,7 +1235,16 @@ func stopAndRemoveAllPods(stopAction cri.StopAction) runtime.TaskExecutionFunc {
 // ResetSystemDisk represents the task to reset the system disk.
 func ResetSystemDisk(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
-		return r.State().Machine().Disk().BlockDevice.Reset()
+		var dev *blockdevice.BlockDevice
+
+		dev, err = blockdevice.Open(r.State().Machine().Disk().Device().Name())
+		if err != nil {
+			return err
+		}
+
+		defer dev.Close() //nolint:errcheck
+
+		return dev.Reset()
 	}, "resetSystemDisk"
 }
 


### PR DESCRIPTION
Update `go-blockdevice` library.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4280)
<!-- Reviewable:end -->
