### PR TITLE
feat: disable PSP by default for Talos >= 0.15

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -124,6 +124,13 @@ Previously default was to omit explicit Kubernetes version, so Talos picked up t
 Old behavior can be achieved by specifiying empty flag value: `--kubernetes-version=`.
 """
 
+    [notes.psp]
+        title = "Pod Security Policy"
+        description="""\
+Pod Security Policy Kubernetes feature is deprecated and is going to be removed in Kubernetes 1.25.
+Talos by default skips setting up PSP now (see machine configuration `.cluster.apiServer.disablePodSecurityPolicy`).
+"""
+
 [make_deps]
 
     [make_deps.tools]

--- a/pkg/machinery/config/contract.go
+++ b/pkg/machinery/config/contract.go
@@ -24,6 +24,7 @@ type VersionContract struct {
 // Well-known Talos version contracts.
 var (
 	TalosVersionCurrent = (*VersionContract)(nil)
+	TalosVersion0_15    = &VersionContract{0, 15}
 	TalosVersion0_14    = &VersionContract{0, 14}
 	TalosVersion0_13    = &VersionContract{0, 13}
 	TalosVersion0_12    = &VersionContract{0, 12}
@@ -96,4 +97,9 @@ func (contract *VersionContract) SupportsECDSASHA256() bool {
 // ClusterDiscoveryEnabled returns true if cluster discovery should be enabled by default.
 func (contract *VersionContract) ClusterDiscoveryEnabled() bool {
 	return contract.Greater(TalosVersion0_13)
+}
+
+// PodSecurityPolicyEnabled returns true if pod security policy should be enabled by default.
+func (contract *VersionContract) PodSecurityPolicyEnabled() bool {
+	return !contract.Greater(TalosVersion0_14)
 }

--- a/pkg/machinery/config/contract_test.go
+++ b/pkg/machinery/config/contract_test.go
@@ -53,6 +53,20 @@ func TestContractCurrent(t *testing.T) {
 	assert.True(t, contract.SupportsDynamicCertSANs())
 	assert.True(t, contract.SupportsECDSASHA256())
 	assert.True(t, contract.ClusterDiscoveryEnabled())
+	assert.False(t, contract.PodSecurityPolicyEnabled())
+}
+
+func TestContract0_15(t *testing.T) {
+	contract := config.TalosVersion0_15
+
+	assert.True(t, contract.SupportsAggregatorCA())
+	assert.True(t, contract.SupportsECDSAKeys())
+	assert.True(t, contract.SupportsServiceAccount())
+	assert.True(t, contract.SupportsRBACFeature())
+	assert.True(t, contract.SupportsDynamicCertSANs())
+	assert.True(t, contract.SupportsECDSASHA256())
+	assert.True(t, contract.ClusterDiscoveryEnabled())
+	assert.False(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_14(t *testing.T) {
@@ -65,6 +79,7 @@ func TestContract0_14(t *testing.T) {
 	assert.True(t, contract.SupportsDynamicCertSANs())
 	assert.True(t, contract.SupportsECDSASHA256())
 	assert.True(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_13(t *testing.T) {
@@ -77,6 +92,7 @@ func TestContract0_13(t *testing.T) {
 	assert.True(t, contract.SupportsDynamicCertSANs())
 	assert.True(t, contract.SupportsECDSASHA256())
 	assert.False(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_12(t *testing.T) {
@@ -89,6 +105,7 @@ func TestContract0_12(t *testing.T) {
 	assert.False(t, contract.SupportsDynamicCertSANs())
 	assert.False(t, contract.SupportsECDSASHA256())
 	assert.False(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_11(t *testing.T) {
@@ -101,6 +118,7 @@ func TestContract0_11(t *testing.T) {
 	assert.False(t, contract.SupportsDynamicCertSANs())
 	assert.False(t, contract.SupportsECDSASHA256())
 	assert.False(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_10(t *testing.T) {
@@ -113,6 +131,7 @@ func TestContract0_10(t *testing.T) {
 	assert.False(t, contract.SupportsDynamicCertSANs())
 	assert.False(t, contract.SupportsECDSASHA256())
 	assert.False(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_9(t *testing.T) {
@@ -125,6 +144,7 @@ func TestContract0_9(t *testing.T) {
 	assert.False(t, contract.SupportsDynamicCertSANs())
 	assert.False(t, contract.SupportsECDSASHA256())
 	assert.False(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }
 
 func TestContract0_8(t *testing.T) {
@@ -137,4 +157,5 @@ func TestContract0_8(t *testing.T) {
 	assert.False(t, contract.SupportsDynamicCertSANs())
 	assert.False(t, contract.SupportsECDSASHA256())
 	assert.False(t, contract.ClusterDiscoveryEnabled())
+	assert.True(t, contract.PodSecurityPolicyEnabled())
 }

--- a/pkg/machinery/config/types/v1alpha1/generate/init.go
+++ b/pkg/machinery/config/types/v1alpha1/generate/init.go
@@ -74,8 +74,9 @@ func initUd(in *Input) (*v1alpha1.Config, error) {
 			Endpoint: &v1alpha1.Endpoint{URL: controlPlaneURL},
 		},
 		APIServerConfig: &v1alpha1.APIServerConfig{
-			CertSANs:       certSANs,
-			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, in.KubernetesVersion), in.KubernetesVersion),
+			CertSANs:                       certSANs,
+			ContainerImage:                 emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesAPIServerImage, in.KubernetesVersion), in.KubernetesVersion),
+			DisablePodSecurityPolicyConfig: !in.VersionContract.PodSecurityPolicyEnabled(),
 		},
 		ControllerManagerConfig: &v1alpha1.ControllerManagerConfig{
 			ContainerImage: emptyIf(fmt.Sprintf("%s:v%s", constants.KubernetesControllerManagerImage, in.KubernetesVersion), in.KubernetesVersion),


### PR DESCRIPTION
This flips the switch in the machine config to skip PSP deployment.

See #5003

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5030)
<!-- Reviewable:end -->
