### PR TITLE
fix: pass path to conformance retrieve results

### DIFF
--- a/pkg/cluster/sonobuoy/product.go
+++ b/pkg/cluster/sonobuoy/product.go
@@ -22,10 +22,10 @@ var talos = product{
 	Vendor:           "Talos Systems",
 	Name:             "Talos",
 	Version:          version.Tag,
-	WebsiteURL:       "https://www.talos-systems.com",
+	WebsiteURL:       "https://www.siderolabs.com/",
 	RepoURL:          "https://github.com/talos-systems/talos",
 	DocumentationURL: "https://www.talos.dev",
-	ProductLogoURL:   "https://www.talos-systems.com/images/TalosSystems_Horizontal_Logo_FullColor_RGB-for-site.svg",
+	ProductLogoURL:   "https://www.talos.dev/images/TalosSystems_Horizontal_Logo_FullColor_RGB-for-site.svg",
 	Type:             "installer",
 	Description:      "Talos is a modern Kubernetes-focused OS designed to be secure, immutable, and minimal.",
 }

--- a/pkg/cluster/sonobuoy/sonobuoy.go
+++ b/pkg/cluster/sonobuoy/sonobuoy.go
@@ -239,6 +239,7 @@ func Run(ctx context.Context, cluster cluster.K8sProvider, options *Options) err
 	if options.RetrieveResults {
 		resultR, errCh, err := sclient.RetrieveResults(&client.RetrieveConfig{
 			Namespace: config.DefaultNamespace,
+			Path:      config.AggregatorResultsPath,
 		})
 		if err != nil {
 			return fmt.Errorf("error retrieving results: %w", err)


### PR DESCRIPTION
Sonobouy once again changed the API in a way that breaks our tool.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4717)
<!-- Reviewable:end -->
