### PR TITLE
feat: store audit logs to disk

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -38,6 +38,14 @@ Of particular note is that Talos now sets the `kernel.panic` reboot interval to 
 If your kubelet fails to start after the upgrade, please check the `kubelet` logs to determine the problem.
 """
 
+    [notes.auditlog]
+        title = "API Server audit logs"
+        description="""\
+`kube-apiserver` is now configured to store its audit logs separately from the `kube-apiserver` standard logs and directly to file.
+The `kube-apiserver` will maintain the rotation and retirement of these logs, which are stored in `/var/log/audit/`.
+Previously, the audit logs were sent to `kube-apiserver`'s `stdout`, along with the rest of its logs, to be collected in the usual manner by Kubernetes.
+"""
+
     [notes.updates]
         title = "Component Updates"
         description="""\

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod.go
@@ -262,10 +262,10 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 		"tls-cipher-suites":                "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256", //nolint:lll
 		"encryption-provider-config":       filepath.Join(constants.KubernetesAPIServerSecretsDir, "encryptionconfig.yaml"),
 		"audit-policy-file":                filepath.Join(constants.KubernetesAPIServerSecretsDir, "auditpolicy.yaml"),
-		"audit-log-path":                   "-",
+		"audit-log-path":                   filepath.Join(constants.KubernetesAuditLogDir, "kube-apiserver.log"),
 		"audit-log-maxage":                 "30",
-		"audit-log-maxbackup":              "3",
-		"audit-log-maxsize":                "50",
+		"audit-log-maxbackup":              "10",
+		"audit-log-maxsize":                "100",
 		"profiling":                        "false",
 		"etcd-cafile":                      filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client-ca.crt"),
 		"etcd-certfile":                    filepath.Join(constants.KubernetesAPIServerSecretsDir, "etcd-client.crt"),
@@ -356,6 +356,11 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 								MountPath: constants.KubernetesAPIServerSecretsDir,
 								ReadOnly:  true,
 							},
+							{
+								Name:      "audit",
+								MountPath: constants.KubernetesAuditLogDir,
+								ReadOnly:  false,
+							},
 						}, volumeMounts(cfg.ExtraVolumes)...),
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -376,6 +381,14 @@ func (ctrl *ControlPlaneStaticPodController) manageAPIServer(ctx context.Context
 						VolumeSource: v1.VolumeSource{
 							HostPath: &v1.HostPathVolumeSource{
 								Path: constants.KubernetesAPIServerSecretsDir,
+							},
+						},
+					},
+					{
+						Name: "audit",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: constants.KubernetesAuditLogDir,
 							},
 						},
 					},

--- a/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/control_plane_static_pod_test.go
@@ -178,8 +178,8 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraMounts() {
 	apiServerPod, err := k8sadapter.StaticPod(r.(*k8s.StaticPod)).Pod()
 	suite.Require().NoError(err)
 
-	suite.Assert().Len(apiServerPod.Spec.Volumes, 2)
-	suite.Assert().Len(apiServerPod.Spec.Containers[0].VolumeMounts, 2)
+	suite.Assert().Len(apiServerPod.Spec.Volumes, 3)
+	suite.Assert().Len(apiServerPod.Spec.Containers[0].VolumeMounts, 3)
 
 	suite.Assert().Equal(v1.Volume{
 		Name: "secrets",
@@ -191,13 +191,22 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraMounts() {
 	}, apiServerPod.Spec.Volumes[0])
 
 	suite.Assert().Equal(v1.Volume{
+		Name: "audit",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: constants.KubernetesAuditLogDir,
+			},
+		},
+	}, apiServerPod.Spec.Volumes[1])
+
+	suite.Assert().Equal(v1.Volume{
 		Name: "foo",
 		VolumeSource: v1.VolumeSource{
 			HostPath: &v1.HostPathVolumeSource{
 				Path: "/var/lib",
 			},
 		},
-	}, apiServerPod.Spec.Volumes[1])
+	}, apiServerPod.Spec.Volumes[2])
 
 	suite.Assert().Equal(v1.VolumeMount{
 		Name:      "secrets",
@@ -206,10 +215,16 @@ func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraMounts() {
 	}, apiServerPod.Spec.Containers[0].VolumeMounts[0])
 
 	suite.Assert().Equal(v1.VolumeMount{
+		Name:      "audit",
+		MountPath: constants.KubernetesAuditLogDir,
+		ReadOnly:  false,
+	}, apiServerPod.Spec.Containers[0].VolumeMounts[1])
+
+	suite.Assert().Equal(v1.VolumeMount{
 		Name:      "foo",
 		MountPath: "/var/foo",
 		ReadOnly:  true,
-	}, apiServerPod.Spec.Containers[0].VolumeMounts[1])
+	}, apiServerPod.Spec.Containers[0].VolumeMounts[2])
 }
 
 func (suite *ControlPlaneStaticPodSuite) TestReconcileExtraArgs() {

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -201,7 +201,10 @@ const (
 	// KubebernetesStaticSecretsDir defines ephemeral directory which contains rendered secrets for controlplane components.
 	KubebernetesStaticSecretsDir = "/system/secrets/kubernetes"
 
-	// KubernetesAPIServerSecretsDir defines ephemeral directory with kube-apiserver secrets.
+	// KubernetesAuditLogDir defines the ephemeral directory where the kube-apiserver will store its audit logs.
+	KubernetesAuditLogDir = EphemeralMountPoint + "/" + "log" + "/" + "audit" + "/" + "kube"
+
+	// KubernetesAPIServerSecretsDir defines directory with kube-apiserver secrets.
 	KubernetesAPIServerSecretsDir = KubebernetesStaticSecretsDir + "/" + "kube-apiserver"
 
 	// KubernetesControllerManagerSecretsDir defines ephemeral directory with kube-controller-manager secrets.


### PR DESCRIPTION
Instead of bundling the apiserver audit logs with the rest of the
apiserver logs, we should store them separately to file, assuring
reasonable defaults for retention and rotation.

Fixes #5000

Signed-off-by: Seán C McCord <ulexus@gmail.com>

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5005)
<!-- Reviewable:end -->
