### PR TITLE
fix: reset inputs back to initial state in secrets.APIController

### DIFF
--- a/internal/app/machined/pkg/controllers/secrets/api.go
+++ b/internal/app/machined/pkg/controllers/secrets/api.go
@@ -76,6 +76,11 @@ func (ctrl *APIController) Run(ctx context.Context, r controller.Runtime, logger
 		case <-r.EventCh():
 		}
 
+		// reset inputs back to what they were initially
+		if err := r.UpdateInputs(ctrl.Inputs()); err != nil {
+			return err
+		}
+
 		machineTypeRes, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineTypeType, config.MachineTypeID, resource.VersionUndefined))
 		if err != nil {
 			if state.IsNotFoundError(err) {
@@ -119,11 +124,6 @@ func (ctrl *APIController) Run(ctx context.Context, r controller.Runtime, logger
 		}
 
 		if err = ctrl.teardownAll(ctx, r); err != nil {
-			return err
-		}
-
-		// reset inputs back to what they were initially
-		if err = r.UpdateInputs(ctrl.Inputs()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This fixes a bug when after an error generating certificates controller
gets into a state of not being able to read its expected inputs
(NetworkStatus specifically).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4302)
<!-- Reviewable:end -->
