### PR TITLE
fix: cleanup affiliates

### DIFF
--- a/internal/app/machined/pkg/controllers/cluster/cluster.go
+++ b/internal/app/machined/pkg/controllers/cluster/cluster.go
@@ -4,3 +4,35 @@
 
 // Package cluster provides controllers which manage Talos cluster resources.
 package cluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+
+	"github.com/talos-systems/talos/pkg/machinery/resources/cluster"
+)
+
+func cleanupAffiliates(ctx context.Context, ctrl controller.Controller, r controller.Runtime, touchedIDs map[resource.ID]struct{}) error {
+	// list keys for cleanup
+	list, err := r.List(ctx, resource.NewMetadata(cluster.RawNamespaceName, cluster.AffiliateType, "", resource.VersionUndefined))
+	if err != nil {
+		return fmt.Errorf("error listing resources: %w", err)
+	}
+
+	for _, res := range list.Items {
+		if res.Metadata().Owner() != ctrl.Name() {
+			continue
+		}
+
+		if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+			if err = r.Destroy(ctx, res.Metadata()); err != nil {
+				return fmt.Errorf("error cleaning up specs: %w", err)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Cleanup affiliates when registries are disabled

Fixes #4290

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4671)
<!-- Reviewable:end -->
