### PR TITLE
fix: cilium documentation cluster creation

### DIFF
--- a/website/content/docs/v0.15/Guides/deploying-cilium.md
+++ b/website/content/docs/v0.15/Guides/deploying-cilium.md
@@ -3,93 +3,110 @@ title: "Deploying Cilium CNI"
 description: "In this guide you will learn how to set up Cilium CNI on Talos."
 ---
 
-From v1.9 onwards cilium doesn't provide a one liner install manifest that can be used to install cilium on a node via `kubectl apply -f` or passing in as extra `urls` in Talos machine configuration.
+From v1.9 onwards Cilium doesn't provide a one-liner install manifest that can
+be used to install Cilium on a node via `kubectl apply -f` or by passing in as
+extra `urls` in Talos machine configuration.
 
-> installing Cilium via `cilium` cli is [broken](https://github.com/cilium/cilium-cli/issues/505), so we'll be using `helm` to install cilium.
+> Installing Cilium via `cilium` CLI is [broken](https://github.com/cilium/cilium-cli/issues/505),
+so we'll be using `helm` to install Cilium.
 
-Refer [Installing with Helm](https://docs.cilium.io/en/v1.11/gettingstarted/k8s-install-helm/) for more information.
+Refer [Installing with Helm](https://docs.cilium.io/en/v1.11/gettingstarted/k8s-install-helm/)
+for more information.
 
-First we'll need to add the helm repo for cilium.
+First we'll need to add the helm repo for Cilium.
 
 ```bash
 helm repo add cilium https://helm.cilium.io/
 helm repo update
 ```
 
-This documentation will outline installing Cilium CNI on Talos in two different ways.
+This documentation will outline installing Cilium CNI on Talos in two different
+ways.
+
+> **Note:** When building a new cluster, an initial CNI must be provided. If you
+want to build your cluster with Cilium as the CNI provider out of the box, you
+will first have to generate the Cilium manifests and host them somewhere the
+API can reach. The Cilium manifests will have secret values, so keep that in
+consideration for where you host them.
 
 ## With Kube Proxy enabled
 
-When generating the machine config for a node add the following config patch.
-An example usage is shown below:
+The following steps will create a Talos cluster with Cilium installed.
 
-```bash
-talosctl gen config \
-    my-cluster https://mycluster.local:6443 \
-    --config-patch '[{"op":"add", "path": "/cluster/network/cni", "value": {"name": "none"}}]'
-```
-
-Now we can move onto installing cilium.
-
-If you want to install with helm run the following:
-
-```bash
-helm install cilium cilium/cilium \
-    --version 1.11.0 \
-    --namespace kube-system
-```
-
-If you want to generate a manifest and apply manually run the following:
+Generate the Cilium manifests with:
 
 ```bash
 helm template cilium cilium/cilium \
     --version 1.11.0 \
     --namespace kube-system > cilium.yaml
-
-kubectl apply -f cilium.yaml
 ```
 
-## Without Kube Proxy
+Then host that `cilium.yaml` file somewhere secure.
 
-If you want to deploy Cilium in strict mode without kube-proxy, you can use the following config patch when generating a machine config.
-This will create the Talos cluster with no CNI and *kube-proxy* disabled.
-
-An example usage is shown below:
+When generating the machine config for a node, add the following config patch
+with your `cilium.yaml` URL:
 
 ```bash
 talosctl gen config \
     my-cluster https://mycluster.local:6443 \
-    --config-patch '[{"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}, {"op":"add", "path": "/cluster/network/cni", "value": {"name": "none"}}]'
+    --config-patch '[{"op":"add", "path": "/cluster/network/cni", "value": {"name": "custom", "urls": ["<your_hosting_url>/cilium.yaml"]}}]'
 ```
 
-You need to pass in the Kubernetes API server address to the `helm` commands.
-Refer [Kube Proxy free](https://docs.cilium.io/en/v1.11/gettingstarted/kubeproxy-free/#quick-start) for more information.
+Next, update the generated `talosconf` file to point to your endpoint:
 
 ```bash
-export KUBERNETES_API_SERVER_ADDRESS=<>
+talosctl --talosconfig ./talosconfig config endpoint mycluster.local
+```
+
+Finally, create your cluster using your generated config files. For example
+with a local Docker deployment:
+
+```bash
+talosctl cluster create --input-dir . --wait
+```
+
+## Without Kube Proxy
+
+The following steps will create a Talos cluster with Cilium installed and
+*kube-proxy* disabled.
+
+Generate the Cilium manifests with the commands below. You need to pass in the
+Kubernetes API server address to the `helm` commands.
+Refer to [Kube Proxy free](https://docs.cilium.io/en/v1.11/gettingstarted/kubeproxy-free/#quick-start)
+for more information.
+
+```bash
+export KUBERNETES_API_SERVER_ADDRESS=mycluster.local
 export KUBERNETES_API_SERVER_PORT=6443
-```
 
-If you want to install with helm run the following:
-
-```bash
-helm install cilium cilium/cilium \
-    --version 1.11.0 \
-    --namespace kube-system \
-    --set kubeProxyReplacement=strict \
-    --set k8sServiceHost="${KUBERNETES_API_SERVER_ADDRESS}" \
-    --set k8sServicePort="${KUBERNETES_API_SERVER_PORT}"
-```
-
-If you want to generate a manifest and apply manually run the following:
-
-```bash
 helm template cilium cilium/cilium \
     --version 1.11.0 \
     --namespace kube-system \
     --set kubeProxyReplacement=strict \
     --set k8sServiceHost="${KUBERNETES_API_SERVER_ADDRESS}" \
     --set k8sServicePort="${KUBERNETES_API_SERVER_PORT}" > cilium.yaml
+```
 
-kubectl apply -f cilium.yaml
+Then host that `cilium.yaml` file somewhere secure.
+
+When generating the machine config for a node, add the following config patch
+with your `cilium.yaml` URL:
+
+```bash
+talosctl gen config \
+    my-cluster https://mycluster.local:6443 \
+    --config-patch '[{"op": "add", "path": "/cluster/proxy", "value": {"disabled": true}}, {"op":"add", "path": "/cluster/network/cni", "value": {"name": "custom", "urls": ["<your_hosting_url>/cilium.yaml"]}}]'
+```
+
+Next, update the generated `talosconf` file to point to your endpoint:
+
+```bash
+talosctl --talosconfig ./talosconfig config endpoint mycluster.local
+```
+
+Finally, create your cluster using your generated config files. For example
+with a local Docker deployment:
+
+```bash
+talosctl cluster create --input-dir . --wait
 ```


### PR DESCRIPTION
Fixes: #4756.
The Cilium documentation includes instructions for creating a cluster without a CNI, followed by installing Cilium. In testing however, it was found that a cluster cannot be initially created without a CNI.

Signed-off-by: Eric Wohltman <eric.wohltman@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
See #4756 

## Why? (reasoning)
So that users who want to build clusters with Cilium are able to do so.

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4757)
<!-- Reviewable:end -->
