### PR TITLE
chore: disable TIPC and B.A.T.M.A.N

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0-2-gd33b4b6
-PKGS ?= v0.10.0-alpha.0-21-g2b8cd88
+PKGS ?= v0.10.0-alpha.0-22-ge34f883
 EXTRAS ?= v0.8.0-alpha.0-1-g7c1f3cc
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1


### PR DESCRIPTION
Ref: https://github.com/talos-systems/pkgs/pull/394

Kernel size also reduced by 1Meg

Before:

```bash
❯ du -sh _out/vmlinuz-amd64
16M     _out/vmlinuz-amd64

❯ file _out/vmlinuz-amd64
_out/vmlinuz-amd64: Linux kernel x86 boot executable bzImage, version 5.15.22-talos (@buildkitsandbox) #1 SMP Wed Feb 9 19:19:47 UTC 2022, RO-rootFS, swap_dev 0xF, Normal VGA

❯ du -sh _out/vmlinuz-arm64
57M     _out/vmlinuz-arm64
```

After:

```bash
❯ du -sh _out/vmlinuz-amd64
15M     _out/vmlinuz-amd64

❯ file _out/vmlinuz-amd64
_out/vmlinuz-amd64: Linux kernel x86 boot executable bzImage, version 5.15.22-talos (@buildkitsandbox) #1 SMP Thu Feb 10 18:20:11 UTC 2022, RO-rootFS, swap_dev 0xE, Normal VGA

❯ du -sh _out/vmlinuz-arm64
56M     _out/vmlinuz-arm64
```

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4962)
<!-- Reviewable:end -->
