### PR TITLE
fix: check trustd API CA on worker nodes

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -337,7 +337,7 @@ func (ctrl *APIController) generateControlPlane(ctx context.Context, r controlle
 
 func (ctrl *APIController) generateJoin(ctx context.Context, r controller.Runtime, logger *zap.Logger,
 	rootSpec *secrets.RootOSSpec, endpointsStr []string, certSANs *secrets.CertSANSpec) error {
-	remoteGen, err := gen.NewRemoteGenerator(rootSpec.Token, endpointsStr)
+	remoteGen, err := gen.NewRemoteGenerator(rootSpec.Token, endpointsStr, rootSpec.CA)
 	if err != nil {
 		return fmt.Errorf("failed creating trustd client: %w", err)
 	}

--- a/pkg/grpc/gen/remote.go
+++ b/pkg/grpc/gen/remote.go
@@ -33,14 +33,14 @@ type RemoteGenerator struct {
 }
 
 // NewRemoteGenerator initializes a RemoteGenerator with a preconfigured grpc.ClientConn.
-func NewRemoteGenerator(token string, endpoints []string) (g *RemoteGenerator, err error) {
+func NewRemoteGenerator(token string, endpoints []string, ca *x509.PEMEncodedCertificateAndKey) (g *RemoteGenerator, err error) {
 	if len(endpoints) == 0 {
 		return nil, fmt.Errorf("at least one root of trust endpoint is required")
 	}
 
 	g = &RemoteGenerator{}
 
-	conn, err := basic.NewConnection(fmt.Sprintf("%s:///%s", trustdResolverScheme, strings.Join(endpoints, ",")), basic.NewTokenCredentials(token))
+	conn, err := basic.NewConnection(fmt.Sprintf("%s:///%s", trustdResolverScheme, strings.Join(endpoints, ",")), basic.NewTokenCredentials(token), ca)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/machinery/config/types/v1alpha1/generate/worker.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/worker.go
@@ -39,6 +39,7 @@ func workerUd(in *Input) (*v1alpha1.Config, error) {
 			KubeletImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubeletImage, in.KubernetesVersion), in.KubernetesVersion),
 		},
 		MachineNetwork: networkConfig,
+		MachineCA:      &x509.PEMEncodedCertificateAndKey{Crt: in.Certs.OS.Crt},
 		MachineInstall: &v1alpha1.InstallConfig{
 			InstallDisk:            in.InstallDisk,
 			InstallImage:           in.InstallImage,


### PR DESCRIPTION
This distributes API CA (just the certificate, not the key) to the
worker nodes on config generation, and if the CA cert is present on the
worker node, it verifies TLS connection to the trustd with the CA
certificate.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4294)
<!-- Reviewable:end -->
