### PR TITLE
chore: add json-tags for SecretsBundle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
-	github.com/talos-systems/crypto v0.3.5-0.20211220133734-6fa2d93d0382
+	github.com/talos-systems/crypto v0.3.5-0.20220209123851-510b0d2753a8
 	github.com/talos-systems/discovery-api v0.1.0
 	github.com/talos-systems/discovery-client v0.1.0
 	github.com/talos-systems/go-blockdevice v0.2.6-0.20220125134504-7b9de26bc6bc

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
+github.com/frezbo/crypto-talos v0.3.5-0.20220209123851-510b0d2753a8 h1:EtY/z1JUfLeOCsNAOKdGUWJDhXQ3mM696UI3ajmGWXA=
+github.com/frezbo/crypto-talos v0.3.5-0.20220209123851-510b0d2753a8/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
@@ -1226,6 +1228,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/talos-systems/crypto v0.3.5-0.20211220133734-6fa2d93d0382 h1:q2p91NCRDFE4DuB8rMh3Oib9rDEcw+uNm0JiKZ4pbN0=
 github.com/talos-systems/crypto v0.3.5-0.20211220133734-6fa2d93d0382/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
+github.com/talos-systems/crypto v0.3.5-0.20220209123851-510b0d2753a8 h1:1LGxMO5Mkt6KRzsI7W4hvisZxVsJOcZYyZtf9KCBdZU=
+github.com/talos-systems/crypto v0.3.5-0.20220209123851-510b0d2753a8/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/talos-systems/discovery-api v0.1.0 h1:aKod6uqakH6VfeQ6HaxPF7obqFAL1QTJe4HHTb2mVKk=
 github.com/talos-systems/discovery-api v0.1.0/go.mod h1:ZsbzzOC5bzToaF3+YvUXDf9paeWV5bedpDu5RPXrglM=
 github.com/talos-systems/discovery-client v0.1.0 h1:m+f96TKGFckMWrhDI+o9+QhcGn8f1A61Jp6YYVwiulI=

--- a/pkg/machinery/config/types/v1alpha1/generate/generate.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/generate.go
@@ -126,38 +126,38 @@ func (i *Input) GetAPIServerSANs() []string {
 
 // Certs holds the base64 encoded keys and certificates.
 type Certs struct {
-	Admin             *x509.PEMEncodedCertificateAndKey
-	Etcd              *x509.PEMEncodedCertificateAndKey
-	K8s               *x509.PEMEncodedCertificateAndKey
-	K8sAggregator     *x509.PEMEncodedCertificateAndKey
-	K8sServiceAccount *x509.PEMEncodedKey
-	OS                *x509.PEMEncodedCertificateAndKey
+	Admin             *x509.PEMEncodedCertificateAndKey `json:"Admin,omitempty"`
+	Etcd              *x509.PEMEncodedCertificateAndKey `json:"Etcd"`
+	K8s               *x509.PEMEncodedCertificateAndKey `json:"K8s"`
+	K8sAggregator     *x509.PEMEncodedCertificateAndKey `json:"K8sAggregator"`
+	K8sServiceAccount *x509.PEMEncodedKey               `json:"K8sServiceAccount"`
+	OS                *x509.PEMEncodedCertificateAndKey `json:"OS"`
 }
 
 // Cluster holds Talos cluster-wide secrets.
 type Cluster struct {
-	ID     string
-	Secret string
+	ID     string `json:"Id"`
+	Secret string `json:"Secret"`
 }
 
 // Secrets holds the sensitive kubeadm data.
 type Secrets struct {
-	BootstrapToken         string
-	AESCBCEncryptionSecret string
+	BootstrapToken         string `json:"BootstrapToken"`
+	AESCBCEncryptionSecret string `json:"AESCBCEncryptionSecret"`
 }
 
 // TrustdInfo holds the trustd credentials.
 type TrustdInfo struct {
-	Token string
+	Token string `json:"Token"`
 }
 
 // SecretsBundle holds trustd, kubeadm and certs information.
 type SecretsBundle struct {
-	Clock      Clock `yaml:"-" json:"-"`
-	Cluster    *Cluster
-	Secrets    *Secrets
-	TrustdInfo *TrustdInfo
-	Certs      *Certs
+	Clock      Clock       `yaml:"-" json:"-"`
+	Cluster    *Cluster    `json:"Cluster"`
+	Secrets    *Secrets    `json:"Secrets"`
+	TrustdInfo *TrustdInfo `json:"TrustdInfo"`
+	Certs      *Certs      `json:"Certs"`
 }
 
 // Clock system clock.


### PR DESCRIPTION
Add JSON tags so that the fields can be un-marshelled by tools like
Pulumi when creating a pulumi provider for Talos SecretsBundle,
ref: https://github.com/frezbo/pulumi-provider-talos/blob/main/provider/cmd/pulumi-resource-talos/schema.json

Ref: https://github.com/talos-systems/crypto/pull/24

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4954)
<!-- Reviewable:end -->
