### PR TITLE
docs: rework vmware assets

### DIFF
--- a/website/content/docs/v0.14/Virtualized Platforms/vmware.md
+++ b/website/content/docs/v0.14/Virtualized Platforms/vmware.md
@@ -5,7 +5,7 @@ description: "Creating Talos Kubernetes cluster using VMware."
 
 ## Creating a Cluster via the `govc` CLI
 
-In this guide we will create an HA Kubernetes cluster with 3 worker nodes.
+In this guide we will create an HA Kubernetes cluster with 2 worker nodes.
 We will use the `govc` cli which can be downloaded [here](https://github.com/vmware/govmomi/tree/master/govc#installation).
 
 ## Prereqs/Assumptions
@@ -21,7 +21,8 @@ Using the VIP chosen in the prereq steps, we will now generate the base configur
 This can be done with the `talosctl gen config ...` command.
 Take note that we will also use a JSON6902 patch when creating the configs so that the control plane nodes get some special information about the VIP we chose earlier, as well as a daemonset to install vmware tools on talos nodes.
 
-First, save [this](./vmware/cp.patch) patch to your local machine as `cp.patch` and edit the VIP to match your chosen IP.
+First, download `the cp.patch` to your local machine and edit the VIP to match your chosen IP.
+You can do this by issuing `https://raw.githubusercontent.com/talos-systems/talos/master/website/content/docs/v0.15/Virtualized%20Platforms/vmware/cp.patch`.
 It's contents should look like the following:
 
 ```yaml
@@ -89,7 +90,8 @@ If you wish to carry out the manual approach, simply skip ahead to the "Manual A
 
 ### Scripted Install
 
-Download [this](./vmware/vmware.sh) script as `vmware.sh` to your local machine.
+Download the `vmware.sh` script to your local machine.
+You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/talos-systems/talos/master/website/content/docs/v0.15/Virtualized%20Platforms/vmware/vmware.sh"`.
 This script has default variables for things like Talos version and cluster name that may be interesting to tweak before deploying.
 
 #### Import OVA

--- a/website/content/docs/v0.15/Virtualized Platforms/vmware.md
+++ b/website/content/docs/v0.15/Virtualized Platforms/vmware.md
@@ -21,7 +21,8 @@ Using the VIP chosen in the prereq steps, we will now generate the base configur
 This can be done with the `talosctl gen config ...` command.
 Take note that we will also use a JSON6902 patch when creating the configs so that the control plane nodes get some special information about the VIP we chose earlier, as well as a daemonset to install vmware tools on talos nodes.
 
-First, save [this](./vmware/cp.patch) patch to your local machine as `cp.patch` and edit the VIP to match your chosen IP.
+First, download `the cp.patch` to your local machine and edit the VIP to match your chosen IP.
+You can do this by issuing `https://raw.githubusercontent.com/talos-systems/talos/master/website/content/docs/v0.14/Virtualized%20Platforms/vmware/cp.patch`.
 It's contents should look like the following:
 
 ```yaml
@@ -89,7 +90,8 @@ If you wish to carry out the manual approach, simply skip ahead to the "Manual A
 
 ### Scripted Install
 
-Download [this](./vmware/vmware.sh) script as `vmware.sh` to your local machine.
+Download the `vmware.sh` script to your local machine.
+You can do this by issuing `curl -fsSLO "https://raw.githubusercontent.com/talos-systems/talos/master/website/content/docs/v0.14/Virtualized%20Platforms/vmware/vmware.sh"`.
 This script has default variables for things like Talos version and cluster name that may be interesting to tweak before deploying.
 
 #### Import OVA


### PR DESCRIPTION
This PR moves to give curl commands for the vmware assets instead of
relying on the local paths that I was using. This matches what we're
doing for gcp docs as well.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4794)
<!-- Reviewable:end -->
