### PR TITLE
fix: check for existence of dhcp6 FQDN first

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
+++ b/internal/app/machined/pkg/controllers/network/operator/dhcp6.go
@@ -177,7 +177,7 @@ func (d *DHCP6) parseReply(reply *dhcpv6.Message) {
 		d.resolvers = nil
 	}
 
-	if len(reply.Options.FQDN().DomainName.Labels) > 0 {
+	if reply.Options.FQDN() != nil && len(reply.Options.FQDN().DomainName.Labels) > 0 {
 		d.hostname = []network.HostnameSpecSpec{
 			{
 				Hostname:    reply.Options.FQDN().DomainName.Labels[0],


### PR DESCRIPTION
Check that dhcpv6.Options.FQDN() is not nil before trying to use it.

This fixes DHCPv6 on GCP.

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4284)
<!-- Reviewable:end -->
