### PR TITLE
fix: parse partition size correctly

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -737,7 +737,7 @@ func getDisks() ([]*provision.Disk, error) {
 				return nil, fmt.Errorf("user disk partitions can only be mounted into /var folder")
 			}
 
-			value, e := strconv.ParseInt(partitions[j+1], 10, -1)
+			value, e := strconv.ParseInt(partitions[j+1], 10, 0)
 			partitionSize := uint64(value)
 
 			if e != nil {


### PR DESCRIPTION
`strconv.ParseInt` always returns error for bitSize -1.

Found by the latest golangci-lint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4522)
<!-- Reviewable:end -->
