### PR TITLE
feat: enable persistence for docker provider

### DIFF
--- a/pkg/provision/providers/docker/docker.go
+++ b/pkg/provision/providers/docker/docker.go
@@ -51,7 +51,6 @@ func (p *provisioner) GenOptions(networkReq provision.NetworkRequest) []generate
 	}
 
 	return []generate.GenOption{
-		generate.WithPersist(false),
 		generate.WithNetworkOptions(
 			v1alpha1.WithNetworkInterfaceIgnore("eth0"),
 			v1alpha1.WithNetworkNameservers(nameservers...),


### PR DESCRIPTION
This PR removes the bit where we disabled persistence for the docker
provider. Doing so allows us to do things like upgrade k8s against a
docker-based cluster for testing purposes. Tested locally and a cluster
created just fine and an `upgrade-k8s` completed successfully.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>
(cherry picked from commit 56b83b08730c13910b0e5eb724decaf27e187047)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4913)
<!-- Reviewable:end -->
