### PR TITLE
fix: containerd failed to load plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -352,12 +352,14 @@ COPY --from=machined-build-amd64 /machined /rootfs/sbin/init
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
-COPY --chmod=0644 hack/containerd.toml /rootfs/etc/cri/containerd.toml
+COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/config.toml
+COPY --chmod=0644 hack/cri-containerd.toml /rootfs/etc/cri/containerd.toml
 RUN touch /rootfs/etc/resolv.conf
 RUN touch /rootfs/etc/hosts
 RUN touch /rootfs/etc/os-release
-RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt,system}
-RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni,usr/libexec/kubernetes}
+RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt,system,opt}
+RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni/net.d,usr/libexec/kubernetes}
+RUN mkdir -pv /rootfs/opt/{containerd/bin,containerd/lib}
 RUN ln -s /etc/ssl /rootfs/etc/pki
 RUN ln -s /etc/ssl /rootfs/usr/share/ca-certificates
 RUN ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates
@@ -394,12 +396,14 @@ COPY --from=machined-build-arm64 /machined /rootfs/sbin/init
 # symlinks to avoid accidentally cleaning them up.
 COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
-COPY --chmod=0644 hack/containerd.toml /rootfs/etc/cri/containerd.toml
+COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/containerd.toml
+COPY --chmod=0644 hack/cri-containerd.toml /rootfs/etc/cri/containerd.toml
 RUN touch /rootfs/etc/resolv.conf
 RUN touch /rootfs/etc/hosts
 RUN touch /rootfs/etc/os-release
-RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt,system}
-RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni,usr/libexec/kubernetes}
+RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt,system,opt}
+RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni/net.d,usr/libexec/kubernetes}
+RUN mkdir -pv /rootfs/opt/{containerd/bin,containerd/lib}
 RUN ln -s /etc/ssl /rootfs/etc/pki
 RUN ln -s /etc/ssl /rootfs/usr/share/ca-certificates
 RUN ln -s /etc/ssl /rootfs/usr/local/share/ca-certificates

--- a/hack/containerd.toml
+++ b/hack/containerd.toml
@@ -1,12 +1,10 @@
 version = 2
 
-disabled_plugins = ["io.containerd.snapshotter.v1.aufs", "io.containerd.v1.zfs", "io.containerd.snapshotter.v1.zfs", "io.containerd.v1.devmapper", "io.containerd.snapshotter.v1.devmapper", "io.containerd.snapshotter.v1.btrfs"]
-
-imports = ["/var/cri/conf.d/*.toml"]
+disabled_plugins = [
+    "io.containerd.grpc.v1.cri",
+    "io.containerd.internal.v1.opt",
+]
 
 [debug]
 level = "info"
 format = "json"
-
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
-    runtime_type = "io.containerd.runc.v2"

--- a/hack/cri-containerd.toml
+++ b/hack/cri-containerd.toml
@@ -1,0 +1,12 @@
+version = 2
+
+disabled_plugins = []
+
+imports = ["/var/cri/conf.d/*.toml"]
+
+[debug]
+level = "info"
+format = "json"
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+    runtime_type = "io.containerd.runc.v2"

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -58,9 +58,12 @@ func (c *Containerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		ID: c.ID(r),
 		ProcessArgs: []string{
 			"/bin/containerd",
-			"--address", constants.SystemContainerdAddress,
-			"--state", filepath.Join(constants.SystemRunPath, "containerd"),
-			"--root", filepath.Join(constants.SystemVarPath, "lib", "containerd"),
+			"--address",
+			constants.SystemContainerdAddress,
+			"--state",
+			filepath.Join(constants.SystemRunPath, "containerd"),
+			"--root",
+			filepath.Join(constants.SystemVarPath, "lib", "containerd"),
 		},
 	}
 


### PR DESCRIPTION
Solve warning message at boot time: failed to load plugin io.containerd.internal.v1.opt

This is part of PR #3975

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4547)
<!-- Reviewable:end -->
