### PR TITLE
Add arm64 option to talosctl download docs

### DIFF
--- a/website/content/docs/v0.13/Introduction/getting-started.md
+++ b/website/content/docs/v0.13/Introduction/getting-started.md
@@ -27,8 +27,19 @@ It also includes a number of useful tools for creating and managing your cluster
 
 You should install `talosctl` before continuing:
 
+#### `amd64`
+
 ```bash
 curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+#### `arm64`
+
+For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.13/Introduction/quickstart.md
+++ b/website/content/docs/v0.13/Introduction/quickstart.md
@@ -11,8 +11,19 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 Download `talosctl`:
 
+#### `amd64`
+
 ```bash
 curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+#### `arm64`
+
+For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.14/Introduction/getting-started.md
+++ b/website/content/docs/v0.14/Introduction/getting-started.md
@@ -27,8 +27,19 @@ It also includes a number of useful tools for creating and managing your cluster
 
 You should install `talosctl` before continuing:
 
+#### `amd64`
+
 ```bash
 curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+#### `arm64`
+
+For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.14/Introduction/quickstart.md
+++ b/website/content/docs/v0.14/Introduction/quickstart.md
@@ -11,8 +11,19 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 Download `talosctl`:
 
+#### `amd64`
+
 ```bash
 curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+#### `arm64`
+
+For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.15/Introduction/getting-started.md
+++ b/website/content/docs/v0.15/Introduction/getting-started.md
@@ -27,8 +27,19 @@ It also includes a number of useful tools for creating and managing your cluster
 
 You should install `talosctl` before continuing:
 
+#### `amd64`
+
 ```bash
 curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+#### `arm64`
+
+For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.15/Introduction/quickstart.md
+++ b/website/content/docs/v0.15/Introduction/quickstart.md
@@ -11,8 +11,19 @@ The easiest way to try Talos is by using the CLI (`talosctl`) to create a cluste
 
 Download `talosctl`:
 
+#### `amd64`
+
 ```bash
 curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+chmod +x /usr/local/bin/talosctl
+```
+
+#### `arm64`
+
+For `linux` and `darwin` operating systems `talosctl` is also available for the `arm64` processor architecture.
+
+```bash
+curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-arm64
 chmod +x /usr/local/bin/talosctl
 ```
 


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Resolves #4704 
This PR updates the `quickstart` and `getting-started` pages for `v0.13` and `v0.14` to show download options for `arm64` 

## Why? (reasoning)
The `talosctl` is available as a `arm64` binary but this is not yet publicated in the `getting-started` or `quickstart` documentation pages. To use the native version this PR adds this option in the docs

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4705)
<!-- Reviewable:end -->
