### PR TITLE
fix: avoid replacing default gRPC codec in machinery

### DIFF
--- a/cmd/talosctl/cmd/talos/root.go
+++ b/cmd/talosctl/cmd/talos/root.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/talos-systems/talos/pkg/cli"
+	_ "github.com/talos-systems/talos/pkg/grpc/codec" //nolint:gci // register codec
 	machineapi "github.com/talos-systems/talos/pkg/machinery/api/machine"
 	"github.com/talos-systems/talos/pkg/machinery/client"
 	clientconfig "github.com/talos-systems/talos/pkg/machinery/client/config"

--- a/pkg/grpc/codec/codec.go
+++ b/pkg/grpc/codec/codec.go
@@ -2,13 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package proto
+// Package codec registers the gRPC for optimized marshaling.
+//
+// Package should be dummy imported to enable.
+package codec
 
 import (
 	"fmt"
 
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/encoding/proto"
+
+	talosproto "github.com/talos-systems/talos/pkg/machinery/proto"
 )
 
 // gogoMessage is the interface for gogoproto additions.
@@ -33,8 +38,8 @@ func (Codec) Marshal(v interface{}) ([]byte, error) {
 	}
 
 	// our types implement Message (with or without vtproto additions depending on build configuration)
-	if m, ok := v.(Message); ok {
-		return Marshal(m)
+	if m, ok := v.(talosproto.Message); ok {
+		return talosproto.Marshal(m)
 	}
 
 	// no types implement protobuf API v1 only, so don't check for it
@@ -50,8 +55,8 @@ func (Codec) Unmarshal(data []byte, v interface{}) error {
 	}
 
 	// our types implement Message (with or without vtproto additions depending on build configuration)
-	if m, ok := v.(Message); ok {
-		return Unmarshal(data, m)
+	if m, ok := v.(talosproto.Message); ok {
+		return talosproto.Unmarshal(data, m)
 	}
 
 	// no types implement protobuf API v1 only, so don't check for it

--- a/pkg/grpc/factory/factory.go
+++ b/pkg/grpc/factory/factory.go
@@ -23,8 +23,8 @@ import (
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 
+	_ "github.com/talos-systems/talos/pkg/grpc/codec" //nolint:gci // register codec
 	grpclog "github.com/talos-systems/talos/pkg/grpc/middleware/log"
-	_ "github.com/talos-systems/talos/pkg/machinery/proto" //nolint:gci // register codec
 )
 
 // Registrator describes the set of methods required in order for a concrete


### PR DESCRIPTION
Fixes #4987

As machinery is supposed to be widely used project, and gRPC lacks
proper support to override default codec easily, it might come into
conflict with other projects.

Instead, move codec to core talos, and register it explicitly in the
server code (which covers machined, apid, trustd) and client code
(talosctl).

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
