### PR TITLE
chore: bump kernel to 5.15.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0-1-g67314b1
-PKGS ?= v0.10.0-alpha.0-18-gc9a6415
+PKGS ?= v0.10.0-alpha.0-20-g407459d
 EXTRAS ?= v0.8.0-alpha.0-1-g7c1f3cc
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -31,7 +31,7 @@ with a single `--mode` flag that can take the following values:
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.21
+* Linux: 5.15.22
 * Kubernetes: 1.23.3
 * CoreDNS: 1.8.7
 * etcd: 3.5.2

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultKernelVersion is the default Linux kernel version.
-	DefaultKernelVersion = "5.15.21-talos"
+	DefaultKernelVersion = "5.15.22-talos"
 
 	// KernelParamConfig is the kernel parameter name for specifying the URL.
 	// to the config.


### PR DESCRIPTION
Bump kernel to 5.15.22 stable

Ref: https://github.com/talos-systems/pkgs/pull/391

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4951)
<!-- Reviewable:end -->
