### PR TITLE
feat: show human-readable aliases in `talosctl get rd`

### DIFF
--- a/cmd/talosctl/cmd/talos/get.go
+++ b/cmd/talosctl/cmd/talos/get.go
@@ -37,8 +37,9 @@ var getCmd = &cobra.Command{
 	Aliases:    []string{"g"},
 	SuggestFor: []string{},
 	Short:      "Get a specific resource or list of resources.",
-	Long:       `Similar to 'kubectl get', 'talosctl get' returns a set of resources from the OS.  To get a list of all available resource definitions, issue 'talosctl get rd'`,
-	Example:    "",
+	Long: `Similar to 'kubectl get', 'talosctl get' returns a set of resources from the OS.
+To get a list of all available resource definitions, issue 'talosctl get rd'`,
+	Example: "",
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		switch len(args) {
 		case 0:

--- a/cmd/talosctl/cmd/talos/output/table.go
+++ b/cmd/talosctl/cmd/talos/output/table.go
@@ -58,6 +58,8 @@ func (table *Table) WriteHeader(definition resource.Resource, withEvents bool) e
 			return fmt.Errorf("error parsing column %q jsonpath: %w", name, err)
 		}
 
+		expr = expr.AllowMissingKeys(true)
+
 		table.dynamicColumns = append(table.dynamicColumns, func(val interface{}) (string, error) {
 			var buf bytes.Buffer
 

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/containernetworking/plugins v1.0.1
 	github.com/coreos/go-iptables v0.6.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/cosi-project/runtime v0.0.0-20210906201716-5cb7f5002d77
+	github.com/cosi-project/runtime v0.0.0-20211216175730-264f8fcd1a4f
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -318,8 +318,9 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosi-project/runtime v0.0.0-20210906201716-5cb7f5002d77 h1:epmZGalngJg+68I3C6lIj9x1Jn7DWSvDT/ZZbojfYic=
 github.com/cosi-project/runtime v0.0.0-20210906201716-5cb7f5002d77/go.mod h1:fWDa1vgmSfHFypuffoq04I++IGMHQcduRKffG51jPfY=
+github.com/cosi-project/runtime v0.0.0-20211216175730-264f8fcd1a4f h1:COaUfDid6VOPrwViW30CdYZ6rHLHMfnN25C+TKQIrgU=
+github.com/cosi-project/runtime v0.0.0-20211216175730-264f8fcd1a4f/go.mod h1:fWDa1vgmSfHFypuffoq04I++IGMHQcduRKffG51jPfY=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/internal/app/resources/server.go
+++ b/internal/app/resources/server.go
@@ -91,7 +91,7 @@ func (s *Server) resolveResourceKind(ctx context.Context, kind *resourceKind) (*
 
 		spec := rd.Spec().(meta.ResourceDefinitionSpec) //nolint:errcheck,forcetypeassert
 
-		for _, alias := range spec.Aliases {
+		for _, alias := range spec.AllAliases {
 			if strings.EqualFold(alias, kind.Type) {
 				matched = append(matched, rd)
 

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -9,7 +9,7 @@ replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20210315173758-8fb3
 require (
 	github.com/AlekSi/pointer v1.2.0
 	github.com/containerd/go-cni v1.1.0
-	github.com/cosi-project/runtime v0.0.0-20210906201716-5cb7f5002d77
+	github.com/cosi-project/runtime v0.0.0-20211216175730-264f8fcd1a4f
 	github.com/dustin/go-humanize v1.0.0
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -29,8 +29,8 @@ github.com/containerd/go-cni v1.1.0 h1:kAe75MdTddsLCZDqP2BJn6e1ovD+il9oFkNlfGULE
 github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containernetworking/cni v1.0.1 h1:9OIL/sZmMYDBe+G8svzILAlulUpaDTUjeAbtH/JNLBo=
 github.com/containernetworking/cni v1.0.1/go.mod h1:AKuhXbN5EzmD4yTNtfSsX3tPcmtrBI6QcRV0NiNt15Y=
-github.com/cosi-project/runtime v0.0.0-20210906201716-5cb7f5002d77 h1:epmZGalngJg+68I3C6lIj9x1Jn7DWSvDT/ZZbojfYic=
-github.com/cosi-project/runtime v0.0.0-20210906201716-5cb7f5002d77/go.mod h1:fWDa1vgmSfHFypuffoq04I++IGMHQcduRKffG51jPfY=
+github.com/cosi-project/runtime v0.0.0-20211216175730-264f8fcd1a4f h1:COaUfDid6VOPrwViW30CdYZ6rHLHMfnN25C+TKQIrgU=
+github.com/cosi-project/runtime v0.0.0-20211216175730-264f8fcd1a4f/go.mod h1:fWDa1vgmSfHFypuffoq04I++IGMHQcduRKffG51jPfY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/machinery/resources/runtime/kernel_params_status.go
+++ b/pkg/machinery/resources/runtime/kernel_params_status.go
@@ -65,7 +65,7 @@ func (r *KernelParamStatus) DeepCopy() resource.Resource {
 func (r *KernelParamStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             KernelParamStatusType,
-		Aliases:          []resource.Type{"Sysctls", "KernelParameters", "KernelParams"},
+		Aliases:          []resource.Type{"sysctls", "kernelparameters", "kernelparams"},
 		DefaultNamespace: NamespaceName,
 		PrintColumns: []meta.PrintColumn{
 			{

--- a/pkg/machinery/resources/runtime/mount_status.go
+++ b/pkg/machinery/resources/runtime/mount_status.go
@@ -66,7 +66,7 @@ func (r *MountStatus) DeepCopy() resource.Resource {
 func (r *MountStatus) ResourceDefinition() meta.ResourceDefinitionSpec {
 	return meta.ResourceDefinitionSpec{
 		Type:             MountStatusType,
-		Aliases:          []resource.Type{"Mounts"},
+		Aliases:          []resource.Type{"mounts"},
 		DefaultNamespace: NamespaceName,
 		PrintColumns: []meta.PrintColumn{
 			{

--- a/website/content/docs/v0.14/Reference/cli.md
+++ b/website/content/docs/v0.14/Reference/cli.md
@@ -1268,7 +1268,8 @@ Get a specific resource or list of resources.
 
 ### Synopsis
 
-Similar to 'kubectl get', 'talosctl get' returns a set of resources from the OS.  To get a list of all available resource definitions, issue 'talosctl get rd'
+Similar to 'kubectl get', 'talosctl get' returns a set of resources from the OS.
+To get a list of all available resource definitions, issue 'talosctl get rd'
 
 ```
 talosctl get <type> [<id>] [flags]


### PR DESCRIPTION
Fixes #4396 

See https://github.com/cosi-project/runtime/pull/60

Sample:

```
ID                                                ALIASES
addressspecs.net.talos.dev                        addressspec as
addressstatuses.net.talos.dev                     address addresses addressstatus as
affiliates.cluster.talos.dev                      affiliate
apicertificates.secrets.talos.dev                 apicertificate ac acs
certsans.secrets.talos.dev                        certsan csan csans
cpustats.perf.talos.dev                           cpustat cpus
discoveryconfigs.cluster.talos.dev                discoveryconfig dc dcs
endpoints.kubernetes.talos.dev                    endpoint
etcdrootsecrets.secrets.talos.dev                 etcdrootsecret ers
etcdsecrets.secrets.talos.dev                     etcdsecret es
etcfilespecs.files.talos.dev                      etcfilespec efs
etcfilestatuses.files.talos.dev                   etcfilestatus efs
hardwareaddresses.net.talos.dev                   hardwareaddress ha has
hostnamespecs.net.talos.dev                       hostnamespec hs
hostnamestatuses.net.talos.dev                    hostname hostnamestatus hs
identities.cluster.talos.dev                      identity
kernelparamdefaultspecs.runtime.talos.dev         kernelparamdefaultspec kpds
kernelparamspecs.runtime.talos.dev                kernelparamspec kps
kernelparamstatuses.runtime.talos.dev             sysctls kernelparameters kernelparams kernelparamstatus kps
kubeletconfigs.kubernetes.talos.dev               kubeletconfig kc kcs
kubeletsecrets.secrets.talos.dev                  kubeletsecret ks
kubeletspecs.kubernetes.talos.dev                 kubeletspec ks
kubernetescontrolplaneconfigs.config.talos.dev    kubernetescontrolplaneconfig kcpc kcpcs
kubernetesrootsecrets.secrets.talos.dev           kubernetesrootsecret krs
kubernetessecrets.secrets.talos.dev               kubernetessecret ks
kubespanconfigs.kubespan.talos.dev                kubespanconfig ksc kscs
kubespanendpoints.kubespan.talos.dev              kubespanendpoint kse kses
kubespanidentities.kubespan.talos.dev             kubespanidentity ksi ksis
kubespanpeerspecs.kubespan.talos.dev              kubespanpeerspec ksps
kubespanpeerstatuses.kubespan.talos.dev           kubespanpeerstatus ksps
linkrefreshes.net.talos.dev                       linkrefresh lr lrs
linkspecs.net.talos.dev                           linkspec ls
linkstatuses.net.talos.dev                        link links linkstatus ls
machineconfigs.config.talos.dev                   machineconfig mc mcs
machinetypes.config.talos.dev                     machinetype mt mts
manifests.kubernetes.talos.dev                    manifest
manifeststatuses.kubernetes.talos.dev             manifeststatus ms
members.cluster.talos.dev                         member
memorystats.perf.talos.dev                        memorystat ms
mountstatuses.runtime.talos.dev                   mounts mountstatus ms
namespaces.meta.cosi.dev                          ns namespace
networkstatuses.net.talos.dev                     netstatus netstatuses networkstatus ns
nodeaddresses.net.talos.dev                       nodeaddress na nas
nodeaddressfilters.net.talos.dev                  nodeaddressfilter naf nafs
nodeipconfigs.kubernetes.talos.dev                nodeipconfig nipc nipcs
nodeips.kubernetes.talos.dev                      nodeip nip nips
nodenames.kubernetes.talos.dev                    nodename
operatorspecs.net.talos.dev                       operatorspec os
osrootsecrets.secrets.talos.dev                   osrootsecret osrs
resolverspecs.net.talos.dev                       resolverspec rs
resolverstatuses.net.talos.dev                    resolvers resolverstatus rs
resourcedefinitions.meta.cosi.dev                 resourcedefinition rd rds
routespecs.net.talos.dev                          routespec rs
routestatuses.net.talos.dev                       route routes routestatus rs
secretstatuses.kubernetes.talos.dev               secretstatus ss
services.v1alpha1.talos.dev                       svc service
staticpods.kubernetes.talos.dev                   staticpod sp sps
staticpodstatuses.kubernetes.talos.dev            podstatus staticpodstatus sps
timeserverspecs.net.talos.dev                     timeserverspec tss
timeserverstatuses.net.talos.dev                  timeserver timeservers timeserverstatus tss
timestatuses.v1alpha1.talos.dev                   timestatus ts
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4701)
<!-- Reviewable:end -->
