### PR TITLE
fix: use #!/usr/bin/env bash as shebang instead of #!/bin/bash

### DIFF
--- a/hack/cloud-image-uploader.sh
+++ b/hack/cloud-image-uploader.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/fix-artifacts.sh
+++ b/hack/fix-artifacts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for platform in $(tr "," "\n" <<< "${PLATFORM}"); do
     echo ${platform}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/start-registry-proxies.sh
+++ b/hack/start-registry-proxies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Sync changes with configuring-pull-through-cache.md.
 

--- a/hack/test/e2e-aws.sh
+++ b/hack/test/e2e-aws.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hack/test/e2e-azure.sh
+++ b/hack/test/e2e-azure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hack/test/e2e-docker.sh
+++ b/hack/test/e2e-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hack/test/e2e-gcp.sh
+++ b/hack/test/e2e-gcp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hack/test/e2e-iso.sh
+++ b/hack/test/e2e-iso.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eoux pipefail
 

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/hack/test/libvirt/libvirt.sh
+++ b/hack/test/libvirt/libvirt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/test/provision-tests.sh
+++ b/hack/test/provision-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eoux pipefail
 

--- a/hack/test/qemu/qemu.sh
+++ b/hack/test/qemu/qemu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
This will fix running these scripts on distros without /bin/bash, but
where bash is in $PATH, such as NixOS.

Currently, `make fmt` otherwise fails to run:

```
make[3]: Leaving directory '/home/flokli/dev/numtide/manifoldfinance/talos'
sh: ./hack/fix-artifacts.sh: /bin/bash: bad interpreter: No such file or directory
make[2]: *** [Makefile:163: local-fmt-protobuf] Error 126
make[2]: Leaving directory '/home/flokli/dev/numtide/manifoldfinance/talos'
make[1]: *** [Makefile:274: fmt-protobuf] Error 2
make[1]: Leaving directory '/home/flokli/dev/numtide/manifoldfinance/talos'
make: *** [Makefile:277: fmt] Error 2
```

Signed-off-by: Florian Klink <flokli@flokli.de>

# Pull Request
## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4861)
<!-- Reviewable:end -->
