### PR TITLE
chore: don't append `initrd=` to the kernel command line

### DIFF
--- a/cmd/installer/pkg/install/install.go
+++ b/cmd/installer/pkg/install/install.go
@@ -7,7 +7,6 @@ package install
 import (
 	"fmt"
 	"log"
-	"path/filepath"
 
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-procfs/procfs"
@@ -272,8 +271,6 @@ func (i *Installer) Install(seq runtime.Sequence) (err error) {
 	if !i.options.Bootloader {
 		return nil
 	}
-
-	i.cmdline.Append("initrd", filepath.Join("/", string(i.Next), constants.InitramfsAsset))
 
 	var conf *grub.Config
 	if i.bootloader == nil {


### PR DESCRIPTION
I believe it serves no purpose in GRUB config: GRUB pre-loads
`initramfs` into memory anyways, so kernel doesn't need to know, nor has
any way to load it from anywhere.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5011)
<!-- Reviewable:end -->
