### PR TITLE
test: pre-fetch CLI tools

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -133,7 +133,7 @@ local setup_ci = {
 
   commands: [
     'setup-ci',
-    'make ./_out/kubectl',
+    'make ./_out/kubectl ./_out/kubestr ./_out/clusterctl',
   ],
   environment: {
     "BUILDKIT_FLAVOR": "cross",


### PR DESCRIPTION
As `_out` is a shared volume across Drone steps, we should prefetch CLI
dependencies early, as fetching them concurrently from multiple steps
might lead to suprising results.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5039)
<!-- Reviewable:end -->
