### PR TITLE
feat: filter out SideroLink addresses by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	github.com/talos-systems/go-retry v0.3.1
 	github.com/talos-systems/go-smbios v0.1.1-0.20211122130416-fd5ec8ce4873
 	github.com/talos-systems/grpc-proxy v0.2.0
-	github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8
+	github.com/talos-systems/net v0.3.1-0.20211129211222-b4b718179a1a
 	github.com/talos-systems/siderolink v0.1.0
 	github.com/talos-systems/talos/pkg/machinery v0.14.0-alpha.1.0.20211118180932-1ffa8e048008
 	github.com/u-root/u-root v7.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1087,8 +1087,8 @@ github.com/talos-systems/go-smbios v0.1.1-0.20211122130416-fd5ec8ce4873 h1:YXgD3
 github.com/talos-systems/go-smbios v0.1.1-0.20211122130416-fd5ec8ce4873/go.mod h1:vk76naUSZaWE8Z95wbDn51FgH0goECM4oK3KY2hYSMU=
 github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1LNzuMEs9Pw=
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
-github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8 h1:oT2MASZ8V3DuZbhaJWJ8oZ373zfmgXpvw2xLHM5cOYk=
-github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
+github.com/talos-systems/net v0.3.1-0.20211129211222-b4b718179a1a h1:FeWCNuAUTNRpEV5+8w7TSkWXCQ2UM9QNFxQinaBLD2Y=
+github.com/talos-systems/net v0.3.1-0.20211129211222-b4b718179a1a/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
 github.com/talos-systems/siderolink v0.1.0 h1:7mkJ9EicQ8J9DHHkwiNYGoccCgFcEIFcmfcKRyI7Y+8=
 github.com/talos-systems/siderolink v0.1.0/go.mod h1:bEGwDYl9QgC3oZ4kdnJTuR2HX/XlUhxZjx/QAakKuBc=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=

--- a/internal/app/machined/pkg/controllers/network/node_address.go
+++ b/internal/app/machined/pkg/controllers/network/node_address.go
@@ -123,6 +123,11 @@ func (ctrl *NodeAddressController) Run(ctx context.Context, r controller.Runtime
 				continue
 			}
 
+			if network.IsULA(ip.IP(), network.ULASideroLink) {
+				// ignore SideroLink addresses, as they are point-to-point addresses
+				continue
+			}
+
 			// set defaultAddress to the smallest IP from the alphabetically first link
 			// ignore address which are not assigned from the physical links
 			if addr.Metadata().Owner() == addressStatusControllerName {

--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -680,6 +680,8 @@ func primaryAndListenAddresses(subnet string) (primary, listen string, err error
 		return "", "", fmt.Errorf("failed to discover interface IP addresses: %w", err)
 	}
 
+	ips = net.IPFilter(ips, network.NotSideroLinkStdIP)
+
 	if len(ips) == 0 {
 		return "", "", errors.New("no valid unicast IP addresses on any interface")
 	}

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -456,6 +456,8 @@ func pickNodeIPs(cidrs []string) ([]stdnet.IP, error) {
 		return nil, fmt.Errorf("failed to discover interface IP addresses: %w", err)
 	}
 
+	ips = net.IPFilter(ips, network.NotSideroLinkStdIP)
+
 	ips, err = net.FilterIPs(ips, cidrs)
 	if err != nil {
 		return nil, err

--- a/internal/app/trustd/main.go
+++ b/internal/app/trustd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/talos-systems/talos/pkg/grpc/middleware/auth/basic"
 	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 	"github.com/talos-systems/talos/pkg/startup"
 )
 
@@ -63,6 +64,8 @@ func Main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	ips = net.IPFilter(ips, network.NotSideroLinkStdIP)
 
 	dnsNames, err := net.DNSNames()
 	if err != nil {

--- a/internal/pkg/etcd/certs.go
+++ b/internal/pkg/etcd/certs.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/talos-systems/crypto/x509"
 	"github.com/talos-systems/net"
+
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 )
 
 // NewCommonOptions set common certificate options.
@@ -21,6 +23,8 @@ func NewCommonOptions() ([]x509.Option, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover IP addresses: %w", err)
 	}
+
+	ips = net.IPFilter(ips, network.NotSideroLinkStdIP)
 
 	ips = append(ips, stdlibnet.ParseIP("127.0.0.1"))
 	if net.IsIPv6(ips...) {

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/talos-systems/crypto v0.3.4
 	github.com/talos-systems/go-blockdevice v0.2.4
 	github.com/talos-systems/go-debug v0.2.1
-	github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8
+	github.com/talos-systems/net v0.3.1-0.20211129211222-b4b718179a1a
 	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1
 	google.golang.org/grpc v1.42.0
 	google.golang.org/protobuf v1.27.1

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -173,8 +173,8 @@ github.com/talos-systems/go-debug v0.2.1 h1:VSN8P1zXWeHWgUBZn4cVT3keBcecCAJBG9Up
 github.com/talos-systems/go-debug v0.2.1/go.mod h1:pR4NjsZQNFqGx3n4qkD4MIj1F2CxyIF8DCiO1+05JO0=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.3.1/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
-github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8 h1:oT2MASZ8V3DuZbhaJWJ8oZ373zfmgXpvw2xLHM5cOYk=
-github.com/talos-systems/net v0.3.1-0.20211112122313-0abe5bdae8f8/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
+github.com/talos-systems/net v0.3.1-0.20211129211222-b4b718179a1a h1:FeWCNuAUTNRpEV5+8w7TSkWXCQ2UM9QNFxQinaBLD2Y=
+github.com/talos-systems/net v0.3.1-0.20211129211222-b4b718179a1a/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
 github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b h1:8pnPjZJU0SYanlmHnhMTeR8OR148K9yStwBz1GsjBsQ=
 github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
As SideroLink addresses are ephemeral and point-to-point, filter them
out for node addresses, Kubelet, etcd, etc.

Fixes #4448

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4617)
<!-- Reviewable:end -->
