### PR TITLE
feat: harvest discovered endpoints and push them via discovery svc

### DIFF
--- a/internal/app/machined/pkg/controllers/kubespan/endpoint.go
+++ b/internal/app/machined/pkg/controllers/kubespan/endpoint.go
@@ -1,0 +1,136 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubespan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"go.uber.org/zap"
+
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/kubespan"
+)
+
+// EndpointController watches KubeSpanPeerStatuses, Affiliates and harvests additional endpoints for the peers.
+type EndpointController struct{}
+
+// Name implements controller.Controller interface.
+func (ctrl *EndpointController) Name() string {
+	return "kubespan.EndpointController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *EndpointController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: cluster.NamespaceName,
+			Type:      cluster.AffiliateType,
+			Kind:      controller.InputWeak,
+		},
+		{
+			Namespace: kubespan.NamespaceName,
+			Type:      kubespan.PeerStatusType,
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *EndpointController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: kubespan.EndpointType,
+			Kind: controller.OutputExclusive,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *EndpointController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		peerStatuses, err := r.List(ctx, resource.NewMetadata(kubespan.NamespaceName, kubespan.PeerStatusType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing cluster affiliates: %w", err)
+		}
+
+		affiliates, err := r.List(ctx, resource.NewMetadata(cluster.NamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing cluster affiliates: %w", err)
+		}
+
+		// build lookup table of affiliate's kubespan public key back to affiliate ID
+		affiliateLookup := make(map[string]string)
+
+		for _, res := range affiliates.Items {
+			affiliate := res.(*cluster.Affiliate).TypedSpec()
+
+			if affiliate.KubeSpan.PublicKey != "" {
+				affiliateLookup[affiliate.KubeSpan.PublicKey] = affiliate.NodeID
+			}
+		}
+
+		// for every kubespan peer, if it's up and has endpoint, harvest that endpoint
+		touchedIDs := make(map[resource.ID]struct{})
+
+		for _, res := range peerStatuses.Items {
+			peerStatus := res.(*kubespan.PeerStatus).TypedSpec()
+
+			if peerStatus.State != kubespan.PeerStateUp {
+				continue
+			}
+
+			if peerStatus.Endpoint.IsZero() {
+				continue
+			}
+
+			affiliateID, ok := affiliateLookup[res.Metadata().ID()]
+			if !ok {
+				continue
+			}
+
+			if err = r.Modify(ctx, kubespan.NewEndpoint(kubespan.NamespaceName, res.Metadata().ID()), func(res resource.Resource) error {
+				*res.(*kubespan.Endpoint).TypedSpec() = kubespan.EndpointSpec{
+					AffiliateID: affiliateID,
+					Endpoint:    peerStatus.Endpoint,
+				}
+
+				return nil
+			}); err != nil {
+				return err
+			}
+
+			touchedIDs[res.Metadata().ID()] = struct{}{}
+		}
+
+		// list keys for cleanup
+		list, err := r.List(ctx, resource.NewMetadata(kubespan.NamespaceName, kubespan.EndpointType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range list.Items {
+			if res.Metadata().Owner() != ctrl.Name() {
+				continue
+			}
+
+			if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+				if err = r.Destroy(ctx, res.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up specs: %w", err)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/machined/pkg/controllers/kubespan/endpoint_test.go
+++ b/internal/app/machined/pkg/controllers/kubespan/endpoint_test.go
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+package kubespan_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+
+	kubespanctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/kubespan"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
+	"github.com/talos-systems/talos/pkg/resources/cluster"
+	"github.com/talos-systems/talos/pkg/resources/kubespan"
+)
+
+type EndpointSuite struct {
+	KubeSpanSuite
+}
+
+func (suite *EndpointSuite) TestReconcile() {
+	suite.Require().NoError(suite.runtime.RegisterController(&kubespanctrl.EndpointController{}))
+
+	suite.startRuntime()
+
+	// create some affiliates and peer statuses
+	affiliate1 := cluster.NewAffiliate(cluster.NamespaceName, "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC")
+	*affiliate1.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "7x1SuC8Ege5BGXdAfTEff5iQnlWZLfv9h1LGMxA2pYkC",
+		Hostname:    "foo.com",
+		Nodename:    "bar",
+		MachineType: machine.TypeControlPlane,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.4")},
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey:           "PLPNBddmTgHJhtw0vxltq1ZBdPP9RNOEUd5JjJZzBRY=",
+			Address:             netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e0"),
+			AdditionalAddresses: []netaddr.IPPrefix{netaddr.MustParseIPPrefix("10.244.3.1/24")},
+			Endpoints:           []netaddr.IPPort{netaddr.MustParseIPPort("10.0.0.2:51820"), netaddr.MustParseIPPort("192.168.3.4:51820")},
+		},
+	}
+
+	affiliate2 := cluster.NewAffiliate(cluster.NamespaceName, "roLng5hmP0Gv9S5Pbfzaa93JSZjsdpXNAn7vzuCfsc8")
+	*affiliate2.TypedSpec() = cluster.AffiliateSpec{
+		NodeID:      "roLng5hmP0Gv9S5Pbfzaa93JSZjsdpXNAn7vzuCfsc8",
+		MachineType: machine.TypeControlPlane,
+		Addresses:   []netaddr.IP{netaddr.MustParseIP("192.168.3.5")},
+		KubeSpan: cluster.KubeSpanAffiliateSpec{
+			PublicKey: "1CXkdhWBm58c36kTpchR8iGlXHG1ruHa5W8gsFqD8Qs=",
+			Address:   netaddr.MustParseIP("fd50:8d60:4238:6302:f857:23ff:fe21:d1e1"),
+		},
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, affiliate1))
+	suite.Require().NoError(suite.state.Create(suite.ctx, affiliate2))
+
+	peerStatus1 := kubespan.NewPeerStatus(kubespan.NamespaceName, affiliate1.TypedSpec().KubeSpan.PublicKey)
+	*peerStatus1.TypedSpec() = kubespan.PeerStatusSpec{
+		Endpoint: netaddr.MustParseIPPort("10.3.4.8:278"),
+		State:    kubespan.PeerStateUp,
+	}
+
+	peerStatus2 := kubespan.NewPeerStatus(kubespan.NamespaceName, affiliate2.TypedSpec().KubeSpan.PublicKey)
+	*peerStatus2.TypedSpec() = kubespan.PeerStatusSpec{
+		Endpoint: netaddr.MustParseIPPort("10.3.4.9:279"),
+		State:    kubespan.PeerStateUnknown,
+	}
+
+	peerStatus3 := kubespan.NewPeerStatus(kubespan.NamespaceName, "LoXPyyYh3kZwyKyWfCcf9VvgVv588cKhSKXavuUZqDg=")
+	*peerStatus3.TypedSpec() = kubespan.PeerStatusSpec{
+		Endpoint: netaddr.MustParseIPPort("10.3.4.10:270"),
+		State:    kubespan.PeerStateUp,
+	}
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, peerStatus1))
+	suite.Require().NoError(suite.state.Create(suite.ctx, peerStatus2))
+	suite.Require().NoError(suite.state.Create(suite.ctx, peerStatus3))
+
+	// peer1 is up and has matching affiliate
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(
+			resource.NewMetadata(
+				kubespan.NamespaceName,
+				kubespan.EndpointType,
+				peerStatus1.Metadata().ID(),
+				resource.VersionUndefined,
+			),
+			func(res resource.Resource) error {
+				spec := res.(*kubespan.Endpoint).TypedSpec()
+
+				suite.Assert().Equal(peerStatus1.TypedSpec().Endpoint, spec.Endpoint)
+				suite.Assert().Equal(affiliate1.TypedSpec().NodeID, spec.AffiliateID)
+
+				return nil
+			},
+		),
+	))
+
+	// peer2 is not up, it shouldn't be published as an endpoint
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertNoResource(
+			resource.NewMetadata(
+				kubespan.NamespaceName,
+				kubespan.EndpointType,
+				peerStatus2.Metadata().ID(),
+				resource.VersionUndefined,
+			),
+		),
+	))
+
+	// peer3 is up, but has not matching affiliate
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertNoResource(
+			resource.NewMetadata(
+				kubespan.NamespaceName,
+				kubespan.EndpointType,
+				peerStatus3.Metadata().ID(),
+				resource.VersionUndefined,
+			),
+		),
+	))
+}
+
+func TestEndpointSuite(t *testing.T) {
+	suite.Run(t, new(EndpointSuite))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -102,6 +102,7 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&k8s.NodenameController{},
 		&k8s.RenderSecretsStaticPodController{},
 		&kubespan.ConfigController{},
+		&kubespan.EndpointController{},
 		&kubespan.IdentityController{},
 		&kubespan.ManagerController{},
 		&kubespan.PeerSpecController{},

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -95,6 +95,7 @@ func NewState() (*State, error) {
 		&k8s.StaticPodStatus{},
 		&k8s.SecretsStatus{},
 		&kubespan.Config{},
+		&kubespan.Endpoint{},
 		&kubespan.Identity{},
 		&kubespan.PeerSpec{},
 		&kubespan.PeerStatus{},

--- a/pkg/resources/kubespan/endpoint.go
+++ b/pkg/resources/kubespan/endpoint.go
@@ -1,0 +1,88 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package kubespan
+
+import (
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/resource/meta"
+	"inet.af/netaddr"
+)
+
+// EndpointType is type of Endpoint resource.
+const EndpointType = resource.Type("KubeSpanEndpoints.kubespan.talos.dev")
+
+// Endpoint is produced from KubeSpanPeerStatuses by mapping back discovered endpoints to the affiliates.
+//
+// Endpoint is identified by the public key of the peer.
+type Endpoint struct {
+	md   resource.Metadata
+	spec EndpointSpec
+}
+
+// EndpointSpec describes Endpoint state.
+type EndpointSpec struct {
+	AffiliateID string         `yaml:"affiliateID"`
+	Endpoint    netaddr.IPPort `yaml:"endpoint"`
+}
+
+// NewEndpoint initializes a Endpoint resource.
+func NewEndpoint(namespace resource.Namespace, id resource.ID) *Endpoint {
+	r := &Endpoint{
+		md:   resource.NewMetadata(namespace, EndpointType, id, resource.VersionUndefined),
+		spec: EndpointSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// Metadata implements resource.Resource.
+func (r *Endpoint) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *Endpoint) Spec() interface{} {
+	return r.spec
+}
+
+func (r *Endpoint) String() string {
+	return fmt.Sprintf("kubespan.Endpoint(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *Endpoint) DeepCopy() resource.Resource {
+	return &Endpoint{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *Endpoint) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             EndpointType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns: []meta.PrintColumn{
+			{
+				Name:     "Endpoint",
+				JSONPath: `{.endpoint}`,
+			},
+			{
+				Name:     "Affiliate ID",
+				JSONPath: `{.affiliateID}`,
+			},
+		},
+	}
+}
+
+// TypedSpec allows to access the Spec with the proper type.
+func (r *Endpoint) TypedSpec() *EndpointSpec {
+	return &r.spec
+}

--- a/pkg/resources/kubespan/kubespan_test.go
+++ b/pkg/resources/kubespan/kubespan_test.go
@@ -26,6 +26,7 @@ func TestRegisterResource(t *testing.T) {
 
 	for _, resource := range []resource.Resource{
 		&kubespan.Config{},
+		&kubespan.Endpoint{},
 		&kubespan.Identity{},
 		&kubespan.PeerSpec{},
 		&kubespan.PeerStatus{},


### PR DESCRIPTION
Fixes #4250

Each KubeSpan peer sees each other KubeSpan peer endpoint as it got
connected. If the peer is behind NAT, the discovered endpoint is
different from the endpoints node knows about itself (as it punched a
hole in NAT). This discovered endpoint is pushed to the discovery
service so that every other peer now can use that punched hole to talk
to the peer.

If the endpoint observed is actually in the list of the endpoints
reported by the peer itself, discovery service will take care of
deduplicating them and suppressing updates.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4304)
<!-- Reviewable:end -->
