### PR TITLE
fix: allow add_key and request_key in kubelet seccomp profile

### DIFF
--- a/internal/app/machined/pkg/system/runner/containerd/containerd.go
+++ b/internal/app/machined/pkg/system/runner/containerd/containerd.go
@@ -287,9 +287,15 @@ func (c *containerdRunner) newOCISpecOpts(image oci.Image) []oci.SpecOpts {
 		c.opts.OCISpecOpts...,
 	)
 
-	specOpts = append(specOpts,
-		seccomp.WithDefaultProfile(), // add seccomp profile last, as it depends on process capabilities
-	)
+	if c.opts.OverrideSeccompProfile != nil {
+		specOpts = append(specOpts,
+			WithCustomSeccompProfile(c.opts.OverrideSeccompProfile),
+		)
+	} else {
+		specOpts = append(specOpts,
+			seccomp.WithDefaultProfile(), // add seccomp profile last, as it depends on process capabilities
+		)
+	}
 
 	return specOpts
 }

--- a/internal/app/machined/pkg/system/runner/containerd/opts.go
+++ b/internal/app/machined/pkg/system/runner/containerd/opts.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -37,6 +38,17 @@ func WithRootfsPropagation(rp string) oci.SpecOpts {
 func WithOOMScoreAdj(score int) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
 		s.Process.OOMScoreAdj = &score
+
+		return nil
+	}
+}
+
+// WithCustomSeccompProfile allows to override default seccomp profile.
+func WithCustomSeccompProfile(override func(*specs.LinuxSeccomp)) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
+		s.Linux.Seccomp = seccomp.DefaultProfile(s)
+
+		override(s.Linux.Seccomp)
 
 		return nil
 	}

--- a/internal/app/machined/pkg/system/runner/runner.go
+++ b/internal/app/machined/pkg/system/runner/runner.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime/logging"
@@ -59,6 +60,8 @@ type Options struct {
 	OOMScoreAdj int
 	// CgroupPath (optional) sets the cgroup path to use
 	CgroupPath string
+	// OverrideSeccompProfile default Linux seccomp profile.
+	OverrideSeccompProfile func(*specs.LinuxSeccomp)
 }
 
 // Option is the functional option func.
@@ -151,5 +154,12 @@ func WithOOMScoreAdj(score int) Option {
 func WithCgroupPath(path string) Option {
 	return func(args *Options) {
 		args.CgroupPath = path
+	}
+}
+
+// WithCustomSeccompProfile sets the function to override seccomp profile.
+func WithCustomSeccompProfile(override func(*specs.LinuxSeccomp)) Option {
+	return func(args *Options) {
+		args.OverrideSeccompProfile = override
 	}
 }


### PR DESCRIPTION
Fixes #4571

Allow two new sysctls in addition to default seccomp profile to fix
cephfs mounts in the kubelet container.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4572)
<!-- Reviewable:end -->
