### PR TITLE
fix: use temporary sonobuoy version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,10 @@ replace (
 	// Use nested module.
 	github.com/talos-systems/talos/pkg/machinery => ./pkg/machinery
 
+	// See https://github.com/vmware-tanzu/sonobuoy/issues/1520
+	// Remove when v0.55.1+ is released.
+	github.com/vmware-tanzu/sonobuoy v0.55.0 => github.com/vmware-tanzu/sonobuoy v1.11.5-prerelease.1.0.20211111171810-0e7f9c9059d6
+
 	// forked go-yaml that introduces RawYAML interface, which can be used to populate YAML fields using bytes
 	// which are then encoded as a valid YAML blocks with proper indentiation
 	gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b

--- a/go.sum
+++ b/go.sum
@@ -1111,8 +1111,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware-tanzu/sonobuoy v0.55.0 h1:EhSXf0jeEQHraX536ZqzJbqTBMWv3AKNX1aSto84pSE=
-github.com/vmware-tanzu/sonobuoy v0.55.0/go.mod h1:VN3+v6dc8g3rU25U+xgi28JATPSWQmNTfVRhg+Y2RBQ=
+github.com/vmware-tanzu/sonobuoy v1.11.5-prerelease.1.0.20211111171810-0e7f9c9059d6 h1:F5qP1vh+xSf4behHBQICqSscTDpImJk6oFFeQrvTWHc=
+github.com/vmware-tanzu/sonobuoy v1.11.5-prerelease.1.0.20211111171810-0e7f9c9059d6/go.mod h1:VN3+v6dc8g3rU25U+xgi28JATPSWQmNTfVRhg+Y2RBQ=
 github.com/vmware/govmomi v0.27.1 h1:Rf3o1btFrkJa9be5KtgJ4CyOO8mbFnBxmNtAVHNyFes=
 github.com/vmware/govmomi v0.27.1/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=

--- a/pkg/cluster/sonobuoy/sonobuoy.go
+++ b/pkg/cluster/sonobuoy/sonobuoy.go
@@ -14,13 +14,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 	"time"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/vmware-tanzu/sonobuoy/cmd/sonobuoy/app"
-	"github.com/vmware-tanzu/sonobuoy/pkg/buildinfo"
 	"github.com/vmware-tanzu/sonobuoy/pkg/client"
 	"github.com/vmware-tanzu/sonobuoy/pkg/config"
 	sonodynamic "github.com/vmware-tanzu/sonobuoy/pkg/dynamic"
@@ -127,11 +125,6 @@ func CertifiedConformance(ctx context.Context, cluster cluster.K8sProvider) erro
 //
 //nolint:gocyclo,cyclop
 func Run(ctx context.Context, cluster cluster.K8sProvider, options *Options) error {
-	// see init() function
-	if buildinfo.Version == "" {
-		return fmt.Errorf("failed to read sonobuoy version")
-	}
-
 	var waitOutput string
 
 	if options.UseSpinner {
@@ -346,31 +339,4 @@ func Run(ctx context.Context, cluster cluster.K8sProvider, options *Options) err
 	}
 
 	return cleanup()
-}
-
-// Workaround for https://github.com/vmware-tanzu/sonobuoy/issues/1520.
-// Remove when this is fixed by upstream.
-func init() {
-	buildinfo.Version = ""
-	config.DefaultImage = ""
-
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
-	}
-
-	for _, dep := range buildInfo.Deps {
-		if dep.Path != "github.com/vmware-tanzu/sonobuoy" {
-			continue
-		}
-
-		if dep.Replace != nil {
-			panic("sonobuoy version replacement is not supported")
-		}
-
-		buildinfo.Version = dep.Version
-		config.DefaultImage = "sonobuoy/sonobuoy:" + dep.Version
-
-		return
-	}
 }


### PR DESCRIPTION
`replace` should be removed when v0.55.1+ is released.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4528)
<!-- Reviewable:end -->
