### PR TITLE
feat: print version in Grub

### DIFF
--- a/cmd/installer/cmd/root.go
+++ b/cmd/installer/cmd/root.go
@@ -44,4 +44,5 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&options.Upgrade, "upgrade", false, "Indicates that the install is being performed by an upgrade")
 	rootCmd.PersistentFlags().BoolVar(&options.Force, "force", false, "Indicates that the install should forcefully format the partition")
 	rootCmd.PersistentFlags().BoolVar(&options.Zero, "zero", false, "Indicates that the install should write zeros to the disk before installing")
+	rootCmd.PersistentFlags().StringVar(&options.PreviousVersion, "previous-version", "", "The previous version of Talos")
 }

--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -37,6 +37,7 @@ type Options struct {
 	Force             bool
 	Zero              bool
 	LegacyBIOSSupport bool
+	PreviousVersion   string
 }
 
 // Install installs Talos.
@@ -264,10 +265,11 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 		Default: i.Next,
 		Labels: []*grub.Label{
 			{
-				Root:   i.Next,
-				Initrd: filepath.Join("/", i.Next, constants.InitramfsAsset),
-				Kernel: filepath.Join("/", i.Next, constants.KernelAsset),
-				Append: i.cmdline.String(),
+				Root:    i.Next,
+				Initrd:  filepath.Join("/", i.Next, constants.InitramfsAsset),
+				Kernel:  filepath.Join("/", i.Next, constants.KernelAsset),
+				Append:  i.cmdline.String(),
+				Version: version.Tag,
 			},
 		},
 	}
@@ -276,10 +278,11 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 		grubcfg.Fallback = i.Current
 
 		grubcfg.Labels = append(grubcfg.Labels, &grub.Label{
-			Root:   i.Current,
-			Initrd: filepath.Join("/", i.Current, constants.InitramfsAsset),
-			Kernel: filepath.Join("/", i.Current, constants.KernelAsset),
-			Append: procfs.ProcCmdline().String(),
+			Root:    i.Current,
+			Initrd:  filepath.Join("/", i.Current, constants.InitramfsAsset),
+			Kernel:  filepath.Join("/", i.Current, constants.KernelAsset),
+			Append:  procfs.ProcCmdline().String(),
+			Version: i.options.PreviousVersion,
 		})
 	}
 

--- a/internal/app/machined/internal/install/install.go
+++ b/internal/app/machined/internal/install/install.go
@@ -29,6 +29,7 @@ import (
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/version"
 )
 
 // RunInstallerContainer performs an installation via the installer container.
@@ -95,6 +96,7 @@ func RunInstallerContainer(disk, platform, ref string, configBytes []byte, reg c
 		"--upgrade=" + upgrade,
 		"--force=" + force,
 		"--zero=" + zero,
+		"--previous-version=" + version.NewVersion().Tag,
 	}
 
 	if c := procfs.ProcCmdline().Get(constants.KernelParamBoard).First(); c != nil {

--- a/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/bootloader/grub/grub.go
@@ -34,10 +34,11 @@ type Cfg struct {
 
 // Label reprsents a label in the cfg file.
 type Label struct {
-	Root   string
-	Kernel string
-	Initrd string
-	Append string
+	Root    string
+	Kernel  string
+	Initrd  string
+	Append  string
+	Version string
 }
 
 const grubCfgTpl = `set default="{{ .Default }}"
@@ -53,6 +54,9 @@ terminal_output console
 
 {{ range $label := .Labels -}}
 menuentry "{{ $label.Root }}" {
+{{ if .Version }}
+  echo "Talos {{ .Version }}"
+{{ end }}
   set gfxmode=auto
   set gfxpayload=text
   linux {{ $label.Kernel }} {{ $label.Append }}


### PR DESCRIPTION
It will be useful to know which version of Talos is booting as early as
possible. This adds the Talos version to the Grub label so that Grub
will print the Talos version.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4797)
<!-- Reviewable:end -->
