### PR TITLE
chore: update k8s upgrade message

### DIFF
--- a/pkg/cluster/kubernetes/talos_managed.go
+++ b/pkg/cluster/kubernetes/talos_managed.go
@@ -200,7 +200,7 @@ func upgradeStaticPodOnNode(ctx context.Context, cluster UpgradeProvider, option
 	}
 
 	options.Log(" > %q: machine configuration patched", node)
-	options.Log(" > %q: waiting for API server state pod update", node)
+	options.Log(" > %q: waiting for %s pod update", node, service)
 
 	var expectedConfigVersion string
 


### PR DESCRIPTION
Update k8s upgrade message

Signed-off-by: Noel Georgi <git@frezbo.dev>

Before:

```bash
❯ talosctl upgrade-k8s --to 1.23.3
automatically detected the lowest Kubernetes version 1.23.2
checking for resource APIs to be deprecated in version 1.23.3
discovered master nodes ["192.168.15.20"]
discovered worker nodes []
updating "kube-apiserver" to version "1.23.3"
 > "192.168.15.20": starting update
 > update kube-apiserver: 1.23.2 -> 1.23.3
 > "192.168.15.20": machine configuration patched
 > "192.168.15.20": waiting for API server state pod update
 < "192.168.15.20": successfully updated
updating "kube-controller-manager" to version "1.23.3"
 > "192.168.15.20": starting update
 > update kube-controller-manager: 1.23.2 -> 1.23.3
 > "192.168.15.20": machine configuration patched
  > "192.168.15.20": waiting for API server state pod update
```

each component in the message used to display `waiting for API server state pod update` which is confusing when a k8s component other than kube apiserver is being updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4902)
<!-- Reviewable:end -->
