### PR TITLE
fix: wait for follow reader to start before writing to the file

### DIFF
--- a/pkg/follow/follow_test.go
+++ b/pkg/follow/follow_test.go
@@ -210,6 +210,8 @@ func (suite *FollowSuite) TestDeleted() {
 	// pass sizeHint as 15+1 to make code read beyond the end and encounter file removed
 	combinedCh := suite.readAll(ctx, "file was removed while watching", 16, time.Second)
 
+	time.Sleep(150 * time.Millisecond)
+
 	//nolint:errcheck
 	suite.writer.WriteString("abc")
 	//nolint:errcheck


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/4518

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4520)
<!-- Reviewable:end -->
