### PR TITLE
fix: multiple usability fixes

### DIFF
--- a/cmd/talosctl/cmd/talos/read.go
+++ b/cmd/talosctl/cmd/talos/read.go
@@ -19,10 +19,11 @@ import (
 
 // readCmd represents the read command.
 var readCmd = &cobra.Command{
-	Use:   "read <path>",
-	Short: "Read a file on the machine",
-	Long:  ``,
-	Args:  cobra.ExactArgs(1),
+	Use:     "read <path>",
+	Short:   "Read a file on the machine",
+	Long:    ``,
+	Args:    cobra.ExactArgs(1),
+	Aliases: []string{"cat"},
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp

--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_spec.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_spec.go
@@ -44,7 +44,7 @@ func (ctrl *KernelModuleSpecController) Outputs() []controller.Output {
 func (ctrl *KernelModuleSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
 	manager, err := kmod.New()
 	if err != nil {
-		return fmt.Errorf("error initializing kmod manager")
+		return fmt.Errorf("error initializing kmod manager: %w", err)
 	}
 
 	for {


### PR DESCRIPTION
Add `cat` alias for `talosctl read`, I always end up writing
`talosctl cat`.

Improve error messages for APIs available only on control plane nodes:

was:

```
$ talosctl -n 172.20.0.5 kubeconfig
rpc error: code = Unknown desc = error getting Kubernetes CA: failed to parse PEM block
error initializing gzip: EOF

$ talosctl -n 172.20.0.5 etcd members
error getting members: 1 error occurred:
	* 172.20.0.5: rpc error: code = Unknown desc = error building etcd client TLS config: open /system/secrets/etcd/admin.crt: no such file or directory
```

now:

```
$ talosctl -n 172.20.0.6 kubeconfig
rpc error: code = Unimplemented desc = kubeconfig is only available on control plane nodes
error initializing gzip: EOF

$ talosctl -n 172.20.0.6 etcd remove-member foo
1 error occurred:
	* 172.20.0.6: rpc error: code = Unimplemented desc = etcd remove member is only available on control plane nodes
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4739)
<!-- Reviewable:end -->
