### PR TITLE
fix: prefer logical on merging link specs

### DIFF
--- a/pkg/machinery/resources/network/link_spec.go
+++ b/pkg/machinery/resources/network/link_spec.go
@@ -66,8 +66,9 @@ var (
 //
 //nolint:gocyclo
 func (spec *LinkSpecSpec) Merge(other *LinkSpecSpec) error {
-	if spec.Logical != other.Logical {
-		return fmt.Errorf("mismatch on logical for %q: %v != %v", spec.Name, spec.Logical, other.Logical)
+	// prefer Logical, as it is defined for bonds/vlans, etc.
+	if other.Logical {
+		spec.Logical = other.Logical
 	}
 
 	if other.Up {


### PR DESCRIPTION
This solves a case when lower layer (platform) defines `bond0` as
logical interface properly, and upper layer (configuration) defines only
some part of the config (e.g. VIP).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/4999)
<!-- Reviewable:end -->
