### PR TITLE
fix: ignore 404 for AWS external IPs

### DIFF
--- a/internal/app/machined/pkg/controllers/network/platform_config.go
+++ b/internal/app/machined/pkg/controllers/network/platform_config.go
@@ -6,6 +6,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cosi-project/runtime/pkg/controller"
@@ -14,6 +15,7 @@ import (
 	"inet.af/netaddr"
 
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
+	platformerrors "github.com/talos-systems/talos/internal/app/machined/pkg/runtime/v1alpha1/platform/errors"
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
 	"github.com/talos-systems/talos/pkg/resources/network"
 )
@@ -68,7 +70,9 @@ func (ctrl *PlatformConfigController) Run(ctx context.Context, r controller.Runt
 	// platform is fetched only once (but controller might fail and restart if fetching platform fails)
 	hostname, err := ctrl.V1alpha1Platform.Hostname(ctx)
 	if err != nil {
-		return fmt.Errorf("error getting hostname: %w", err)
+		if !errors.Is(err, platformerrors.ErrNoHostname) {
+			return fmt.Errorf("error getting hostname: %w", err)
+		}
 	}
 
 	if len(hostname) > 0 {
@@ -89,7 +93,9 @@ func (ctrl *PlatformConfigController) Run(ctx context.Context, r controller.Runt
 
 	externalIPs, err := ctrl.V1alpha1Platform.ExternalIPs(ctx)
 	if err != nil {
-		return fmt.Errorf("error getting external IPs: %w", err)
+		if !errors.Is(err, platformerrors.ErrNoExternalIPs) {
+			return fmt.Errorf("error getting external IPs: %w", err)
+		}
 	}
 
 	touchedIDs := make(map[resource.ID]struct{})

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -194,8 +194,12 @@ func (a *AWS) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	//nolint:errcheck
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		return addrs, fmt.Errorf("failed to retrieve external addresses for instance")
+		return addrs, fmt.Errorf("failed to retrieve external addresses for instance: %d", resp.StatusCode)
 	}
 
 	if body, err = ioutil.ReadAll(resp.Body); err != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/gcp/gcp.go
@@ -80,7 +80,7 @@ func (g *GCP) ExternalIPs(ctx context.Context) (addrs []net.IP, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return addrs, fmt.Errorf("failed to retrieve external addresses for instance")
+		return addrs, fmt.Errorf("failed to retrieve external addresses for instance: %d", resp.StatusCode)
 	}
 
 	type metadata []struct {

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -127,8 +127,8 @@ func (s *Scaleway) Hostname(ctx context.Context) (hostname []byte, err error) {
 	log.Printf("fetching hostname from: %q", ScalewayMetadataEndpoint)
 
 	metadataDl, err := download.Download(ctx, ScalewayMetadataEndpoint,
-		download.WithErrorOnNotFound(errors.ErrNoExternalIPs),
-		download.WithErrorOnEmptyResponse(errors.ErrNoExternalIPs))
+		download.WithErrorOnNotFound(errors.ErrNoHostname),
+		download.WithErrorOnEmptyResponse(errors.ErrNoHostname))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also ignore expected errors for other platforms to keep controller from
failing over and over again.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4310)
<!-- Reviewable:end -->
