### PR TITLE
fix: relax validation for wireguard endpoints

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -554,8 +554,8 @@ func checkWireguard(b *DeviceWireguardConfig) error {
 		}
 
 		if peer.WireguardEndpoint != "" {
-			if _, err := net.ResolveUDPAddr("", peer.WireguardEndpoint); err != nil {
-				result = multierror.Append(result, fmt.Errorf("peer endpoint %q is invalid: %w", peer.WireguardEndpoint, err))
+			if !talosnet.AddressContainsPort(peer.WireguardEndpoint) {
+				result = multierror.Append(result, fmt.Errorf("peer endpoint %q is invalid", peer.WireguardEndpoint))
 			}
 		}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -644,6 +644,7 @@ func TestValidate(t *testing.T) {
 										{},
 										{
 											WireguardPublicKey: "4A3rogGVHuVjeZz5cbqryWXGkGBdIGC0E6+5mX2Iz1A=",
+											WireguardEndpoint:  "example.com:1234",
 											WireguardAllowedIPs: []string{
 												"10.2.0.5/31",
 												"2.4.5.3/32",
@@ -651,6 +652,7 @@ func TestValidate(t *testing.T) {
 										},
 										{
 											WireguardPublicKey: "4A3rogGVHuVjeZz5cbqryWXGkGBdIGC0E6+5mX2Iz1==",
+											WireguardEndpoint:  "12.3.4.5",
 											WireguardAllowedIPs: []string{
 												"10.2.0",
 											},
@@ -669,8 +671,8 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "3 errors occurred:\n\t* public key invalid: wrong key \"\" length: 0\n\t* public key invalid: wrong key \"4A3rogGVHuVjeZz5cbqryWXGkGBdIGC0E6+5mX2Iz1==\" length: 31\n" +
-				"\t* peer allowed IP \"10.2.0\" is invalid: invalid CIDR address: 10.2.0\n\n",
+			expectedError: "4 errors occurred:\n\t* public key invalid: wrong key \"\" length: 0\n\t* public key invalid: wrong key \"4A3rogGVHuVjeZz5cbqryWXGkGBdIGC0E6+5mX2Iz1==\" length: 31\n" +
+				"\t* peer endpoint \"12.3.4.5\" is invalid\n\t* peer allowed IP \"10.2.0\" is invalid: invalid CIDR address: 10.2.0\n\n",
 		},
 		{
 			name: "StaticRoutes",


### PR DESCRIPTION
Fixes #4463

Talos supports hostnames as Wireguard endpoints in the runtime, as it
will try resolving to a IP:port before sending to Wireguard.

But config validation shouldn't try to resolve the hostname.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4657)
<!-- Reviewable:end -->
