### PR TITLE
feat: enable protectKernelDefaults in kubelet_spec

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -28,6 +28,16 @@ with a single `--mode` flag that can take the following values:
 - `interactive` starts interactive installer, only for `apply`.
 """
 
+    [notes.kubelet]
+        title = "Kubelet conformance tweaks"
+        description="""\
+A number of conformance tweaks have been made to the `kubelet` to allow it to run without
+`protectKernelDefaults`.
+This includes both kubelet configuration options and sysctls.
+Of particular note is that Talos now sets the `kernel.panic` reboot interval to 10s instead of 1s.
+If your kubelet fails to start after the upgrade, please check the `kubelet` logs to determine the problem.
+"""
+
     [notes.updates]
         title = "Component Updates"
         description="""\

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults.go
@@ -114,8 +114,16 @@ func (ctrl *KernelParamDefaultsController) getKernelParams() []*kernel.Param {
 			Value: "60",
 		},
 		{
+			Key:   "kernel.panic",
+			Value: "10",
+		},
+		{
 			Key:   "kernel.pid_max",
 			Value: "262144",
+		},
+		{
+			Key:   "vm.overcommit_memory",
+			Value: "1",
 		},
 	}...)
 

--- a/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
+++ b/internal/app/machined/pkg/controllers/runtime/kernel_param_defaults_test.go
@@ -37,8 +37,16 @@ func getParams(mode runtime.Mode) []*kernel.Param {
 			Value: "2",
 		},
 		{
+			Key:   "kernel.panic",
+			Value: "10",
+		},
+		{
 			Key:   "kernel.pid_max",
 			Value: "262144",
+		},
+		{
+			Key:   "vm.overcommit_memory",
+			Value: "1",
 		},
 	}
 

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -114,7 +114,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 		&k8s.KubeletServiceController{
 			V1Alpha1Services: system.Services(ctrl.v1alpha1Runtime),
 		},
-		&k8s.KubeletSpecController{},
+		&k8s.KubeletSpecController{
+			V1Alpha1Mode: ctrl.v1alpha1Runtime.State().Platform().Mode(),
+		},
 		&k8s.KubeletStaticPodController{},
 		&k8s.ManifestController{},
 		&k8s.ManifestApplyController{},


### PR DESCRIPTION
Enable the kubelet's builtin kernel configuration checks.

Fixes #5002
Fixes #4990

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5004)
<!-- Reviewable:end -->
