### PR TITLE
fix: derive machine-id from node identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -377,9 +377,7 @@ COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
 COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/config.toml
 COPY --chmod=0644 hack/cri-containerd.toml /rootfs/etc/cri/containerd.toml
-RUN touch /rootfs/etc/resolv.conf
-RUN touch /rootfs/etc/hosts
-RUN touch /rootfs/etc/os-release
+RUN touch /rootfs/etc/{resolv.conf,hosts,os-release,machine-id}
 RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt,system,opt}
 RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni/net.d,usr/libexec/kubernetes}
 RUN mkdir -pv /rootfs/opt/{containerd/bin,containerd/lib}
@@ -421,9 +419,7 @@ COPY ./hack/cleanup.sh /toolchain/bin/cleanup.sh
 RUN cleanup.sh /rootfs
 COPY --chmod=0644 hack/containerd.toml /rootfs/etc/containerd/containerd.toml
 COPY --chmod=0644 hack/cri-containerd.toml /rootfs/etc/cri/containerd.toml
-RUN touch /rootfs/etc/resolv.conf
-RUN touch /rootfs/etc/hosts
-RUN touch /rootfs/etc/os-release
+RUN touch /rootfs/etc/{resolv.conf,hosts,os-release,machine-id}
 RUN mkdir -pv /rootfs/{boot,usr/local/share,mnt,system,opt}
 RUN mkdir -pv /rootfs/{etc/kubernetes/manifests,etc/cni/net.d,usr/libexec/kubernetes}
 RUN mkdir -pv /rootfs/opt/{containerd/bin,containerd/lib}

--- a/internal/app/machined/pkg/adapters/cluster/identity.go
+++ b/internal/app/machined/pkg/adapters/cluster/identity.go
@@ -6,6 +6,7 @@ package cluster
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"io"
 
 	"github.com/jxskiss/base62"
@@ -38,4 +39,17 @@ func (a identity) Generate() error {
 	a.IdentitySpec.NodeID = base62.EncodeToString(buf)
 
 	return nil
+}
+
+// ConvertMachineID returns /etc/machine-id compatible representation.
+func (a identity) ConvertMachineID() ([]byte, error) {
+	raw, err := base62.DecodeString(a.IdentitySpec.NodeID)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, 32)
+	hex.Encode(buf, raw[:16])
+
+	return buf, nil
 }

--- a/internal/app/machined/pkg/adapters/cluster/identity_test.go
+++ b/internal/app/machined/pkg/adapters/cluster/identity_test.go
@@ -27,3 +27,14 @@ func TestIdentityGenerate(t *testing.T) {
 	assert.GreaterOrEqual(t, length, 43)
 	assert.LessOrEqual(t, length, 44)
 }
+
+func TestIdentityConvertMachineID(t *testing.T) {
+	spec := cluster.IdentitySpec{
+		NodeID: "sou7yy34ykX3n373Zw1DXKb8zD7UnyKT6HT3QDsGH6L",
+	}
+
+	machineID, err := clusteradapter.IdentitySpec(&spec).ConvertMachineID()
+	require.NoError(t, err)
+
+	assert.Equal(t, "be871ac0d0dd31fa4caca753b0f3f1b2", string(machineID))
+}

--- a/internal/app/machined/pkg/controllers/cluster/node_identity.go
+++ b/internal/app/machined/pkg/controllers/cluster/node_identity.go
@@ -20,6 +20,7 @@ import (
 	"github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/machinery/resources/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/resources/files"
 	runtimeres "github.com/talos-systems/talos/pkg/machinery/resources/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/resources/v1alpha1"
 )
