### PR TITLE
feat: provide SideroLink client implementation

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -22,6 +22,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 	"github.com/talos-systems/go-blockdevice/blockdevice/encryption"
+	"github.com/talos-systems/go-procfs/procfs"
 	talosnet "github.com/talos-systems/net"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -110,6 +111,7 @@ var (
 	configPatchControlPlane   string
 	configPatchWorker         string
 	badRTC                    bool
+	extraBootKernelArgs       string
 )
 
 // createCmd represents the cluster up command.
@@ -494,6 +496,12 @@ func create(ctx context.Context) (err error) {
 		}
 	}
 
+	var extraKernelArgs *procfs.Cmdline
+
+	if extraBootKernelArgs != "" {
+		extraKernelArgs = procfs.NewCmdline(extraBootKernelArgs)
+	}
+
 	// Add talosconfig to provision options so we'll have it to parse there
 	provisionOptions = append(provisionOptions, provision.WithTalosConfig(configBundle.TalosConfig()))
 
@@ -515,6 +523,7 @@ func create(ctx context.Context) (err error) {
 			Disks:               disks,
 			SkipInjectingConfig: skipInjectingConfig,
 			BadRTC:              badRTC,
+			ExtraKernelArgs:     extraKernelArgs,
 		}
 
 		if i == 0 {
@@ -567,6 +576,7 @@ func create(ctx context.Context) (err error) {
 				Config:              cfg,
 				SkipInjectingConfig: skipInjectingConfig,
 				BadRTC:              badRTC,
+				ExtraKernelArgs:     extraKernelArgs,
 			})
 	}
 
