### PR TITLE
fix: drop unpacked layers from containerd image store

### DIFF
--- a/hack/cri-containerd.toml
+++ b/hack/cri-containerd.toml
@@ -10,3 +10,4 @@ format = "json"
 
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
     runtime_type = "io.containerd.runc.v2"
+    discard_unpacked_layers = true

--- a/pkg/cli/formatters.go
+++ b/pkg/cli/formatters.go
@@ -57,7 +57,7 @@ func RenderMounts(resp *machine.MountsResponse, output io.Writer, remotePeer *pe
 			if defaultNode != "" {
 				format = "%s\t" + format
 
-				args = append([]interface{}{node}, args)
+				args = append([]interface{}{node}, args...)
 			}
 
 			fmt.Fprintf(w, format, args...)


### PR DESCRIPTION
See https://github.com/containerd/cri/pull/1543

Fixes #4274

Fix is applied on two levels:

* for Talos-initiated pulls, update API call
* for Kubernetes-initiated pulls, update CRI plugin config

Comparison of `/var` usage before/after, as reported by
`talosctl mounts` (in GiB):

|              | before | after |
|--------------|:------:|------:|
| controlplane |  1.98  |  1.74 |
| worker       |  1.17  |  1.01 |

(this is on freshly bootstrapped but otherwise empty cluster)

It's hard to measure effect on pulls to system containerd, like
`installer` image, as it's ephemeral, but it should also reduce space
usage in `tmpfs`.

Also fixes output of `talosctl mounts`.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4653)
<!-- Reviewable:end -->
