### PR TITLE
fix: qemu: always use runtime.GOARCH for CNI bundle

### DIFF
--- a/pkg/provision/providers/qemu/preflight.go
+++ b/pkg/provision/providers/qemu/preflight.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -164,8 +165,9 @@ func (check *preflightCheckContext) cniBundle(ctx context.Context) error {
 	}
 
 	client := getter.Client{
-		Ctx:  ctx,
-		Src:  strings.ReplaceAll(check.request.Network.CNI.BundleURL, constants.ArchVariable, check.options.TargetArch),
+		Ctx: ctx,
+		// Network CNI runs on the host
+		Src:  strings.ReplaceAll(check.request.Network.CNI.BundleURL, constants.ArchVariable, runtime.GOARCH),
 		Dst:  check.request.Network.CNI.BinPath[0],
 		Pwd:  pwd,
 		Mode: getter.ClientModeDir,


### PR DESCRIPTION
The CNI is executed on the host. Even if we want to run an arm64 qemu,
we still need to execute the amd64 CNI on the host.

Fixes https://github.com/talos-systems/talos/issues/4859

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4860)
<!-- Reviewable:end -->
