### PR TITLE
perf: raspberry PIs clockspeed as fast as firmware allows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.9.0-alpha.0-5-g96e0231
-PKGS ?= v0.9.0-alpha.0-12-gf307e64
+PKGS ?= v0.9.0-alpha.0-14-g740da24
 EXTRAS ?= v0.7.0-alpha.0-1-g2bb2efc
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/config.txt
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/config.txt
@@ -1,4 +1,4 @@
-# See https://www.raspberrypi.org/documentation/configuration/config-txt/
+# See https://www.raspberrypi.com/documentation/computers/configuration.html
 # Reduce GPU memory to give more to CPU.
 gpu_mem=32
 # Enable maximum compatibility on both HDMI ports;
@@ -9,6 +9,8 @@ hdmi_safe:1=1
 kernel=u-boot.bin
 # Forces the kernel loading system to assume a 64-bit kernel.
 arm_64bit=1
+# Run as fast as firmware / board allows.
+arm_boost=1
 # Enable the primary/console UART.
 enable_uart=1
 # Disable Bluetooth.


### PR DESCRIPTION
The recent PI OS came with a default turbo-mode clock increase for newer PI4s. (https://www.raspberrypi.com/news/bullseye-bonus-1-8ghz-raspberry-pi-4/)
Check your model with:
`talosctl -n <node> read /sys/firmware/devicetree/base/model`
if it says:
`Raspberry Pi 4 Model B Rev 1.4`
This change will bring your boost clockspeed to `1800000`

To check your increase of this feature execute:
`talosctl -n <node> read /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`

Please merge first PR : https://github.com/talos-systems/pkgs/pull/353

Signed-off-by: Nico Berlee <nico.berlee@on2it.net>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4537)
<!-- Reviewable:end -->
