### PR TITLE
fix: ignore EBUSY from `kexec_file_load`

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1740,6 +1740,8 @@ func ActivateLogicalVolumes(seq runtime.Sequence, data interface{}) (runtime.Tas
 }
 
 // KexecPrepare loads next boot kernel via kexec_file_load.
+//
+//nolint:gocyclo
 func KexecPrepare(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
 		if r.Config() == nil {
@@ -1791,6 +1793,10 @@ func KexecPrepare(seq runtime.Sequence, data interface{}) (runtime.TaskExecution
 				return nil
 			case errors.Is(err, unix.EPERM):
 				log.Printf("kexec support is disabled via sysctl")
+
+				return nil
+			case errors.Is(err, unix.EBUSY):
+				log.Printf("kexec is busy")
 
 				return nil
 			default:


### PR DESCRIPTION
This seems to happen on some versions of Raspberry PI, and we want Talos
to degrade gracefully to regular reboot vs. using `kexec`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4552)
<!-- Reviewable:end -->
