### PR TITLE
backport: feat: update containerd to 1.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.7.0-1-ga33ccc1
-PKGS ?= v0.7.0
+PKGS ?= v0.7.0-1-g7b36021
 EXTRAS ?= v0.5.0
 GO_VERSION ?= 1.16
 GOFUMPT_VERSION ?= v0.1.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -311,7 +311,7 @@ const (
 	TrustdUserID = 51
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.5.5"
+	DefaultContainerdVersion = "1.5.6"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
This backports a change from 0.13.

See https://github.com/containerd/containerd/releases/tag/v1.5.6

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4315)
<!-- Reviewable:end -->
