### PR TITLE
fix: increase boot and etcd join timeouts

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -357,7 +357,7 @@ func buildInitialCluster(ctx context.Context, r runtime.Runtime, name, ip string
 		lastNag time.Time
 	)
 
-	err = retry.Constant(10*time.Minute,
+	err = retry.Constant(constants.EtcdJoinTimeout,
 		retry.WithUnits(3*time.Second),
 		retry.WithJitter(time.Second),
 		retry.WithErrorLogging(true),

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -455,7 +455,12 @@ const (
 	DefaultDNSDomain = "cluster.local"
 
 	// BootTimeout is the timeout to run all services.
-	BootTimeout = 15 * time.Minute
+	BootTimeout = 35 * time.Minute
+
+	// EtcdJoinTimeout is the timeout for etcd to join the existing cluster.
+	//
+	// BootTimeout should be higher than EtcdJoinTimeout.
+	EtcdJoinTimeout = 30 * time.Minute
 
 	// NodeReadyTimeout is the timeout to wait for the node to be ready (CNI to be running).
 	// For bootstrap API, this includes time to run bootstrap.


### PR DESCRIPTION
Fixes #4626

On bare metal, booting machines might take a long time to go through the
whole BIOS boot sequence, or pulling images might take considerably
longer than expected.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4658)
<!-- Reviewable:end -->
