### PR TITLE
fix: use default time servers in time API if none are configured

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_time.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_time.go
@@ -16,6 +16,7 @@ import (
 
 	timeapi "github.com/talos-systems/talos/pkg/machinery/api/time"
 	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/constants"
 )
 
 // ConfigProvider defines an interface sufficient for the TimeServer.
@@ -40,7 +41,7 @@ func (r *TimeServer) Time(ctx context.Context, in *emptypb.Empty) (reply *timeap
 	timeServers := r.ConfigProvider.Config().Machine().Time().Servers()
 
 	if len(timeServers) == 0 {
-		return nil, fmt.Errorf("no time servers configured")
+		timeServers = []string{constants.DefaultNTPServer}
 	}
 
 	return r.TimeCheck(ctx, &timeapi.TimeRequest{

--- a/internal/integration/cli/time.go
+++ b/internal/integration/cli/time.go
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//go:build integration_cli
+// +build integration_cli
+
+package cli
+
+import (
+	"regexp"
+
+	"github.com/talos-systems/talos/internal/integration/base"
+)
+
+// TimeSuite verifies dmesg command.
+type TimeSuite struct {
+	base.CLISuite
+}
+
+// SuiteName ...
+func (suite *TimeSuite) SuiteName() string {
+	return "cli.TimeSuite"
+}
+
+// TestDefault runs default time check.
+func (suite *TimeSuite) TestDefault() {
+	suite.RunCLI([]string{"time", "--nodes", suite.RandomDiscoveredNode()},
+		base.StdoutShouldMatch(regexp.MustCompile(`NTP-SERVER`)),
+		base.StdoutShouldMatch(regexp.MustCompile(`UTC`)),
+	)
+}
+
+func init() {
+	allSuites = append(allSuites, new(TimeSuite))
+}


### PR DESCRIPTION
This fixes simple bug:

```
$ talosctl -n 172.20.0.2 time
error fetching time: 1 error occurred:
	* 172.20.0.2: rpc error: code = Unknown desc = no time servers configured
```

After the change:

```
$ talosctl -n 172.20.0.2 time
NODE         NTP-SERVER     NODE-TIME                                 NTP-SERVER-TIME
172.20.0.2   pool.ntp.org   2021-12-10 14:25:38.871656717 +0000 UTC   2021-12-10 14:25:38.92119139 +0000 UTC
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4674)
<!-- Reviewable:end -->
