### PR TITLE
chore: remove unused parameters

### DIFF
--- a/internal/app/machined/pkg/system/mocks_test.go
+++ b/internal/app/machined/pkg/system/mocks_test.go
@@ -100,7 +100,7 @@ type MockRunner struct {
 	exitCh chan error
 }
 
-func (m *MockRunner) Open(ctx context.Context) error {
+func (m *MockRunner) Open() error {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -57,7 +57,7 @@ func NewRunner(debug bool, args *runner.Args, setters ...runner.Option) runner.R
 }
 
 // Open implements the Runner interface.
-func (c *containerdRunner) Open(ctx context.Context) error {
+func (c *containerdRunner) Open() error {
 	// Create the containerd client.
 	var err error
 

--- a/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd_test.go
@@ -116,7 +116,7 @@ func (suite *ContainerdSuite) SetupSuite() {
 		runner.WithEnv([]string{"PATH=/bin:" + constants.PATH}),
 		runner.WithCgroupPath(suite.tmpDir),
 	)
-	suite.Require().NoError(suite.containerdRunner.Open(context.Background()))
+	suite.Require().NoError(suite.containerdRunner.Open())
 	suite.containerdWg.Add(1)
 
 	go func() {
@@ -174,7 +174,7 @@ func (suite *ContainerdSuite) TestRunSuccess() {
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
 
-	suite.Require().NoError(r.Open(context.Background()))
+	suite.Require().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -194,7 +194,7 @@ func (suite *ContainerdSuite) TestRunTwice() {
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
 
-	suite.Require().NoError(r.Open(context.Background()))
+	suite.Require().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -228,7 +228,7 @@ func (suite *ContainerdSuite) TestContainerCleanup() {
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
 
-	suite.Require().NoError(r1.Open(context.Background()))
+	suite.Require().NoError(r1.Open())
 
 	r2 := containerdrunner.NewRunner(false, &runner.Args{
 		ID:          suite.containerID,
@@ -239,7 +239,7 @@ func (suite *ContainerdSuite) TestContainerCleanup() {
 		runner.WithContainerImage(busyboxImage),
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
-	suite.Require().NoError(r2.Open(context.Background()))
+	suite.Require().NoError(r2.Open())
 
 	defer func() { suite.Assert().NoError(r2.Close()) }()
 
@@ -259,7 +259,7 @@ func (suite *ContainerdSuite) TestRunLogs() {
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
 
-	suite.Require().NoError(r.Open(context.Background()))
+	suite.Require().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -303,7 +303,7 @@ func (suite *ContainerdSuite) TestStopFailingAndRestarting() {
 		restart.WithRestartInterval(5*time.Millisecond),
 	)
 
-	suite.Require().NoError(r.Open(context.Background()))
+	suite.Require().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -374,7 +374,7 @@ func (suite *ContainerdSuite) TestStopSigKill() {
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
 
-	suite.Require().NoError(r.Open(context.Background()))
+	suite.Require().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -411,7 +411,7 @@ func (suite *ContainerdSuite) TestContainerStdin() {
 		runner.WithContainerdAddress(suite.containerdAddress),
 	)
 
-	suite.Require().NoError(r.Open(context.Background()))
+	suite.Require().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine.go
@@ -55,7 +55,7 @@ func NewRunner(r runtime.Runtime, id string, main FuncMain, setters ...runner.Op
 }
 
 // Open implements the Runner interface.
-func (r *goroutineRunner) Open(ctx context.Context) error {
+func (r *goroutineRunner) Open() error {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
+++ b/internal/app/machined/pkg/system/runner/goroutine/goroutine_test.go
@@ -70,7 +70,7 @@ func (suite *GoroutineSuite) TestRunSuccess() {
 			return nil
 		}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -85,7 +85,7 @@ func (suite *GoroutineSuite) TestRunFail() {
 			return errors.New("service failed")
 		}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -100,7 +100,7 @@ func (suite *GoroutineSuite) TestRunPanic() {
 			panic("service panic")
 		}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -119,7 +119,7 @@ func (suite *GoroutineSuite) TestStop() {
 			return ctx.Err()
 		}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -150,7 +150,7 @@ func (suite *GoroutineSuite) TestRunLogs() {
 			return nil
 		}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 

--- a/internal/app/machined/pkg/system/runner/process/process.go
+++ b/internal/app/machined/pkg/system/runner/process/process.go
@@ -5,7 +5,6 @@
 package process
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -52,7 +51,7 @@ func NewRunner(debug bool, args *runner.Args, setters ...runner.Option) runner.R
 }
 
 // Open implements the Runner interface.
-func (p *processRunner) Open(ctx context.Context) error {
+func (p *processRunner) Open() error {
 	return nil
 }
 

--- a/internal/app/machined/pkg/system/runner/process/process_test.go
+++ b/internal/app/machined/pkg/system/runner/process/process_test.go
@@ -5,7 +5,6 @@
 package process_test
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -66,7 +65,7 @@ func (suite *ProcessSuite) TestRunSuccess() {
 		ProcessArgs: []string{"/bin/sh", "-c", "exit 0"},
 	}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -81,7 +80,7 @@ func (suite *ProcessSuite) TestRunLogs() {
 		ProcessArgs: []string{"/bin/sh", "-c", "echo -n \"Test 1\nTest 2\n\""},
 	}, runner.WithLoggingManager(suite.loggingManager))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -109,7 +108,7 @@ func (suite *ProcessSuite) TestRunRestartFailed() {
 		ProcessArgs: []string{"/bin/sh", "-c", "echo \"ran\"; test -f " + testFile},
 	}, runner.WithLoggingManager(suite.loggingManager)), restart.WithType(restart.UntilSuccess), restart.WithRestartInterval(time.Millisecond))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -162,7 +161,7 @@ func (suite *ProcessSuite) TestStopFailingAndRestarting() {
 		ProcessArgs: []string{"/bin/sh", "-c", "test -f " + testFile},
 	}, runner.WithLoggingManager(suite.loggingManager)), restart.WithType(restart.Forever), restart.WithRestartInterval(5*time.Millisecond))
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -209,7 +208,7 @@ func (suite *ProcessSuite) TestStopSigKill() {
 		runner.WithGracefulShutdownTimeout(10*time.Millisecond),
 	)
 
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 

--- a/internal/app/machined/pkg/system/runner/restart/restart.go
+++ b/internal/app/machined/pkg/system/runner/restart/restart.go
@@ -5,7 +5,6 @@
 package restart
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -96,8 +95,8 @@ func WithRestartInterval(interval time.Duration) Option {
 }
 
 // Open implements the Runner interface.
-func (r *restarter) Open(ctx context.Context) error {
-	return r.wrappedRunner.Open(ctx)
+func (r *restarter) Open() error {
+	return r.wrappedRunner.Open()
 }
 
 // Run implements the Runner interface

--- a/internal/app/machined/pkg/system/runner/restart/restart_test.go
+++ b/internal/app/machined/pkg/system/runner/restart/restart_test.go
@@ -5,7 +5,6 @@
 package restart_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -29,7 +28,7 @@ type MockRunner struct {
 	stopped chan struct{}
 }
 
-func (m *MockRunner) Open(ctx context.Context) error {
+func (m *MockRunner) Open() error {
 	m.stop = make(chan struct{})
 	m.stopped = make(chan struct{})
 
@@ -84,7 +83,7 @@ func (suite *RestartSuite) TestRunOnce() {
 	}
 
 	r := restart.New(&mock, restart.WithType(restart.Once))
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -104,7 +103,7 @@ func (suite *RestartSuite) TestRunOnceStop() {
 	}
 
 	r := restart.New(&mock, restart.WithType(restart.Once))
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -124,7 +123,7 @@ func (suite *RestartSuite) TestRunUntilSuccess() {
 	}
 
 	r := restart.New(&mock, restart.WithType(restart.UntilSuccess), restart.WithRestartInterval(time.Millisecond))
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 
@@ -151,7 +150,7 @@ func (suite *RestartSuite) TestRunForever() {
 	}
 
 	r := restart.New(&mock, restart.WithType(restart.Forever), restart.WithRestartInterval(time.Millisecond))
-	suite.Assert().NoError(r.Open(context.Background()))
+	suite.Assert().NoError(r.Open())
 
 	defer func() { suite.Assert().NoError(r.Close()) }()
 

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -5,7 +5,6 @@
 package runner
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"time"
@@ -22,7 +21,7 @@ import (
 // Runner describes the requirements for running a process.
 type Runner interface {
 	fmt.Stringer
-	Open(ctx context.Context) error
+	Open() error
 	Run(events.Recorder) error
 	Stop() error
 	Close() error

--- a/internal/app/machined/pkg/system/service_runner.go
+++ b/internal/app/machined/pkg/system/service_runner.go
@@ -268,7 +268,7 @@ func (svcrunner *ServiceRunner) run(ctx context.Context, runnr runner.Runner) er
 		return nil
 	}
 
-	if err := runnr.Open(ctx); err != nil {
+	if err := runnr.Open(); err != nil {
 		return fmt.Errorf("error opening runner: %w", err)
 	}
 

--- a/internal/pkg/containers/containerd/containerd_test.go
+++ b/internal/pkg/containers/containerd/containerd_test.go
@@ -120,7 +120,7 @@ func (suite *ContainerdSuite) SetupSuite() {
 		runner.WithEnv([]string{"PATH=/bin:" + constants.PATH}),
 		runner.WithCgroupPath(suite.tmpDir),
 	)
-	suite.Require().NoError(suite.containerdRunner.Open(context.Background()))
+	suite.Require().NoError(suite.containerdRunner.Open())
 	suite.containerdWg.Add(1)
 
 	go func() {
@@ -159,7 +159,7 @@ func (suite *ContainerdSuite) run(runners ...runner.Runner) {
 	runningCh := make(chan bool, 2*len(runners))
 
 	for _, r := range runners {
-		suite.Require().NoError(r.Open(context.Background()))
+		suite.Require().NoError(r.Open())
 
 		suite.containerRunners = append(suite.containerRunners, r)
 

--- a/internal/pkg/containers/cri/cri_test.go
+++ b/internal/pkg/containers/cri/cri_test.go
@@ -114,7 +114,7 @@ func (suite *CRISuite) SetupSuite() {
 		runner.WithEnv([]string{"PATH=/bin:" + constants.PATH}),
 		runner.WithCgroupPath(suite.tmpDir),
 	)
-	suite.Require().NoError(suite.containerdRunner.Open(context.Background()))
+	suite.Require().NoError(suite.containerdRunner.Open())
 	suite.containerdWg.Add(1)
 
 	go func() {

--- a/internal/pkg/cri/cri_test.go
+++ b/internal/pkg/cri/cri_test.go
@@ -107,7 +107,7 @@ func (suite *CRISuite) SetupSuite() {
 		runner.WithEnv([]string{"PATH=/bin:" + constants.PATH}),
 		runner.WithCgroupPath(suite.tmpDir),
 	)
-	suite.Require().NoError(suite.containerdRunner.Open(context.Background()))
+	suite.Require().NoError(suite.containerdRunner.Open())
 	suite.containerdWg.Add(1)
 
 	go func() {


### PR DESCRIPTION
That context is not actually used.

Discovered by new golangci-lint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4506)
<!-- Reviewable:end -->
