### PR TITLE
fix: unblock events watch on context cancel

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -264,7 +264,11 @@ func generatePKI(ctx context.Context, r runtime.Runtime) (err error) {
 	var event state.Event
 
 	for {
-		event = <-watchCh
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event = <-watchCh:
+		}
 
 		if event.Type == state.Created || event.Type == state.Updated {
 			break


### PR DESCRIPTION
Fixes #4563 

This fixes an issue when `etcd` get stuck in `Pre` state so that even
`bootstrap` request doesn't kill it. This looks like a cluster which
fails to bootstrap itself and get stuck on reboot.

Even though `Watch()` aborts on cancel, channel recieve will block
forever as no events are delivered.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4564)
<!-- Reviewable:end -->
