### PR TITLE
test: uplift capi versions and templates

### DIFF
--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -4,10 +4,10 @@ set -eou pipefail
 
 source ./hack/test/e2e.sh
 
-export CAPI_VERSION="${CAPI_VERSION:-0.4.3}"
-export CABPT_VERSION="${CABPT_VERSION:-0.4.0}"
-export CACPPT_VERSION="${CACPPT_VERSION:-0.3.0}"
-export CAPA_VERSION="${CAPA_VERSION:-0.7.0}"
+export CAPI_VERSION="${CAPI_VERSION:-0.4.4}"
+export CABPT_VERSION="${CABPT_VERSION:-0.4.2}"
+export CACPPT_VERSION="${CACPPT_VERSION:-0.3.1}"
+export CAPA_VERSION="${CAPA_VERSION:-0.7.2}"
 export CAPG_VERSION="${CAPG_VERSION:-0.4.0}"
 
 # We need to override this here since e2e.sh will set it to ${TMP}/capi/kubeconfig.

--- a/hack/test/e2e-gcp.sh
+++ b/hack/test/e2e-gcp.sh
@@ -19,6 +19,8 @@ function setup {
   export GCP_PROJECT=talos-testbed
   export GCP_REGION=us-central1
   export GCP_NETWORK=default
+  export GCP_VM_SVC_ACCOUNT=e2e-tester@talos-testbed.iam.gserviceaccount.com
+
 
   ## Control plane vars
   export CONTROL_PLANE_MACHINE_COUNT=3


### PR DESCRIPTION
This PR will use the latest templates for v1alpha4 and the supporting
CAPI provider versions. We'll bump again when we land v1beta1

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4631)
<!-- Reviewable:end -->
