### PR TITLE
Cgroup system reservation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/aws/aws-sdk-go v1.43.8
 	github.com/beevik/ntp v0.3.0
 	github.com/cenkalti/backoff/v4 v4.1.2
-	github.com/containerd/cgroups v1.0.3
+	github.com/containerd/cgroups v1.0.4-0.20220301195952-2e502f6b9e43
 	github.com/containerd/containerd v1.6.0
 	github.com/containerd/cri v1.19.0
 	github.com/containerd/typeurl v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,9 @@ github.com/containerd/cgroups v0.0.0-20200710171044-318312a37340/go.mod h1:s5q4S
 github.com/containerd/cgroups v0.0.0-20200824123100-0b889c03f102/go.mod h1:s5q4SojHctfxANBDvMeIaIovkq29IP48TKAxnhYRxvo=
 github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68/go.mod h1:ZJeTFisyysqgcCdecO57Dj79RfL0LNeGiFUqLYQRYLE=
 github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
-github.com/containerd/cgroups v1.0.3 h1:ADZftAkglvCiD44c77s5YmMqaP2pzVCFZvBmAlBdAP4=
 github.com/containerd/cgroups v1.0.3/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
+github.com/containerd/cgroups v1.0.4-0.20220301195952-2e502f6b9e43 h1:heo8yArk63uJ8TyN/fZ3Tj1xlAPfT8GaXTqzHH+t07w=
+github.com/containerd/cgroups v1.0.4-0.20220301195952-2e502f6b9e43/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=

--- a/internal/app/machined/pkg/system/services/containerd.go
+++ b/internal/app/machined/pkg/system/services/containerd.go
@@ -78,7 +78,7 @@ func (c *Containerd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithEnv(env),
 		runner.WithOOMScoreAdj(-999),
-		runner.WithCgroupPath(constants.CgroupRuntime),
+		runner.WithCgroupPath(constants.CgroupSystemRuntime),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -79,7 +79,7 @@ func (c *Udevd) Runner(r runtime.Runtime) (runner.Runner, error) {
 		args,
 		runner.WithLoggingManager(r.Logging()),
 		runner.WithEnv(env),
-		runner.WithCgroupPath(constants.CgroupRuntime),
+		runner.WithCgroupPath(constants.CgroupSystemRuntime),
 	),
 		restart.WithType(restart.Forever),
 	), nil

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -287,7 +287,7 @@ const (
 	KubeletSystemReservedCPU = "50m"
 
 	// KubeletSystemReservedMemory memory system reservation value for kubelet kubeconfig.
-	KubeletSystemReservedMemory = "128Mi"
+	KubeletSystemReservedMemory = "192Mi"
 
 	// KubeletSystemReservedPid pid system reservation value for kubelet kubeconfig.
 	KubeletSystemReservedPid = "100"
@@ -458,11 +458,17 @@ const (
 	// CgroupInit is the cgroup name for init process.
 	CgroupInit = "/init"
 
+	// CgroupInitReservedMemory is the hard memory protection for the init process.
+	CgroupInitReservedMemory = 96 * 1024 * 1024
+
 	// CgroupSystem is the cgroup name for system processes.
 	CgroupSystem = "/system"
 
-	// CgroupRuntime is the cgroup name for containerd runtime processes.
-	CgroupRuntime = CgroupSystem + "/runtime"
+	// CgroupSystemReservedMemory is the hard memory protection for the system processes.
+	CgroupSystemReservedMemory = 96 * 1024 * 1024
+
+	// CgroupSystemRuntime is the cgroup name for containerd runtime processes.
+	CgroupSystemRuntime = CgroupSystem + "/runtime"
 
 	// CgroupExtensions is the cgroup name for system extension processes.
 	CgroupExtensions = CgroupSystem + "/extensions"
@@ -470,8 +476,14 @@ const (
 	// CgroupPodRuntime is the cgroup name for kubernetes containerd runtime processes.
 	CgroupPodRuntime = "/podruntime/runtime"
 
+	// CgroupPodRuntimeReservedMemory is the hard memory protection for the cri runtime processes.
+	CgroupPodRuntimeReservedMemory = 128 * 1024 * 1024
+
 	// CgroupKubelet is the cgroup name for kubelet process.
 	CgroupKubelet = "/podruntime/kubelet"
+
+	// CgroupKubeletReservedMemory is the hard memory protection for the kubelet processes.
+	CgroupKubeletReservedMemory = 64 * 1024 * 1024
 
 	// FlannelCNI is the string to use Tanos-managed Flannel CNI (default).
 	FlannelCNI = "flannel"


### PR DESCRIPTION
Set to init/sysstem processes hard memory reservation.

* init possess starts from 6Mb and grow to ~90Mb
* system processes usually use ~128Mb (with etcd)
* kubelet - 64Mb 
* cri + containerd-shim - 128Mb

When node has memory issue, init process is trying to allocate memory and get not enough memory issue.
Because this is affect the kubelet/containerd. They cannot start pod-eviction process (start very slowly). 

It also helps to gather metrics from Talos api (talosctl dashboard) or reboot the node. 

Almost ready, but I will wait this PR https://github.com/containerd/cgroups/pull/211 (merged)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4637)
<!-- Reviewable:end -->
