### PR TITLE
feat: override static pods default args by extra Args

### DIFF
--- a/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
+++ b/internal/app/machined/pkg/controllers/config/k8s_control_plane.go
@@ -7,6 +7,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/AlekSi/pointer"
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -15,6 +16,7 @@ import (
 	talosnet "github.com/talos-systems/net"
 	"go.uber.org/zap"
 
+	"github.com/talos-systems/talos/pkg/argsbuilder"
 	"github.com/talos-systems/talos/pkg/images"
 	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
@@ -213,16 +215,20 @@ func (ctrl *K8sControlPlaneController) manageManifestsConfig(ctx context.Context
 	return r.Modify(ctx, config.NewK8sManifests(), func(r resource.Resource) error {
 		images := images.List(cfgProvider)
 
+		proxyArgs, err := getProxyArgs(cfgProvider)
+		if err != nil {
+			return err
+		}
+
 		r.(*config.K8sControlPlane).SetManifests(config.K8sManifestsSpec{
 			Server:        cfgProvider.Cluster().Endpoint().String(),
 			ClusterDomain: cfgProvider.Cluster().Network().DNSDomain(),
 
 			PodCIDRs: cfgProvider.Cluster().Network().PodCIDRs(),
 
-			ProxyEnabled:   cfgProvider.Cluster().Proxy().Enabled(),
-			ProxyImage:     cfgProvider.Cluster().Proxy().Image(),
-			ProxyMode:      cfgProvider.Cluster().Proxy().Mode(),
-			ProxyExtraArgs: cfgProvider.Cluster().Proxy().ExtraArgs(),
+			ProxyEnabled: cfgProvider.Cluster().Proxy().Enabled(),
+			ProxyImage:   cfgProvider.Cluster().Proxy().Image(),
+			ProxyArgs:    proxyArgs,
 
 			CoreDNSEnabled: cfgProvider.Cluster().CoreDNS().Enabled(),
 			CoreDNSImage:   cfgProvider.Cluster().CoreDNS().Image(),
@@ -286,4 +292,26 @@ func (ctrl *K8sControlPlaneController) manageExtraManifestsConfig(ctx context.Co
 
 func (ctrl *K8sControlPlaneController) teardownAll(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	return nil
+}
+
+func getProxyArgs(cfgProvider talosconfig.Provider) ([]string, error) {
+	clusterCidr := strings.Join(cfgProvider.Cluster().Network().PodCIDRs(), ",")
+
+	builder := argsbuilder.Args{
+		"cluster-cidr":           clusterCidr,
+		"hostname-override":      "$(NODE_NAME)",
+		"kubeconfig":             "/etc/kubernetes/kubeconfig",
+		"proxy-mode":             cfgProvider.Cluster().Proxy().Mode(),
+		"conntrack-max-per-core": "0",
+	}
+
+	policies := argsbuilder.MergePolicies{
+		"kubeconfig": argsbuilder.MergeDenied,
+	}
+
+	if err := builder.Merge(cfgProvider.Cluster().Proxy().ExtraArgs(), argsbuilder.WithMergePolicies(policies)); err != nil {
+		return nil, err
+	}
+
+	return builder.Args(), nil
 }

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/AlekSi/pointer"
@@ -20,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/talos-systems/talos/pkg/argsbuilder"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/resources/config"
 	"github.com/talos-systems/talos/pkg/resources/k8s"
@@ -203,52 +205,80 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 
 	args := []string{
 		"/usr/local/bin/kube-apiserver",
-		fmt.Sprintf("--enable-admission-plugins=%s", strings.Join(enabledAdmissionPlugins, ",")),
-		"--advertise-address=$(POD_IP)",
-		"--allow-privileged=true",
-		fmt.Sprintf("--api-audiences=%s", cfg.ControlPlaneEndpoint),
-		"--authorization-mode=Node,RBAC",
-		"--bind-address=0.0.0.0",
-		fmt.Sprintf("--client-ca-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "ca.crt")),
-		fmt.Sprintf("--requestheader-client-ca-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "aggregator-ca.crt")),
-		"--requestheader-allowed-names=front-proxy-client",
-		"--requestheader-extra-headers-prefix=X-Remote-Extra-",
-		"--requestheader-group-headers=X-Remote-Group",
-		"--requestheader-username-headers=X-Remote-User",
-		fmt.Sprintf("--proxy-client-cert-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "front-proxy-client.crt")),
-		fmt.Sprintf("--proxy-client-key-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "front-proxy-client.key")),
-		"--enable-bootstrap-token-auth=true",
-		"--tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256", //nolint:lll
-		fmt.Sprintf("--encryption-provider-config=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "encryptionconfig.yaml")),
-		fmt.Sprintf("--audit-policy-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "auditpolicy.yaml")),
-		"--audit-log-path=-",
-		"--audit-log-maxage=30",
-		"--audit-log-maxbackup=3",
-		"--audit-log-maxsize=50",
-		"--profiling=false",
-		fmt.Sprintf("--etcd-cafile=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client-ca.crt")),
-		fmt.Sprintf("--etcd-certfile=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client.crt")),
-		fmt.Sprintf("--etcd-keyfile=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client.key")),
-		fmt.Sprintf("--etcd-servers=%s", strings.Join(cfg.EtcdServers, ",")),
-		fmt.Sprintf("--kubelet-client-certificate=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver-kubelet-client.crt")),
-		fmt.Sprintf("--kubelet-client-key=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver-kubelet-client.key")),
-		fmt.Sprintf("--secure-port=%d", cfg.LocalPort),
-		fmt.Sprintf("--service-account-issuer=%s", cfg.ControlPlaneEndpoint),
-		fmt.Sprintf("--service-account-key-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "service-account.pub")),
-		fmt.Sprintf("--service-account-signing-key-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "service-account.key")),
-		fmt.Sprintf("--service-cluster-ip-range=%s", strings.Join(cfg.ServiceCIDRs, ",")),
-		fmt.Sprintf("--tls-cert-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver.crt")),
-		fmt.Sprintf("--tls-private-key-file=%s", filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver.key")),
-		"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+	}
+
+	builder := argsbuilder.Args{
+		"enable-admission-plugins":           strings.Join(enabledAdmissionPlugins, ","),
+		"advertise-address":                  "$(POD_IP)",
+		"allow-privileged":                   "true",
+		"api-audiences":                      cfg.ControlPlaneEndpoint,
+		"authorization-mode":                 "Node,RBAC",
+		"bind-address":                       "0.0.0.0",
+		"client-ca-file":                     filepath.Join(constants.KubernetesAPIServerSecretsDir, "ca.crt"),
+		"requestheader-client-ca-file":       filepath.Join(constants.KubernetesAPIServerSecretsDir, "aggregator-ca.crt"),
+		"requestheader-allowed-names":        "front-proxy-client",
+		"requestheader-extra-headers-prefix": "X-Remote-Extra-",
+		"requestheader-group-headers":        "X-Remote-Group",
+		"requestheader-username-headers":     "X-Remote-User",
+		"proxy-client-cert-file":             filepath.Join(constants.KubernetesAPIServerSecretsDir, "front-proxy-client.crt"),
+		"proxy-client-key-file":              filepath.Join(constants.KubernetesAPIServerSecretsDir, "front-proxy-client.key"),
+		"enable-bootstrap-token-auth":        "true",
+		"tls-cipher-suites":                  "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256", //nolint:lll
+		"encryption-provider-config":         filepath.Join(constants.KubernetesAPIServerSecretsDir, "encryptionconfig.yaml"),
+		"audit-policy-file":                  filepath.Join(constants.KubernetesAPIServerSecretsDir, "auditpolicy.yaml"),
+		"audit-log-path":                     "-",
+		"audit-log-maxage":                   "30",
+		"audit-log-maxbackup":                "3",
+		"audit-log-maxsize":                  "50",
+		"profiling":                          "false",
+		"etcd-cafile":                        filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client-ca.crt"),
+		"etcd-certfile":                      filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client.crt"),
+		"etcd-keyfile":                       filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client.key"),
+		"etcd-servers":                       strings.Join(cfg.EtcdServers, ","),
+		"kubelet-client-certificate":         filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver-kubelet-client.crt"),
+		"kubelet-client-key":                 filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver-kubelet-client.key"),
+		"secure-port":                        strconv.FormatInt(int64(cfg.LocalPort), 10),
+		"service-account-issuer":             cfg.ControlPlaneEndpoint,
+		"service-account-key-file":           filepath.Join(constants.KubernetesAPIServerSecretsDir, "service-account.pub"),
+		"service-account-signing-key-file":   filepath.Join(constants.KubernetesAPIServerSecretsDir, "service-account.key"),
+		"service-cluster-ip-range":           strings.Join(cfg.ServiceCIDRs, ","),
+		"tls-cert-file":                      filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver.crt"),
+		"tls-private-key-file":               filepath.Join(constants.KubernetesAPIServerSecretsDir, "apiserver.key"),
+		"kubelet-preferred-address-types":    "InternalIP,ExternalIP,Hostname",
 	}
 
 	if cfg.CloudProvider != "" {
-		args = append(args, fmt.Sprintf("--cloud-provider=%s", cfg.CloudProvider))
+		builder.Set("cloud-provider", cfg.CloudProvider)
 	}
 
-	for k, v := range cfg.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", k, v))
+	mergePolicies := argsbuilder.MergePolicies{
+		"enable-admission-plugins": argsbuilder.MergeAdditive,
+		"authorization-mode":       argsbuilder.MergeAdditive,
+		"tls-cipher-suites":        argsbuilder.MergeAdditive,
+
+		"etcd-servers":                     argsbuilder.MergeDenied,
+		"client-ca-file":                   argsbuilder.MergeDenied,
+		"requestheader-client-ca-file":     argsbuilder.MergeDenied,
+		"proxy-client-cert-file":           argsbuilder.MergeDenied,
+		"proxy-client-key-file":            argsbuilder.MergeDenied,
+		"encryption-provider-config":       argsbuilder.MergeDenied,
+		"audit-policy-file":                argsbuilder.MergeDenied,
+		"etcd-cafile":                      argsbuilder.MergeDenied,
+		"etcd-certfile":                    argsbuilder.MergeDenied,
+		"etcd-keyfile":                     argsbuilder.MergeDenied,
+		"kubelet-client-certificate":       argsbuilder.MergeDenied,
+		"kubelet-client-key":               argsbuilder.MergeDenied,
+		"service-account-key-file":         argsbuilder.MergeDenied,
+		"service-account-signing-key-file": argsbuilder.MergeDenied,
+		"tls-cert-file":                    argsbuilder.MergeDenied,
+		"tls-private-key-file":             argsbuilder.MergeDenied,
 	}
+
+	if err := builder.Merge(cfg.ExtraArgs, argsbuilder.WithMergePolicies(mergePolicies)); err != nil {
+		return err
+	}
+
+	args = append(args, builder.Args()...)
 
 	return r.Modify(ctx, k8s.NewStaticPod(k8s.ControlPlaneNamespaceName, "kube-apiserver", nil), func(r resource.Resource) error {
 		r.(*k8s.StaticPod).SetPod(&v1.Pod{
@@ -328,32 +358,49 @@ func (ctrl *ControlPlaneStaticPodController) manageControllerManager(ctx context
 
 	args := []string{
 		"/usr/local/bin/kube-controller-manager",
-		"--allocate-node-cidrs=true",
-		"--bind-address=127.0.0.1",
-		"--port=0",
-		fmt.Sprintf("--cluster-cidr=%s", strings.Join(cfg.PodCIDRs, ",")),
-		fmt.Sprintf("--service-cluster-ip-range=%s", strings.Join(cfg.ServiceCIDRs, ",")),
-		fmt.Sprintf("--cluster-signing-cert-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.crt")),
-		fmt.Sprintf("--cluster-signing-key-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.key")),
-		"--controllers=*,tokencleaner",
-		"--configure-cloud-routes=false",
-		fmt.Sprintf("--kubeconfig=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "kubeconfig")),
-		fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "kubeconfig")),
-		fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "kubeconfig")),
-		"--leader-elect=true",
-		fmt.Sprintf("--root-ca-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.crt")),
-		fmt.Sprintf("--service-account-private-key-file=%s", filepath.Join(constants.KubernetesControllerManagerSecretsDir, "service-account.key")),
-		"--profiling=false",
 		"--use-service-account-credentials",
 	}
 
-	if cfg.CloudProvider != "" {
-		args = append(args, fmt.Sprintf("--cloud-provider=%s", cfg.CloudProvider))
+	builder := argsbuilder.Args{
+		"allocate-node-cidrs":              "true",
+		"bind-address":                     "127.0.0.1",
+		"port":                             "0",
+		"cluster-cidr":                     strings.Join(cfg.PodCIDRs, ","),
+		"service-cluster-ip-range":         strings.Join(cfg.ServiceCIDRs, ","),
+		"cluster-signing-cert-file":        filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.crt"),
+		"cluster-signing-key-file":         filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.key"),
+		"controllers":                      "*,tokencleaner",
+		"configure-cloud-routes":           "false",
+		"kubeconfig":                       filepath.Join(constants.KubernetesControllerManagerSecretsDir, "kubeconfig"),
+		"authentication-kubeconfig":        filepath.Join(constants.KubernetesControllerManagerSecretsDir, "kubeconfig"),
+		"authorization-kubeconfig":         filepath.Join(constants.KubernetesControllerManagerSecretsDir, "kubeconfig"),
+		"leader-elect":                     "true",
+		"root-ca-file":                     filepath.Join(constants.KubernetesControllerManagerSecretsDir, "ca.crt"),
+		"service-account-private-key-file": filepath.Join(constants.KubernetesControllerManagerSecretsDir, "service-account.key"),
+		"profiling":                        "false",
 	}
 
-	for k, v := range cfg.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", k, v))
+	if cfg.CloudProvider != "" {
+		builder.Set("cloud-provider", cfg.CloudProvider)
 	}
+
+	mergePolicies := argsbuilder.MergePolicies{
+		"service-cluster-ip-range": argsbuilder.MergeAdditive,
+		"controllers":              argsbuilder.MergeAdditive,
+
+		"cluster-signing-cert-file":        argsbuilder.MergeDenied,
+		"cluster-signing-key-file":         argsbuilder.MergeDenied,
+		"authentication-kubeconfig":        argsbuilder.MergeDenied,
+		"authorization-kubeconfig":         argsbuilder.MergeDenied,
+		"root-ca-file":                     argsbuilder.MergeDenied,
+		"service-account-private-key-file": argsbuilder.MergeDenied,
+	}
+
+	if err := builder.Merge(cfg.ExtraArgs, argsbuilder.WithMergePolicies(mergePolicies)); err != nil {
+		return err
+	}
+
+	args = append(args, builder.Args()...)
 
 	//nolint:dupl
 	return r.Modify(ctx, k8s.NewStaticPod(k8s.ControlPlaneNamespaceName, "kube-controller-manager", nil), func(r resource.Resource) error {
@@ -436,19 +483,30 @@ func (ctrl *ControlPlaneStaticPodController) manageScheduler(ctx context.Context
 
 	args := []string{
 		"/usr/local/bin/kube-scheduler",
-		fmt.Sprintf("--kubeconfig=%s", filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig")),
-		"--authentication-tolerate-lookup-failure=false",
-		fmt.Sprintf("--authentication-kubeconfig=%s", filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig")),
-		fmt.Sprintf("--authorization-kubeconfig=%s", filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig")),
-		"--bind-address=127.0.0.1",
-		"--port=0",
-		"--leader-elect=true",
-		"--profiling=false",
 	}
 
-	for k, v := range cfg.ExtraArgs {
-		args = append(args, fmt.Sprintf("--%s=%s", k, v))
+	builder := argsbuilder.Args{
+		"kubeconfig":                             filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig"),
+		"authentication-tolerate-lookup-failure": "false",
+		"authentication-kubeconfig":              filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig"),
+		"authorization-kubeconfig":               filepath.Join(constants.KubernetesSchedulerSecretsDir, "kubeconfig"),
+		"bind-address":                           "127.0.0.1",
+		"port":                                   "0",
+		"leader-elect":                           "true",
+		"profiling":                              "false",
 	}
+
+	mergePolicies := argsbuilder.MergePolicies{
+		"kubeconfig":                argsbuilder.MergeDenied,
+		"authentication-kubeconfig": argsbuilder.MergeDenied,
+		"authorization-kubeconfig":  argsbuilder.MergeDenied,
+	}
+
+	if err := builder.Merge(cfg.ExtraArgs, argsbuilder.WithMergePolicies(mergePolicies)); err != nil {
+		return err
+	}
+
+	args = append(args, builder.Args()...)
 
 	//nolint:dupl
 	return r.Modify(ctx, k8s.NewStaticPod(k8s.ControlPlaneNamespaceName, "kube-scheduler", nil), func(r resource.Resource) error {

--- a/internal/app/machined/pkg/controllers/k8s/manifest_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/manifest_test.go
@@ -95,6 +95,13 @@ var defaultManifestSpec = config.K8sManifestsSpec{
 
 	ProxyEnabled: true,
 	ProxyImage:   "foo/bar",
+	ProxyArgs: []string{
+		fmt.Sprintf("--cluster-cidr=%s", constants.DefaultIPv4PodNet),
+		"--hostname-override=$(NODE_NAME)",
+		"--kubeconfig=/etc/kubernetes/kubeconfig",
+		"--proxy-mode=iptables",
+		"--conntrack-max-per-core=0",
+	},
 
 	CoreDNSEnabled: true,
 	CoreDNSImage:   "foo/bar",
@@ -171,9 +178,7 @@ func (suite *ManifestSuite) TestReconcileKubeProxyExtraArgs() {
 	rootSecrets := secrets.NewRoot(secrets.RootKubernetesID)
 	manifestConfig := config.NewK8sManifests()
 	spec := defaultManifestSpec
-	spec.ProxyExtraArgs = map[string]string{
-		"bind-address": "\"::\"",
-	}
+	spec.ProxyArgs = append(spec.ProxyArgs, "--bind-address=\"::\"")
 	manifestConfig.SetManifests(spec)
 
 	suite.Require().NoError(suite.state.Create(suite.ctx, rootSecrets))

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -138,13 +138,8 @@ spec:
         image: {{ .ProxyImage }}
         command:
         - /usr/local/bin/kube-proxy
-        - --cluster-cidr={{ join .PodCIDRs "," }}
-        - --hostname-override=$(NODE_NAME)
-        - --kubeconfig=/etc/kubernetes/kubeconfig
-        - --proxy-mode={{ .ProxyMode }}
-        - --conntrack-max-per-core=0
-        {{- range $k, $v := .ProxyExtraArgs }}
-        - {{ printf "--%s=%s" $k $v | json }}
+        {{- range $arg := .ProxyArgs }}
+        - {{ $arg | json }}
         {{- end }}
         env:
           - name: NODE_NAME

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -313,13 +313,11 @@ func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 
 	extraArgs := argsbuilder.Args(r.Config().Machine().Kubelet().ExtraArgs())
 
-	for k := range denyListArgs {
-		if extraArgs.Contains(k) {
-			return nil, argsbuilder.NewDenylistError(k)
-		}
+	if err = denyListArgs.Merge(extraArgs, argsbuilder.WithDenyList(denyListArgs)); err != nil {
+		return nil, err
 	}
 
-	return denyListArgs.Merge(extraArgs).Args(), nil
+	return denyListArgs.Args(), nil
 }
 
 func writeKubeletConfig(r runtime.Runtime) error {

--- a/pkg/argsbuilder/argsbuilder_args.go
+++ b/pkg/argsbuilder/argsbuilder_args.go
@@ -4,7 +4,10 @@
 
 package argsbuilder
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Key represents an arg key.
 type Key = string
@@ -15,13 +18,64 @@ type Value = string
 // Args represents a set of args.
 type Args map[Key]Value
 
+// MustMerge implements the ArgsBuilder interface.
+func (a Args) MustMerge(args Args, setters ...MergeOption) {
+	if err := a.Merge(args, setters...); err != nil {
+		panic(err)
+	}
+}
+
 // Merge implements the ArgsBuilder interface.
-func (a Args) Merge(args Args) ArgsBuilder {
-	for key, val := range args {
-		a[key] = val
+//nolint:gocyclo
+func (a Args) Merge(args Args, setters ...MergeOption) error {
+	var opts MergeOptions
+
+	for _, s := range setters {
+		s(&opts)
 	}
 
-	return a
+	policies := opts.Policies
+	if policies == nil {
+		policies = MergePolicies{}
+	}
+
+	for key, val := range args {
+		policy := policies[key]
+
+		switch policy {
+		case MergeDenied:
+			return NewDenylistError(key)
+		case MergeAdditive:
+			values := strings.Split(a[key], ",")
+			definedValues := map[string]struct{}{}
+
+			i := 0
+
+			for _, v := range values {
+				definedValues[strings.TrimSpace(v)] = struct{}{}
+
+				if v != "" {
+					values[i] = v
+					i++
+				}
+			}
+
+			values = values[:i]
+
+			for _, v := range strings.Split(val, ",") {
+				v = strings.TrimSpace(v)
+				if _, defined := definedValues[v]; !defined {
+					values = append(values, v)
+				}
+			}
+
+			a[key] = strings.Join(values, ",")
+		case MergeOverwrite:
+			a[key] = val
+		}
+	}
+
+	return nil
 }
 
 // Set implements the ArgsBuilder interface.

--- a/pkg/argsbuilder/argsbuilder_interface.go
+++ b/pkg/argsbuilder/argsbuilder_interface.go
@@ -4,9 +4,53 @@
 
 package argsbuilder
 
+// MergePolicy defines args builder args merging policy.
+type MergePolicy int
+
+const (
+	// MergeOverwrite overwrite arg when merging.
+	MergeOverwrite = iota
+	// MergeAdditive concat argument lists.
+	MergeAdditive
+	// MergeDenied fail merge if another object has the arg defined.
+	MergeDenied
+)
+
+// MergePolicies merge policy map.
+type MergePolicies map[string]MergePolicy
+
+// MergeOptions provides optional arguments for merge.
+type MergeOptions struct {
+	Policies MergePolicies
+}
+
+// MergeOption optional merge argument setter.
+type MergeOption func(*MergeOptions)
+
+// WithMergePolicies set merge policies during merge.
+func WithMergePolicies(policies MergePolicies) MergeOption {
+	return func(o *MergeOptions) {
+		o.Policies = policies
+	}
+}
+
+// WithDenyList disable merge for all keys in map.
+func WithDenyList(denyList Args) MergeOption {
+	return func(o *MergeOptions) {
+		if o.Policies == nil {
+			o.Policies = MergePolicies{}
+		}
+
+		for k := range denyList {
+			o.Policies[k] = MergeDenied
+		}
+	}
+}
+
 // ArgsBuilder defines the requirements to build and manage a set of args.
 type ArgsBuilder interface {
-	Merge(Args) ArgsBuilder
+	MustMerge(Args, ...MergeOption)
+	Merge(Args, ...MergeOption) error
 	Set(string, string) ArgsBuilder
 	Args() []string
 }

--- a/pkg/argsbuilder/argsbuilder_test.go
+++ b/pkg/argsbuilder/argsbuilder_test.go
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package argsbuilder_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/talos-systems/talos/pkg/argsbuilder"
+)
+
+type ArgsbuilderSuite struct {
+	suite.Suite
+}
+
+func (suite *ArgsbuilderSuite) TestMergeAdditive() {
+	args := argsbuilder.Args{
+		"param":  "value1,value2,value3",
+		"param2": "",
+	}
+
+	suite.Require().NoError(
+		args.Merge(argsbuilder.Args{
+			"param": "value2, value10",
+		},
+			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
+				"param": argsbuilder.MergeAdditive,
+			}),
+		),
+	)
+
+	suite.Require().Equal("value1,value2,value3,value10", args["param"])
+
+	suite.Require().NoError(
+		args.Merge(argsbuilder.Args{
+			"param2": "value1, value5",
+		},
+			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
+				"param2": argsbuilder.MergeAdditive,
+			}),
+		),
+	)
+
+	suite.Require().Equal("value1,value5", args["param2"])
+}
+
+func (suite *ArgsbuilderSuite) TestMergeOverwrite() {
+	args := argsbuilder.Args{
+		"param": "value1,value2",
+	}
+
+	suite.Require().NoError(
+		args.Merge(argsbuilder.Args{
+			"param": "value10",
+		},
+			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
+				"param2": argsbuilder.MergeAdditive,
+			}),
+		),
+	)
+
+	suite.Require().Equal("value10", args["param"])
+}
+
+func (suite *ArgsbuilderSuite) TestMergeDenied() {
+	args := argsbuilder.Args{
+		"param": "value1,value2",
+	}
+
+	suite.Require().Error(
+		args.Merge(argsbuilder.Args{
+			"param": "value10",
+		},
+			argsbuilder.WithMergePolicies(argsbuilder.MergePolicies{
+				"param": argsbuilder.MergeDenied,
+			}),
+		),
+	)
+}
+
+func (suite *ArgsbuilderSuite) TestMergeDenyList() {
+	args := argsbuilder.Args{
+		"param": "value1,value2",
+	}
+
+	denyList := argsbuilder.Args{
+		"param1": "",
+		"param2": "",
+		"param3": "",
+	}
+
+	suite.Require().Error(
+		args.Merge(argsbuilder.Args{
+			"param2": "value10",
+		},
+			argsbuilder.WithDenyList(denyList),
+		),
+	)
+}
+
+func TestArgsbuilderSuite(t *testing.T) {
+	suite.Run(t, &ArgsbuilderSuite{})
+}

--- a/pkg/resources/config/k8s_control_plane.go
+++ b/pkg/resources/config/k8s_control_plane.go
@@ -83,10 +83,9 @@ type K8sManifestsSpec struct {
 
 	PodCIDRs []string `yaml:"podCIDRs"`
 
-	ProxyEnabled   bool              `yaml:"proxyEnabled"`
-	ProxyImage     string            `yaml:"proxyImage"`
-	ProxyMode      string            `yaml:"proxyMode"`
-	ProxyExtraArgs map[string]string `yaml:"proxyExtraArgs"`
+	ProxyEnabled bool     `yaml:"proxyEnabled"`
+	ProxyImage   string   `yaml:"proxyImage"`
+	ProxyArgs    []string `yaml:"proxyArgs"`
 
 	CoreDNSEnabled bool   `yaml:"coreDNSEnabled"`
 	CoreDNSImage   string `yaml:"coreDNSImage"`


### PR DESCRIPTION
Use `argsbuilder` same way as it's used in services.
Rewrite `kubeProxy` generation code to override default args.

As a consequence of this change now flags do not have determined order
as they all come from a single merged map.

Fixes: https://github.com/talos-systems/talos/issues/4238

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4292)
<!-- Reviewable:end -->
