### PR TITLE
chore: remove unused methods in AWS platform

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.1
-	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa
 	github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -433,7 +433,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
-github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa h1:RDBNVkRviHZtvDvId8XSGPu3rmpmSe+wKRcEWNgsfWU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/aws/aws.go
@@ -6,16 +6,12 @@ package aws
 
 import (
 	"context"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
-	"time"
 
-	"github.com/fullsailor/pkcs7"
 	"github.com/talos-systems/go-procfs/procfs"
 
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
@@ -28,111 +24,12 @@ const (
 	AWSExternalIPEndpoint = "http://169.254.169.254/latest/meta-data/public-ipv4"
 	// AWSHostnameEndpoint is the local EC2 endpoint for the hostname.
 	AWSHostnameEndpoint = "http://169.254.169.254/latest/meta-data/hostname"
-	// AWSPKCS7Endpoint is the local EC2 endpoint for the PKCS7 signature.
-	AWSPKCS7Endpoint = "http://169.254.169.254/latest/dynamic/instance-identity/pkcs7"
-	// AWSPublicCertificate is the AWS public certificate for the regions
-	// provided by an AWS account.
-	AWSPublicCertificate = `-----BEGIN CERTIFICATE-----
-MIIC7TCCAq0CCQCWukjZ5V4aZzAJBgcqhkjOOAQDMFwxCzAJBgNVBAYTAlVTMRkw
-FwYDVQQIExBXYXNoaW5ndG9uIFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYD
-VQQKExdBbWF6b24gV2ViIFNlcnZpY2VzIExMQzAeFw0xMjAxMDUxMjU2MTJaFw0z
-ODAxMDUxMjU2MTJaMFwxCzAJBgNVBAYTAlVTMRkwFwYDVQQIExBXYXNoaW5ndG9u
-IFN0YXRlMRAwDgYDVQQHEwdTZWF0dGxlMSAwHgYDVQQKExdBbWF6b24gV2ViIFNl
-cnZpY2VzIExMQzCCAbcwggEsBgcqhkjOOAQBMIIBHwKBgQCjkvcS2bb1VQ4yt/5e
-ih5OO6kK/n1Lzllr7D8ZwtQP8fOEpp5E2ng+D6Ud1Z1gYipr58Kj3nssSNpI6bX3
-VyIQzK7wLclnd/YozqNNmgIyZecN7EglK9ITHJLP+x8FtUpt3QbyYXJdmVMegN6P
-hviYt5JH/nYl4hh3Pa1HJdskgQIVALVJ3ER11+Ko4tP6nwvHwh6+ERYRAoGBAI1j
-k+tkqMVHuAFcvAGKocTgsjJem6/5qomzJuKDmbJNu9Qxw3rAotXau8Qe+MBcJl/U
-hhy1KHVpCGl9fueQ2s6IL0CaO/buycU1CiYQk40KNHCcHfNiZbdlx1E9rpUp7bnF
-lRa2v1ntMX3caRVDdbtPEWmdxSCYsYFDk4mZrOLBA4GEAAKBgEbmeve5f8LIE/Gf
-MNmP9CM5eovQOGx5ho8WqD+aTebs+k2tn92BBPqeZqpWRa5P/+jrdKml1qx4llHW
-MXrs3IgIb6+hUIB+S8dz8/mmO0bpr76RoZVCXYab2CZedFut7qc3WUH9+EUAH5mw
-vSeDCOUMYQR7R9LINYwouHIziqQYMAkGByqGSM44BAMDLwAwLAIUWXBlk40xTwSw
-7HX32MxXYruse9ACFBNGmdX2ZBrVNGrN9N2f6ROk0k9K
------END CERTIFICATE-----`
 	// AWSUserDataEndpoint is the local EC2 endpoint for the config.
 	AWSUserDataEndpoint = "http://169.254.169.254/latest/user-data"
 )
 
 // AWS is the concrete type that implements the runtime.Platform interface.
 type AWS struct{}
-
-// IsEC2 uses the EC2 PKCS7 signature to verify the instance by validating it
-// against the appropriate AWS public certificate. See
-// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
-func IsEC2() (b bool) {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer ctxCancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, AWSPKCS7Endpoint, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return
-	}
-	//nolint:errcheck
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		fmt.Printf("failed to download PKCS7 signature: %d\n", resp.StatusCode)
-
-		return
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Println(err)
-
-		return
-	}
-
-	data = append([]byte("-----BEGIN PKCS7-----\n"), data...)
-	data = append(data, []byte("\n-----END PKCS7-----\n")...)
-
-	pemBlock, _ := pem.Decode(data)
-	if pemBlock == nil {
-		log.Println("failed to decode PEM block")
-
-		return
-	}
-
-	p7, err := pkcs7.Parse(pemBlock.Bytes)
-	if err != nil {
-		log.Printf("failed to parse PKCS7 signature: %v\n", err)
-
-		return
-	}
-
-	pemBlock, _ = pem.Decode([]byte(AWSPublicCertificate))
-	if pemBlock == nil {
-		log.Println("failed to decode PEM block")
-
-		return
-	}
-
-	certificate, err := x509.ParseCertificate(pemBlock.Bytes)
-	if err != nil {
-		log.Printf("failed to parse X509 certificate: %v\n", err)
-
-		return
-	}
-
-	p7.Certificates = []*x509.Certificate{certificate}
-
-	err = p7.Verify()
-	if err != nil {
-		log.Printf("failed to verify PKCS7 signature: %v", err)
-
-		return
-	}
-
-	b = true
-
-	return b
-}
 
 // Name implements the runtime.Platform interface.
 func (a *AWS) Name() string {


### PR DESCRIPTION
These are I guess artifacts from the time Talos tried to auto-detect the
platform it is running on.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4743)
<!-- Reviewable:end -->
