### PR TITLE
fix: ignore not existing nodes on cordoning

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -348,6 +348,11 @@ func (h *Client) Cordon(ctx context.Context, name string) error {
 				return retry.ExpectedError(err)
 			}
 
+			if apierrors.IsNotFound(err) {
+				// node not found, should have already been deleted, skip cordoning
+				return nil
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
Fixes #4557

When running `reset` for a node which was already deleted from
Kubernetes, we should ignore failure to cordon and proceed with other
actions.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4558)
<!-- Reviewable:end -->
