### PR TITLE
fix: leave only a single IPv4/IPv6 address as kubelet's node IP

### DIFF
--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"log"
 	stdnet "net"
 	"net/http"
 	"os"
@@ -348,19 +349,24 @@ func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 		}
 	}
 
-	nodeIPs, err := pickNodeIPs(validSubnets)
-	if err != nil {
-		return nil, err
-	}
+	// if the user supplied node-ip via extra args, no need to pick automatically
+	if !extraArgs.Contains("node-ip") {
+		var nodeIPs []stdnet.IP
 
-	if len(nodeIPs) > 0 {
-		nodeIPsString := make([]string, len(nodeIPs))
-
-		for i := range nodeIPs {
-			nodeIPsString[i] = nodeIPs[i].String()
+		nodeIPs, err = pickNodeIPs(validSubnets)
+		if err != nil {
+			return nil, err
 		}
 
-		args["node-ip"] = strings.Join(nodeIPsString, ",")
+		if len(nodeIPs) > 0 {
+			nodeIPsString := make([]string, len(nodeIPs))
+
+			for i := range nodeIPs {
+				nodeIPsString[i] = nodeIPs[i].String()
+			}
+
+			args["node-ip"] = strings.Join(nodeIPsString, ",")
+		}
 	}
 
 	if err = args.Merge(extraArgs, argsbuilder.WithMergePolicies(
@@ -372,7 +378,6 @@ func (k *Kubelet) args(r runtime.Runtime) ([]string, error) {
 			"config":                     argsbuilder.MergeDenied,
 			"cert-dir":                   argsbuilder.MergeDenied,
 			"cni-conf-dir":               argsbuilder.MergeDenied,
-			"node-ip":                    argsbuilder.MergeAdditive,
 		},
 	)); err != nil {
 		return nil, err
@@ -451,7 +456,36 @@ func pickNodeIPs(cidrs []string) ([]stdnet.IP, error) {
 		return nil, fmt.Errorf("failed to discover interface IP addresses: %w", err)
 	}
 
-	return net.FilterIPs(ips, cidrs)
+	ips, err = net.FilterIPs(ips, cidrs)
+	if err != nil {
+		return nil, err
+	}
+
+	// filter down to make sure only one IPv4 and one IPv6 address stays
+	var hasIPv4, hasIPv6 bool
+
+	result := make([]stdnet.IP, 0, 2)
+
+	for _, ip := range ips {
+		switch {
+		case ip.To4() != nil:
+			if !hasIPv4 {
+				result = append(result, ip)
+				hasIPv4 = true
+			} else {
+				log.Printf("kubelet: warning: skipped node IP %s, please use .machine.kubelet.nodeIP to provide explicit subnet for the node IP", ip)
+			}
+		case ip.To16() != nil:
+			if !hasIPv6 {
+				result = append(result, ip)
+				hasIPv6 = true
+			} else {
+				log.Printf("kubelet: warning: skipped node IP %s, please use .machine.kubelet.nodeIP to provide explicit subnet for the node IP", ip)
+			}
+		}
+	}
+
+	return result, nil
 }
 
 func kubeletSeccomp(seccomp *specs.LinuxSeccomp) {


### PR DESCRIPTION
In Talos 0.13 we introduced a way to pick kubelet's node IP via machine
configuration, and later enforced that Talos picks up node IPs
automatically on boot (which got backported to 0.13.x).

The problem is that if the node has multiple IPv4/IPv6 addresses, Talos
builds broken configuration by default (with multiple `--node-ip` of the
same family) which won't let the kubelet start.

To fix the multiple addresses issue, one has to apply machine
configuration changes to pick just a single subnet.

To make matters worse, Talos 0.12.x won't accept any `nodeIP` machine
config setting (as it's not supported yet in 0.12), so upgrading to 0.13
leaves the node in a non-functional state.

The fix is to pick just a single IP of each family on Talos side and
print a warning to make sure user knows that one IP was ignored.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4596)
<!-- Reviewable:end -->
