### PR TITLE
test: retry in discovery tests

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_module_spec.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_module_spec.go
@@ -13,11 +13,14 @@ import (
 	"github.com/pmorjan/kmod"
 	"go.uber.org/zap"
 
+	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/resources/runtime"
 )
 
 // KernelModuleSpecController watches KernelModuleSpecs, sets/resets kernel params.
-type KernelModuleSpecController struct{}
+type KernelModuleSpecController struct {
+	V1Alpha1Mode v1alpha1runtime.Mode
+}
 
 // Name implements controller.Controller interface.
 func (ctrl *KernelModuleSpecController) Name() string {
@@ -42,6 +45,11 @@ func (ctrl *KernelModuleSpecController) Outputs() []controller.Output {
 
 // Run implements controller.Controller interface.
 func (ctrl *KernelModuleSpecController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	if ctrl.V1Alpha1Mode == v1alpha1runtime.ModeContainer {
+		// not supported in container mode
+		return nil
+	}
+
 	manager, err := kmod.New()
 	if err != nil {
 		return fmt.Errorf("error initializing kmod manager: %w", err)

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -185,7 +185,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			Drainer:        drainer,
 		},
 		&runtimecontrollers.KernelModuleConfigController{},
-		&runtimecontrollers.KernelModuleSpecController{},
+		&runtimecontrollers.KernelModuleSpecController{
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&runtimecontrollers.KernelParamConfigController{},
 		&runtimecontrollers.KernelParamDefaultsController{
 			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),

--- a/internal/integration/api/discovery.go
+++ b/internal/integration/api/discovery.go
@@ -151,10 +151,25 @@ func (suite *DiscoverySuite) TestRegistries() {
 
 		members := suite.getMembers(nodeCtx)
 		localIdentity := suite.getNodeIdentity(nodeCtx)
-		rawAffiliates := suite.getAffiliates(nodeCtx, cluster.RawNamespaceName)
 
 		// raw affiliates don't contain the local node
-		suite.Assert().Len(rawAffiliates, len(registries)*(len(members)-1))
+		expectedRawAffiliates := len(registries) * (len(members) - 1)
+
+		var rawAffiliates []*cluster.Affiliate
+
+		for i := 0; i < 30; i++ {
+			rawAffiliates = suite.getAffiliates(nodeCtx, cluster.RawNamespaceName)
+
+			if len(rawAffiliates) == expectedRawAffiliates {
+				break
+			}
+
+			suite.T().Logf("waiting for cluster affiliates to be discovered: %d expected, %d found", expectedRawAffiliates, len(rawAffiliates))
+
+			time.Sleep(2 * time.Second)
+		}
+
+		suite.Assert().Len(rawAffiliates, expectedRawAffiliates)
 
 		rawAffiliatesByID := make(map[string]*cluster.Affiliate)
 


### PR DESCRIPTION
Sometimes pushing/pulling to Kubernetes registry is delayed due to
backoff on failed attempts to talk to the API server when the cluster is
still bootstrapping. Workaround that by adding retries.

Also disable kernel module controller in container mode, as it will keep
always failing.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4746)
<!-- Reviewable:end -->
