### PR TITLE
hack: PoC for system extensions

### DIFF
--- a/internal/app/init/main.go
+++ b/internal/app/init/main.go
@@ -51,12 +51,23 @@ func run() (err error) {
 	// Mount the rootfs.
 	log.Println("mounting the rootfs")
 
-	squashfs, err := mount.SquashfsMountPoints(constants.NewRoot)
+	squashfs, err := mount.SquashfsMountPoints("/layers")
 	if err != nil {
 		return err
 	}
 
 	if err = mount.Mount(squashfs); err != nil {
+		return err
+	}
+
+	overlay := mount.NewMountPoints()
+	overlay.Set(constants.NewRoot, mount.NewMountPoint("/layers/layer2:/layers/layer1", constants.NewRoot, "", unix.MS_I_VERSION, "", mount.WithFlags(mount.ReadOnly|mount.ReadonlyOverlay)))
+
+	if err = mount.Mount(overlay); err != nil {
+		return err
+	}
+
+	if err = mount.Unmount(squashfs); err != nil {
 		return err
 	}
 

--- a/internal/pkg/mount/options.go
+++ b/internal/pkg/mount/options.go
@@ -17,6 +17,9 @@ const (
 	// Overlay indicates that a the partition for a given mount point should be
 	// mounted using overlayfs.
 	Overlay
+	// ReadonlyOverlay indicates that a the partition for a given mount point should be
+	// mounted using multi-layer readonly overlay from multiple partitions given as sources.
+	ReadonlyOverlay
 	// SkipIfMounted is a flag for skipping mount if the mountpoint is already mounted.
 	SkipIfMounted
 	// SkipIfNoFilesystem is a flag for skipping formatting and mounting if the mountpoint has not filesystem.

--- a/internal/pkg/mount/squashfs.go
+++ b/internal/pkg/mount/squashfs.go
@@ -21,7 +21,14 @@ func SquashfsMountPoints(prefix string) (mountpoints *Points, err error) {
 	}
 
 	squashfs := NewMountPoints()
-	squashfs.Set("squashfs", NewMountPoint(dev.Path(), "/", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithFlags(ReadOnly|Shared)))
+	squashfs.Set("layer1", NewMountPoint(dev.Path(), "/layer1", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithFlags(ReadOnly|Shared)))
+
+	dev, err = losetup.Attach("/extension.sqsh", 0, true)
+	if err != nil {
+		return nil, err
+	}
+
+	squashfs.Set("layer2", NewMountPoint(dev.Path(), "/layer2", "squashfs", unix.MS_RDONLY|unix.MS_I_VERSION, "", WithPrefix(prefix), WithFlags(ReadOnly|Shared)))
 
 	return squashfs, nil
 }


### PR DESCRIPTION
This doesn't cover any real work to be done with installing system
extensions, but rather just shows that the implementation is possible.

End result is that we have extra file in `/usr/bin`:

```
$ talosctl -n 172.20.0.2 ls -l /usr/bin
NODE         MODE         UID   GID   SIZE(B)   LASTMOD           NAME
172.20.0.2   drwxr-xr-x   0     0     32        Jan 10 23:46:33   .
172.20.0.2   -rw-r--r--   0     0     0         Jan 10 23:46:33   extension
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4786)
<!-- Reviewable:end -->
