### PR TITLE
chore: update the kernel with IGC driver enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ DOCKER_LOGIN_ENABLED ?= true
 NAME = Talos
 
 ARTIFACTS := _out
-TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0-1-g67314b1
-PKGS ?= v0.10.0-alpha.0-20-g407459d
+TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0-2-gd33b4b6
+PKGS ?= v0.10.0-alpha.0-21-g2b8cd88
 EXTRAS ?= v0.8.0-alpha.0-1-g7c1f3cc
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1


### PR DESCRIPTION
https://linux-hardware.org/?id=pci:8086-15f3-1043-87d2

Also bump tools to the version with zstd compression to match pkgs
build.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4961)
<!-- Reviewable:end -->
