### PR TITLE
fix: avoid panic in config loading/validation

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -429,7 +429,7 @@ func LoadConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 
 			if e != nil {
 				r.Events().Publish(&machineapi.ConfigLoadErrorEvent{
-					Error: err.Error(),
+					Error: e.Error(),
 				})
 
 				return e
@@ -440,7 +440,7 @@ func LoadConfig(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFu
 			cfg, e := r.LoadAndValidateConfig(b)
 			if e != nil {
 				r.Events().Publish(&machineapi.ConfigLoadErrorEvent{
-					Error: err.Error(),
+					Error: e.Error(),
 				})
 
 				return e


### PR DESCRIPTION
As wrong `error` value was used, publishing an event was causing a panic
in Talos.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4796)
<!-- Reviewable:end -->
