### PR TITLE
fix: validate kubelet node IP subnets correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	github.com/talos-systems/go-retry v0.3.1
 	github.com/talos-systems/go-smbios v0.1.1
 	github.com/talos-systems/grpc-proxy v0.2.0
-	github.com/talos-systems/net v0.3.1
+	github.com/talos-systems/net v0.3.2-0.20220207192449-409926aec1c3
 	github.com/talos-systems/siderolink v0.1.0
 	github.com/talos-systems/talos/pkg/machinery v0.15.0-alpha.1
 	github.com/u-root/u-root v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1251,8 +1251,8 @@ github.com/talos-systems/go-smbios v0.1.1 h1:Au6obB/Pp0i0JHhvPlzONk5aoNseosO2BUs
 github.com/talos-systems/go-smbios v0.1.1/go.mod h1:vk76naUSZaWE8Z95wbDn51FgH0goECM4oK3KY2hYSMU=
 github.com/talos-systems/grpc-proxy v0.2.0 h1:DN75bLfaW4xfhq0r0mwFRnfGhSB+HPhK1LNzuMEs9Pw=
 github.com/talos-systems/grpc-proxy v0.2.0/go.mod h1:sm97Vc/z2cok3pu6ruNeszQej4KDxFrDgfWs4C1mtC4=
-github.com/talos-systems/net v0.3.1 h1:F9mlDgKE4XVfgpoRmacVUTEAMAeQ5xuOaeCl+A9a0Ok=
-github.com/talos-systems/net v0.3.1/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
+github.com/talos-systems/net v0.3.2-0.20220207192449-409926aec1c3 h1:VIh+SOGK9XjanOQoo9w/ZurHfI6hd7hkMXpySc7Mte4=
+github.com/talos-systems/net v0.3.2-0.20220207192449-409926aec1c3/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
 github.com/talos-systems/siderolink v0.1.0 h1:7mkJ9EicQ8J9DHHkwiNYGoccCgFcEIFcmfcKRyI7Y+8=
 github.com/talos-systems/siderolink v0.1.0/go.mod h1:bEGwDYl9QgC3oZ4kdnJTuR2HX/XlUhxZjx/QAakKuBc=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -728,7 +728,7 @@ func (k *KubeletConfig) Validate() ([]string, error) {
 	for _, cidr := range k.KubeletNodeIP.KubeletNodeIPValidSubnets {
 		cidr = strings.TrimPrefix(cidr, "!")
 
-		if _, _, err := net.ParseCIDR(cidr); err != nil {
+		if _, err := talosnet.ParseCIDR(cidr); err != nil {
 			result = multierror.Append(result, fmt.Errorf("kubelet nodeIP subnet is not valid: %q", cidr))
 		}
 	}

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -883,6 +883,7 @@ func TestValidate(t *testing.T) {
 							KubeletNodeIPValidSubnets: []string{
 								"10.0.0.0/8",
 								"!10.0.0.3/32",
+								"!fd00::169:254:2:53/128",
 							},
 						},
 					},
@@ -906,7 +907,8 @@ func TestValidate(t *testing.T) {
 					MachineKubelet: &v1alpha1.KubeletConfig{
 						KubeletNodeIP: v1alpha1.KubeletNodeIPConfig{
 							KubeletNodeIPValidSubnets: []string{
-								"10.0.0.0",
+								"10.0.0.0.3",
+								"[fd00::169:254:2:53]:344",
 							},
 						},
 					},
@@ -919,7 +921,10 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "1 error occurred:\n\t* kubelet nodeIP subnet is not valid: \"10.0.0.0\"\n\n",
+			expectedError: "2 errors occurred:\n" +
+				"\t* kubelet nodeIP subnet is not valid: \"10.0.0.0.3\"\n" +
+				"\t* kubelet nodeIP subnet is not valid: \"[fd00::169:254:2:53]:344\"\n" +
+				"\n",
 		},
 	} {
 		test := test

--- a/pkg/machinery/go.mod
+++ b/pkg/machinery/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/talos-systems/crypto v0.3.5-0.20211220133734-6fa2d93d0382
 	github.com/talos-systems/go-blockdevice v0.2.6-0.20220125134504-7b9de26bc6bc
 	github.com/talos-systems/go-debug v0.2.1
-	github.com/talos-systems/net v0.3.1
+	github.com/talos-systems/net v0.3.2-0.20220207192449-409926aec1c3
 	google.golang.org/genproto v0.0.0-20220204002441-d6cc3cc0770e
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1

--- a/pkg/machinery/go.sum
+++ b/pkg/machinery/go.sum
@@ -149,8 +149,8 @@ github.com/talos-systems/go-debug v0.2.1 h1:VSN8P1zXWeHWgUBZn4cVT3keBcecCAJBG9Up
 github.com/talos-systems/go-debug v0.2.1/go.mod h1:pR4NjsZQNFqGx3n4qkD4MIj1F2CxyIF8DCiO1+05JO0=
 github.com/talos-systems/go-retry v0.1.1-0.20201113203059-8c63d290a688/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
 github.com/talos-systems/go-retry v0.3.1/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
-github.com/talos-systems/net v0.3.1 h1:F9mlDgKE4XVfgpoRmacVUTEAMAeQ5xuOaeCl+A9a0Ok=
-github.com/talos-systems/net v0.3.1/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
+github.com/talos-systems/net v0.3.2-0.20220207192449-409926aec1c3 h1:VIh+SOGK9XjanOQoo9w/ZurHfI6hd7hkMXpySc7Mte4=
+github.com/talos-systems/net v0.3.2-0.20220207192449-409926aec1c3/go.mod h1:zhcGixNJz9dgwFiUwc7gkkAqdVqXagU1SNNoIVXYKGo=
 github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b h1:8pnPjZJU0SYanlmHnhMTeR8OR148K9yStwBz1GsjBsQ=
 github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Use same `talosnet` method as in the actual filtering code.

See also https://github.com/talos-systems/net/pull/9

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4942)
<!-- Reviewable:end -->