@@ -54,6 +55,10 @@ func (ctrl *NodeIdentityController) Outputs() []controller.Output {
 	return []controller.Output{
 		{
 			Type: cluster.IdentityType,
+			Kind: controller.OutputShared,
+		},
+		{
+			Type: files.EtcFileSpecType,
 			Kind: controller.OutputShared,
 		},
 	}
@@ -100,6 +105,19 @@ func (ctrl *NodeIdentityController) Run(ctx context.Context, r controller.Runtim
 			return nil
 		}); err != nil {
 			return fmt.Errorf("error modifying resource: %w", err)
+		}
+
+		// generate `/etc/machine-id` from node identity
+		if err := r.Modify(ctx, files.NewEtcFileSpec(files.NamespaceName, "machine-id"),
+			func(r resource.Resource) error {
+				var err error
+
+				r.(*files.EtcFileSpec).TypedSpec().Contents, err = clusteradapter.IdentitySpec(&localIdentity).ConvertMachineID()
+				r.(*files.EtcFileSpec).TypedSpec().Mode = 0o444
+
+				return err
+			}); err != nil {
+			return fmt.Errorf("error modifying resolv.conf: %w", err)
 		}
 
 		if !ctrl.identityEstablished {

--- a/internal/app/machined/pkg/controllers/cluster/node_identity_test.go
+++ b/internal/app/machined/pkg/controllers/cluster/node_identity_test.go
@@ -19,6 +19,7 @@ import (
 	v1alpha1runtime "github.com/talos-systems/talos/internal/app/machined/pkg/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
 	"github.com/talos-systems/talos/pkg/machinery/resources/cluster"
+	"github.com/talos-systems/talos/pkg/machinery/resources/files"
 	runtimeres "github.com/talos-systems/talos/pkg/machinery/resources/runtime"
 	"github.com/talos-systems/talos/pkg/machinery/resources/v1alpha1"
 )
@@ -68,6 +69,12 @@ func (suite *NodeIdentitySuite) TestDefault() {
 			return nil
 		}),
 	))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*files.NewEtcFileSpec(files.NamespaceName, "machine-id").Metadata(), func(_ resource.Resource) error {
+			return nil
+		}),
+	))
 }
 
 func (suite *NodeIdentitySuite) TestLoad() {
@@ -89,6 +96,14 @@ func (suite *NodeIdentitySuite) TestLoad() {
 	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
 		suite.assertResource(*cluster.NewIdentity(cluster.NamespaceName, cluster.LocalIdentity).Metadata(), func(r resource.Resource) error {
 			suite.Assert().Equal("gvqfS27LxD58lPlASmpaueeRVzuof16iXoieRgEvBWaE", r.(*cluster.Identity).TypedSpec().NodeID)
+
+			return nil
+		}),
+	))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		suite.assertResource(*files.NewEtcFileSpec(files.NamespaceName, "machine-id").Metadata(), func(r resource.Resource) error {
+			suite.Assert().Equal("8d2c0de2408fa2a178bad7f45d9aa8fb", string(r.(*files.EtcFileSpec).TypedSpec().Contents))
 
 			return nil
 		}),

--- a/internal/app/machined/pkg/system/services/kubelet.go
+++ b/internal/app/machined/pkg/system/services/kubelet.go
@@ -108,6 +108,7 @@ func (k *Kubelet) Runner(r runtime.Runtime) (runner.Runner, error) {
 		{Type: "bind", Destination: constants.CgroupMountPath, Source: constants.CgroupMountPath, Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/lib/modules", Source: "/lib/modules", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/kubernetes", Source: "/etc/kubernetes", Options: []string{"bind", "rshared", "rw"}},
+		{Type: "bind", Destination: "/etc/machine-id", Source: "/etc/machine-id", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/os-release", Source: "/etc/os-release", Options: []string{"bind", "ro"}},
 		{Type: "bind", Destination: "/etc/cni", Source: "/etc/cni", Options: []string{"rbind", "rshared", "rw"}},
 		{Type: "bind", Destination: "/usr/libexec/kubernetes", Source: "/usr/libexec/kubernetes", Options: []string{"rbind", "rshared", "rw"}},


### PR DESCRIPTION
Fixes #4759

This uses existing features: Talos always generates 32 bytes random node
identity, we use first 16 bytes of that to generate `machine-id` in
compliant format and mount that into the `kubelet` container.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4775)
<!-- Reviewable:end -->
