### PR TITLE
fix: allow 404 when querying external IP in AWS

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -195,6 +195,11 @@ func (a *AWS) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// nb: we "accept" NotFound because AWS metadata endpoints will return a 404
+		// when there is no public IP attached to the instance.
+		if resp.StatusCode == http.StatusNotFound {
+			return addrs, nil
+		}
 		return addrs, fmt.Errorf("failed to retrieve external addresses for instance")
 	}
 


### PR DESCRIPTION
This PR fixes an issue where we weren't allowing for a 404 to be
returned when querying
http://169.254.169.254/latest/meta-data/public-ipv4. This path won't
exist if there's no public IP on the instance.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4309)
<!-- Reviewable:end -->
