### PR TITLE
chore: update kernel to stable 5.15.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0-1-g67314b1
-PKGS ?= v0.10.0-alpha.0-13-gc14eb99
+PKGS ?= v0.10.0-alpha.0-14-g388ce13
 EXTRAS ?= v0.8.0-alpha.0-1-g7c1f3cc
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -31,7 +31,7 @@ with a single `--mode` flag that can take the following values:
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.16
+* Linux: 5.15.17
 * Kubernetes: 1.23.3
 * CoreDNS: 1.8.7
 * containerd: 1.6.0-rc.0

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.16-talos"
+	DefaultKernelVersion = "5.15.17-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump kernel to 5.15.17

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4890)
<!-- Reviewable:end -->
