### PR TITLE
refactor: get rid of prometheus/procfs dependency in pkg/resources

### DIFF
--- a/internal/app/machined/pkg/adapters/perf/cpu.go
+++ b/internal/app/machined/pkg/adapters/perf/cpu.go
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf
+
+import (
+	"github.com/prometheus/procfs"
+
+	"github.com/talos-systems/talos/pkg/resources/perf"
+)
+
+// CPU adapter provides conversion from procfs.
+//
+//nolint:revive,golint
+func CPU(r *perf.CPU) cpu {
+	return cpu{
+		CPU: r,
+	}
+}
+
+type cpu struct {
+	*perf.CPU
+}
+
+// Update current CPU snapshot.
+func (a cpu) Update(stat *procfs.Stat) {
+	translateCPUStat := func(in procfs.CPUStat) perf.CPUStat {
+		return perf.CPUStat{
+			User:      in.User,
+			Nice:      in.Nice,
+			System:    in.System,
+			Idle:      in.Idle,
+			Iowait:    in.Iowait,
+			Irq:       in.IRQ,
+			SoftIrq:   in.SoftIRQ,
+			Steal:     in.Steal,
+			Guest:     in.Guest,
+			GuestNice: in.GuestNice,
+		}
+	}
+
+	translateListOfCPUStat := func(in []procfs.CPUStat) []perf.CPUStat {
+		res := make([]perf.CPUStat, len(in))
+
+		for i := range in {
+			res[i] = translateCPUStat(in[i])
+		}
+
+		return res
+	}
+
+	*a.CPU.TypedSpec() = perf.CPUSpec{
+		CPUTotal:        translateCPUStat(stat.CPUTotal),
+		CPU:             translateListOfCPUStat(stat.CPU),
+		IRQTotal:        stat.IRQTotal,
+		ContextSwitches: stat.ContextSwitches,
+		ProcessCreated:  stat.ProcessCreated,
+		ProcessRunning:  stat.ProcessesRunning,
+		ProcessBlocked:  stat.ProcessesBlocked,
+		SoftIrqTotal:    stat.SoftIRQTotal,
+	}
+}

--- a/internal/app/machined/pkg/adapters/perf/mem.go
+++ b/internal/app/machined/pkg/adapters/perf/mem.go
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package perf
+
+import (
+	"github.com/AlekSi/pointer"
+	"github.com/prometheus/procfs"
+
+	"github.com/talos-systems/talos/pkg/resources/perf"
+)
+
+// Memory adapter provides conversion from procfs.
+//
+//nolint:revive,golint
+func Memory(r *perf.Memory) memory {
+	return memory{
+		Memory: r,
+	}
+}
+
+type memory struct {
+	*perf.Memory
+}
+
+// Update current Mem snapshot.
+func (a memory) Update(info *procfs.Meminfo) {
+	*a.Memory.TypedSpec() = perf.MemorySpec{
+		MemTotal:          pointer.GetUint64(info.MemTotal),
+		MemUsed:           pointer.GetUint64(info.MemTotal) - pointer.GetUint64(info.MemFree),
+		MemAvailable:      pointer.GetUint64(info.MemAvailable),
+		Buffers:           pointer.GetUint64(info.Buffers),
+		Cached:            pointer.GetUint64(info.Cached),
+		SwapCached:        pointer.GetUint64(info.SwapCached),
+		Active:            pointer.GetUint64(info.Active),
+		Inactive:          pointer.GetUint64(info.Inactive),
+		ActiveAnon:        pointer.GetUint64(info.ActiveAnon),
+		InactiveAnon:      pointer.GetUint64(info.InactiveAnon),
+		ActiveFile:        pointer.GetUint64(info.ActiveFile),
+		InactiveFile:      pointer.GetUint64(info.InactiveFile),
+		Unevictable:       pointer.GetUint64(info.Unevictable),
+		Mlocked:           pointer.GetUint64(info.Mlocked),
+		SwapTotal:         pointer.GetUint64(info.SwapTotal),
+		SwapFree:          pointer.GetUint64(info.SwapFree),
+		Dirty:             pointer.GetUint64(info.Dirty),
+		Writeback:         pointer.GetUint64(info.Writeback),
+		AnonPages:         pointer.GetUint64(info.AnonPages),
+		Mapped:            pointer.GetUint64(info.Mapped),
+		Shmem:             pointer.GetUint64(info.Shmem),
+		Slab:              pointer.GetUint64(info.Slab),
+		SReclaimable:      pointer.GetUint64(info.SReclaimable),
+		SUnreclaim:        pointer.GetUint64(info.SUnreclaim),
+		KernelStack:       pointer.GetUint64(info.KernelStack),
+		PageTables:        pointer.GetUint64(info.PageTables),
+		NFSunstable:       pointer.GetUint64(info.NFSUnstable),
+		Bounce:            pointer.GetUint64(info.Bounce),
+		WritebackTmp:      pointer.GetUint64(info.WritebackTmp),
+		CommitLimit:       pointer.GetUint64(info.CommitLimit),
+		CommittedAS:       pointer.GetUint64(info.CommittedAS),
+		VmallocTotal:      pointer.GetUint64(info.VmallocTotal),
+		VmallocUsed:       pointer.GetUint64(info.VmallocUsed),
+		VmallocChunk:      pointer.GetUint64(info.VmallocChunk),
+		HardwareCorrupted: pointer.GetUint64(info.HardwareCorrupted),
+		AnonHugePages:     pointer.GetUint64(info.AnonHugePages),
+		ShmemHugePages:    pointer.GetUint64(info.ShmemHugePages),
+		ShmemPmdMapped:    pointer.GetUint64(info.ShmemPmdMapped),
+		CmaTotal:          pointer.GetUint64(info.CmaTotal),
+		CmaFree:           pointer.GetUint64(info.CmaFree),
+		HugePagesTotal:    pointer.GetUint64(info.HugePagesTotal),
+		HugePagesFree:     pointer.GetUint64(info.HugePagesFree),
+		HugePagesRsvd:     pointer.GetUint64(info.HugePagesRsvd),
+		HugePagesSurp:     pointer.GetUint64(info.HugePagesSurp),
+		Hugepagesize:      pointer.GetUint64(info.Hugepagesize),
+		DirectMap4k:       pointer.GetUint64(info.DirectMap4k),
+		DirectMap2m:       pointer.GetUint64(info.DirectMap2M),
+		DirectMap1g:       pointer.GetUint64(info.DirectMap1G),
+	}
+}

