### PR TITLE
Add --extra-uefi-search-paths option

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -70,6 +70,7 @@ var (
 	applyConfigEnabled        bool
 	bootloaderEnabled         bool
 	uefiEnabled               bool
+	extraUEFISearchPaths      []string
 	configDebug               bool
 	networkCIDR               string
 	networkMTU                int
@@ -264,6 +265,7 @@ func create(ctx context.Context) (err error) {
 		provision.WithDockerPortsHostIP(dockerHostIP),
 		provision.WithBootlader(bootloaderEnabled),
 		provision.WithUEFI(uefiEnabled),
+		provision.WithExtraUEFISearchPaths(extraUEFISearchPaths),
 		provision.WithTargetArch(targetArch),
 	}
 	configBundleOpts := []bundle.Option{}
@@ -814,6 +816,7 @@ func init() {
 	createCmd.Flags().BoolVar(&applyConfigEnabled, "with-apply-config", false, "enable apply config when the VM is starting in maintenance mode")
 	createCmd.Flags().BoolVar(&bootloaderEnabled, "with-bootloader", true, "enable bootloader to load kernel and initramfs from disk image after install")
 	createCmd.Flags().BoolVar(&uefiEnabled, "with-uefi", false, "enable UEFI on x86_64 architecture (always enabled for arm64)")
+	createCmd.Flags().StringSliceVar(&extraUEFISearchPaths, "extra-uefi-search-paths", []string{}, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 	createCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
 	createCmd.Flags().StringSliceVar(&registryInsecure, "registry-insecure-skip-verify", []string{}, "list of registry hostnames to skip TLS verification for")
 	createCmd.Flags().BoolVar(&configDebug, "with-debug", false, "enable debug in Talos config to send service logs to the console")

--- a/pkg/provision/options.go
+++ b/pkg/provision/options.go
@@ -70,6 +70,15 @@ func WithUEFI(enabled bool) Option {
 	}
 }
 
+// WithExtraUEFISearchPaths configures additional search paths to look for UEFI firmware.
+func WithExtraUEFISearchPaths(extraUEFISearchPaths []string) Option {
+	return func(o *Options) error {
+		o.ExtraUEFISearchPaths = extraUEFISearchPaths
+
+		return nil
+	}
+}
+
 // WithTargetArch specifies target architecture for the cluster.
 func WithTargetArch(arch string) Option {
 	return func(o *Options) error {
@@ -110,6 +119,8 @@ type Options struct {
 
 	// Enable UEFI (for amd64), arm64 can only boot UEFI
 	UEFIEnabled bool
+	// Configure additional search paths to look for UEFI firmware.
+	ExtraUEFISearchPaths []string
 
 	// Expose ports to worker machines in docker provisioner
 	DockerPorts       []string

--- a/pkg/provision/providers/qemu/arch.go
+++ b/pkg/provision/providers/qemu/arch.go
@@ -4,7 +4,10 @@
 
 package qemu
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 // Arch abstracts away differences between different architectures.
 type Arch string
@@ -68,13 +71,18 @@ type PFlash struct {
 }
 
 // PFlash returns settings for parallel flash.
-func (arch Arch) PFlash(uefiEnabled bool) []PFlash {
+func (arch Arch) PFlash(uefiEnabled bool, extraUEFISearchPaths []string) []PFlash {
 	switch arch {
 	case ArchArm64:
+		uefiSourcePaths := []string{"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd", "/usr/share/OVMF/QEMU_EFI.fd"}
+		for _, p := range extraUEFISearchPaths {
+			uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, "QEMU_EFI.fd"))
+		}
+
 		return []PFlash{
 			{
 				Size:        64 * 1024 * 1024,
-				SourcePaths: []string{"/usr/share/qemu-efi-aarch64/QEMU_EFI.fd", "/usr/share/OVMF/QEMU_EFI.fd"},
+				SourcePaths: uefiSourcePaths,
 			},
 			{
 				Size: 64 * 1024 * 1024,
@@ -85,10 +93,15 @@ func (arch Arch) PFlash(uefiEnabled bool) []PFlash {
 			return nil
 		}
 
+		uefiSourcePaths := []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd"}
+		for _, p := range extraUEFISearchPaths {
+			uefiSourcePaths = append(uefiSourcePaths, filepath.Join(p, "OVMF.fd"))
+		}
+
 		return []PFlash{
 			{
 				Size:        0,
-				SourcePaths: []string{"/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF.fd"},
+				SourcePaths: uefiSourcePaths,
 			},
 		}
 	default:

--- a/pkg/provision/providers/qemu/node.go
+++ b/pkg/provision/providers/qemu/node.go
@@ -35,7 +35,7 @@ func (p *provisioner) createNode(state *vm.State, clusterReq provision.ClusterRe
 
 	var pflashImages []string
 
-	if pflashSpec := arch.PFlash(opts.UEFIEnabled); pflashSpec != nil {
+	if pflashSpec := arch.PFlash(opts.UEFIEnabled, opts.ExtraUEFISearchPaths); pflashSpec != nil {
 		var err error
 
 		if pflashImages, err = p.createPFlashImages(state, nodeReq.Name, pflashSpec); err != nil {

--- a/pkg/provision/providers/qemu/preflight.go
+++ b/pkg/provision/providers/qemu/preflight.go
@@ -76,7 +76,7 @@ func (check *preflightCheckContext) qemuExecutable(ctx context.Context) error {
 }
 
 func (check *preflightCheckContext) checkFlashImages(ctx context.Context) error {
-	for _, flashImage := range check.arch.PFlash(check.options.UEFIEnabled) {
+	for _, flashImage := range check.arch.PFlash(check.options.UEFIEnabled, check.options.ExtraUEFISearchPaths) {
 		if len(flashImage.SourcePaths) == 0 {
 			continue
 		}
@@ -93,7 +93,8 @@ func (check *preflightCheckContext) checkFlashImages(ctx context.Context) error 
 		}
 
 		if !found {
-			return fmt.Errorf("the required flash image was not found in any of the expected paths for (%q), please install it with the package manager", flashImage.SourcePaths)
+			return fmt.Errorf("the required flash image was not found in any of the expected paths for (%q), "+
+				"please install it with the package manager or specify --extra-uefi-search-paths", flashImage.SourcePaths)
 		}
 	}
 

--- a/website/content/docs/v0.15/Reference/cli.md
+++ b/website/content/docs/v0.15/Reference/cli.md
@@ -112,6 +112,7 @@ talosctl cluster create [flags]
       --extra-boot-kernel-args string           add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)
       --extra-disks int                         number of extra disks to create for each worker VM
       --extra-disks-size int                    default limit on disk size in MB (each VM) (default 5120)
+      --extra-uefi-search-paths strings         additional search paths for UEFI firmware (only applies when UEFI is enabled)
   -h, --help                                    help for create
       --image string                            the image to use (default "ghcr.io/talos-systems/talos:latest")
       --init-node-as-endpoint                   use init node as endpoint instead of any load balancer endpoint


### PR DESCRIPTION
# Pull Request

## What? (description)
This allows specifying an additional search paths to look for UEFI firmware.

This is useful when invoking qemu in UEFI mode (either by running arm64, or by running an amd64 image with uefi enabled), but without the firmware installed in the `/usr/share/{OVMF,ovmf}` directories, or when using some custom firmware.

In the case of NixOS, this path doesn't even exist at all, so there's no way to install firmware into that location.

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4865)
<!-- Reviewable:end -->
