### PR TITLE
refactor: rewrite the check for unknown keys in the machine configuration

### DIFF
--- a/pkg/machinery/config/decoder/testdata/controlplane.yaml
+++ b/pkg/machinery/config/decoder/testdata/controlplane.yaml
@@ -1,0 +1,385 @@
+version: v1alpha1 # Indicates the schema used to decode the contents.
+debug: false # Enable verbose logging to the console.
+persist: true # Indicates whether to pull the machine config upon every boot.
+# Provides machine specific configuration options.
+machine:
+    type: controlplane # Defines the role of the machine within the cluster.
+    token: 2z19nz.e8oeemr4l3caw64b # The `token` is used by a machine to join the PKI of the cluster.
+    # The root certificate authority of the PKI.
+    ca:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJQekNCOHFBREFnRUNBaEVBMHZWRnd5cWJJOU5oeDFVb0swRGJtREFGQmdNclpYQXdFREVPTUF3R0ExVUUKQ2hNRmRHRnNiM013SGhjTk1qRXhNakUxTVRneE1qTXhXaGNOTXpFeE1qRXpNVGd4TWpNeFdqQVFNUTR3REFZRApWUVFLRXdWMFlXeHZjekFxTUFVR0F5dGxjQU1oQU12ckJiTXdPOTVxTncydHFqSlBiZDEyWU5PS3lFb1Z2VjZqCk9iOXNxOFBTbzJFd1h6QU9CZ05WSFE4QkFmOEVCQU1DQW9Rd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUcKQ0NzR0FRVUZCd01DTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRksyWkFaSkdCTmhKRU9DSAorVTJ0cmFjVExmMjdNQVVHQXl0bGNBTkJBRDIvb29WeEZpanNhRXBzQ0JpU3RpMnNQMFdISDc5TjdISlpra3VXClNXYkhRQ3cyZkhmTnZtTUhkK1poaTNCSzdLN2RyWVFydTUvaTVhMGlRYU9IRndFPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: LS0tLS1CRUdJTiBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0KTUM0Q0FRQXdCUVlESzJWd0JDSUVJTCtucmxTRVlpZFZSZm1PaEJvbXAzN296ZHFZWGgwZGg4TnFjanBqUko2TQotLS0tLUVORCBFRDI1NTE5IFBSSVZBVEUgS0VZLS0tLS0K
+    # Extra certificate subject alternative names for the machine's certificate.
+    certSANs: []
+    #   # Uncomment this to enable SANs.
+    #   - 10.0.0.10
+    #   - 172.16.0.10
+    #   - 192.168.0.10
+
+    # Used to provide additional options to the kubelet.
+    kubelet:
+        image: ghcr.io/talos-systems/kubelet:v1.23.0
+
+        clusterDNS:
+            - 10.96.0.10
+            - 169.254.2.53
+
+        # # The `extraArgs` field is used to provide additional flags to the kubelet.
+        extraArgs:
+            key: value
+
+        # # The `extraMounts` field is used to add additional mounts to the kubelet container.
+        extraMounts:
+            - destination: /var/lib/example
+              type: bind
+              source: /var/lib/example
+              options:
+                  - bind
+                  - rshared
+                  - rw
+
+        # # The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.
+        nodeIP:
+            validSubnets:
+                - 10.0.0.0/8
+                - '!10.0.0.3/32'
+                - fdc7::/16
+
+    # Provides machine specific network configuration options.
+    network:
+        # Configures KubeSpan feature.
+        kubespan:
+            enabled: true # Enable the KubeSpan feature.
+
+        # # `interfaces` is used to define the network interface configuration.
+        # interfaces:
+        #     - interface: eth0 # The interface name.
+        #       # Assigns static IP addresses to the interface.
+        #       addresses:
+        #         - 192.168.2.0/24
+        #       # A list of routes associated with the interface.
+        #       routes:
+        #         - network: 0.0.0.0/0 # The route's network.
+        #           gateway: 192.168.2.1 # The route's gateway.
+        #           metric: 1024 # The optional metric for the route.
+        #       mtu: 1500 # The interface's MTU.
+        #
+        #       # # Bond specific options.
+        #       # bond:
+        #       #     # The interfaces that make up the bond.
+        #       #     interfaces:
+        #       #         - eth0
+        #       #         - eth1
+        #       #     mode: 802.3ad # A bond option.
+        #       #     lacpRate: fast # A bond option.
+
+        #       # # Indicates if DHCP should be used to configure the interface.
+        #       # dhcp: true
+
+        #       # # DHCP specific options.
+        #       # dhcpOptions:
+        #       #     routeMetric: 1024 # The priority of all routes received via DHCP.
+
+        #       # # Wireguard specific configuration.
+
+        #       # # wireguard server example
+        #       # wireguard:
+        #       #     privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
+        #       #     listenPort: 51111 # Specifies a device's listening port.
+        #       #     # Specifies a list of peer configurations to apply to a device.
+        #       #     peers:
+        #       #         - publicKey: ABCDEF... # Specifies the public key of this peer.
+        #       #           endpoint: 192.168.1.3 # Specifies the endpoint of this peer entry.
+        #       #           # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
+        #       #           allowedIPs:
+        #       #             - 192.168.1.0/24
+        #       # # wireguard peer example
+        #       # wireguard:
+        #       #     privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
+        #       #     # Specifies a list of peer configurations to apply to a device.
+        #       #     peers:
+        #       #         - publicKey: ABCDEF... # Specifies the public key of this peer.
+        #       #           endpoint: 192.168.1.2 # Specifies the endpoint of this peer entry.
+        #       #           persistentKeepaliveInterval: 10s # Specifies the persistent keepalive interval for this peer.
+        #       #           # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
+        #       #           allowedIPs:
+        #       #             - 192.168.1.0/24
+
+        #       # # Virtual (shared) IP address configuration.
+        #       # vip:
+        #       #     ip: 172.16.199.55 # Specifies the IP address to be used.
+
+        # # Used to statically set the nameservers for the machine.
+        # nameservers:
+        #     - 8.8.8.8
+        #     - 1.1.1.1
+
+        # # Allows for extra entries to be added to the `/etc/hosts` file
+        # extraHostEntries:
+        #     - ip: 192.168.1.100 # The IP of the host.
+        #       # The host alias.
+        #       aliases:
+        #         - example
+        #         - example.domain.tld
+    # Used to provide instructions for installations.
+    install:
+        disk: /dev/sda # The disk used for installations.
+        image: ghcr.io/talos-systems/installer:v0.14.0-alpha.2-36-g936b4c4c-dirty # Allows for supplying the image used to perform the installation.
+        bootloader: true # Indicates if a bootloader should be installed.
+        wipe: false # Indicates if the installation disk should be wiped at installation time.
+
+        # # Look up disk using disk attributes like model, size, serial and others.
+        # diskSelector:
+        #     size: 4GB # Disk size.
+        #     model: WDC* # Disk model `/sys/block/<dev>/device/model`.
+
+        # # Allows for supplying extra kernel args via the bootloader.
+        # extraKernelArgs:
+        #     - talos.platform=metal
+        #     - reboot=k
+    # Features describe individual Talos features that can be switched on or off.
+    features:
+        rbac: true # Enable role-based access control (RBAC).
+
+    # # Provides machine specific contolplane configuration options.
+
+    # # ControlPlane definition example.
+    controlPlane:
+        # Controller manager machine specific configuration options.
+        controllerManager:
+            disabled: false # Disable kube-controller-manager on the node.
+        # Scheduler machine specific configuration options.
+        scheduler:
+            disabled: true # Disable kube-scheduler on the node.
+
+    # # Used to partition, format and mount additional disks.
+
+    # # MachineDisks list example.
+    # disks:
+    #     - device: /dev/sdb # The name of the disk to use.
+    #       # A list of partitions to create on the disk.
+    #       partitions:
+    #         - mountpoint: /var/mnt/extra # Where to mount the partition.
+    #
+    #           # # The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk.
+
+    #           # # Human readable representation.
+    #           # size: 100 MB
+    #           # # Precise value in bytes.
+    #           # size: 1073741824
+
+    # # Allows the addition of user specified files.
+
+    # # MachineFiles usage example.
+    files:
+        - content: '...' # The contents of the file.
+          permissions: 0o666 # The file's permissions in octal.
+          path: /tmp/file.txt # The path of the file.
+          op: append # The operation to use
+
+    # # The `env` field allows for the addition of environment variables.
+
+    # # Environment variables definition examples.
+    env:
+        GRPC_GO_LOG_SEVERITY_LEVEL: info
+        GRPC_GO_LOG_VERBOSITY_LEVEL: "99"
+        https_proxy: http://SERVER:PORT/
+    # env:
+    #     GRPC_GO_LOG_SEVERITY_LEVEL: error
+    #     https_proxy: https://USERNAME:PASSWORD@SERVER:PORT/
+    # env:
+    #     https_proxy: http://DOMAIN\USERNAME:PASSWORD@SERVER:PORT/
+
+    # # Used to configure the machine's time settings.
+
+    # # Example configuration for cloudflare ntp server.
+    # time:
+    #     disabled: false # Indicates if the time service is disabled for the machine.
+    #     # Specifies time (NTP) servers to use for setting the system time.
+    #     servers:
+    #         - time.cloudflare.com
+    #     bootTimeout: 2m0s # Specifies the timeout when the node time is considered to be in sync unlocking the boot sequence.
+
+    # # Used to configure the machine's sysctls.
+
+    # # MachineSysctls usage example.
+    sysctls:
+        kernel.domainname: talos.dev
+        net.ipv4.ip_forward: "0"
+
+    # # Used to configure the machine's container image registry mirrors.
+    registries:
+        # Specifies mirror configuration for each registry.
+        mirrors:
+            ghcr.io:
+                # List of endpoints (URLs) for registry mirrors to use.
+                endpoints:
+                    - https://registry.insecure
+                    - https://ghcr.io/v2/
+        # Specifies TLS & auth configuration for HTTPS image registries.
+        config:
+            registry.insecure:
+                # The TLS configuration for the registry.
+                tls:
+                    insecureSkipVerify: true # Skip TLS server certificate verification (not recommended).
+    #
+    #                 # # Enable mutual TLS authentication with the registry.
+    #                 # clientIdentity:
+    #                 #     crt: TFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSklla05DTUhGLi4u
+    #                 #     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
+    #
+    #             # # The auth configuration for this registry.
+    #             # auth:
+    #             #     username: username # Optional registry authentication.
+    #             #     password: password # Optional registry authentication.
+
+    # # Machine system disk encryption configuration.
+    systemDiskEncryption:
+        # Ephemeral partition encryption.
+        ephemeral:
+            provider: luks2 # Encryption provider to use for the encryption.
+            # Defines the encryption keys generation and storage method.
+            keys:
+                - # Deterministically generated key from the node UUID and PartitionLabel.
+                  nodeID: {}
+                  slot: 0 # Key slot number for LUKS2 encryption.
+            cipher: aes-xts-plain64
+
+            # Defines the encryption sector size.
+            blockSize: 4096
+
+    #         # # Additional --perf parameters for the LUKS2 encryption.
+    #         # options:
+    #         #     - no_read_workqueue
+    #         #     - no_write_workqueue
+
+    # # Configures the udev system.
+    # udev:
+    #     # List of udev rules to apply to the udev system
+    #     rules:
+    #         - SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="44", MODE="0660"
+
+    # # Configures the logging system.
+    # logging:
+    #     # Logging destination.
+    #     destinations:
+    #         - endpoint: tcp://1.2.3.4:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
+    #           format: json_lines # Logs format.
+# Provides cluster specific configuration options.
+cluster:
+    id: jW8IQKoSCDbhlCNm5K59er5jawHVIechsTuLNZ2_0Z8= # Globally unique identifier for this cluster (base64 encoded random 32 bytes).
+    secret: BVpg0EsnQ5vfvHvMN5Yc2+qyzbvJpLNokgdNqmYRxEU= # Shared secret of cluster (base64 encoded random 32 bytes).
+    # Provides control plane specific configuration options.
+    controlPlane:
+        endpoint: https://localhost:6443/ # Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
+    clusterName: foo # Configures the cluster's name.
+    # Provides cluster specific network configuration options.
+    network:
+        dnsDomain: cluster.local # The domain used by Kubernetes DNS.
+        # The pod subnet CIDR.
+        podSubnets:
+            - 10.244.0.0/16
+        # The service subnet CIDR.
+        serviceSubnets:
+            - 10.96.0.0/12
+
+        # # The CNI used.
+        # cni:
+        #     name: custom # Name of CNI to use.
+        #     # URLs containing manifests to apply for the CNI.
+        #     urls:
+        #         - https://raw.githubusercontent.com/cilium/cilium/v1.8/install/kubernetes/quick-install.yaml
+    token: 9qbh68.dc9ya8gx9tornbbc # The [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/) used to join the cluster.
+    aescbcEncryptionSecret: +AdmkjvLQAOGUwMfsd2OkAsZ6nj4RgVEOupJVbvkmhM= # The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+    # The base64 encoded root certificate authority used by Kubernetes.
+    ca:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpakNDQVRDZ0F3SUJBZ0lSQUxENi9BNVREb2UxMmRHdTFEbzVJcVV3Q2dZSUtvWkl6ajBFQXdJd0ZURVQKTUJFR0ExVUVDaE1LYTNWaVpYSnVaWFJsY3pBZUZ3MHlNVEV5TVRVeE9ERXlNekZhRncwek1URXlNVE14T0RFeQpNekZhTUJVeEV6QVJCZ05WQkFvVENtdDFZbVZ5Ym1WMFpYTXdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CCkJ3TkNBQVQyTW83U3cxSUZiMTIwMDlLOFRoYUFxRDFhSmFNa0ZTbHZxN1Z5VzdJN2ZhbS93ZDJ1cERFb3M0TisKaVdCSFJyejVLejFscTRXcnhTNnd4ZlJ2RUROVm8yRXdYekFPQmdOVkhROEJBZjhFQkFNQ0FvUXdIUVlEVlIwbApCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPCkJCWUVGTEpFWHZ0ZkZTbmxvMk4wY29JYnpCVWNCRFJwTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUI3SnZLaS8KZEV4WEZ2WUN3TXM2b2lwcHd4ZVRwdW1KMGFPTzVjZFc5Z2xoQWlFQXhwdTl4bFBGOFlkZThvV0tnYXNrMmRiZQpZUGZZMGdxUVdHV09qMDE1WGIwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUttbm51UmZnd29rT3pIQ0pmNXVOSENWMldKeXVaT3dIQlBWMUcrRGM0eUxvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFOWpLTzBzTlNCVzlkdE5QU3ZFNFdnS2c5V2lXakpCVXBiNnUxY2x1eU8zMnB2OEhkcnFReApLTE9EZm9sZ1IwYTgrU3M5WmF1RnE4VXVzTVgwYnhBelZRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+    # The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.
+    aggregatorCA:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJZRENDQVFhZ0F3SUJBZ0lSQVAvU2JicUtoYmRkeFdzeUVjSkRSVWN3Q2dZSUtvWkl6ajBFQXdJd0FEQWUKRncweU1URXlNVFV4T0RFeU16RmFGdzB6TVRFeU1UTXhPREV5TXpGYU1BQXdXVEFUQmdjcWhrak9QUUlCQmdncQpoa2pPUFFNQkJ3TkNBQVJLUzN0VlU4Y2ZyRFZ1bHJRZjEwQmJGZS9ZMVFITThZVWtYM2JTSTNKMmx2ZEFQK2ZECnhCaFE5OUVwd1lLYlplZXl0UHowTTlxYnI5WDF5K2FSNHhycW8yRXdYekFPQmdOVkhROEJBZjhFQkFNQ0FvUXcKSFFZRFZSMGxCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01BOEdBMVVkRXdFQi93UUZNQU1CQWY4dwpIUVlEVlIwT0JCWUVGTFFWaG1rckFVSWk1aTVWb0lybkJVVE04cEZETUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDCklRRFh5QWhWbDFSdHpqdUhvR09icjRDZlpIbisrOThaNXRWQWdLUFNacHdtSFFJZ1hBWWhtOXJub2oxNkVTWXYKcm1qYkVLdkFqT2pDbWlxS3dLYkt6Z2ZmdXdBPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUliaVhxMWlVNW90RTV3YzIwbUhDZk0vTkEybUd1SFJqNmFQOFZPZFhVbkVvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFU2t0N1ZWUEhINncxYnBhMEg5ZEFXeFh2Mk5VQnpQR0ZKRjkyMGlOeWRwYjNRRC9udzhRWQpVUGZSS2NHQ20yWG5zclQ4OURQYW02L1Y5Y3Zta2VNYTZnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+    # The base64 encoded private key for service account token generation.
+    serviceAccount:
+        key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSU5FMzRITGNEamdWbGc2VHNqOUVzQk9ycWRLNlozcTBMOVVnQXpyK0Z5SG1vQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFb3MvRndOODJiZGs1UGY4L2lSTkNOL0NwVEc1MytTbTJrV1IxTGFWbitQYlA4di9ML3VKUQordWdEN1NCRmZ5b3pyUWk3SU40eklUVlZZV3VLcDl5N3lnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+    # API server specific configuration options.
+    apiServer:
+        # Extra certificate subject alternative names for the API server's certificate.
+        certSANs:
+            - localhost
+
+        # # The container image used in the API server manifest.
+        # image: k8s.gcr.io/kube-apiserver:v1.23.0
+    # Controller manager server specific configuration options.
+    controllerManager: {}
+    # # The container image used in the controller manager manifest.
+    # image: k8s.gcr.io/kube-controller-manager:v1.23.0
+
+    # Kube-proxy server-specific configuration options
+    proxy: {}
+    # # The container image used in the kube-proxy manifest.
+    # image: k8s.gcr.io/kube-proxy:v1.23.0
+
+    # Scheduler server specific configuration options.
+    scheduler: {}
+    # # The container image used in the scheduler manifest.
+    # image: k8s.gcr.io/kube-scheduler:v1.23.0
+
+    # Configures cluster member discovery.
+    discovery:
+        enabled: true # Enable the cluster membership discovery feature.
+        # Configure registries used for cluster member discovery.
+        registries:
+            # Kubernetes registry uses Kubernetes API server to discover cluster members and stores additional information
+            kubernetes: {}
+            # Service registry is using an external service to push and pull information about cluster members.
+            service: {}
+            # # External service endpoint.
+            # endpoint: https://discovery.talos.dev/
+    # Etcd specific configuration options.
+    etcd:
+        # The `ca` is the root certificate authority of the PKI.
+        ca:
+            crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJmakNDQVNTZ0F3SUJBZ0lSQUtVd1BtN0kvVUphRHd2d0FoMXJERUl3Q2dZSUtvWkl6ajBFQXdJd0R6RU4KTUFzR0ExVUVDaE1FWlhSalpEQWVGdzB5TVRFeU1UVXhPREV5TXpGYUZ3MHpNVEV5TVRNeE9ERXlNekZhTUE4eApEVEFMQmdOVkJBb1RCR1YwWTJRd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFUbXBCTHcxdnprCkV3LzR4QTRaTTNoUUNoVUsvbTBoZitQZ0lPR3hwYnZpTkdFMFpDM0VTaTlYOFQzYmZEVHdXZjZORFRhYmRmcXoKT01wU1VEQUlhWTJ2bzJFd1h6QU9CZ05WSFE4QkFmOEVCQU1DQW9Rd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSApBd0VHQ0NzR0FRVUZCd01DTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRk5wUHlFZHhkd216Ckp2WmE2YjM4SVhpZWgwU0pNQW9HQ0NxR1NNNDlCQU1DQTBnQU1FVUNJQ0ZGYzRRNXpVU0RFbytkMWJyWGJvYWgKRVJseGJNZ0V0T2FzWXR3NFpubDVBaUVBNDEwSFdpbHBreXV3cTNYam1xN1FFR0FIcjFabjdhOFZRb2QxUzB5UAoxMUU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+            key: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUErazdPK3VVaGdnMy9vMHc0U3VOeXBxZG5SQ2xDYXpXWmtaT0NOcVVhZjJvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFNXFRUzhOYjg1Qk1QK01RT0dUTjRVQW9WQ3Y1dElYL2o0Q0Roc2FXNzRqUmhOR1F0eEVvdgpWL0U5MjN3MDhGbitqUTAybTNYNnN6aktVbEF3Q0dtTnJ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
+
+        # # The container image used to create the etcd service.
+        # image: gcr.io/etcd-development/etcd:v3.5.1
+
+        # # The subnet from which the advertise URL should be.
+        # subnet: 10.0.0.0/8
+    # A list of urls that point to additional manifests.
+    extraManifests: []
+    #   - https://www.example.com/manifest1.yaml
+    #   - https://www.example.com/manifest2.yaml
+
+    # A list of inline Kubernetes manifests.
+    inlineManifests: []
+    #   - name: namespace-ci # Name of the manifest.
+    #     contents: |- # Manifest contents as a string.
+    #       apiVersion: v1
+    #       kind: Namespace
+    #       metadata:
+    #       	name: ci
+
+
+    # # Core DNS specific configuration options.
+    # coreDNS:
+    #     image: docker.io/coredns/coredns:1.8.6 # The `image` field is an override to the default coredns image.
+
+    # # External cloud provider configuration.
+    # externalCloudProvider:
+    #     enabled: true # Enable external cloud provider.
+    #     # A list of urls that point to additional manifests for an external cloud provider.
+    #     manifests:
+    #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
+    #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
+
+    # # A map of key value pairs that will be added while fetching the extraManifests.
+    # extraManifestHeaders:
+    #     Token: "1234567"
+    #     X-ExtraInfo: info
+
+    # # Settings for admin kubeconfig generation.
+    # adminKubeconfig:
+    #     certLifetime: 1h0m0s # Admin kubeconfig certificate lifetime (default is 1 year).