--- a/internal/app/machined/pkg/adapters/perf/perf.go
+++ b/internal/app/machined/pkg/adapters/perf/perf.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package perf providers adapters wrapping resources/perf to provide additional functionality.
+package perf

--- a/internal/app/machined/pkg/controllers/perf/perf.go
+++ b/internal/app/machined/pkg/controllers/perf/perf.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/procfs"
 	"go.uber.org/zap"
 
+	perfadapter "github.com/talos-systems/talos/internal/app/machined/pkg/adapters/perf"
 	"github.com/talos-systems/talos/pkg/resources/perf"
 )
 
@@ -88,7 +89,7 @@ func (ctrl *StatsController) updateCPU(ctx context.Context, r controller.Runtime
 	}
 
 	return r.Modify(ctx, cpu, func(r resource.Resource) error {
-		r.(*perf.CPU).Update(&stat)
+		perfadapter.CPU(r.(*perf.CPU)).Update(&stat)
 
 		return nil
 	})
@@ -103,7 +104,7 @@ func (ctrl *StatsController) updateMemory(ctx context.Context, r controller.Runt
 	}
 
 	return r.Modify(ctx, mem, func(r resource.Resource) error {
-		r.(*perf.Memory).Update(&info)
+		perfadapter.Memory(r.(*perf.Memory)).Update(&info)
 
 		return nil
 	})

--- a/pkg/resources/.importvet.yaml
+++ b/pkg/resources/.importvet.yaml
@@ -17,7 +17,7 @@ rules:
   #  action: deny
   #- regexp: ^github.com/mdlayher/netx
   #  action: deny
-  #- regexp: ^github.com/prometheus/procfs
-  #  action: deny
+  - regexp: ^github.com/prometheus/procfs
+    action: deny
   #- regexp: ^golang.zx2c4.com/wireguard/wgctrl
   #  action: deny

--- a/pkg/resources/perf/cpu.go
+++ b/pkg/resources/perf/cpu.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
-	"github.com/prometheus/procfs"
 )
 
 // CPUType is type of Etcd resource.
@@ -102,41 +101,7 @@ func (r *CPU) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Update current CPU snapshot.
-func (r *CPU) Update(stat *procfs.Stat) {
-	translateCPUStat := func(in procfs.CPUStat) CPUStat {
-		return CPUStat{
-			User:      in.User,
-			Nice:      in.Nice,
-			System:    in.System,
-			Idle:      in.Idle,
-			Iowait:    in.Iowait,
-			Irq:       in.IRQ,
-			SoftIrq:   in.SoftIRQ,
-			Steal:     in.Steal,
-			Guest:     in.Guest,
-			GuestNice: in.GuestNice,
-		}
-	}
-
-	translateListOfCPUStat := func(in []procfs.CPUStat) []CPUStat {
-		res := make([]CPUStat, len(in))
-
-		for i := range in {
-			res[i] = translateCPUStat(in[i])
-		}
-
-		return res
-	}
-
-	r.spec = CPUSpec{
-		CPUTotal:        translateCPUStat(stat.CPUTotal),
-		CPU:             translateListOfCPUStat(stat.CPU),
-		IRQTotal:        stat.IRQTotal,
-		ContextSwitches: stat.ContextSwitches,
-		ProcessCreated:  stat.ProcessCreated,
-		ProcessRunning:  stat.ProcessesRunning,
-		ProcessBlocked:  stat.ProcessesBlocked,
-		SoftIrqTotal:    stat.SoftIRQTotal,
-	}
+// TypedSpec returns .spec.
+func (r *CPU) TypedSpec() *CPUSpec {
+	return &r.spec
 }

--- a/pkg/resources/perf/mem.go
+++ b/pkg/resources/perf/mem.go
@@ -7,10 +7,8 @@ package perf
 import (
 	"fmt"
 
-	"github.com/AlekSi/pointer"
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
-	"github.com/prometheus/procfs"
 )
 
 // MemoryType is type of Etcd resource.
@@ -129,56 +127,7 @@ func (r *Memory) ResourceDefinition() meta.ResourceDefinitionSpec {
 	}
 }
 
