### PR TITLE
feat: update CoreDNS to 1.8.7

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -33,6 +33,7 @@ with a single `--mode` flag that can take the following values:
         description="""\
 * Linux: 5.15.11
 * containerd: 1.5.9
+* CoreDNS: 1.8.7
 
 Talos is built with Go 1.17.6
 """

--- a/internal/app/machined/pkg/controllers/k8s/templates.go
+++ b/internal/app/machined/pkg/controllers/k8s/templates.go
@@ -309,9 +309,6 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         forward . /etc/resolv.conf
-        {{- if not .DNSServiceIPv6 }}
-        rewrite stop type AAAA A
-        {{- end }}
         cache 30
         loop
         reload

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -245,7 +245,7 @@ const (
 	CoreDNSImage = "docker.io/coredns/coredns"
 
 	// DefaultCoreDNSVersion is the default version for the CoreDNS.
-	DefaultCoreDNSVersion = "1.8.6"
+	DefaultCoreDNSVersion = "1.8.7"
 
 	// LabelNodeRoleMaster is the node label required by a control plane node.
 	LabelNodeRoleMaster = "node-role.kubernetes.io/master"

--- a/website/content/docs/v0.15/Reference/configuration.md
+++ b/website/content/docs/v0.15/Reference/configuration.md
@@ -1275,7 +1275,7 @@ Examples:
 
 ``` yaml
 coreDNS:
-    image: docker.io/coredns/coredns:1.8.6 # The `image` field is an override to the default coredns image.
+    image: docker.io/coredns/coredns:1.8.7 # The `image` field is an override to the default coredns image.
 ```
 
 
@@ -2575,7 +2575,7 @@ Appears in:
 
 
 ``` yaml
-image: docker.io/coredns/coredns:1.8.6 # The `image` field is an override to the default coredns image.
+image: docker.io/coredns/coredns:1.8.7 # The `image` field is an override to the default coredns image.
 ```
 
 <hr />


### PR DESCRIPTION
Drop the rewrite rule which seems to be causing issues for
`ingress-nginx` when Kubernetes IPv4-only cluster runs in the
IPv6-enabled environment.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4821)
<!-- Reviewable:end -->
