### PR TITLE
feat: make machine configuration read-only in Talos (almost)

### DIFF
--- a/cmd/talosctl/pkg/mgmt/helpers/wireguard.go
+++ b/cmd/talosctl/pkg/mgmt/helpers/wireguard.go
@@ -14,7 +14,6 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 
 	"github.com/talos-systems/talos/pkg/machinery/config"
-	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 )
 
@@ -98,21 +97,7 @@ type WireguardConfigBundle struct {
 
 // PatchConfig generates config patch for a node and patches the configuration data.
 func (w *WireguardConfigBundle) PatchConfig(ip fmt.Stringer, cfg config.Provider) (config.Provider, error) {
-	bytes, err := cfg.Bytes()
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := configloader.NewFromBytes(bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	config, ok := c.(*v1alpha1.Config)
-
-	if !ok {
-		return nil, fmt.Errorf("failed to get wireguard config for node %s", ip.String())
-	}
+	config := cfg.Raw().(*v1alpha1.Config).DeepCopy()
 
 	if config.MachineConfig.MachineNetwork == nil {
 		config.MachineConfig.MachineNetwork = &v1alpha1.NetworkConfig{

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/azure/azure.go
@@ -75,7 +75,7 @@ func (a *Azure) Name() string {
 func (a *Azure) ConfigurationNetwork(metadataNetworkConfig []byte, confProvider config.Provider) (config.Provider, error) {
 	var machineConfig *v1alpha1.Config
 
-	machineConfig, ok := confProvider.(*v1alpha1.Config)
+	machineConfig, ok := confProvider.Raw().(*v1alpha1.Config)
 	if !ok {
 		return nil, fmt.Errorf("unable to determine machine config type")
 	}
@@ -114,7 +114,7 @@ func (a *Azure) ConfigurationNetwork(metadataNetworkConfig []byte, confProvider 
 		}
 	}
 
-	return confProvider, nil
+	return machineConfig, nil
 }
 
 // Configuration implements the platform.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/hcloud/hcloud.go
@@ -76,7 +76,7 @@ func (h *Hcloud) ConfigurationNetwork(metadataNetworkConfig []byte, confProvider
 
 	var machineConfig *v1alpha1.Config
 
-	machineConfig, ok := confProvider.(*v1alpha1.Config)
+	machineConfig, ok := confProvider.Raw().(*v1alpha1.Config)
 	if !ok {
 		return nil, fmt.Errorf("unable to determine machine config type")
 	}
@@ -127,7 +127,7 @@ func (h *Hcloud) ConfigurationNetwork(metadataNetworkConfig []byte, confProvider
 		)
 	}
 
-	return confProvider, nil
+	return machineConfig, nil
 }
 
 // Configuration implements the runtime.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/openstack/openstack.go
@@ -101,7 +101,7 @@ func (o *Openstack) ConfigurationNetwork(metadataNetworkConfig []byte, metadataC
 		unmarshalledMetadataConfig = MetadataConfig{}
 	}
 
-	machineConfig, ok := confProvider.(*v1alpha1.Config)
+	machineConfig, ok := confProvider.Raw().(*v1alpha1.Config)
 	if !ok {
 		return nil, fmt.Errorf("unable to determine machine config type")
 	}
@@ -241,7 +241,7 @@ func (o *Openstack) ConfigurationNetwork(metadataNetworkConfig []byte, metadataC
 		}
 	}
 
-	return confProvider, nil
+	return machineConfig, nil
 }
 
 // Configuration implements the runtime.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/packet/packet.go
@@ -108,7 +108,7 @@ func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 
 	var machineConfig *v1alpha1.Config
 
-	machineConfig, ok := confProvider.(*v1alpha1.Config)
+	machineConfig, ok := confProvider.Raw().(*v1alpha1.Config)
 	if !ok {
 		return nil, fmt.Errorf("unable to determine machine config type")
 	}
@@ -212,7 +212,7 @@ func (p *Packet) Configuration(ctx context.Context) ([]byte, error) {
 		&bondDev,
 	)
 
-	return confProvider.Bytes()
+	return machineConfig.Bytes()
 }
 
 // Mode implements the platform.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/upcloud/upcloud.go
@@ -75,7 +75,7 @@ func (u *UpCloud) Name() string {
 func (u *UpCloud) ConfigurationNetwork(metadataConfig []byte, confProvider config.Provider) (config.Provider, error) {
 	var machineConfig *v1alpha1.Config
 
-	machineConfig, ok := confProvider.(*v1alpha1.Config)
+	machineConfig, ok := confProvider.Raw().(*v1alpha1.Config)
 	if !ok {
 		return nil, fmt.Errorf("unable to determine machine config type")
 	}
@@ -129,7 +129,7 @@ func (u *UpCloud) ConfigurationNetwork(metadataConfig []byte, confProvider confi
 		}
 	}
 
-	return confProvider, nil
+	return machineConfig, nil
 }
 
 // Configuration implements the runtime.Platform interface.

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_runtime.go
@@ -65,24 +65,12 @@ func (r *Runtime) SetConfig(cfg config.Provider) error {
 
 // CanApplyImmediate implements the Runtime interface.
 func (r *Runtime) CanApplyImmediate(cfg config.Provider) error {
-	// serialize and load back current config to remove any changes made
-	// to the config in-memory while the node was running
-	currentBytes, err := r.Config().Bytes()
-	if err != nil {
-		return fmt.Errorf("error serializing current config: %w", err)
-	}
-
-	currentConfigProvider, err := configloader.NewFromBytes(currentBytes)
-	if err != nil {
-		return fmt.Errorf("error loading current config: %w", err)
-	}
-
-	currentConfig, ok := currentConfigProvider.(*v1alpha1.Config)
+	currentConfig, ok := r.Config().Raw().(*v1alpha1.Config)
 	if !ok {
 		return fmt.Errorf("current config is not v1alpha1")
 	}
 
-	newConfig, ok := cfg.(*v1alpha1.Config)
+	newConfig, ok := cfg.Raw().(*v1alpha1.Config)
 	if !ok {
 		return fmt.Errorf("new config is not v1alpha1")
 	}

--- a/pkg/cluster/kubernetes/detect.go
+++ b/pkg/cluster/kubernetes/detect.go
@@ -34,12 +34,6 @@ func DetectLowestVersion(ctx context.Context, cluster UpgradeProvider, options U
 	}
 
 	var version *semver.Version
-	if options.ToVersion != "" {
-		version, err = semver.NewVersion(options.ToVersion)
-		if err != nil {
-			return "", err
-		}
-	}
 
 	for _, pod := range pods.Items {
 		app := pod.GetObjectMeta().GetLabels()["k8s-app"]

--- a/pkg/cluster/kubernetes/kubelet.go
+++ b/pkg/cluster/kubernetes/kubelet.go
@@ -224,6 +224,8 @@ func upgradeKubeletPatcher(options UpgradeOptions, kubeletSpec resource.Resource
 				version = parts[1]
 			}
 
+			version = strings.TrimLeft(version, "v")
+
 			options.Log(" > update %s: %s -> %s", kubelet, version, options.ToVersion)
 
 			if options.DryRun {

--- a/pkg/cluster/kubernetes/patch.go
+++ b/pkg/cluster/kubernetes/patch.go
@@ -49,7 +49,7 @@ func patchNodeConfig(ctx context.Context, cluster UpgradeProvider, node string, 
 		return fmt.Errorf("error loading config: %w", err)
 	}
 
-	cfg, ok := config.(*v1alpha1config.Config)
+	cfg, ok := config.Raw().(*v1alpha1config.Config)
 	if !ok {
 		return fmt.Errorf("config is not v1alpha1 config")
 	}

--- a/pkg/machinery/config/configloader/configloader.go
+++ b/pkg/machinery/config/configloader/configloader.go
@@ -34,7 +34,7 @@ func newConfig(source []byte) (config config.Provider, err error) {
 	// a special way.
 	for _, manifest := range manifests {
 		if talosconfig, ok := manifest.(*v1alpha1.Config); ok {
-			return talosconfig, nil
+			return v1alpha1.WrapReadonly(talosconfig, source), nil
 		}
 	}
 

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -20,15 +20,25 @@ import (
 
 // Provider defines the configuration consumption interface.
 type Provider interface {
+	// Config parts accessor.
 	Version() string
 	Debug() bool
 	Persist() bool
 	Machine() MachineConfig
 	Cluster() ClusterConfig
+
 	// Validate checks configuration and returns warnings and fatal errors (as multierror).
 	Validate(RuntimeMode, ...ValidationOption) ([]string, error)
-	String(encoderOptions ...encoder.Option) (string, error)
-	Bytes(encoderOptions ...encoder.Option) ([]byte, error)
+
+	// Bytes returns source YAML representation (if available) or does default encoding.
+	Bytes() ([]byte, error)
+
+	// Encode configuration to YAML using the provided options.
+	EncodeString(encoderOptions ...encoder.Option) (string, error)
+	EncodeBytes(encoderOptions ...encoder.Option) ([]byte, error)
+
+	// Raw returns internal config representation.
+	Raw() interface{}
 }
 
 // MachineConfig defines the requirements for a config that pertains to machine

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_configurator_bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_configurator_bundle.go
@@ -63,17 +63,17 @@ func (c *ConfigBundle) Write(outputDir string, commentsFlags encoder.CommentsFla
 
 		switch t {
 		case machine.TypeInit:
-			configString, err = c.Init().String(encoder.WithComments(commentsFlags))
+			configString, err = c.Init().EncodeString(encoder.WithComments(commentsFlags))
 			if err != nil {
 				return err
 			}
 		case machine.TypeControlPlane:
-			configString, err = c.ControlPlane().String(encoder.WithComments(commentsFlags))
+			configString, err = c.ControlPlane().EncodeString(encoder.WithComments(commentsFlags))
 			if err != nil {
 				return err
 			}
 		case machine.TypeWorker:
-			configString, err = c.Worker().String(encoder.WithComments(commentsFlags))
+			configString, err = c.Worker().EncodeString(encoder.WithComments(commentsFlags))
 			if err != nil {
 				return err
 			}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -60,9 +60,9 @@ func (c *Config) Cluster() config.ClusterConfig {
 	return c.ClusterConfig
 }
 
-// String implements the config.Provider interface.
-func (c *Config) String(options ...encoder.Option) (string, error) {
-	b, err := c.Bytes(options...)
+// EncodeString implements the config.Provider interface.
+func (c *Config) EncodeString(options ...encoder.Option) (string, error) {
+	b, err := c.EncodeBytes(options...)
 	if err != nil {
 		return "", err
 	}
@@ -70,9 +70,19 @@ func (c *Config) String(options ...encoder.Option) (string, error) {
 	return string(b), nil
 }
 
-// Bytes implements the config.Provider interface.
-func (c *Config) Bytes(options ...encoder.Option) ([]byte, error) {
+// EncodeBytes implements the config.Provider interface.
+func (c *Config) EncodeBytes(options ...encoder.Option) ([]byte, error) {
 	return encoder.NewEncoder(c, options...).Encode()
+}
+
+// Bytes implements the config.Provider interface.
+func (c *Config) Bytes() ([]byte, error) {
+	return c.EncodeBytes()
+}
+
+// Raw implements the config.Provider interface.
+func (c *Config) Raw() interface{} {
+	return c
 }
 
 // Install implements the config.Provider interface.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_readonly_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_readonly_provider.go
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package v1alpha1
+
+import (
+	"github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
+)
+
+// ReadonlyProvider wraps the *v1alpha1.Config to make config read-only.
+//
+// +k8s:deepcopy-gen=false
+type ReadonlyProvider struct {
+	cfg   *Config
+	bytes []byte
+}
+
+// WrapReadonly the v1alpha.Config providing read-only interface to it.
+func WrapReadonly(cfg *Config, bytes []byte) *ReadonlyProvider {
+	return &ReadonlyProvider{
+		cfg:   cfg,
+		bytes: bytes,
+	}
+}
+
+// Version implements the config.Provider interface.
+func (r *ReadonlyProvider) Version() string {
+	return r.cfg.Version()
+}
+
+// Debug implements the config.Provider interface.
+func (r *ReadonlyProvider) Debug() bool {
+	return r.cfg.Debug()
+}
+
+// Persist implements the config.Provider interface.
+func (r *ReadonlyProvider) Persist() bool {
+	return r.cfg.Persist()
+}
+
+// Machine implements the config.Provider interface.
+func (r *ReadonlyProvider) Machine() config.MachineConfig {
+	return r.cfg.Machine()
+}
+
+// Cluster implements the config.Provider interface.
+func (r *ReadonlyProvider) Cluster() config.ClusterConfig {
+	return r.cfg.Cluster()
+}
+
+// Validate checks configuration and returns warnings and fatal errors (as multierror).
+func (r *ReadonlyProvider) Validate(mode config.RuntimeMode, opts ...config.ValidationOption) ([]string, error) {
+	return r.cfg.Validate(mode, opts...)
+}
+
+// Bytes returns source YAML representation (if available) or does default encoding.
+func (r *ReadonlyProvider) Bytes() ([]byte, error) {
+	if r.bytes != nil {
+		return r.bytes, nil
+	}
+
+	var err error
+
+	r.bytes, err = r.EncodeBytes()
+
+	return r.bytes, err
+}
+
+// EncodeString implements the config.Provider interface.
+func (r *ReadonlyProvider) EncodeString(encoderOptions ...encoder.Option) (string, error) {
+	return r.cfg.EncodeString(encoderOptions...)
+}
+
+// EncodeBytes implements the config.Provider interface.
+func (r *ReadonlyProvider) EncodeBytes(encoderOptions ...encoder.Option) ([]byte, error) {
+	return r.cfg.EncodeBytes(encoderOptions...)
+}
+
+// Raw implements the config.Provider interface.
+func (r *ReadonlyProvider) Raw() interface{} {
+	return r.cfg.DeepCopy()
+}

--- a/pkg/machinery/resources/config/machine_config_test.go
+++ b/pkg/machinery/resources/config/machine_config_test.go
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/configloader"
+	"github.com/talos-systems/talos/pkg/machinery/resources/config"
+)
+
+func TestMachineConfigMarshal(t *testing.T) {
+	cfg, err := configloader.NewFromBytes([]byte(`version: v1alpha1
+persist: true # foo
+debug: false
+machine:
+  type: controlplane
+`))
+	require.NoError(t, err)
+
+	r := config.NewMachineConfig(cfg)
+
+	m, err := resource.MarshalYAML(r)
+	require.NoError(t, err)
+
+	enc, err := yaml.Marshal(m)
+	require.NoError(t, err)
+
+	enc = regexp.MustCompile("(created|updated): [0-9-:TZ+]+").ReplaceAll(enc, nil)
+
+	assert.Equal(t,
+		"metadata:\n    namespace: config\n    type: MachineConfigs.config.talos.dev\n    id: v1alpha1\n    version: 1\n    owner:\n    phase: running\n    \n    \n"+
+			"spec:\n    version: v1alpha1\n    persist: true # foo\n    debug: false\n    machine:\n      type: controlplane\n",
+		string(enc))
+}

--- a/pkg/provision/providers/docker/node.go
+++ b/pkg/provision/providers/docker/node.go
@@ -66,7 +66,7 @@ func (p *provisioner) createNode(ctx context.Context, clusterReq provision.Clust
 	env := []string{"PLATFORM=container"}
 
 	if !nodeReq.SkipInjectingConfig {
-		cfg, err := nodeReq.Config.String()
+		cfg, err := nodeReq.Config.EncodeString()
 		if err != nil {
 			return provision.NodeInfo{}, err
 		}

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -94,7 +94,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 	if !nodeReq.SkipInjectingConfig {
 		cmdline.Append("talos.config", "{TALOS_CONFIG_URL}") // to be patched by launcher
 
-		nodeConfig, err = nodeReq.Config.String()
+		nodeConfig, err = nodeReq.Config.EncodeString()
 		if err != nil {
 			return provision.NodeInfo{}, err
 		}


### PR DESCRIPTION
Talos shouldn't try to re-encode the machine config it was provided
with.

So add a `ReadonlyWrapper` around `*v1alpha1.Config` which makes sure
that raw config object is not available anymore (it's a private field),
but config accessors are available for read-only access.

Another thing that `ReadonlyWrapper` does is that it preserves the
original `[]byte` encoding of the config keeping it exactly same way as
it was loaded from file or read over the network.

Improved `talosctl edit mc` to preserve the config as it was submitted,
and preserve the edits on error from Talos (previously edits were lost).

`ReadonlyWrapper` is not used on config generation path though - config
there is represented by `*v1alpha.Config` and can be freely modified.

Why almost? Some parts of Talos (platform code) patch the machine
configuration with new data. We need to fix platforms to provide
networking configuration in a different way, but this will come with
other PRs later.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4736)
<!-- Reviewable:end -->
