### PR TITLE
docs: clarify Filebeat example

### DIFF
--- a/website/content/docs/v0.14/Guides/logging.md
+++ b/website/content/docs/v0.14/Guides/logging.md
@@ -117,8 +117,14 @@ Sample message:
 
 ### Filebeat example
 
-Talos logs can be sent to [Filebeat](https://www.elastic.co/beats/filebeat).
-If [Elastic Cloud on Kubernetes](https://www.elastic.co/elastic-cloud-kubernetes) is being used, the following Beat (custom resource) configuration might be helpful:
+To forward logs to other Log collection services, one way to do this is sending
+them to a [Filebeat](https://www.elastic.co/beats/filebeat) running in the
+cluster itself (in the host network), which takes care of forwarding it to
+other endpoints (and the necessary transformations).
+
+If [Elastic Cloud on Kubernetes](https://www.elastic.co/elastic-cloud-kubernetes)
+is being used, the following Beat (custom resource) configuration might be
+helpful:
 
 ```yaml
 apiVersion: beat.k8s.elastic.co/v1beta1
@@ -167,5 +173,11 @@ spec:
                 hostPort: 12345
 ```
 
-That input configuration ensures that messages and timestamps are extracted properly.
-In `daemonSet` configuration, make sure that the host network is being used and that the port is exposed.
+The input configuration ensures that messages and timestamps are extracted properly.
+Refer to the Filebeat documentation on how to forward logs to other outputs.
+
+Also note the `hostNetwork: true` in the `daemonSet` configuration.
+
+This ensures filebeat uses the host network, and listens on `127.0.0.1:12345`
+(UDP) on every machine, which can then be specified as a logging endpoint in
+the machine configuration.

--- a/website/content/docs/v0.15/Guides/logging.md
+++ b/website/content/docs/v0.15/Guides/logging.md
@@ -117,8 +117,14 @@ Sample message:
 
 ### Filebeat example
 
-Talos logs can be sent to [Filebeat](https://www.elastic.co/beats/filebeat).
-If [Elastic Cloud on Kubernetes](https://www.elastic.co/elastic-cloud-kubernetes) is being used, the following Beat (custom resource) configuration might be helpful:
+To forward logs to other Log collection services, one way to do this is sending
+them to a [Filebeat](https://www.elastic.co/beats/filebeat) running in the
+cluster itself (in the host network), which takes care of forwarding it to
+other endpoints (and the necessary transformations).
+
+If [Elastic Cloud on Kubernetes](https://www.elastic.co/elastic-cloud-kubernetes)
+is being used, the following Beat (custom resource) configuration might be
+helpful:
 
 ```yaml
 apiVersion: beat.k8s.elastic.co/v1beta1
@@ -167,5 +173,11 @@ spec:
                 hostPort: 12345
 ```
 
-That input configuration ensures that messages and timestamps are extracted properly.
-In `daemonSet` configuration, make sure that the host network is being used and that the port is exposed.
+The input configuration ensures that messages and timestamps are extracted properly.
+Refer to the Filebeat documentation on how to forward logs to other outputs.
+
+Also note the `hostNetwork: true` in the `daemonSet` configuration.
+
+This ensures filebeat uses the host network, and listens on `127.0.0.1:12345`
+(UDP) on every machine, which can then be specified as a logging endpoint in
+the machine configuration.


### PR DESCRIPTION
As explained in https://github.com/talos-systems/talos/issues/4880#issuecomment-1022656510,
right now the recommended way to push logs to log collectors is by
running a configuring Filebeat in the local cluster, with a DaemonSet
using the host network, and pointing Talos to push logs to an UDP port
on 127.0.0.1.

I updated both v0.14 and v0.15 docs, as it should be more clear for both
versions.

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4893)
<!-- Reviewable:end -->