@@ -837,6 +847,7 @@ func init() {
 	createCmd.Flags().StringVar(&configPatchControlPlane, "config-patch-control-plane", "", "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")
 	createCmd.Flags().StringVar(&configPatchWorker, "config-patch-worker", "", "patch generated machineconfigs (applied to 'worker' type)")
 	createCmd.Flags().BoolVar(&badRTC, "bad-rtc", false, "launch VM with bad RTC state (QEMU only)")
+	createCmd.Flags().StringVar(&extraBootKernelArgs, "extra-boot-kernel-args", "", "add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)")
 
 	Cmd.AddCommand(createCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -95,10 +95,11 @@ require (
 	github.com/talos-systems/go-loadbalancer v0.1.1
 	github.com/talos-systems/go-procfs v0.1.0
 	github.com/talos-systems/go-retry v0.3.1
-	github.com/talos-systems/go-smbios v0.1.0
+	github.com/talos-systems/go-smbios v0.1.1-0.20211122130416-fd5ec8ce4873
 	github.com/talos-systems/grpc-proxy v0.2.0
 	github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8
-	github.com/talos-systems/talos/pkg/machinery v0.0.0-00010101000000-000000000000
+	github.com/talos-systems/siderolink v0.0.0-20211119180852-0755b24d4682
+	github.com/talos-systems/talos/pkg/machinery v0.14.0-alpha.1.0.20211118180932-1ffa8e048008
 	github.com/u-root/u-root v7.0.0+incompatible
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	github.com/vmware-tanzu/sonobuoy v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -1078,12 +1078,14 @@ github.com/talos-systems/go-retry v0.1.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lI
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.3.1 h1:GjjyHB8i1CJpb1O5qYPMljq74cRQ5uiDoyMaWddA5FA=
 github.com/talos-systems/go-retry v0.3.1/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
-github.com/talos-systems/go-smbios v0.1.0 h1:C6ooNSKyw2bzJxDTPeNbom5sri53h6bJgTWDSf9EAn8=
-github.com/talos-systems/go-smbios v0.1.0/go.mod h1:HxhrzAoTZ7ed5Z5VvtCvnCIrOxyXDS7V2B5hCetAMW8=
+github.com/talos-systems/go-smbios v0.1.1-0.20211122130416-fd5ec8ce4873 h1:YXgD3A1kdxpP+yEp0vED/IQrwMLyIy7HFRNfGYQgcUs=
+github.com/talos-systems/go-smbios v0.1.1-0.20211122130416-fd5ec8ce4873/go.mod h1:vk76naUSZaWE8Z95wbDn51FgH0goECM4oK3KY2hYSMU=
 github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1LNzuMEs9Pw=
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
 github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8 h1:oT2MASZ8V3DuZbhaJWJ8oZ373zfmgXpvw2xLHM5cOYk=
 github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
+github.com/talos-systems/siderolink v0.0.0-20211119180852-0755b24d4682 h1:0rXuO5pwwqXnNR/q33iB8vaAaSPNLKbS/d9PwkCFQkE=
+github.com/talos-systems/siderolink v0.0.0-20211119180852-0755b24d4682/go.mod h1:e3PMKivoq1tpggh8esTxLQrKiZvPgPe060/ukWcJOJw=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -102,7 +102,11 @@ func RunInstallerContainer(disk, platform, ref string, configBytes []byte, reg c
 	}
 
 	for _, arg := range options.ExtraKernelArgs {
-		args = append(args, []string{"--extra-kernel-arg", arg}...)
+		args = append(args, "--extra-kernel-arg", arg)
+	}
+
+	if c := procfs.ProcCmdline().Get(constants.KernelParamSideroLink).First(); c != nil {
+		args = append(args, "--extra-kernel-arg", fmt.Sprintf("%s=%s", constants.KernelParamSideroLink, *c))
 	}
 
 	specOpts := []oci.SpecOpts{

--- a/internal/app/machined/pkg/controllers/siderolink/manager.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager.go
@@ -1,0 +1,198 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package siderolink
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/talos-systems/go-procfs/procfs"
+	"github.com/talos-systems/go-smbios/smbios"
+	pb "github.com/talos-systems/siderolink/api/siderolink"
+	"go.uber.org/zap"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+	"google.golang.org/grpc"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
+)
+
+// ManagerController interacts with SideroLink API and brings up the SideroLink Wireguard interface.
+type ManagerController struct {
+	Cmdline *procfs.Cmdline
+
+	nodeKey wgtypes.Key
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *ManagerController) Name() string {
+	return "siderolink.ManagerController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *ManagerController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: network.NamespaceName,
+			Type:      network.StatusType,
+			ID:        pointer.ToString(network.StatusID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *ManagerController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: network.AddressSpecType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: network.LinkSpecType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo
+func (ctrl *ManagerController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if ctrl.Cmdline == nil || ctrl.Cmdline.Get(constants.KernelParamSideroLink).First() == nil {
+		// no SideroLink command line argument, skip controller
+		return nil
+	}
+
+	s, err := smbios.New()
+	if err != nil {
+		return fmt.Errorf("error reading node UUID: %w", err)
+	}
+
+	nodeUUID, err := s.SystemInformation().UUID()
+	if err != nil {
+		return fmt.Errorf("error getting node UUID: %w", err)
+	}
+
+	var zeroKey wgtypes.Key
+
+	if bytes.Equal(ctrl.nodeKey[:], zeroKey[:]) {
+		ctrl.nodeKey, err = wgtypes.GeneratePrivateKey()
+		if err != nil {
+			return fmt.Errorf("error generating Wireguard key: %w", err)
+		}
+	}
+
+	apiEndpoint := *ctrl.Cmdline.Get(constants.KernelParamSideroLink).First()
+
+	conn, err := grpc.DialContext(ctx, apiEndpoint, grpc.WithInsecure())
+	if err != nil {
+		return fmt.Errorf("error dialing SideroLink endpoint %q: %w", apiEndpoint, err)
+	}
+
+	sideroLinkClient := pb.NewProvisionServiceClient(conn)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		netStatus, err := r.Get(ctx, resource.NewMetadata(network.NamespaceName, network.StatusType, network.StatusID, resource.VersionUndefined))
+		if err != nil {
+			if state.IsNotFoundError(err) {
+				// no network state yet
+				continue
+			}
+
+			return fmt.Errorf("error reading network status: %w", err)
+		}
+
+		if !netStatus.(*network.Status).TypedSpec().AddressReady {
+			// wait for address
+			continue
+		}
+
+		resp, err := sideroLinkClient.Provision(ctx, &pb.ProvisionRequest{
+			NodeUuid:      nodeUUID.String(),
+			NodePublicKey: ctrl.nodeKey.PublicKey().String(),
+		})
+		if err != nil {
+			return fmt.Errorf("error accessing SideroLink API: %w", err)
+		}
+
+		serverAddress, err := netaddr.ParseIP(resp.ServerAddress)
+		if err != nil {
+			return fmt.Errorf("error parsing server address: %w", err)
+		}
+
+		nodeAddress, err := netaddr.ParseIPPrefix(resp.NodeAddressPrefix)
+		if err != nil {
+			return fmt.Errorf("error parsing node address: %w", err)
+		}
+
+		if err = r.Modify(ctx,
+			network.NewLinkSpec(network.ConfigNamespaceName, network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName))),
+			func(r resource.Resource) error {
+				spec := r.(*network.LinkSpec).TypedSpec()
+
+				spec.ConfigLayer = network.ConfigOperator
+				spec.Name = constants.SideroLinkName
+				spec.Type = nethelpers.LinkNone
+				spec.Kind = "wireguard"
+				spec.Up = true
+				spec.Logical = true
+
+				spec.Wireguard = network.WireguardSpec{
+					PrivateKey: ctrl.nodeKey.String(),
+					Peers: []network.WireguardPeer{
+						{
+							PublicKey: resp.ServerPublicKey,
+							Endpoint:  resp.ServerEndpoint,
+							AllowedIPs: []netaddr.IPPrefix{
+								netaddr.IPPrefixFrom(serverAddress, serverAddress.BitLen()),
+							},
+							// make sure Talos pings SideroLink endpoint, so that tunnel is established:
+							// SideroLink doesn't know Talos endpoint.
+							PersistentKeepaliveInterval: constants.SideroLinkDefaultPeerKeepalive,
+						},
+					},
+				}
+				spec.Wireguard.Sort()
+
+				return nil
+			}); err != nil {
+			return fmt.Errorf("error creating siderolink spec: %w", err)
+		}
+
+		if err = r.Modify(ctx,
+			network.NewAddressSpec(network.ConfigNamespaceName, network.LayeredID(network.ConfigOperator, network.AddressID(constants.SideroLinkName, nodeAddress))),
+			func(r resource.Resource) error {
+				spec := r.(*network.AddressSpec).TypedSpec()
+
+				spec.ConfigLayer = network.ConfigOperator
+				spec.Address = nodeAddress
+				spec.Family = nethelpers.FamilyInet6
+				spec.Flags = nethelpers.AddressFlags(nethelpers.AddressPermanent)
+				spec.LinkName = constants.SideroLinkName
+				spec.Scope = nethelpers.ScopeGlobal
+
+				return nil
+			}); err != nil {
+			return fmt.Errorf("error creating address spec: %w", err)
+		}
+
+		// all done, terminate controller
+		return nil
+	}
+}

--- a/internal/app/machined/pkg/controllers/siderolink/manager_test.go
+++ b/internal/app/machined/pkg/controllers/siderolink/manager_test.go
@@ -1,0 +1,180 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package siderolink_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-procfs/procfs"
+	"github.com/talos-systems/go-retry/retry"
+	pb "github.com/talos-systems/siderolink/api/siderolink"
+	"google.golang.org/grpc"
+	"inet.af/netaddr"
+
+	siderolinkctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/siderolink"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
+)
+
+type ManagerSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	s *grpc.Server
+}
+
+type mockServer struct {
+	pb.UnimplementedProvisionServiceServer
+}
+
+const (
+	mockServerEndpoint    = "127.0.0.11:51820"
+	mockServerAddress     = "fdae:41e4:649b:9303:b6db:d99c:215e:dfc4"
+	mockServerPublicKey   = "2aq/V91QyrHAoH24RK0bldukgo2rWk+wqE5Eg6TArCM="
+	mockNodeAddressPrefix = "fdae:41e4:649b:9303:2a07:9c7:5b08:aef7/64"
+)
+
+func (srv mockServer) Provision(ctx context.Context, req *pb.ProvisionRequest) (*pb.ProvisionResponse, error) {
+	return &pb.ProvisionResponse{
+		ServerEndpoint:    mockServerEndpoint,
+		ServerAddress:     mockServerAddress,
+		ServerPublicKey:   mockServerPublicKey,
+		NodeAddressPrefix: mockNodeAddressPrefix,
+	}, nil
+}
+
+func (suite *ManagerSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+
+	suite.startRuntime()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	suite.Require().NoError(err)
+
+	suite.s = grpc.NewServer()
+	pb.RegisterProvisionServiceServer(suite.s, mockServer{})
+
+	go func() {
+		suite.Require().NoError(suite.s.Serve(lis))
+	}()
+
+	cmdline := procfs.NewCmdline(fmt.Sprintf("%s=%s", constants.KernelParamSideroLink, lis.Addr().String()))
+
+	suite.Require().NoError(suite.runtime.RegisterController(&siderolinkctrl.ManagerController{
+		Cmdline: cmdline,
+	}))
+}
+
+func (suite *ManagerSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *ManagerSuite) TestReconcile() {
+	networkStatus := network.NewStatus(network.NamespaceName, network.StatusID)
+	networkStatus.TypedSpec().AddressReady = true
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, networkStatus))
+
+	nodeAddress := netaddr.MustParseIPPrefix(mockNodeAddressPrefix)
+
+	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			addressResource, err := suite.state.Get(suite.ctx, resource.NewMetadata(
+				network.ConfigNamespaceName,
+				network.AddressSpecType,
+				network.LayeredID(network.ConfigOperator, network.AddressID(constants.SideroLinkName, nodeAddress)),
+				resource.VersionUndefined,
+			))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					return retry.ExpectedError(err)
+				}
+
+				return err
+			}
+
+			address := addressResource.(*network.AddressSpec).TypedSpec()
+
+			suite.Assert().Equal(nodeAddress, address.Address)
+			suite.Assert().Equal(network.ConfigOperator, address.ConfigLayer)
+			suite.Assert().Equal(nethelpers.FamilyInet6, address.Family)
+			suite.Assert().Equal(constants.SideroLinkName, address.LinkName)
+
+			linkResource, err := suite.state.Get(suite.ctx, resource.NewMetadata(
+				network.ConfigNamespaceName,
+				network.LinkSpecType,
+				network.LayeredID(network.ConfigOperator, network.LinkID(constants.SideroLinkName)),
+				resource.VersionUndefined,
+			))
+			if err != nil {
+				if state.IsNotFoundError(err) {
+					return retry.ExpectedError(err)
+				}
+
+				return err
+			}
+
+			link := linkResource.(*network.LinkSpec).TypedSpec()
+
+			suite.Assert().Equal("wireguard", link.Kind)
+			suite.Assert().Equal(network.ConfigOperator, link.ConfigLayer)
+			suite.Assert().NotEmpty(link.Wireguard.PrivateKey)
+			suite.Assert().Len(link.Wireguard.Peers, 1)
+			suite.Assert().Equal(mockServerEndpoint, link.Wireguard.Peers[0].Endpoint)
+			suite.Assert().Equal(mockServerPublicKey, link.Wireguard.Peers[0].PublicKey)
+			suite.Assert().Equal([]netaddr.IPPrefix{netaddr.IPPrefixFrom(netaddr.MustParseIP(mockServerAddress), 128)}, link.Wireguard.Peers[0].AllowedIPs)
+			suite.Assert().Equal(constants.SideroLinkDefaultPeerKeepalive, link.Wireguard.Peers[0].PersistentKeepaliveInterval)
+
+			return nil
+		}))
+}
+
+func (suite *ManagerSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.s.Stop()
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+}
+
+func TestManagerSuite(t *testing.T) {
+	suite.Run(t, new(ManagerSuite))
+}

