### PR TITLE
docs: fix troubleshooting guide

### DIFF
--- a/website/content/docs/v0.12/Guides/troubleshooting-control-plane.md
+++ b/website/content/docs/v0.12/Guides/troubleshooting-control-plane.md
@@ -8,16 +8,6 @@ description: "Troubleshoot control plane failures for running cluster and bootst
 This guide is written as series of topics and detailed answers for each topic.
 It starts with basics of control plane and goes into Talos specifics.
 
-This document mostly applies only to Talos 0.9 control plane based on static pods.
-If Talos was upgraded from version 0.8, it might be still running self-hosted control plane, current status can
-be checked with the command `talosctl get bootstrapstatus`:
-
-```bash
-$ talosctl -n <IP> get bs
-NODE         NAMESPACE   TYPE              ID              VERSION   SELF HOSTED
-172.20.0.2   runtime     BootstrapStatus   control-plane   1         false
-```
-
 In this guide we assume that Talos client config is available and Talos API access is available.
 Kubernetes client configuration can be pulled from control plane nodes with `talosctl -n <IP> kubeconfig`
 (this command works before Kubernetes is fully booted).

--- a/website/content/docs/v0.13/Guides/troubleshooting-control-plane.md
+++ b/website/content/docs/v0.13/Guides/troubleshooting-control-plane.md
@@ -8,16 +8,6 @@ description: "Troubleshoot control plane failures for running cluster and bootst
 This guide is written as series of topics and detailed answers for each topic.
 It starts with basics of control plane and goes into Talos specifics.
 
-This document mostly applies only to Talos 0.9 control plane based on static pods.
-If Talos was upgraded from version 0.8, it might be still running self-hosted control plane, current status can
-be checked with the command `talosctl get bootstrapstatus`:
-
-```bash
-$ talosctl -n <IP> get bs
-NODE         NAMESPACE   TYPE              ID              VERSION   SELF HOSTED
-172.20.0.2   runtime     BootstrapStatus   control-plane   1         false
-```
-
 In this guide we assume that Talos client config is available and Talos API access is available.
 Kubernetes client configuration can be pulled from control plane nodes with `talosctl -n <IP> kubeconfig`
 (this command works before Kubernetes is fully booted).

--- a/website/content/docs/v0.14/Guides/troubleshooting-control-plane.md
+++ b/website/content/docs/v0.14/Guides/troubleshooting-control-plane.md
@@ -8,16 +8,6 @@ description: "Troubleshoot control plane failures for running cluster and bootst
 This guide is written as series of topics and detailed answers for each topic.
 It starts with basics of control plane and goes into Talos specifics.
 
-This document mostly applies only to Talos 0.9 control plane based on static pods.
-If Talos was upgraded from version 0.8, it might be still running self-hosted control plane, current status can
-be checked with the command `talosctl get bootstrapstatus`:
-
-```bash
-$ talosctl -n <IP> get bs
-NODE         NAMESPACE   TYPE              ID              VERSION   SELF HOSTED
-172.20.0.2   runtime     BootstrapStatus   control-plane   1         false
-```
-
 In this guide we assume that Talos client config is available and Talos API access is available.
 Kubernetes client configuration can be pulled from control plane nodes with `talosctl -n <IP> kubeconfig`
 (this command works before Kubernetes is fully booted).

--- a/website/content/docs/v0.15/Guides/troubleshooting-control-plane.md
+++ b/website/content/docs/v0.15/Guides/troubleshooting-control-plane.md
@@ -8,16 +8,6 @@ description: "Troubleshoot control plane failures for running cluster and bootst
 This guide is written as series of topics and detailed answers for each topic.
 It starts with basics of control plane and goes into Talos specifics.
 
-This document mostly applies only to Talos 0.9 control plane based on static pods.
-If Talos was upgraded from version 0.8, it might be still running self-hosted control plane, current status can
-be checked with the command `talosctl get bootstrapstatus`:
-
-```bash
-$ talosctl -n <IP> get bs
-NODE         NAMESPACE   TYPE              ID              VERSION   SELF HOSTED
-172.20.0.2   runtime     BootstrapStatus   control-plane   1         false
-```
-
 In this guide we assume that Talos client config is available and Talos API access is available.
 Kubernetes client configuration can be pulled from control plane nodes with `talosctl -n <IP> kubeconfig`
 (this command works before Kubernetes is fully booted).


### PR DESCRIPTION
It references legacy `BootstrapStatus` which was removed with the
dropped support for bootkube-based control plane.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4738)
<!-- Reviewable:end -->
