### PR TITLE
feat: move kubelet/cri proccesses from system cgroup

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -155,6 +155,8 @@ func CreateSystemCgroups(seq runtime.Sequence, data interface{}) (runtime.TaskEx
 		groups := []string{
 			constants.CgroupInit,
 			constants.CgroupRuntime,
+			constants.CgroupPodRuntime,
+			constants.CgroupKubelet,
 		}
 
 		for _, c := range groups {

--- a/internal/app/machined/pkg/system/services/cri.go
+++ b/internal/app/machined/pkg/system/services/cri.go
@@ -78,7 +78,7 @@ func (c *CRI) Runner(r runtime.Runtime) (runner.Runner, error) {
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithEnv(env),
 		runner.WithOOMScoreAdj(-500),
-		runner.WithCgroupPath(constants.CgroupRuntime),
+		runner.WithCgroupPath(constants.CgroupPodRuntime),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -202,6 +202,7 @@ func (k *Kubelet) Runner(r runtime.Runtime) (runner.Runner, error) {
 		runner.WithEnv(env),
 		runner.WithOCISpecOpts(
 			containerd.WithRootfsPropagation("shared"),
+			oci.WithCgroup(constants.CgroupKubelet),
 			oci.WithMounts(mounts),
 			oci.WithHostNamespace(specs.NetworkNamespace),
 			oci.WithHostNamespace(specs.PIDNamespace),
@@ -295,7 +296,13 @@ func newKubeletConfiguration(clusterDNS []string, dnsDomain string) *kubeletconf
 		FailSwapOn:          &f,
 		CgroupRoot:          "/",
 		SystemCgroups:       constants.CgroupSystem,
-		KubeletCgroups:      constants.CgroupSystem + "/kubelet",
+		SystemReserved: map[string]string{
+			"cpu":               constants.KubeletSystemReservedCPU,
+			"memory":            constants.KubeletSystemReservedMemory,
+			"pid":               constants.KubeletSystemReservedPid,
+			"ephemeral-storage": constants.KubeletSystemReservedEphemeralStorage,
+		},
+		KubeletCgroups: constants.CgroupKubelet,
 	}
 }
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -258,6 +258,18 @@ const (
 	// KubeletKubeconfig is the generated kubeconfig for kubelet.
 	KubeletKubeconfig = "/etc/kubernetes/kubeconfig-kubelet"
 
+	// KubeletSystemReservedCPU cpu system reservation value for kubelet kubeconfig.
+	KubeletSystemReservedCPU = "50m"
+
+	// KubeletSystemReservedMemory memory system reservation value for kubelet kubeconfig.
+	KubeletSystemReservedMemory = "128Mi"
+
+	// KubeletSystemReservedPid pid system reservation value for kubelet kubeconfig.
+	KubeletSystemReservedPid = "100"
+
+	// KubeletSystemReservedEphemeralStorage ephemeral-storage system reservation value for kubelet kubeconfig.
+	KubeletSystemReservedEphemeralStorage = "256Mi"
+
 	// DefaultEtcdVersion is the default target version of etcd.
 	DefaultEtcdVersion = "v3.5.1"
 
@@ -411,6 +423,12 @@ const (
 
 	// CgroupRuntime is the cgroup name for containerd runtime processes.
 	CgroupRuntime = CgroupSystem + "/runtime"
+
+	// CgroupPodRuntime is the cgroup name for kubernetes containerd runtime processes.
+	CgroupPodRuntime = "/podruntime/runtime"
+
+	// CgroupKubelet is the cgroup name for kubelet process.
+	CgroupKubelet = "/podruntime/kubelet"
 
 	// FlannelCNI is the string to use Tanos-managed Flannel CNI (default).
 	FlannelCNI = "flannel"


### PR DESCRIPTION
This changes helps kubelet/control-plane to collect resource metrics.
And kubelet can start eviction process at right moment.

* move kubelet process to special cgroup /podruntime/kubelet
* all cri containerd-shim-* proccesses will use cgroup /podruntime/runtime
* cgroup /system will store only Talos processes + etcd

I've set system reservation:
* cpu - 50m
* memory - 128mb usually Talos uses ~100Mb
* disk - 256Mi this is enough to store/recreate custom files from machineconfig
* pids - 100

Source documentation https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/node-allocatable.md


result:

```shell
1	0::/init		/sbin/init
1072	0::/system/runtime		/bin/containerd --address /system/run/containerd/containerd.sock --state /system/run/containerd --root /system/var/lib/containerd
1423	0::/system/runtime		/sbin/udevd --resolve-names=never
1844	0::/podruntime/runtime		/bin/containerd --address /run/containerd/containerd.sock --config /etc/cri/containerd.toml
1870	0::/system/runtime		/bin/containerd-shim-runc-v2 -namespace system -id apid -address /system/run/containerd/containerd.sock
1871	0::/system/runtime		/bin/containerd-shim-runc-v2 -namespace system -id trustd -address /system/run/containerd/containerd.sock
1915	0::/system/trustd		/trustd
1916	0::/system/apid		/apid --enable-rbac
1971	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace system -id kubelet -address /run/containerd/containerd.sock
1991	0::/podruntime/kubelet		/usr/local/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubeconfig --cert-dir=/var/lib/kubelet/pki --cni-conf-dir=/
2020	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace system -id etcd -address /run/containerd/containerd.sock
2039	0::/system/etcd		/usr/local/bin/etcd --advertise-client-urls=https://192.168.10.202:2379 --cert-file=/system/secrets/etcd/peer.crt --client-cert-auth=true
2147	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id 2995caad47742a0d9082b7ea0dad7688304bce558e5dd04e5aa55bcb050aabc7 -address /run/c
2172	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id 6e048091c6fc9290a29da477acd883f5b06afd28781ed4819241621fe39bdb06 -address /run/c
2198	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id f170ee1dd1d2c4942b2e024733fee1f1700afd5415031ba61cb0dfc4c2f7481f -address /run/c
2677	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id 77b87ded968fa9d96ae2397d39d20a7cae6e28654d80eaf924003934b8d4a21d -address /run/c
2693	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id fa519af6ab562c079b90a64eea38e29eb7244f33390c935af19c947556e36bd4 -address /run/c
2823	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id 8c95689650a5fc7d764eb6c957e3e09548c17cbd80aa5058de956302c91c02a0 -address /run/c
3346	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id b559d39a2604732926b43fe9c7f67e6386eecb83748699ba2b480ff5e30a6964 -address /run/c
3433	0::/podruntime/runtime		/bin/containerd-shim-runc-v2 -namespace k8s.io -id c74fbbf55b66c211d2effdbc25e45585742c4d9bdc4e2ad00f5d15b6cb2565ef -address /run/c
```

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4602)
<!-- Reviewable:end -->