--- a/internal/app/machined/pkg/controllers/siderolink/siderolink.go
+++ b/internal/app/machined/pkg/controllers/siderolink/siderolink.go
@@ -1,0 +1,6 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package siderolink provides controllers which manage file resources.
+package siderolink

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/perf"
 	runtimecontrollers "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/secrets"
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/siderolink"
 	timecontrollers "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/time"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/v1alpha1"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -181,6 +182,9 @@ func (ctrl *Controller) Run(ctx context.Context) error {
 		&secrets.KubernetesController{},
 		&secrets.KubernetesCertSANsController{},
 		&secrets.RootController{},
+		&siderolink.ManagerController{
+			Cmdline: procfs.ProcCmdline(),
+		},
 	} {
 		if err := ctrl.controllerRuntime.RegisterController(c); err != nil {
 			return err

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -65,6 +65,9 @@ const (
 	// KernelParamPanic is the kernel parameter name for specifying the time to wait until rebooting after kernel panic (0 disables reboot).
 	KernelParamPanic = "panic"
 
+	// KernelParamSideroLink is the kernel paramater name to specify SideroLink API endpoint.
+	KernelParamSideroLink = "siderolink.api"
+
 	// NewRoot is the path where the switchroot target is mounted.
 	NewRoot = "/root"
 
@@ -521,6 +524,12 @@ const (
 
 	// LoggingFormatJSONLines represents "JSON lines" logging format.
 	LoggingFormatJSONLines = "json_lines"
+
+	// SideroLinkName is the interface name for SideroLink.
+	SideroLinkName = "siderolink"
+
+	// SideroLinkDefaultPeerKeepalive is the interval at which Wireguard Peer Keepalives should be sent.
+	SideroLinkDefaultPeerKeepalive = 25 * time.Second
 )
 
 // See https://linux.die.net/man/3/klogctl

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -82,6 +82,13 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	// Talos config
 	cmdline.Append("talos.platform", "metal")
 
+	// add overrides
+	if nodeReq.ExtraKernelArgs != nil {
+		if err = cmdline.AppendAll(nodeReq.ExtraKernelArgs.Strings()); err != nil {
+			return provision.NodeInfo{}, err
+		}
+	}
+
 	var nodeConfig string
 
 	if !nodeReq.SkipInjectingConfig {

--- a/pkg/provision/request.go
+++ b/pkg/provision/request.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/talos-systems/go-procfs/procfs"
+
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
@@ -147,6 +149,12 @@ type NodeRequest struct {
 	//
 	// BootOrder can be forced to be "nc" (PXE boot) via the API in QEMU provisioner.
 	DefaultBootOrder string
+
+	// ExtraKernelArgs passes additional kernel args
+	// to the initial boot from initramfs and vmlinuz.
+	//
+	// This doesn't apply to boots from ISO or from the disk image.
+	ExtraKernelArgs *procfs.Cmdline
 
 	// Testing features
 

--- a/website/content/docs/v0.14/Reference/cli.md
+++ b/website/content/docs/v0.14/Reference/cli.md
@@ -110,6 +110,7 @@ talosctl cluster create [flags]
       --encrypt-state                           enable state partition encryption
       --endpoint string                         use endpoint instead of provider defaults
   -p, --exposed-ports string                    Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
+      --extra-boot-kernel-args string           add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)
   -h, --help                                    help for create
       --image string                            the image to use (default "ghcr.io/talos-systems/talos:latest")
       --init-node-as-endpoint                   use init node as endpoint instead of any load balancer endpoint


### PR DESCRIPTION
Related to #4448

The only remaining part is filtering out SideroLink addresses when Talos
looks for a node address.

See also https://github.com/talos-systems/siderolink/pull/2

The way to test it out:

```
$ talosctl cluster create ... --extra-boot-kernel-args
siderolink.api=172.20.0.1:4000
```

(where 172.20.0.1 is the bridge IP)

Run `siderolink-agent` (test implementation):

```
$ sudo _out/siderolink-agent-linux-amd64
```

Now on the host, there should be a `siderolink` Wireguard userspace
tunnel:

```
$ sudo wg
interface: siderolink
  public key: 2aq/V91QyrHAoH24RK0bldukgo2rWk+wqE5Eg6TArCM=
  private key: (hidden)
  listening port: 51821

peer: Tyr6C/F3FFLWtnzqq7Dsm54B40bOPq6++PTiD/zqn2Y=
  endpoint: 172.20.0.1:47857
  allowed ips: fdae:41e4:649b:9303:b6db:d99c:215e:dfc4/128
  latest handshake: 2 minutes, 2 seconds ago
  transfer: 3.62 KiB received, 1012 B sent

...
```

Each Talos node will be registered as a peer, tunnel is established.

You can now ping Talos nodes from the host over the tunnel:

```
$ ping fdae:41e4:649b:9303:b6db:d99c:215e:dfc4
PING fdae:41e4:649b:9303:b6db:d99c:215e:dfc4(fdae:41e4:649b:9303:b6db:d99c:215e:dfc4) 56 data bytes
64 bytes from fdae:41e4:649b:9303:b6db:d99c:215e:dfc4: icmp_seq=1 ttl=64 time=0.352 ms
64 bytes from fdae:41e4:649b:9303:b6db:d99c:215e:dfc4: icmp_seq=2 ttl=64 time=0.437 ms
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4565)
<!-- Reviewable:end -->
