### PR TITLE
fix: don't run kexec prepare on shutdown and reset

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -65,7 +65,7 @@ func (*Sequencer) ApplyConfiguration(r runtime.Runtime, req *machineapi.ApplyCon
 		"cleanup",
 		StopAllPods,
 	).AppendList(
-		stopAllPhaselist(r),
+		stopAllPhaselist(r, true),
 	).Append(
 		"reboot",
 		Reboot,
@@ -289,7 +289,7 @@ func (*Sequencer) Reboot(r runtime.Runtime) []runtime.Phase {
 		"cleanup",
 		StopAllPods,
 	).
-		AppendList(stopAllPhaselist(r)).
+		AppendList(stopAllPhaselist(r, true)).
 		Append("reboot", Reboot)
 
 	return phases
@@ -301,7 +301,7 @@ func (*Sequencer) Reset(r runtime.Runtime, in runtime.ResetOptions) []runtime.Ph
 
 	switch r.State().Platform().Mode() { //nolint:exhaustive
 	case runtime.ModeContainer:
-		phases = phases.AppendList(stopAllPhaselist(r)).
+		phases = phases.AppendList(stopAllPhaselist(r, false)).
 			Append(
 				"shutdown",
 				Shutdown,
@@ -324,7 +324,7 @@ func (*Sequencer) Reset(r runtime.Runtime, in runtime.ResetOptions) []runtime.Ph
 			"leave",
 			LeaveEtcd,
 		).AppendList(
-			stopAllPhaselist(r),
+			stopAllPhaselist(r, false),
 		).AppendWhen(
 			len(in.GetSystemDiskTargets()) == 0,
 			"reset",
@@ -354,7 +354,7 @@ func (*Sequencer) Shutdown(r runtime.Runtime) []runtime.Phase {
 			"cleanup",
 			StopAllPods,
 		).
-		AppendList(stopAllPhaselist(r)).
+		AppendList(stopAllPhaselist(r, false)).
 		Append("shutdown", Shutdown)
 
 	return phases
@@ -376,7 +376,7 @@ func (*Sequencer) StageUpgrade(r runtime.Runtime, in *machineapi.UpgradeRequest)
 			"leave",
 			LeaveEtcd,
 		).AppendList(
-			stopAllPhaselist(r),
+			stopAllPhaselist(r, true),
 		).Append(
 			"reboot",
 			Reboot,
@@ -453,7 +453,7 @@ func (*Sequencer) Upgrade(r runtime.Runtime, in *machineapi.UpgradeRequest) []ru
 	return phases
 }
 
-func stopAllPhaselist(r runtime.Runtime) PhaseList {
+func stopAllPhaselist(r runtime.Runtime, enableKexec bool) PhaseList {
 	phases := PhaseList{}
 
 	switch r.State().Platform().Mode() { //nolint:exhaustive
@@ -480,13 +480,16 @@ func stopAllPhaselist(r runtime.Runtime) PhaseList {
 			"unmountSystem",
 			UnmountEphemeralPartition,
 			UnmountStatePartition,
-		).Append(
+		).AppendWhen(
+			enableKexec,
 			"mountBoot",
 			MountBootPartition,
-		).Append(
+		).AppendWhen(
+			enableKexec,
 			"kexec",
 			KexecPrepare,
-		).Append(
+		).AppendWhen(
+			enableKexec,
 			"unmountBoot",
 			UnmountBootPartition,
 		)


### PR DESCRIPTION
We don't expect to kexec on these actions, so no need to run kexec which
might fail blocking those two actions.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4549)
<!-- Reviewable:end -->
