### PR TITLE
fix: do not use yaml.v2 in the support cmd

### DIFF
--- a/cmd/talosctl/cmd/talos/support.go
+++ b/cmd/talosctl/cmd/talos/support.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/talos-systems/talos/pkg/cluster"
 	"github.com/talos-systems/talos/pkg/machinery/client"


### PR DESCRIPTION
`gopls` automatic importer always includes yaml.v2.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4505)
<!-- Reviewable:end -->