-// Update current Mem snapshot.
-func (r *Memory) Update(info *procfs.Meminfo) {
-	r.spec = MemorySpec{
-		MemTotal:          pointer.GetUint64(info.MemTotal),
-		MemUsed:           pointer.GetUint64(info.MemTotal) - pointer.GetUint64(info.MemFree),
-		MemAvailable:      pointer.GetUint64(info.MemAvailable),
-		Buffers:           pointer.GetUint64(info.Buffers),
-		Cached:            pointer.GetUint64(info.Cached),
-		SwapCached:        pointer.GetUint64(info.SwapCached),
-		Active:            pointer.GetUint64(info.Active),
-		Inactive:          pointer.GetUint64(info.Inactive),
-		ActiveAnon:        pointer.GetUint64(info.ActiveAnon),
-		InactiveAnon:      pointer.GetUint64(info.InactiveAnon),
-		ActiveFile:        pointer.GetUint64(info.ActiveFile),
-		InactiveFile:      pointer.GetUint64(info.InactiveFile),
-		Unevictable:       pointer.GetUint64(info.Unevictable),
-		Mlocked:           pointer.GetUint64(info.Mlocked),
-		SwapTotal:         pointer.GetUint64(info.SwapTotal),
-		SwapFree:          pointer.GetUint64(info.SwapFree),
-		Dirty:             pointer.GetUint64(info.Dirty),
-		Writeback:         pointer.GetUint64(info.Writeback),
-		AnonPages:         pointer.GetUint64(info.AnonPages),
-		Mapped:            pointer.GetUint64(info.Mapped),
-		Shmem:             pointer.GetUint64(info.Shmem),
-		Slab:              pointer.GetUint64(info.Slab),
-		SReclaimable:      pointer.GetUint64(info.SReclaimable),
-		SUnreclaim:        pointer.GetUint64(info.SUnreclaim),
-		KernelStack:       pointer.GetUint64(info.KernelStack),
-		PageTables:        pointer.GetUint64(info.PageTables),
-		NFSunstable:       pointer.GetUint64(info.NFSUnstable),
-		Bounce:            pointer.GetUint64(info.Bounce),
-		WritebackTmp:      pointer.GetUint64(info.WritebackTmp),
-		CommitLimit:       pointer.GetUint64(info.CommitLimit),
-		CommittedAS:       pointer.GetUint64(info.CommittedAS),
-		VmallocTotal:      pointer.GetUint64(info.VmallocTotal),
-		VmallocUsed:       pointer.GetUint64(info.VmallocUsed),
-		VmallocChunk:      pointer.GetUint64(info.VmallocChunk),
-		HardwareCorrupted: pointer.GetUint64(info.HardwareCorrupted),
-		AnonHugePages:     pointer.GetUint64(info.AnonHugePages),
-		ShmemHugePages:    pointer.GetUint64(info.ShmemHugePages),
-		ShmemPmdMapped:    pointer.GetUint64(info.ShmemPmdMapped),
-		CmaTotal:          pointer.GetUint64(info.CmaTotal),
-		CmaFree:           pointer.GetUint64(info.CmaFree),
-		HugePagesTotal:    pointer.GetUint64(info.HugePagesTotal),
-		HugePagesFree:     pointer.GetUint64(info.HugePagesFree),
-		HugePagesRsvd:     pointer.GetUint64(info.HugePagesRsvd),
-		HugePagesSurp:     pointer.GetUint64(info.HugePagesSurp),
-		Hugepagesize:      pointer.GetUint64(info.Hugepagesize),
-		DirectMap4k:       pointer.GetUint64(info.DirectMap4k),
-		DirectMap2m:       pointer.GetUint64(info.DirectMap2M),
-		DirectMap1g:       pointer.GetUint64(info.DirectMap1G),
-	}
+// TypedSpec returns .spec.
+func (r *Memory) TypedSpec() *MemorySpec {
+	return &r.spec
 }


### PR DESCRIPTION
This PR introduces the concept of the resource adapter: something which
wraps core resource (which defines presentation) and adds additional
fatures to it which we don't want to have in `pkg/machinery` in the
future, but at the same time there's value in keeping it next to the
resource itself.

If the concept looks good, I will continue doing it same way for other
resources.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4469)
<!-- Reviewable:end -->
