### PR TITLE
fix: improve NTP sync process

### DIFF
--- a/internal/pkg/ntp/consts.go
+++ b/internal/pkg/ntp/consts.go
@@ -7,12 +7,19 @@ package ntp
 import "time"
 
 const (
-	// MaxAllowablePoll is the 'recommended' interval for querying a time server.
-	MaxAllowablePoll = 1024 * time.Second
 	// MinAllowablePoll is the minimum time allowed for a client to query a time server.
-	MinAllowablePoll = 4 * time.Second
+	MinAllowablePoll = 32 * time.Second
+	// MaxAllowablePoll is the maximum allowed interval for querying a time server.
+	MaxAllowablePoll = 2048 * time.Second
+	// RetryPoll is the interval between retries if the error is not Kiss-o-Death.
+	RetryPoll = time.Second
 	// AdjustTimeLimit is a maximum time drift to compensate via adjtimex().
-	AdjustTimeLimit = 128 * time.Millisecond
+	//
+	// Deltas smaller than AdjustTimeLimit are gradually adjusted (slewed) to approach the network time.
+	// Deltas larger than AdjustTimeLimit are set by letting the system time jump.
+	AdjustTimeLimit = 400 * time.Millisecond
 	// EpochLimit is a minimum time difference to signal that change as epoch change.
 	EpochLimit = 15 * time.Minute
+	// ExpectedAccuracy is the expected time sync accuracy, used to adjust poll interval.
+	ExpectedAccuracy = 200 * time.Millisecond
 )


### PR DESCRIPTION
Fixes #4425

* add more logging for responses and sync process
* adjust time sync constants
* change the way poll interval is chosen (increasing on good sync,
decreasing on variation)
* filter out spikes

Based on flow in https://github.com/systemd/systemd/blob/main/src/timesync/timesyncd-manager.c

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4521)
<!-- Reviewable:end -->
