### PR TITLE
fix: kexec on RPI4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0
-PKGS ?= v0.10.0-alpha.0-3-g950361f
+PKGS ?= v0.10.0-alpha.0-4-g2779c3f
 EXTRAS ?= v0.8.0-alpha.0
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/config.txt
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/config.txt
@@ -5,6 +5,8 @@ gpu_mem=32
 # only the one closest to the power/USB-C port will work in practice.
 hdmi_safe:0=1
 hdmi_safe:1=1
+armstub=bl31.bin
+enable_gic=1
 # Load U-Boot.
 kernel=u-boot.bin
 # Forces the kernel loading system to assume a 64-bit kernel.

--- a/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/board/rpi_4/rpi_4.go
@@ -40,6 +40,11 @@ func (r *RPi4) Install(disk string) (err error) {
 		return err
 	}
 
+	err = copy.File("/usr/install/arm64/u-boot/rpi_4/bl31.bin", "/boot/EFI/bl31.bin")
+	if err != nil {
+		return err
+	}
+
 	return ioutil.WriteFile("/boot/EFI/config.txt", configTxt, 0o600)
 }
 
@@ -47,7 +52,6 @@ func (r *RPi4) Install(disk string) (err error) {
 func (r *RPi4) KernelArgs() procfs.Parameters {
 	return []*procfs.Parameter{
 		procfs.NewParameter("console").Append("tty0").Append("ttyAMA0,115200"),
-		procfs.NewParameter("sysctl.kernel.kexec_load_disabled").Append("1"),
 	}
 }
 


### PR DESCRIPTION
Fixes kexec on RPI4

Since BL31 is now enabled `talosctl shutdown` puts the Pi in a low power state instead of rebooting

Ref: https://github.com/talos-systems/pkgs/pull/375

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4742)
<!-- Reviewable:end -->
