### PR TITLE
test: retry `talosctl time` call in the tests

### DIFF
--- a/internal/integration/cli/time.go
+++ b/internal/integration/cli/time.go
@@ -9,6 +9,9 @@ package cli
 
 import (
 	"regexp"
+	"time"
+
+	"github.com/talos-systems/go-retry/retry"
 
 	"github.com/talos-systems/talos/internal/integration/base"
 )
@@ -28,6 +31,7 @@ func (suite *TimeSuite) TestDefault() {
 	suite.RunCLI([]string{"time", "--nodes", suite.RandomDiscoveredNode()},
 		base.StdoutShouldMatch(regexp.MustCompile(`NTP-SERVER`)),
 		base.StdoutShouldMatch(regexp.MustCompile(`UTC`)),
+		base.WithRetry(retry.Constant(time.Minute, retry.WithUnits(time.Second))),
 	)
 }
 

--- a/internal/pkg/miniprocfs/testdata/1920080/exe
+++ b/internal/pkg/miniprocfs/testdata/1920080/exe
@@ -1,1 +1,1 @@
-/usr/bin/fish
+usr/bin/fish

--- a/internal/pkg/miniprocfs/testdata/3731034/exe
+++ b/internal/pkg/miniprocfs/testdata/3731034/exe
@@ -1,1 +1,1 @@
-/usr/bin/tail
+usr/bin/tail


### PR DESCRIPTION
As `talosctl time` relies on default time server set in the config, and
our nodes start with `pool.ntp.org`, sometimes request to the timeserver
fails failing the tests.

Retry such errors in the tests to avoid spurious failures.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4702)
<!-- Reviewable:end -->
