### PR TITLE
feat: add multiple config patches, patches from files, YAML support

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -70,6 +70,13 @@ even if Talos is booted in maintenance mode (without machine configuration is pl
 Talos now supports Jetson Nano SBC.
 """
 
+    [notes.patching]
+        title = "Machine Configuration Patching"
+        description="""\
+`talosctl` commands which accept JSON patches (`gen config`, `cluster create`, `patch machineconfig`) now support multiple patches, loading patches
+from files with `@file.json` syntax, and support loading from YAML format.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/config/configpatcher/configpatcher_test.go
+++ b/pkg/machinery/config/configpatcher/configpatcher_test.go
@@ -2,14 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//nolint:scopelint,testpackage
-package configpatcher
+package configpatcher_test
 
 import (
 	"reflect"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/configpatcher"
 )
 
 const dummyConfig = `machine:
@@ -53,7 +54,7 @@ func TestJSON6902(t *testing.T) {
 				return
 			}
 
-			got, err := JSON6902(tt.args.talosMachineConfig, patch)
+			got, err := configpatcher.JSON6902(tt.args.talosMachineConfig, patch)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JSON6902 error: %v, but wanted: %v", err, tt.wantErr)
 

--- a/pkg/machinery/config/configpatcher/load.go
+++ b/pkg/machinery/config/configpatcher/load.go
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package configpatcher
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"gopkg.in/yaml.v3"
+)
+
+type patch []map[string]interface{}
+
+// LoadPatch loads the JSON patch either from JSON or YAML.
+func LoadPatch(in []byte) (p jsonpatch.Patch, err error) {
+	var jsonErr error
+
+	// try JSON first
+	if p, jsonErr = jsonpatch.DecodePatch(in); jsonErr == nil {
+		return p, nil
+	}
+
+	// try YAML
+	var yamlPatch patch
+
+	if err = yaml.Unmarshal(in, &yamlPatch); err != nil {
+		// not YAML either, return JSON error
+		return p, jsonErr
+	}
+
+	p = make(jsonpatch.Patch, 0, len(yamlPatch))
+
+	for _, yp := range yamlPatch {
+		op := make(jsonpatch.Operation, len(yp))
+
+		for key, value := range yp {
+			m, err := json.Marshal(value)
+			if err != nil {
+				return p, err
+			}
+
+			op[key] = (*json.RawMessage)(&m)
+		}
+
+		p = append(p, op)
+	}
+
+	return p, nil
+}
+
+// LoadPatches loads the JSON patch either from value literal or from a file if the patch starts with '@'.
+func LoadPatches(in []string) (jsonpatch.Patch, error) {
+	var result jsonpatch.Patch
+
+	for _, patchString := range in {
+		var (
+			p        jsonpatch.Patch
+			contents []byte
+			err      error
+		)
+
+		if strings.HasPrefix(patchString, "@") {
+			filename := patchString[1:]
+
+			contents, err = os.ReadFile(filename)
+			if err != nil {
+				return result, err
+			}
+		} else {
+			contents = []byte(patchString)
+		}
+
+		p, err = LoadPatch(contents)
+		if err != nil {
+			return result, err
+		}
+
+		result = append(result, p...)
+	}
+
+	return result, nil
+}

--- a/pkg/machinery/config/configpatcher/load_test.go
+++ b/pkg/machinery/config/configpatcher/load_test.go
@@ -1,0 +1,68 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package configpatcher_test
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/configpatcher"
+)
+
+//go:embed testdata/patch.json
+var jsonPatch []byte
+
+//go:embed testdata/patch.yaml
+var yamlPatch []byte
+
+func TestLoadJSON(t *testing.T) {
+	p, err := configpatcher.LoadPatch(jsonPatch)
+	require.NoError(t, err)
+
+	assert.Len(t, p, 1)
+	assert.Equal(t, p[0].Kind(), "add")
+
+	var path string
+	path, err = p[0].Path()
+
+	require.NoError(t, err)
+	assert.Equal(t, path, "/machine/certSANs")
+}
+
+func TestLoadYAML(t *testing.T) {
+	p, err := configpatcher.LoadPatch(yamlPatch)
+	require.NoError(t, err)
+
+	assert.Len(t, p, 1)
+	assert.Equal(t, p[0].Kind(), "add")
+
+	var path string
+	path, err = p[0].Path()
+
+	require.NoError(t, err)
+	assert.Equal(t, path, "/some/path")
+
+	var v interface{}
+	v, err = p[0].ValueInterface()
+	require.NoError(t, err)
+	assert.Equal(t, v, []interface{}{"a", "b", "c"})
+}
+
+func TestLoadPatches(t *testing.T) {
+	p, err := configpatcher.LoadPatches([]string{
+		"@testdata/patch.json",
+		"@testdata/patch.yaml",
+		`[{"op":"replace","path":"/some","value": []}]`,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, p, 3)
+	assert.Equal(t, p[0].Kind(), "add")
+	assert.Equal(t, p[1].Kind(), "add")
+	assert.Equal(t, p[2].Kind(), "replace")
+}

--- a/pkg/machinery/config/configpatcher/testdata/patch.json
+++ b/pkg/machinery/config/configpatcher/testdata/patch.json
@@ -1,0 +1,7 @@
+[
+    {
+        "op": "add",
+        "path": "/machine/certSANs",
+        "value": ["foo.com"]
+    }
+]

--- a/pkg/machinery/config/configpatcher/testdata/patch.yaml
+++ b/pkg/machinery/config/configpatcher/testdata/patch.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /some/path
+  value:
+    - a
+    - b
+    - c

--- a/website/content/docs/v0.15/Guides/editing-machine-configuration.md
+++ b/website/content/docs/v0.15/Guides/editing-machine-configuration.md
@@ -99,7 +99,7 @@ talosctl -n <IP> edit machineconfig --mode=no-reboot
 
 ### `talosctl patch machineconfig`
 
-Command `talosctl patch` works similar to `talosctl edit` command - it loads current machine configuration, but instead of launching configured editor it applies [JSON patch](http://jsonpatch.com/) to the configuration and writes result back to the node.
+Command `talosctl patch` works similar to `talosctl edit` command - it loads current machine configuration, but instead of launching configured editor it applies a set of [JSON patches](http://jsonpatch.com/) to the configuration and writes the result back to the node.
 
 Example, updating kubelet version (in auto mode):
 
@@ -115,14 +115,32 @@ $ talosctl -n <IP> patch machineconfig --mode=no-reboot -p '[{"op": "replace", "
 patched mc at the node <IP>
 ```
 
-Patch might be applied to multiple nodes when multiple IPs are specified:
+A patch might be applied to multiple nodes when multiple IPs are specified:
 
 ```bash
-taloctl -n <IP1>,<IP2>,... patch machineconfig -p '[{...}]'
+talosctl -n <IP1>,<IP2>,... patch machineconfig -p '[{...}]'
+```
+
+Patches can also be sourced from files using `@file` syntax:
+
+```bash
+talosctl -n <IP> patch machineconfig -p @kubelet-patch.json -p @manifest-patch.json
+```
+
+It might be easier to store patches in YAML format vs. the default JSON format.
+Talos can detect file format automatically:
+
+```yaml
+# kubelet-patch.yaml
+- op: replace
+  path: /machine/kubelet/image
+  value: ghcr.io/talos-systems/kubelet:v1.23.3
+```
+
+```bash
+talosctl -n <IP> patch machineconfig -p @kubelet-patch.yaml
 ```
 
 ### Recovering from Node Boot Failures
 
 If a Talos node fails to boot because of wrong configuration (for example, control plane endpoint is incorrect), configuration can be updated to fix the issue.
-If the boot sequence is still running, Talos might refuse applying config in default mode.
-In that case `--mode=staged` mode can be used coupled with `talosctl reboot` command to trigger a reboot and apply configuration update.

--- a/website/content/docs/v0.15/Reference/cli.md
+++ b/website/content/docs/v0.15/Reference/cli.md
@@ -87,66 +87,66 @@ talosctl cluster create [flags]
 ### Options
 
 ```
-      --arch string                             cluster architecture (default "amd64")
-      --bad-rtc                                 launch VM with bad RTC state (QEMU only)
-      --cidr string                             CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
-      --cni-bin-path strings                    search path for CNI binaries (VM only) (default [/home/user/.talos/cni/bin])
-      --cni-bundle-url string                   URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.15.0-alpha.1/talosctl-cni-bundle-${ARCH}.tar.gz")
-      --cni-cache-dir string                    CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
-      --cni-conf-dir string                     CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
-      --config-patch string                     patch generated machineconfigs (applied to all node types)
-      --config-patch-control-plane string       patch generated machineconfigs (applied to 'init' and 'controlplane' types)
-      --config-patch-worker string              patch generated machineconfigs (applied to 'worker' type)
-      --cpus string                             the share of CPUs as fraction (each control plane/VM) (default "2.0")
-      --cpus-workers string                     the share of CPUs as fraction (each worker/VM) (default "2.0")
-      --crashdump                               print debug crashdump to stderr when cluster startup fails
-      --custom-cni-url string                   install custom CNI from the URL (Talos cluster)
-      --disk int                                default limit on disk size in MB (each VM) (default 6144)
-      --disk-image-path string                  disk image to use
-      --dns-domain string                       the dns domain to use for cluster (default "cluster.local")
-      --docker-host-ip string                   Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
-      --encrypt-ephemeral                       enable ephemeral partition encryption
-      --encrypt-state                           enable state partition encryption
-      --endpoint string                         use endpoint instead of provider defaults
-  -p, --exposed-ports string                    Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
-      --extra-boot-kernel-args string           add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)
-      --extra-disks int                         number of extra disks to create for each worker VM
-      --extra-disks-size int                    default limit on disk size in MB (each VM) (default 5120)
-      --extra-uefi-search-paths strings         additional search paths for UEFI firmware (only applies when UEFI is enabled)
-  -h, --help                                    help for create
-      --image string                            the image to use (default "ghcr.io/talos-systems/talos:latest")
-      --init-node-as-endpoint                   use init node as endpoint instead of any load balancer endpoint
-      --initrd-path string                      initramfs image to use (default "_out/initramfs-${ARCH}.xz")
-  -i, --input-dir string                        location of pre-generated config files
-      --install-image string                    the installer image to use (default "ghcr.io/talos-systems/installer:latest")
-      --ipv4                                    enable IPv4 network in the cluster (default true)
-      --ipv6                                    enable IPv6 network in the cluster (QEMU provisioner only)
-      --iso-path string                         the ISO path to use for the initial boot (VM only)
-      --kubernetes-version string               desired kubernetes version to run (default "1.23.3")
-      --masters int                             the number of masters to create (default 1)
-      --memory int                              the limit on memory usage in MB (each control plane/VM) (default 2048)
-      --memory-workers int                      the limit on memory usage in MB (each worker/VM) (default 2048)
-      --mtu int                                 MTU of the cluster network (default 1500)
-      --nameservers strings                     list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
-      --registry-insecure-skip-verify strings   list of registry hostnames to skip TLS verification for
-      --registry-mirror strings                 list of registry mirrors to use in format: <registry host>=<mirror URL>
-      --skip-injecting-config                   skip injecting config from embedded metadata server, write config files to current directory
-      --skip-kubeconfig                         skip merging kubeconfig from the created cluster
-      --talos-version string                    the desired Talos version to generate config for (if not set, defaults to image version)
-      --use-vip                                 use a virtual IP for the controlplane endpoint instead of the loadbalancer
-      --user-disk strings                       list of disks to create for each VM in format: <mount_point1>:<size1>:<mount_point2>:<size2>
-      --vmlinuz-path string                     the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")
-      --wait                                    wait for the cluster to be ready before returning (default true)
-      --wait-timeout duration                   timeout to wait for the cluster to be ready (default 20m0s)
-      --wireguard-cidr string                   CIDR of the wireguard network
-      --with-apply-config                       enable apply config when the VM is starting in maintenance mode
-      --with-bootloader                         enable bootloader to load kernel and initramfs from disk image after install (default true)
-      --with-cluster-discovery                  enable cluster discovery (default true)
-      --with-debug                              enable debug in Talos config to send service logs to the console
-      --with-init-node                          create the cluster with an init node
-      --with-kubespan                           enable KubeSpan system
-      --with-uefi                               enable UEFI on x86_64 architecture (always enabled for arm64)
-      --workers int                             the number of workers to create (default 1)
+      --arch string                              cluster architecture (default "amd64")
+      --bad-rtc                                  launch VM with bad RTC state (QEMU only)
+      --cidr string                              CIDR of the cluster network (IPv4, ULA network for IPv6 is derived in automated way) (default "10.5.0.0/24")
+      --cni-bin-path strings                     search path for CNI binaries (VM only) (default [/home/user/.talos/cni/bin])
+      --cni-bundle-url string                    URL to download CNI bundle from (VM only) (default "https://github.com/talos-systems/talos/releases/download/v0.15.0-alpha.1/talosctl-cni-bundle-${ARCH}.tar.gz")
+      --cni-cache-dir string                     CNI cache directory path (VM only) (default "/home/user/.talos/cni/cache")
+      --cni-conf-dir string                      CNI config directory path (VM only) (default "/home/user/.talos/cni/conf.d")
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
+      --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
+      --cpus string                              the share of CPUs as fraction (each control plane/VM) (default "2.0")
+      --cpus-workers string                      the share of CPUs as fraction (each worker/VM) (default "2.0")
+      --crashdump                                print debug crashdump to stderr when cluster startup fails
+      --custom-cni-url string                    install custom CNI from the URL (Talos cluster)
+      --disk int                                 default limit on disk size in MB (each VM) (default 6144)
+      --disk-image-path string                   disk image to use
+      --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
+      --docker-host-ip string                    Host IP to forward exposed ports to (Docker provisioner only) (default "0.0.0.0")
+      --encrypt-ephemeral                        enable ephemeral partition encryption
+      --encrypt-state                            enable state partition encryption
+      --endpoint string                          use endpoint instead of provider defaults
+  -p, --exposed-ports string                     Comma-separated list of ports/protocols to expose on init node. Ex -p <hostPort>:<containerPort>/<protocol (tcp or udp)> (Docker provisioner only)
+      --extra-boot-kernel-args string            add extra kernel args to the initial boot from vmlinuz and initramfs (QEMU only)
+      --extra-disks int                          number of extra disks to create for each worker VM
+      --extra-disks-size int                     default limit on disk size in MB (each VM) (default 5120)
+      --extra-uefi-search-paths strings          additional search paths for UEFI firmware (only applies when UEFI is enabled)
+  -h, --help                                     help for create
+      --image string                             the image to use (default "ghcr.io/talos-systems/talos:latest")
+      --init-node-as-endpoint                    use init node as endpoint instead of any load balancer endpoint
+      --initrd-path string                       initramfs image to use (default "_out/initramfs-${ARCH}.xz")
+  -i, --input-dir string                         location of pre-generated config files
+      --install-image string                     the installer image to use (default "ghcr.io/talos-systems/installer:latest")
+      --ipv4                                     enable IPv4 network in the cluster (default true)
+      --ipv6                                     enable IPv6 network in the cluster (QEMU provisioner only)
+      --iso-path string                          the ISO path to use for the initial boot (VM only)
+      --kubernetes-version string                desired kubernetes version to run (default "1.23.3")
+      --masters int                              the number of masters to create (default 1)
+      --memory int                               the limit on memory usage in MB (each control plane/VM) (default 2048)
+      --memory-workers int                       the limit on memory usage in MB (each worker/VM) (default 2048)
+      --mtu int                                  MTU of the cluster network (default 1500)
+      --nameservers strings                      list of nameservers to use (default [8.8.8.8,1.1.1.1,2001:4860:4860::8888,2606:4700:4700::1111])
+      --registry-insecure-skip-verify strings    list of registry hostnames to skip TLS verification for
+      --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --skip-injecting-config                    skip injecting config from embedded metadata server, write config files to current directory
+      --skip-kubeconfig                          skip merging kubeconfig from the created cluster
+      --talos-version string                     the desired Talos version to generate config for (if not set, defaults to image version)
+      --use-vip                                  use a virtual IP for the controlplane endpoint instead of the loadbalancer
+      --user-disk strings                        list of disks to create for each VM in format: <mount_point1>:<size1>:<mount_point2>:<size2>
+      --vmlinuz-path string                      the compressed kernel image to use (default "_out/vmlinuz-${ARCH}")
+      --wait                                     wait for the cluster to be ready before returning (default true)
+      --wait-timeout duration                    timeout to wait for the cluster to be ready (default 20m0s)
+      --wireguard-cidr string                    CIDR of the wireguard network
+      --with-apply-config                        enable apply config when the VM is starting in maintenance mode
+      --with-bootloader                          enable bootloader to load kernel and initramfs from disk image after install (default true)
+      --with-cluster-discovery                   enable cluster discovery (default true)
+      --with-debug                               enable debug in Talos config to send service logs to the console
+      --with-init-node                           create the cluster with an init node
+      --with-kubespan                            enable KubeSpan system
+      --with-uefi                                enable UEFI on x86_64 architecture (always enabled for arm64)
+      --workers int                              the number of workers to create (default 1)
 ```
 
 ### Options inherited from parent commands
@@ -1084,24 +1084,24 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
 ### Options
 
 ```
-      --additional-sans strings             additional Subject-Alt-Names for the APIServer certificate
-      --config-patch string                 patch generated machineconfigs (applied to all node types)
-      --config-patch-control-plane string   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
-      --config-patch-worker string          patch generated machineconfigs (applied to 'worker' type)
-      --dns-domain string                   the dns domain to use for cluster (default "cluster.local")
-  -h, --help                                help for config
-      --install-disk string                 the disk to install to (default "/dev/sda")
-      --install-image string                the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
-      --kubernetes-version string           desired kubernetes version to run
-  -o, --output-dir string                   destination to output generated files
-  -p, --persist                             the desired persist value for configs (default true)
-      --registry-mirror strings             list of registry mirrors to use in format: <registry host>=<mirror URL>
-      --talos-version string                the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
-      --version string                      the desired machine config version to generate (default "v1alpha1")
-      --with-cluster-discovery              enable cluster discovery feature (default true)
-      --with-docs                           renders all machine configs adding the documentation for each field (default true)
-      --with-examples                       renders all machine configs with the commented examples (default true)
-      --with-kubespan                       enable KubeSpan feature
+      --additional-sans strings                  additional Subject-Alt-Names for the APIServer certificate
+      --config-patch stringArray                 patch generated machineconfigs (applied to all node types), use @file to read a patch from file
+      --config-patch-control-plane stringArray   patch generated machineconfigs (applied to 'init' and 'controlplane' types)
+      --config-patch-worker stringArray          patch generated machineconfigs (applied to 'worker' type)
+      --dns-domain string                        the dns domain to use for cluster (default "cluster.local")
+  -h, --help                                     help for config
+      --install-disk string                      the disk to install to (default "/dev/sda")
+      --install-image string                     the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
+      --kubernetes-version string                desired kubernetes version to run
+  -o, --output-dir string                        destination to output generated files
+  -p, --persist                                  the desired persist value for configs (default true)
+      --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>
+      --talos-version string                     the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)
+      --version string                           the desired machine config version to generate (default "v1alpha1")
+      --with-cluster-discovery                   enable cluster discovery feature (default true)
+      --with-docs                                renders all machine configs adding the documentation for each field (default true)
+      --with-examples                            renders all machine configs with the commented examples (default true)
+      --with-kubespan                            enable KubeSpan feature
 ```
 
 ### Options inherited from parent commands
@@ -1593,7 +1593,7 @@ talosctl patch <type> [<id>] [flags]
   -h, --help                                   help for patch
   -m, --mode auto, no-reboot, reboot, staged   apply config mode (default auto)
       --namespace string                       resource namespace (default is to use default namespace per resource)
-  -p, --patch string                           the patch to be applied to the resource file.
+  -p, --patch stringArray                      the patch to be applied to the resource file, use @file to read a patch from file.
       --patch-file string                      a file containing a patch to be applied to the resource.
 ```
 


### PR DESCRIPTION
Include filename content if value begins with @ (see curl for example).

Add multiple config-path option on cmdline to apply them in order.

ex:

```
talosctl-linux-amd64 gen config talos1 https://127.0.0.1:6443 --config-patch-control-plan @cidrs.json --config-patch-worker @sysctls-workders.json --config-path @cluster-name.json
```

Load JSON patch from YAML.

This applies to all commands handling config patches.

Closes: https://github.com/talos-systems/talos/issues/4764

Signed-off-by: Sébastien Bernard <sbernard@nerim.net>
Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4892)
<!-- Reviewable:end -->
