### PR TITLE
fix: disable kexec on RPi4

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
@@ -47,6 +47,7 @@ func (r *RPi4) Install(disk string) (err error) {
 func (r *RPi4) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty0").Append("ttyAMA0,115200"),
+		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 


### PR DESCRIPTION
`kexec` doesn't bring much benefit to Raspberry PI 4, as boot sequence
is anyways pretty fast.

It looks like `kexec` is broken with many UEFI/firmware versions, and
even if it works properly, it doesn't properly re-initialize HDMI
output.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4608)
<!-- Reviewable:end -->
