### PR TITLE
fix: use correct error in `kernel_param_spec` Modify call handling

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_spec.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_spec.go
@@ -112,7 +112,7 @@ func (ctrl *KernelParamSpecController) Run(ctx context.Context, r controller.Run
 
 							return nil
 						}); e != nil {
-							errs = multierror.Append(errs, err)
+							errs = multierror.Append(errs, e)
 						}
 					} else {
 						errs = multierror.Append(errs, err)


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/4834
Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4837)
<!-- Reviewable:end -->