--- a/pkg/machinery/config/decoder/testdata/worker.yaml
+++ b/pkg/machinery/config/decoder/testdata/worker.yaml
@@ -1,0 +1,409 @@
+version: v1alpha1 # Indicates the schema used to decode the contents.
+debug: false # Enable verbose logging to the console.
+persist: true # Indicates whether to pull the machine config upon every boot.
+# Provides machine specific configuration options.
+machine:
+    type: worker # Defines the role of the machine within the cluster.
+    token: 2z19nz.e8oeemr4l3caw64b # The `token` is used by a machine to join the PKI of the cluster.
+    # The root certificate authority of the PKI.
+    ca:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJQekNCOHFBREFnRUNBaEVBMHZWRnd5cWJJOU5oeDFVb0swRGJtREFGQmdNclpYQXdFREVPTUF3R0ExVUUKQ2hNRmRHRnNiM013SGhjTk1qRXhNakUxTVRneE1qTXhXaGNOTXpFeE1qRXpNVGd4TWpNeFdqQVFNUTR3REFZRApWUVFLRXdWMFlXeHZjekFxTUFVR0F5dGxjQU1oQU12ckJiTXdPOTVxTncydHFqSlBiZDEyWU5PS3lFb1Z2VjZqCk9iOXNxOFBTbzJFd1h6QU9CZ05WSFE4QkFmOEVCQU1DQW9Rd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUcKQ0NzR0FRVUZCd01DTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRksyWkFaSkdCTmhKRU9DSAorVTJ0cmFjVExmMjdNQVVHQXl0bGNBTkJBRDIvb29WeEZpanNhRXBzQ0JpU3RpMnNQMFdISDc5TjdISlpra3VXClNXYkhRQ3cyZkhmTnZtTUhkK1poaTNCSzdLN2RyWVFydTUvaTVhMGlRYU9IRndFPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: ""
+    # Extra certificate subject alternative names for the machine's certificate.
+    certSANs: []
+    #   # Uncomment this to enable SANs.
+    #   - 10.0.0.10
+    #   - 172.16.0.10
+    #   - 192.168.0.10
+
+    # Used to provide additional options to the kubelet.
+    kubelet: {}
+    # # The `image` field is an optional reference to an alternative kubelet image.
+    # image: ghcr.io/talos-systems/kubelet:v1.23.0
+
+    # # The `ClusterDNS` field is an optional reference to an alternative kubelet clusterDNS ip list.
+    # clusterDNS:
+    #     - 10.96.0.10
+    #     - 169.254.2.53
+
+    # # The `extraArgs` field is used to provide additional flags to the kubelet.
+    # extraArgs:
+    #     key: value
+
+    # # The `extraMounts` field is used to add additional mounts to the kubelet container.
+    # extraMounts:
+    #     - destination: /var/lib/example
+    #       type: bind
+    #       source: /var/lib/example
+    #       options:
+    #         - bind
+    #         - rshared
+    #         - rw
+
+    # # The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.
+    # nodeIP:
+    #     # The `validSubnets` field configures the networks to pick kubelet node IP from.
+    #     validSubnets:
+    #         - 10.0.0.0/8
+    #         - '!10.0.0.3/32'
+    #         - fdc7::/16
+
+    # Provides machine specific network configuration options.
+    network:
+        # Configures KubeSpan feature.
+        kubespan:
+            enabled: true # Enable the KubeSpan feature.
+        
+        # # `interfaces` is used to define the network interface configuration.
+        # interfaces:
+        #     - interface: eth0 # The interface name.
+        #       # Assigns static IP addresses to the interface.
+        #       addresses:
+        #         - 192.168.2.0/24
+        #       # A list of routes associated with the interface.
+        #       routes:
+        #         - network: 0.0.0.0/0 # The route's network.
+        #           gateway: 192.168.2.1 # The route's gateway.
+        #           metric: 1024 # The optional metric for the route.
+        #       mtu: 1500 # The interface's MTU.
+        #       
+        #       # # Bond specific options.
+        #       # bond:
+        #       #     # The interfaces that make up the bond.
+        #       #     interfaces:
+        #       #         - eth0
+        #       #         - eth1
+        #       #     mode: 802.3ad # A bond option.
+        #       #     lacpRate: fast # A bond option.
+
+        #       # # Indicates if DHCP should be used to configure the interface.
+        #       # dhcp: true
+
+        #       # # DHCP specific options.
+        #       # dhcpOptions:
+        #       #     routeMetric: 1024 # The priority of all routes received via DHCP.
+
+        #       # # Wireguard specific configuration.
+
+        #       # # wireguard server example
+        #       # wireguard:
+        #       #     privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
+        #       #     listenPort: 51111 # Specifies a device's listening port.
+        #       #     # Specifies a list of peer configurations to apply to a device.
+        #       #     peers:
+        #       #         - publicKey: ABCDEF... # Specifies the public key of this peer.
+        #       #           endpoint: 192.168.1.3 # Specifies the endpoint of this peer entry.
+        #       #           # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
+        #       #           allowedIPs:
+        #       #             - 192.168.1.0/24
+        #       # # wireguard peer example
+        #       # wireguard:
+        #       #     privateKey: ABCDEF... # Specifies a private key configuration (base64 encoded).
+        #       #     # Specifies a list of peer configurations to apply to a device.
+        #       #     peers:
+        #       #         - publicKey: ABCDEF... # Specifies the public key of this peer.
+        #       #           endpoint: 192.168.1.2 # Specifies the endpoint of this peer entry.
+        #       #           persistentKeepaliveInterval: 10s # Specifies the persistent keepalive interval for this peer.
+        #       #           # AllowedIPs specifies a list of allowed IP addresses in CIDR notation for this peer.
+        #       #           allowedIPs:
+        #       #             - 192.168.1.0/24
+
+        #       # # Virtual (shared) IP address configuration.
+        #       # vip:
+        #       #     ip: 172.16.199.55 # Specifies the IP address to be used.
+
+        # # Used to statically set the nameservers for the machine.
+        # nameservers:
+        #     - 8.8.8.8
+        #     - 1.1.1.1
+
+        # # Allows for extra entries to be added to the `/etc/hosts` file
+        # extraHostEntries:
+        #     - ip: 192.168.1.100 # The IP of the host.
+        #       # The host alias.
+        #       aliases:
+        #         - example
+        #         - example.domain.tld
+    # Used to provide instructions for installations.
+    install:
+        disk: /dev/sda # The disk used for installations.
+        image: ghcr.io/talos-systems/installer:v0.14.0-alpha.2-36-g936b4c4c-dirty # Allows for supplying the image used to perform the installation.
+        bootloader: true # Indicates if a bootloader should be installed.
+        wipe: false # Indicates if the installation disk should be wiped at installation time.
+        
+        # # Look up disk using disk attributes like model, size, serial and others.
+        # diskSelector:
+        #     size: 4GB # Disk size.
+        #     model: WDC* # Disk model `/sys/block/<dev>/device/model`.
+
+        # # Allows for supplying extra kernel args via the bootloader.
+        # extraKernelArgs:
+        #     - talos.platform=metal
+        #     - reboot=k
+    # Features describe individual Talos features that can be switched on or off.
+    features:
+        rbac: true # Enable role-based access control (RBAC).
+    
+    # # Provides machine specific contolplane configuration options.
+
+    # # ControlPlane definition example.
+    # controlPlane:
+    #     # Controller manager machine specific configuration options.
+    #     controllerManager:
+    #         disabled: false # Disable kube-controller-manager on the node.
+    #     # Scheduler machine specific configuration options.
+    #     scheduler:
+    #         disabled: true # Disable kube-scheduler on the node.
+
+    # # Used to partition, format and mount additional disks.
+
+    # # MachineDisks list example.
+    # disks:
+    #     - device: /dev/sdb # The name of the disk to use.
+    #       # A list of partitions to create on the disk.
+    #       partitions:
+    #         - mountpoint: /var/mnt/extra # Where to mount the partition.
+    #           
+    #           # # The size of partition: either bytes or human readable representation. If `size:` is omitted, the partition is sized to occupy the full disk.
+
+    #           # # Human readable representation.
+    #           # size: 100 MB
+    #           # # Precise value in bytes.
+    #           # size: 1073741824
+
+    # # Allows the addition of user specified files.
+
+    # # MachineFiles usage example.
+    # files:
+    #     - content: '...' # The contents of the file.
+    #       permissions: 0o666 # The file's permissions in octal.
+    #       path: /tmp/file.txt # The path of the file.
+    #       op: append # The operation to use
+
+    # # The `env` field allows for the addition of environment variables.
+
+    # # Environment variables definition examples.
+    # env:
+    #     GRPC_GO_LOG_SEVERITY_LEVEL: info
+    #     GRPC_GO_LOG_VERBOSITY_LEVEL: "99"
+    #     https_proxy: http://SERVER:PORT/
+    # env:
+    #     GRPC_GO_LOG_SEVERITY_LEVEL: error
+    #     https_proxy: https://USERNAME:PASSWORD@SERVER:PORT/
+    # env:
+    #     https_proxy: http://DOMAIN\USERNAME:PASSWORD@SERVER:PORT/
+
+    # # Used to configure the machine's time settings.
+
+    # # Example configuration for cloudflare ntp server.
+    # time:
+    #     disabled: false # Indicates if the time service is disabled for the machine.
+    #     # Specifies time (NTP) servers to use for setting the system time.
+    #     servers:
+    #         - time.cloudflare.com
+    #     bootTimeout: 2m0s # Specifies the timeout when the node time is considered to be in sync unlocking the boot sequence.
+
+    # # Used to configure the machine's sysctls.
+
+    # # MachineSysctls usage example.
+    # sysctls:
+    #     kernel.domainname: talos.dev
+    #     net.ipv4.ip_forward: "0"
+
+    # # Used to configure the machine's container image registry mirrors.
+    # registries:
+    #     # Specifies mirror configuration for each registry.
+    #     mirrors:
+    #         ghcr.io:
+    #             # List of endpoints (URLs) for registry mirrors to use.
+    #             endpoints:
+    #                 - https://registry.insecure
+    #                 - https://ghcr.io/v2/
+    #     # Specifies TLS & auth configuration for HTTPS image registries.
+    #     config:
+    #         registry.insecure:
+    #             # The TLS configuration for the registry.
+    #             tls:
+    #                 insecureSkipVerify: true # Skip TLS server certificate verification (not recommended).
+    #                 
+    #                 # # Enable mutual TLS authentication with the registry.
+    #                 # clientIdentity:
+    #                 #     crt: TFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSklla05DTUhGLi4u
+    #                 #     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
+    #             
+    #             # # The auth configuration for this registry.
+    #             # auth:
+    #             #     username: username # Optional registry authentication.
+    #             #     password: password # Optional registry authentication.
+
+    # # Machine system disk encryption configuration.
+    # systemDiskEncryption:
+    #     # Ephemeral partition encryption.
+    #     ephemeral:
+    #         provider: luks2 # Encryption provider to use for the encryption.
+    #         # Defines the encryption keys generation and storage method.
+    #         keys:
+    #             - # Deterministically generated key from the node UUID and PartitionLabel.
+    #               nodeID: {}
+    #               slot: 0 # Key slot number for LUKS2 encryption.
+    #         
+    #         # # Cipher kind to use for the encryption. Depends on the encryption provider.
+    #         # cipher: aes-xts-plain64
+
+    #         # # Defines the encryption sector size.
+    #         # blockSize: 4096
+
+    #         # # Additional --perf parameters for the LUKS2 encryption.
+    #         # options:
+    #         #     - no_read_workqueue
+    #         #     - no_write_workqueue
+
+    # # Configures the udev system.
+    # udev:
+    #     # List of udev rules to apply to the udev system
+    #     rules:
+    #         - SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="44", MODE="0660"
+
+    # # Configures the logging system.
+    # logging:
+    #     # Logging destination.
+    #     destinations:
+    #         - endpoint: tcp://1.2.3.4:12345 # Where to send logs. Supported protocols are "tcp" and "udp".
+    #           format: json_lines # Logs format.
+# Provides cluster specific configuration options.
+cluster:
+    id: jW8IQKoSCDbhlCNm5K59er5jawHVIechsTuLNZ2_0Z8= # Globally unique identifier for this cluster (base64 encoded random 32 bytes).
+    secret: BVpg0EsnQ5vfvHvMN5Yc2+qyzbvJpLNokgdNqmYRxEU= # Shared secret of cluster (base64 encoded random 32 bytes).
+    # Provides control plane specific configuration options.
+    controlPlane:
+        endpoint: https://localhost:6443/ # Endpoint is the canonical controlplane endpoint, which can be an IP address or a DNS hostname.
+    # Provides cluster specific network configuration options.
+    network:
+        dnsDomain: cluster.local # The domain used by Kubernetes DNS.
+        # The pod subnet CIDR.
+        podSubnets:
+            - 10.244.0.0/16
+        # The service subnet CIDR.
+        serviceSubnets:
+            - 10.96.0.0/12
+        
+        # # The CNI used.
+        # cni:
+        #     name: custom # Name of CNI to use.
+        #     # URLs containing manifests to apply for the CNI.
+        #     urls:
+        #         - https://raw.githubusercontent.com/cilium/cilium/v1.8/install/kubernetes/quick-install.yaml
+    token: 9qbh68.dc9ya8gx9tornbbc # The [bootstrap token](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/) used to join the cluster.
+    aescbcEncryptionSecret: "" # The key used for the [encryption of secret data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+    #   # Decryption secret example (do not use in production!).
+    #   z01mye6j16bspJYtTB/5SFX8j7Ph4JXxM2Xuu4vsBPM=
+
+    # The base64 encoded root certificate authority used by Kubernetes.
+    ca:
+        crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpakNDQVRDZ0F3SUJBZ0lSQUxENi9BNVREb2UxMmRHdTFEbzVJcVV3Q2dZSUtvWkl6ajBFQXdJd0ZURVQKTUJFR0ExVUVDaE1LYTNWaVpYSnVaWFJsY3pBZUZ3MHlNVEV5TVRVeE9ERXlNekZhRncwek1URXlNVE14T0RFeQpNekZhTUJVeEV6QVJCZ05WQkFvVENtdDFZbVZ5Ym1WMFpYTXdXVEFUQmdjcWhrak9QUUlCQmdncWhrak9QUU1CCkJ3TkNBQVQyTW83U3cxSUZiMTIwMDlLOFRoYUFxRDFhSmFNa0ZTbHZxN1Z5VzdJN2ZhbS93ZDJ1cERFb3M0TisKaVdCSFJyejVLejFscTRXcnhTNnd4ZlJ2RUROVm8yRXdYekFPQmdOVkhROEJBZjhFQkFNQ0FvUXdIUVlEVlIwbApCQll3RkFZSUt3WUJCUVVIQXdFR0NDc0dBUVVGQndNQ01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPCkJCWUVGTEpFWHZ0ZkZTbmxvMk4wY29JYnpCVWNCRFJwTUFvR0NDcUdTTTQ5QkFNQ0EwZ0FNRVVDSUI3SnZLaS8KZEV4WEZ2WUN3TXM2b2lwcHd4ZVRwdW1KMGFPTzVjZFc5Z2xoQWlFQXhwdTl4bFBGOFlkZThvV0tnYXNrMmRiZQpZUGZZMGdxUVdHV09qMDE1WGIwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+        key: ""
+    # Configures cluster member discovery.
+    discovery:
+        enabled: true # Enable the cluster membership discovery feature.
+        # Configure registries used for cluster member discovery.
+        registries:
+            # Kubernetes registry uses Kubernetes API server to discover cluster members and stores additional information
+            kubernetes: {}
+            # Service registry is using an external service to push and pull information about cluster members.
+            service: {}
+            # # External service endpoint.
+            # endpoint: https://discovery.talos.dev/
+    
+    # # The base64 encoded aggregator certificate authority used by Kubernetes for front-proxy certificate generation.
+
+    # # AggregatorCA example.
+    # aggregatorCA:
+    #     crt: TFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSklla05DTUhGLi4u
+    #     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
+
+    # # The base64 encoded private key for service account token generation.
+
+    # # AggregatorCA example.
+    # serviceAccount:
+    #     key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
+
+    # # API server specific configuration options.
+    # apiServer:
+    #     image: k8s.gcr.io/kube-apiserver:v1.23.0 # The container image used in the API server manifest.
+    #     # Extra arguments to supply to the API server.
+    #     extraArgs:
+    #         feature-gates: ServerSideApply=true
+    #         http2-max-streams-per-connection: "32"
+    #     # Extra certificate subject alternative names for the API server's certificate.
+    #     certSANs:
+    #         - 1.2.3.4
+    #         - 4.5.6.7
+
+    # # Controller manager server specific configuration options.
+    # controllerManager:
+    #     image: k8s.gcr.io/kube-controller-manager:v1.23.0 # The container image used in the controller manager manifest.
+    #     # Extra arguments to supply to the controller manager.
+    #     extraArgs:
+    #         feature-gates: ServerSideApply=true
+
+    # # Kube-proxy server-specific configuration options
+    # proxy:
+    #     image: k8s.gcr.io/kube-proxy:v1.23.0 # The container image used in the kube-proxy manifest.
+    #     mode: ipvs # proxy mode of kube-proxy.
+    #     # Extra arguments to supply to kube-proxy.
+    #     extraArgs:
+    #         proxy-mode: iptables
+
+    # # Scheduler server specific configuration options.
+    # scheduler:
+    #     image: k8s.gcr.io/kube-scheduler:v1.23.0 # The container image used in the scheduler manifest.
+    #     # Extra arguments to supply to the scheduler.
+    #     extraArgs:
+    #         feature-gates: AllBeta=true
+
+    # # Etcd specific configuration options.
+    # etcd:
+    #     image: gcr.io/etcd-development/etcd:v3.5.1 # The container image used to create the etcd service.
+    #     # The `ca` is the root certificate authority of the PKI.
+    #     ca:
+    #         crt: TFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVSklla05DTUhGLi4u
+    #         key: TFMwdExTMUNSVWRKVGlCRlJESTFOVEU1SUZCU1NWWkJWRVVnUzBWWkxTMHRMUzBLVFVNLi4u
+    #     # Extra arguments to supply to etcd.
+    #     extraArgs:
+    #         election-timeout: "5000"
+    #     subnet: 10.0.0.0/8 # The subnet from which the advertise URL should be.
+
+    # # Core DNS specific configuration options.
+    # coreDNS:
+    #     image: docker.io/coredns/coredns:1.8.6 # The `image` field is an override to the default coredns image.
+
+    # # External cloud provider configuration.
+    # externalCloudProvider:
+    #     enabled: true # Enable external cloud provider.
+    #     # A list of urls that point to additional manifests for an external cloud provider.
+    #     manifests:
+    #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/rbac.yaml
+    #         - https://raw.githubusercontent.com/kubernetes/cloud-provider-aws/v1.20.0-alpha.0/manifests/aws-cloud-controller-manager-daemonset.yaml
+
+    # # A list of urls that point to additional manifests.
+    # extraManifests:
+    #     - https://www.example.com/manifest1.yaml
+    #     - https://www.example.com/manifest2.yaml
+
+    # # A map of key value pairs that will be added while fetching the extraManifests.
+    # extraManifestHeaders:
+    #     Token: "1234567"
+    #     X-ExtraInfo: info
+
+    # # A list of inline Kubernetes manifests.
+    # inlineManifests:
+    #     - name: namespace-ci # Name of the manifest.
+    #       contents: |- # Manifest contents as a string.
+    #         apiVersion: v1
+    #         kind: Namespace
+    #         metadata:
+    #         	name: ci
+
+    # # Settings for admin kubeconfig generation.
+    # adminKubeconfig:
+    #     certLifetime: 1h0m0s # Admin kubeconfig certificate lifetime (default is 1 year).

