### PR TITLE
fix: vultr define interface ip

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/vultr/testdata/expected.yaml
@@ -1,5 +1,5 @@
 addresses:
-    - address: 10.7.96.0/20
+    - address: 10.7.96.3/20
       linkName: eth1
       family: inet4
       scope: global


### PR DESCRIPTION
netaddr.Netmask changes the source ip to net clean subnet:
    10.1.2.3/24 -> 10.1.2.0/24

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4995)
<!-- Reviewable:end -->
