### PR TITLE
chore: pin kubernetes version to `talosctl gen config`

### DIFF
--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -838,7 +838,7 @@ func init() {
 	createCmd.Flags().DurationVar(&clusterWaitTimeout, "wait-timeout", 20*time.Minute, "timeout to wait for the cluster to be ready")
 	createCmd.Flags().BoolVar(&forceInitNodeAsEndpoint, "init-node-as-endpoint", false, "use init node as endpoint instead of any load balancer endpoint")
 	createCmd.Flags().StringVar(&forceEndpoint, "endpoint", "", "use endpoint instead of provider defaults")
-	createCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", "", fmt.Sprintf("desired kubernetes version to run (default %q)", constants.DefaultKubernetesVersion))
+	createCmd.Flags().StringVar(&kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 	createCmd.Flags().StringVarP(&inputDir, "input-dir", "i", "", "location of pre-generated config files")
 	createCmd.Flags().StringSliceVar(&cniBinPath, "cni-bin-path", []string{filepath.Join(defaultCNIDir, "bin")}, "search path for CNI binaries (VM only)")
 	createCmd.Flags().StringVar(&cniConfDir, "cni-conf-dir", filepath.Join(defaultCNIDir, "conf.d"), "CNI config directory path (VM only)")

--- a/cmd/talosctl/cmd/mgmt/config.go
+++ b/cmd/talosctl/cmd/mgmt/config.go
@@ -272,7 +272,7 @@ func init() {
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.dnsDomain, "dns-domain", "cluster.local", "the dns domain to use for cluster")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.configVersion, "version", "v1alpha1", "the desired machine config version to generate")
 	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.talosVersion, "talos-version", "", "the desired Talos version to generate config for (backwards compatibility, e.g. v0.8)")
-	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.kubernetesVersion, "kubernetes-version", "", "desired kubernetes version to run")
+	genConfigCmd.Flags().StringVar(&genConfigCmdFlags.kubernetesVersion, "kubernetes-version", constants.DefaultKubernetesVersion, "desired kubernetes version to run")
 	genConfigCmd.Flags().StringVarP(&genConfigCmdFlags.outputDir, "output-dir", "o", "", "destination to output generated files")
 	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatch, "config-patch", nil, "patch generated machineconfigs (applied to all node types), use @file to read a patch from file")
 	genConfigCmd.Flags().StringArrayVar(&genConfigCmdFlags.configPatchControlPlane, "config-patch-control-plane", nil, "patch generated machineconfigs (applied to 'init' and 'controlplane' types)")

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -98,6 +98,14 @@ Please note that static pod definitions are not validated by Talos.
 Static pod definitions can be updated without a node reboot.
 """
 
+    [notes.k8sversion]
+        title = "Pinned Kubernets Version"
+        description="""\
+Command `talosctl gen config` now defaults to Kubernetes version pinning in the generate machine configuration.
+Previously default was to omit explicit Kubernetes version, so Talos picked up the default version it was built against.
+Old behavior can be achieved by specifiying empty flag value: `--kubernetes-version=`.
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/website/content/docs/v0.15/Reference/cli.md
+++ b/website/content/docs/v0.15/Reference/cli.md
@@ -1092,7 +1092,7 @@ talosctl gen config <cluster name> <cluster endpoint> [flags]
   -h, --help                                     help for config
       --install-disk string                      the disk to install to (default "/dev/sda")
       --install-image string                     the image used to perform an installation (default "ghcr.io/talos-systems/installer:latest")
-      --kubernetes-version string                desired kubernetes version to run
+      --kubernetes-version string                desired kubernetes version to run (default "1.23.3")
   -o, --output-dir string                        destination to output generated files
   -p, --persist                                  the desired persist value for configs (default true)
       --registry-mirror strings                  list of registry mirrors to use in format: <registry host>=<mirror URL>


### PR DESCRIPTION
Pin talos default k8s version to `talosctl gen config`

Signed-off-by: Charlie Haley <charlie.haley@hotmail.com>

# Pull Request
<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
The worlds smallest PR 😄

Uses the `DefaultKubernetesVersion` defined in the `constants` package as the default value for the `--kubernetes-version` flag for the `config` comand.
## Why? (reasoning)

Fixes #4917

## Acceptance

Please use the following checklist:

- [x] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [x] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [x] you generated documentation (`make docs`)
- [x] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4966)
<!-- Reviewable:end -->