--- a/pkg/machinery/config/decoder/unknown_keys.go
+++ b/pkg/machinery/config/decoder/unknown_keys.go
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package decoder
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+func checkUnknownKeys(target interface{}, spec *yaml.Node) error {
+	unknown, err := internalCheckUnknownKeys(reflect.TypeOf(target), spec)
+	if err != nil {
+		return err
+	}
+
+	if unknown != nil {
+		var data []byte
+
+		if data, err = yaml.Marshal(unknown); err != nil {
+			return fmt.Errorf("failed to marshal error summary %w", err)
+		}
+
+		return fmt.Errorf("unknown keys found during decoding:\n%s", string(data))
+	}
+
+	return nil
+}
+
+// structKeys builds a set of known YAML fields by name and their indexes in the struct.
+func structKeys(typ reflect.Type) map[string][]int {
+	fields := reflect.VisibleFields(typ)
+
+	availableKeys := make(map[string][]int, len(fields))
+
+	for _, field := range fields {
+		if tag := field.Tag.Get("yaml"); tag != "" {
+			if tag == "-" {
+				continue
+			}
+
+			idx := strings.IndexByte(tag, ',')
+
+			if idx == -1 {
+				availableKeys[tag] = field.Index
+			} else if idx > 0 {
+				availableKeys[tag[:idx]] = field.Index
+			}
+		} else {
+			availableKeys[strings.ToLower(field.Name)] = field.Index
+		}
+	}
+
+	return availableKeys
+}
+
+//nolint:gocyclo,cyclop
+func internalCheckUnknownKeys(typ reflect.Type, spec *yaml.Node) (unknown interface{}, err error) {
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	switch spec.Kind { //nolint:exhaustive // not checking for scalar types
+	case yaml.MappingNode:
+		var availableKeys map[string][]int
+
+		switch typ.Kind() { //nolint:exhaustive
+		case reflect.Map:
+			// any key is fine in the map
+		case reflect.Struct:
+			availableKeys = structKeys(typ)
+		default:
+			return unknown, fmt.Errorf("unexpected type for yaml mapping: %s", typ)
+		}
+
+		for i := 0; i < len(spec.Content); i += 2 {
+			keyNode := spec.Content[i]
+
+			if keyNode.Kind != yaml.ScalarNode {
+				return unknown, fmt.Errorf("unexpected mapping key type")
+			}
+
+			key := keyNode.Value
+
+			var elemType reflect.Type
+
+			switch typ.Kind() { //nolint:exhaustive
+			case reflect.Struct:
+				if fieldIndex, ok := availableKeys[key]; !ok {
+					if unknown == nil {
+						unknown = map[string]interface{}{}
+					}
+
+					unknown.(map[string]interface{})[key] = spec.Content[i+1]
+
+					continue
+				} else {
+					elemType = typ.FieldByIndex(fieldIndex).Type
+				}
+			case reflect.Map:
+				elemType = typ.Elem()
+			}
+
+			// validate nested values
+			innerUnknown, err := internalCheckUnknownKeys(elemType, spec.Content[i+1])
+			if err != nil {
+				return unknown, err
+			}
+
+			if innerUnknown != nil {
+				if unknown == nil {
+					unknown = map[string]interface{}{}
+				}
+
+				unknown.(map[string]interface{})[key] = innerUnknown
+			}
+		}
+	case yaml.SequenceNode:
+		if typ.Kind() != reflect.Slice {
+			return unknown, fmt.Errorf("unexpected type for yaml sequence: %s", typ)
+		}
+
+		for i := 0; i < len(spec.Content); i++ {
+			innerUnknown, err := internalCheckUnknownKeys(typ.Elem(), spec.Content[i])
+			if err != nil {
+				return unknown, err
+			}
+
+			if innerUnknown != nil {
+				if unknown == nil {
+					unknown = []interface{}{}
+				}
+
+				unknown = append(unknown.([]interface{}), innerUnknown)
+			}
+		}
+	}
+
+	return unknown, nil
+}


### PR DESCRIPTION
Fixes #4687 

This avoids doing multiple rounds of marshal/unmarshal to check for
unknown keys.

New version simply walks the type tree of the `*v1alpha1.Config` and
maps that to the values in YAML.

Benchmark result comparing old and new implementations:

```
~/go/bin/benchstat old.txt new.txt                  7.9s  Ср 15 дек 2021 21:32:00
name                      old time/op    new time/op    delta
DecoderV1Alpha1Config-16    7.83ms ± 7%    0.98ms ±22%  -87.50%  (p=0.008 n=5+5)

name                      old alloc/op   new alloc/op   delta
DecoderV1Alpha1Config-16    6.39MB ± 0%    0.24MB ± 0%  -96.24%  (p=0.008 n=5+5)

name                      old allocs/op  new allocs/op  delta
DecoderV1Alpha1Config-16     25.7k ± 0%      2.4k ± 0%  -90.55%  (p=0.008 n=5+5)
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4695)
<!-- Reviewable:end -->
