### PR TITLE
fix: disable auto-tls for etcd

### DIFF
--- a/internal/app/machined/pkg/system/services/etcd.go
+++ b/internal/app/machined/pkg/system/services/etcd.go
@@ -456,6 +456,8 @@ func (e *Etcd) argsForInit(ctx context.Context, r runtime.Runtime) error {
 	// TODO(scm): see issue #2121 and description below in argsForControlPlane.
 	denyListArgs := argsbuilder.Args{
 		"name":                  hostname,
+		"auto-tls":              "false",
+		"peer-auto-tls":         "false",
 		"data-dir":              constants.EtcdDataPath,
 		"listen-peer-urls":      "https://" + net.FormatAddress(listenAddress) + ":2380",
 		"listen-client-urls":    "https://" + net.FormatAddress(listenAddress) + ":2379",
@@ -539,6 +541,8 @@ func (e *Etcd) argsForControlPlane(ctx context.Context, r runtime.Runtime) error
 
 	denyListArgs := argsbuilder.Args{
 		"name":                  hostname,
+		"auto-tls":              "false",
+		"peer-auto-tls":         "false",
 		"data-dir":              constants.EtcdDataPath,
 		"listen-peer-urls":      "https://" + net.FormatAddress(listenAddress) + ":2380",
 		"listen-client-urls":    "https://" + net.FormatAddress(listenAddress) + ":2379",


### PR DESCRIPTION
While we use properly-generated certs, it is (according to STIG 242379)
possible to allow a client to downgrade to self-signed acceptance without explicitly
disabling `auto-tls`.
This patch sets `auto-tls` to `false`, preventing the downgrade.

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4925)
<!-- Reviewable:end -->
