### PR TITLE
fix: clear time adjustment error when setting time to specific value

### DIFF
--- a/internal/pkg/ntp/ntp.go
+++ b/internal/pkg/ntp/ntp.go
@@ -288,11 +288,13 @@ func (syncer *Syncer) adjustTime(offset time.Duration, leapSecond ntp.LeapIndica
 		fmt.Fprintf(&buf, "adjusting time (jump) by %s via %s", offset, server)
 
 		req = syscall.Timex{
-			Modes: timex.ADJ_SETOFFSET | timex.ADJ_NANO | timex.ADJ_STATUS,
+			Modes: timex.ADJ_SETOFFSET | timex.ADJ_NANO | timex.ADJ_STATUS | timex.ADJ_MAXERROR | timex.ADJ_ESTERROR,
 			Time: syscall.Timeval{
 				Sec:  int64(offset / time.Second),
 				Usec: int64(offset / time.Nanosecond % time.Second),
 			},
+			Maxerror: 0,
+			Esterror: 0,
 		}
 
 		// kernel wants tv_usec to be positive


### PR DESCRIPTION
I don't think this is going to fix time issues, so just a small cleanup.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4468)
<!-- Reviewable:end -->
