### PR TITLE
chore: update docker image in the pipeline

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -103,7 +103,7 @@ local volumes = {
 // This provides the docker service.
 local docker = {
   name: 'docker',
-  image: 'docker:20.10-dind',
+  image: 'ghcr.io/smira/docker:20.10-dind-hacked',
   entrypoint: ['dockerd'],
   privileged: true,
   command: [


### PR DESCRIPTION
We use hacked version with a workaround for capability issues with
`--privileged` in Docker.

See moby/moby#42906

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4329)
<!-- Reviewable:end -->
