### PR TITLE
feat: update containerd to 1.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.8.0-alpha.0-3-g2790b55
-PKGS ?= v0.8.0-alpha.0-4-g28cda67
+PKGS ?= v0.8.0-alpha.0-5-gf22ce18
 EXTRAS ?= v0.6.0-alpha.0
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -311,7 +311,7 @@ const (
 	TrustdUserID = 51
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.5.5"
+	DefaultContainerdVersion = "1.5.6"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
This also updates runc to 1.0.2, libseccomp to 2.5.2.

See also https://github.com/containerd/containerd/releases/tag/v1.5.6

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4308)
<!-- Reviewable:end -->
