### PR TITLE
test: set proper pod CIDR for Cilium tests

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -363,6 +363,7 @@ local integration_provision_tests_track_2 = Step("provision-tests-track-2", priv
 local integration_cilium = Step("e2e-cilium-1.9.10", target="e2e-qemu", privileged=true, depends_on=[load_artifacts], environment={
         "SHORT_INTEGRATION_TEST": "yes",
         "CUSTOM_CNI_URL": "https://raw.githubusercontent.com/cilium/cilium/v1.9.10/install/kubernetes/quick-install.yaml",
+        "WITH_CONFIG_PATCH": '[{"op": "replace", "path": "/cluster/network/podSubnets", "value": ["10.0.0.0/8"]}]', # use Pod CIDRs as hardcoded in Cilium's quick-install
         "IMAGE_REGISTRY": local_registry,
 });
 local integration_uefi = Step("e2e-uefi", target="e2e-qemu", privileged=true, depends_on=[integration_cilium], environment={

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -72,6 +72,16 @@ case "${WITH_DISK_ENCRYPTION:-false}" in
     ;;
 esac
 
+case "${WITH_CONFIG_PATCH:-false}" in
+  # using arrays here to preserve spaces properly in WITH_CONFIG_PATCH
+  false)
+     CONFIG_PATCH_FLAG=()
+    ;;
+  *)
+    CONFIG_PATCH_FLAG=(--config-patch "${WITH_CONFIG_PATCH}")
+    ;;
+esac
+
 function create_cluster {
   build_registry_mirrors
 
@@ -95,7 +105,8 @@ function create_cluster {
     ${DISK_ENCRYPTION_FLAG} \
     ${REGISTRY_MIRROR_FLAGS} \
     ${QEMU_FLAGS} \
-    ${CUSTOM_CNI_FLAG}
+    ${CUSTOM_CNI_FLAG} \
+    "${CONFIG_PATCH_FLAG[@]}"
 
   "${TALOSCTL}" config node 172.20.1.2
 }


### PR DESCRIPTION
This fixes the issue with kubelet picking up wrong IP on restart, as
Talos doesn't know pod IPs (Cilium is using its own pod CIDR, it doesn't
look up Kubernetes settings).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4546)
<!-- Reviewable:end -->
