### PR TITLE
test: unlock CABPT/CACPPT provider versions

### DIFF
--- a/hack/test/e2e-capi.sh
+++ b/hack/test/e2e-capi.sh
@@ -5,8 +5,6 @@ set -eou pipefail
 source ./hack/test/e2e.sh
 
 export CAPI_VERSION="${CAPI_VERSION:-1.0.4}"
-export CABPT_VERSION="${CABPT_VERSION:-0.5.0}"
-export CACPPT_VERSION="${CACPPT_VERSION:-0.4.2}"
 export CAPA_VERSION="${CAPA_VERSION:-1.2.0}"
 export CAPG_VERSION="${CAPG_VERSION:-1.0.0}"
 
@@ -27,9 +25,9 @@ set -x
 
 ${CLUSTERCTL} init \
     --core "cluster-api:v${CAPI_VERSION}" \
-    --control-plane "talos:v${CACPPT_VERSION}" \
+    --control-plane "talos" \
     --infrastructure "aws:v${CAPA_VERSION},gcp:v${CAPG_VERSION}" \
-    --bootstrap "talos:v${CABPT_VERSION}"
+    --bootstrap "talos"
 
 # Wait for the talosconfig
 timeout=$(($(date +%s) + ${TIMEOUT}))

--- a/internal/integration/api/discovery.go
+++ b/internal/integration/api/discovery.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/cosi-project/runtime/pkg/resource"
@@ -187,7 +188,11 @@ func (suite *DiscoverySuite) TestRegistries() {
 				rawAffiliate := rawAffiliatesByID[registry+member.TypedSpec().NodeID]
 				suite.Require().NotNil(rawAffiliate)
 
-				suite.Assert().Equal(member.TypedSpec().Hostname, rawAffiliate.TypedSpec().Hostname)
+				stripDomain := func(s string) string { return strings.Split(s, ".")[0] }
+
+				// registries can be a bit inconsistent, e.g. whether they report fqdn or just hostname
+				suite.Assert().Contains([]string{member.TypedSpec().Hostname, stripDomain(member.TypedSpec().Hostname)}, rawAffiliate.TypedSpec().Hostname)
+
 				suite.Assert().Equal(member.TypedSpec().Addresses, rawAffiliate.TypedSpec().Addresses)
 				suite.Assert().Equal(member.TypedSpec().OperatingSystem, rawAffiliate.TypedSpec().OperatingSystem)
 				suite.Assert().Equal(member.TypedSpec().MachineType, rawAffiliate.TypedSpec().MachineType)


### PR DESCRIPTION
We should always test latest versions of our providers.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4956)
<!-- Reviewable:end -->
