### PR TITLE
fix: close client provider instead of Talos client in the upgrade module

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -333,7 +333,7 @@ func getManifests(ctx context.Context, cluster UpgradeProvider) ([]*unstructured
 		return nil, err
 	}
 
-	defer talosclient.Close() //nolint:errcheck
+	defer cluster.Close() //nolint:errcheck
 
 	listClient, err := talosclient.Resources.List(ctx, k8s.ControlPlaneNamespaceName, k8s.ManifestType)
 	if err != nil {


### PR DESCRIPTION
Otherwise it breaks Theila, which never closes Talos clients during
operation.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4887)
<!-- Reviewable:end -->
