### PR TITLE
fix: pass proper sequence to shutdown sequence on ACPI shutdown

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_controller.go
@@ -198,7 +198,7 @@ func (c *Controller) ListenForEvents(ctx context.Context) error {
 
 		log.Printf("shutdown via SIGTERM received")
 
-		if err := c.Run(ctx, runtime.SequenceShutdown, nil, runtime.WithTakeover()); err != nil {
+		if err := c.Run(ctx, runtime.SequenceShutdown, &machine.ShutdownRequest{Force: true}, runtime.WithTakeover()); err != nil {
 			log.Printf("shutdown failed: %v", err)
 		}
 
@@ -218,7 +218,7 @@ func (c *Controller) ListenForEvents(ctx context.Context) error {
 
 		log.Printf("shutdown via ACPI received")
 
-		if err := c.Run(ctx, runtime.SequenceShutdown, nil, runtime.WithTakeover()); err != nil {
+		if err := c.Run(ctx, runtime.SequenceShutdown, &machine.ShutdownRequest{Force: true}, runtime.WithTakeover()); err != nil {
 			log.Printf("failed to run shutdown sequence: %s", err)
 		}
 


### PR DESCRIPTION
Shutdown sequence was refactored to support draining and force mode, but
other invocations of the shutdown sequence haven't been updated.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4921)
<!-- Reviewable:end -->
