### PR TITLE
fix: ignore missing init.yaml for cluster create

### DIFF
--- a/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
+++ b/pkg/machinery/config/types/v1alpha1/bundle/bundle.go
@@ -42,6 +42,10 @@ func NewConfigBundle(opts ...Option) (*v1alpha1.ConfigBundle, error) {
 		for _, configType := range []machine.Type{machine.TypeInit, machine.TypeControlPlane, machine.TypeWorker} {
 			data, err := ioutil.ReadFile(filepath.Join(options.ExistingConfigs, strings.ToLower(configType.String())+".yaml"))
 			if err != nil {
+				if configType == machine.TypeInit && os.IsNotExist(err) {
+					continue
+				}
+
 				return bundle, err
 			}
 


### PR DESCRIPTION
Resolves  #4362

Signed-off-by: Eric Wohltman <eric.wohltman@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
When running `talosctl cluster create --input-dir` using files created from `talosctl gen config`, an error occurs because `cluster create` expects an `init.yaml` file which `gen config` does not create.

```
$ talosctl version --client
Client:
	Tag:         v0.14.0
	SHA:         675dee0e
	Built:
	Go version:  go1.17.5
	OS/Arch:     linux/amd64

$ talosctl gen config talos-default https://10.5.0.2:6443 --output-dir /tmp/talos --additional-sans 127.0.0.1 --registry-mirror '*'=http://10.5.0.1:6000 --config-patch '[{"op":"add", "path": "/cluster/network/cni", "value": {"name": "none"}}]'
generating PKI and tokens
created /tmp/talos/controlplane.yaml
created /tmp/talos/worker.yaml
created /tmp/talos/talosconfig

$ talosctl cluster create --input-dir /tmp/talos --nameservers 8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111 --masters 1 --workers 1 --wait
validating CIDR and reserving IPs
open /tmp/talos/init.yaml: no such file or directory
```

## Why? (reasoning)
This is to allow creating a cluster directly from files created by `gen config`. It should also support backwards compatibility if `init.yaml` is in fact present.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4752)
<!-- Reviewable:end -->
