### PR TITLE
docs: add Talos partions info

### DIFF
--- a/website/content/docs/v0.14/Guides/resetting-a-machine.md
+++ b/website/content/docs/v0.14/Guides/resetting-a-machine.md
@@ -7,13 +7,18 @@ From time to time, it may be beneficial to reset a Talos machine to its "origina
 Bear in mind that this is a destructive action for the given machine.
 Doing this means removing the machine from Kubernetes, Etcd (if applicable), and clears any data on the machine that would normally persist a reboot.
 
+> WARNING: Running a `talosctl reset` on cloud VM's might result in the VM being unable to boot as this wipes the entire disk.
+It might be more useful to just wipe the `STATE` and `EPHEMERAL` partitions on a cloud VM if not booting via `iPXE`.
+`talosctl reset --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL`
+
 The API command for doing this is `talosctl reset`.
 There are a couple of flags as part of this command:
 
 ```bash
 Flags:
-      --graceful   if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
-      --reboot     if true, reboot the node after resetting instead of shutting down
+      --graceful                        if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
+      --reboot                          if true, reboot the node after resetting instead of shutting down
+      --system-labels-to-wipe strings   if set, just wipe selected system disk partitions by label but keep other partitions intact keep other partitions intact
 ```
 
 The `graceful` flag is especially important when considering HA vs. non-HA Talos clusters.

--- a/website/content/docs/v0.14/Learn More/architecture.md
+++ b/website/content/docs/v0.14/Learn More/architecture.md
@@ -18,6 +18,17 @@ This imposes a clear separation of concerns and ensures that changes over time w
 The benefit is that each component may be iterated and changed as its needs dictate, so long as the external API is controlled.
 This is a key component in reducing coupling and maintaining modularity.
 
+## File system partitions
+
+Talos uses these partions with the following labels:
+
+    - **EFI**: The EFI partition, which is the first partition on the disk and used for EFI boot.
+    - **BIOS**: The BIOS partition, which is the second partition on the disk and used for GRUB's second stage boot.
+    - **BOOT**: The boot partition, which is the third partition on the disk and used for the bootloader.
+    - **META**: The meta partition, which is the fourth partition on the disk and used for storing metadata about the talos node, such as node id's.
+    - **STATE**: The state partition, which is the fifth partition on the disk and used for storing persistent state information.
+    - **EPHEMERAL**: The ephemeral partition, which is the sixth partition on the disk and used for storing ephemeral state information. All the data in this partition can be re-created from the information from the talos machine configuration.
+
 ## The File System
 
 One of the more unique design decisions in Talos is the layout of the root file system.


### PR DESCRIPTION
Fixes #4512

- Add Talos partitions info
- Document `--system-labels-to-wipe` flag for `talosctl reset`

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4529)
<!-- Reviewable:end -->
