### PR TITLE
feat: disable reboots via kexec

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1731,6 +1731,11 @@ func KexecPrepare(seq runtime.Sequence, data interface{}) (runtime.TaskExecution
 			}
 		}
 
+		// disable kexec due to initramfs corruption: see https://github.com/talos-systems/talos/issues/4947
+		if true {
+			return nil
+		}
+
 		if r.Config() == nil {
 			return nil
 		}


### PR DESCRIPTION
See #4947

The goal is to disable kexec temporarily to move on with the system
extensions, and to find the root cause and fix kexec before the next
release.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4948)
<!-- Reviewable:end -->
