### PR TITLE
feat: allow overriding KSPP kernel parameters

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -36,7 +36,7 @@ func (ctrl *KernelParamDefaultsController) Inputs() []controller.Input {
 func (ctrl *KernelParamDefaultsController) Outputs() []controller.Output {
 	return []controller.Output{
 		{
-			Type: runtime.KernelParamSpecType,
+			Type: runtime.KernelParamDefaultSpecType,
 			Kind: controller.OutputShared,
 		},
 	}
@@ -55,13 +55,13 @@ func (ctrl *KernelParamDefaultsController) Run(ctx context.Context, r controller
 
 		for _, prop := range kernelParams {
 			value := prop.Value
-			item := runtime.NewKernelParamSpec(runtime.NamespaceName, prop.Key)
+			item := runtime.NewKernelParamDefaultSpec(runtime.NamespaceName, prop.Key)
 
 			if err := r.Modify(ctx, item, func(res resource.Resource) error {
-				res.(*runtime.KernelParamSpec).TypedSpec().Value = value
+				res.(*runtime.KernelParamDefaultSpec).TypedSpec().Value = value
 
 				if item.Metadata().ID() == "net.ipv6.conf.default.forwarding" {
-					res.(*runtime.KernelParamSpec).TypedSpec().IgnoreErrors = true
+					res.(*runtime.KernelParamDefaultSpec).TypedSpec().IgnoreErrors = true
 				}
 
 				return nil

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
@@ -69,9 +69,9 @@ func (suite *KernelParamDefaultsSuite) TestContainerMode() {
 
 		suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			suite.assertResource(
-				resource.NewMetadata(runtimeresource.NamespaceName, runtimeresource.KernelParamSpecType, prop.Key, resource.VersionUndefined),
+				resource.NewMetadata(runtimeresource.NamespaceName, runtimeresource.KernelParamDefaultSpecType, prop.Key, resource.VersionUndefined),
 				func(res resource.Resource) bool {
-					return res.(*runtimeresource.KernelParamSpec).TypedSpec().Value == prop.Value
+					return res.(runtimeresource.KernelParam).TypedSpec().Value == prop.Value
 				},
 			),
 		))
@@ -93,9 +93,9 @@ func (suite *KernelParamDefaultsSuite) TestMetalMode() {
 
 		suite.Assert().NoError(retry.Constant(10*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 			suite.assertResource(
-				resource.NewMetadata(runtimeresource.NamespaceName, runtimeresource.KernelParamSpecType, prop.Key, resource.VersionUndefined),
+				resource.NewMetadata(runtimeresource.NamespaceName, runtimeresource.KernelParamDefaultSpecType, prop.Key, resource.VersionUndefined),
 				func(res resource.Resource) bool {
-					return res.(*runtimeresource.KernelParamSpec).TypedSpec().Value == prop.Value
+					return res.(runtimeresource.KernelParam).TypedSpec().Value == prop.Value
 				},
 			),
 		))

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_state.go
@@ -120,6 +120,7 @@ func NewState() (*State, error) {
 		&perf.CPU{},
 		&perf.Memory{},
 		&runtime.KernelParamSpec{},
+		&runtime.KernelParamDefaultSpec{},
 		&runtime.KernelParamStatus{},
 		&runtime.MountStatus{},
 		&secrets.API{},

--- a/internal/integration/cli/support.go
+++ b/internal/integration/cli/support.go
@@ -61,7 +61,6 @@ func (suite *SupportSuite) TestSupport() {
 		"machined.state",
 		"kubelet.log",
 		"kubelet.state",
-		"talosResources/kernelparamspecs.runtime.talos.dev.yaml",
 		"talosResources/kernelparamstatuses.runtime.talos.dev.yaml",
 		"kube-system/kube-apiserver.log",
 		"mounts",

--- a/pkg/machinery/resources/runtime/kernel_params_spec.go
+++ b/pkg/machinery/resources/runtime/kernel_params_spec.go
@@ -19,6 +19,14 @@ const NamespaceName resource.Namespace = v1alpha1.NamespaceName
 // KernelParamSpecType is type of KernelParam resource.
 const KernelParamSpecType = resource.Type("KernelParamSpecs.runtime.talos.dev")
 
+// KernelParamDefaultSpecType is type of KernelParam resource for default kernel params.
+const KernelParamDefaultSpecType = resource.Type("KernelParamDefaultSpecs.runtime.talos.dev")
+
+// KernelParam interface.
+type KernelParam interface {
+	TypedSpec() *KernelParamSpecSpec
+}
+
 // KernelParamSpec resource holds sysctl flags to define.
 type KernelParamSpec struct {
 	md   resource.Metadata
@@ -77,5 +85,60 @@ func (r *KernelParamSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
 
 // TypedSpec allows to access the KernelParamSpecSpec with the proper type.
 func (r *KernelParamSpec) TypedSpec() *KernelParamSpecSpec {
+	return &r.spec
+}
+
+// NewKernelParamDefaultSpec initializes a KernelParamSpec resource.
+func NewKernelParamDefaultSpec(namespace resource.Namespace, id resource.ID) *KernelParamDefaultSpec {
+	r := &KernelParamDefaultSpec{
+		md:   resource.NewMetadata(namespace, KernelParamDefaultSpecType, id, resource.VersionUndefined),
+		spec: KernelParamSpecSpec{},
+	}
+
+	r.md.BumpVersion()
+
+	return r
+}
+
+// KernelParamDefaultSpec implements meta.ResourceDefinitionProvider interface.
+type KernelParamDefaultSpec struct {
+	md   resource.Metadata
+	spec KernelParamSpecSpec
+}
+
+// Metadata implements resource.Resource.
+func (r *KernelParamDefaultSpec) Metadata() *resource.Metadata {
+	return &r.md
+}
+
+// Spec implements resource.Resource.
+func (r *KernelParamDefaultSpec) Spec() interface{} {
+	return r.spec
+}
+
+func (r *KernelParamDefaultSpec) String() string {
+	return fmt.Sprintf("runtime.KernelParamDefaultSpec.(%q)", r.md.ID())
+}
+
+// DeepCopy implements resource.Resource.
+func (r *KernelParamDefaultSpec) DeepCopy() resource.Resource {
+	return &KernelParamDefaultSpec{
+		md:   r.md,
+		spec: r.spec,
+	}
+}
+
+// ResourceDefinition implements meta.ResourceDefinitionProvider interface.
+func (r *KernelParamDefaultSpec) ResourceDefinition() meta.ResourceDefinitionSpec {
+	return meta.ResourceDefinitionSpec{
+		Type:             KernelParamDefaultSpecType,
+		Aliases:          []resource.Type{},
+		DefaultNamespace: NamespaceName,
+		PrintColumns:     []meta.PrintColumn{},
+	}
+}
+
+// TypedSpec allows to access the KernelParamSpecSpec with the proper type.
+func (r *KernelParamDefaultSpec) TypedSpec() *KernelParamSpecSpec {
 	return &r.spec
 }


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/4385

Now sysctls defined in the config can override kernel args defined by
defaults controller.
In that case controller shows the warning that tells which param was
overridden, new value and tells that it is not recommended.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4636)
<!-- Reviewable:end -->
