### PR TITLE
fix: ignore virtual IP as kubelet node IPs

### DIFF
--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -297,6 +297,7 @@ func newKubeletConfiguration(clusterDNS []string, dnsDomain string) *kubeletconf
 	}
 }
 
+//nolint:gocyclo
 func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 	nodename, err := r.NodeName()
 	if err != nil {
@@ -337,6 +338,13 @@ func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 	// anyway filter out pod cidrs, they can't be node IPs
 	for _, cidr := range r.Config().Cluster().Network().PodCIDRs() {
 		validSubnets = append(validSubnets, "!"+cidr)
+	}
+
+	// filter out any virtual IPs, they can't be node IPs either
+	for _, device := range r.Config().Machine().Network().Devices() {
+		if device.VIPConfig() != nil {
+			validSubnets = append(validSubnets, "!"+device.VIPConfig().IP())
+		}
 	}
 
 	nodeIPs, err := pickNodeIPs(validSubnets)


### PR DESCRIPTION
As now Talos picks up node IPs by default, we need to make sure kubelet
never picks up the VIP as the node IP.

This issue doesn't show up with HA control plane nodes, as Talos
releases VIP when kubelet restarts, but with single-node control plane
nodes VIP stays on the node (as there's nowhere to  move it to), so we
need to filter the VIP out.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4550)
<!-- Reviewable:end -->
