### PR TITLE
chore: clean up /usr/bin from unneeded files

### DIFF
--- a/hack/cleanup.sh
+++ b/hack/cleanup.sh
@@ -19,10 +19,10 @@ function remove_symlinks() {
 remove_symlinks
 
 # Remove any archives as we do not need them since everything is dynamically linked.
-find ${PREFIX} -type f -name \*.a -print0 | xargs -0 rm -rf || true
-find ${PREFIX} -type f -name \*.la -print0 | xargs -0 rm -rf || true
+find ${PREFIX} -type f -name \*.a -delete
+find ${PREFIX} -type f -name \*.la -delete
 # Remove static binaries.
-find ${PREFIX} -type f -name \*.static -print0 | xargs -0 rm -rf || true
+find ${PREFIX} -type f -name \*.static -delete
 # Strip debug symbols from all libraries and binaries.
 find ${PREFIX}/{lib,usr/lib} -type f \( -name \*.so* -a ! -name \*dbg \) -exec strip --strip-unneeded {} ';' || true
 find ${PREFIX}/{bin,sbin,usr/bin,usr/sbin} -type f -exec strip --strip-all {} ';' || true
@@ -34,3 +34,6 @@ rm -rf ${PREFIX}/{lib,usr/lib}/pkgconfig/ \
        ${PREFIX}/lib/gconv/ \
        ${PREFIX}/usr/libexec/getconf \
        ${PREFIX}/var/db
+
+# Remove contents of /usr/bin except for udevadm
+find ${PREFIX}/usr/bin \( -type f -o -type l \) ! -name udevadm -delete


### PR DESCRIPTION
This removes all files but leaves `udevadm` which is actually used by
Talos.

Size reduction for `initramfs-amd64`: 54380024 -> 54228188

Files removed:

```
NODE         MODE         UID   GID   SIZE(B)   LASTMOD           NAME
172.20.0.2   drwxr-xr-x   0     0     107       Jan 10 23:46:33   .
172.20.0.2   Lrwxrwxrwx   0     0     26        Jan 10 23:46:33   iptables-xml -> /sbin/xtables-legacy-multi
172.20.0.2   -rwxr-xr-x   0     0     30496     Jan 10 23:46:33   ocspcheck
172.20.0.2   -rwxr-xr-x   0     0     442008    Jan 10 23:46:33   openssl
172.20.0.2   -rwxr-xr-x   0     0     14240     Jan 10 23:46:33   scmp_sys_resolver
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4787)
<!-- Reviewable:end -->
