### PR TITLE
feat: enable accept_ra when IPv6 forwarding

### DIFF
--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -101,6 +101,10 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 			Value: "1",
 		},
 		{
+			Key:   "net.ipv6.conf.default.accept_ra",
+			Value: "2",
+		},
+		{
 			Key:   "kernel.pid_max",
 			Value: "262144",
 		},

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
@@ -33,6 +33,10 @@ func getParams(mode runtime.Mode) []*kernel.Param {
 			Value: "1",
 		},
 		{
+			Key:   "net.ipv6.conf.default.accept_ra",
+			Value: "2",
+		},
+		{
 			Key:   "kernel.pid_max",
 			Value: "262144",
 		},


### PR DESCRIPTION
Enables `accept_ra = 2` when IPv6 forwarding is enabled.

When IPv6 forwarding is enabled, the default `accept_ra = 1` no longer
functions.
This is intentional by the kernel developers, because routers generally should not
accept router advertisements (they supply their own).
However, in the case of a machine running Kubernetes, while IP
forwarding is enabled, the machine is still treated more as an end node
than a router.
It is common for a Kubernetes node to be configured via SLAAC and
therefore to expect to receive router advertisements, while at the same
time, IP forwarding must be enabled to handle container communication.

Fixes #3841

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4939)
<!-- Reviewable:end -->
