### PR TITLE
feat: add a way to override kubelet configuration via machine config

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -16,7 +16,7 @@ preface = """\
 [notes]
 
     [notes.equinixMetal]
-        title = "Rename packer to equinixMetal in talos.platform"
+        title = "Equinix Metal Platform"
         description="""\
 `talos.platform` for Equinix Metal is renamed from `packet` to `equinixMetal`, the older name is still supported for backwards compatibility.
 """
@@ -35,8 +35,12 @@ with a single `--mode` flag that can take the following values:
 """
 
     [notes.kubelet]
-        title = "Kubelet conformance tweaks"
+        title = "Kubelet"
         description="""\
+Kubelet configuration can now be overridden with the `.machine.kubelet.extraConfig` machine configuration field.
+As most of the kubelet command line arguments are being depreacted, it is recommended to migrate to `extraConfig`
+instead of using `extraArgs`.
+
 A number of conformance tweaks have been made to the `kubelet` to allow it to run without
 `protectKernelDefaults`.
 This includes both kubelet configuration options and sysctls.
@@ -45,7 +49,7 @@ If your kubelet fails to start after the upgrade, please check the `kubelet` log
 """
 
     [notes.auditlog]
-        title = "API Server audit logs"
+        title = "API Server Audit Logs"
         description="""\
 `kube-apiserver` is now configured to store its audit logs separately from the `kube-apiserver` standard logs and directly to file.
 The `kube-apiserver` will maintain the rotation and retirement of these logs, which are stored in `/var/log/audit/`.

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config.go
@@ -97,6 +97,7 @@ func (ctrl *KubeletConfigController) Run(ctx context.Context, r controller.Runti
 				kubeletConfig.ClusterDomain = cfgProvider.Cluster().Network().DNSDomain()
 				kubeletConfig.ExtraArgs = cfgProvider.Machine().Kubelet().ExtraArgs()
 				kubeletConfig.ExtraMounts = cfgProvider.Machine().Kubelet().ExtraMounts()
+				kubeletConfig.ExtraConfig = cfgProvider.Machine().Kubelet().ExtraConfig()
 				kubeletConfig.CloudProviderExternal = cfgProvider.Cluster().ExternalCloudProvider().Enabled()
 
 				return nil

--- a/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_config_test.go
@@ -89,6 +89,11 @@ func (suite *KubeletConfigSuite) TestReconcile() {
 						},
 					},
 				},
+				KubeletExtraConfig: v1alpha1.Unstructured{
+					Object: map[string]interface{}{
+						"serverTLSBootstrap": true,
+					},
+				},
 			},
 		},
 		ClusterConfig: &v1alpha1.ClusterConfig{
@@ -138,6 +143,12 @@ func (suite *KubeletConfigSuite) TestReconcile() {
 					},
 				},
 				spec.ExtraMounts)
+			suite.Assert().Equal(
+				map[string]interface{}{
+					"serverTLSBootstrap": true,
+				},
+				spec.ExtraConfig,
+			)
 			suite.Assert().True(spec.CloudProviderExternal)
 
 			return nil

--- a/pkg/machinery/config/provider.go
+++ b/pkg/machinery/config/provider.go
@@ -275,6 +275,7 @@ type Kubelet interface {
 	ClusterDNS() []string
 	ExtraArgs() map[string]string
 	ExtraMounts() []specs.Mount
+	ExtraConfig() map[string]interface{}
 	RegisterWithFQDN() bool
 	NodeIP() KubeletNodeIP
 }

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_provider.go
@@ -335,6 +335,11 @@ func (k *KubeletConfig) ExtraMounts() []specs.Mount {
 	return out
 }
 
+// ExtraConfig implements the config.Provider interface.
+func (k *KubeletConfig) ExtraConfig() map[string]interface{} {
+	return k.KubeletExtraConfig.Object
+}
+
 // RegisterWithFQDN implements the config.Provider interface.
 func (k *KubeletConfig) RegisterWithFQDN() bool {
 	return k.KubeletRegisterWithFQDN

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types.go
@@ -480,6 +480,12 @@ metadata:
 		},
 	}
 
+	kubeletExtraConfigExample = Unstructured{
+		Object: map[string]interface{}{
+			"serverTLSBootstrap": true,
+		},
+	}
+
 	loggingEndpointExample1 = &Endpoint{
 		mustParseURL("udp://127.0.0.1:12345"),
 	}
@@ -978,6 +984,14 @@ type KubeletConfig struct {
 	//   examples:
 	//     - value: kubeletExtraMountsExample
 	KubeletExtraMounts []ExtraMount `yaml:"extraMounts,omitempty"`
+	//   description: |
+	//     The `extraConfig` field is used to provide kubelet configuration overrides.
+	//
+	//     Some fields are not allowed to be overridden: authentication and authorization, cgroups
+	//     configuration, ports, etc.
+	//   examples:
+	//     - value: kubeletExtraConfigExample
+	KubeletExtraConfig Unstructured `yaml:"extraConfig,omitempty"`
 	//   description: |
 	//     The `registerWithFQDN` field is used to force kubelet to use the node FQDN for registration.
 	//     This is required in clouds like AWS.

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_types_doc.go
@@ -551,7 +551,7 @@ func init() {
 			FieldName: "kubelet",
 		},
 	}
-	KubeletConfigDoc.Fields = make([]encoder.Doc, 6)
+	KubeletConfigDoc.Fields = make([]encoder.Doc, 7)
 	KubeletConfigDoc.Fields[0].Name = "image"
 	KubeletConfigDoc.Fields[0].Type = "string"
 	KubeletConfigDoc.Fields[0].Note = ""
@@ -582,24 +582,31 @@ func init() {
 	KubeletConfigDoc.Fields[3].Comments[encoder.LineComment] = "The `extraMounts` field is used to add additional mounts to the kubelet container."
 
 	KubeletConfigDoc.Fields[3].AddExample("", kubeletExtraMountsExample)
-	KubeletConfigDoc.Fields[4].Name = "registerWithFQDN"
-	KubeletConfigDoc.Fields[4].Type = "bool"
+	KubeletConfigDoc.Fields[4].Name = "extraConfig"
+	KubeletConfigDoc.Fields[4].Type = "Unstructured"
 	KubeletConfigDoc.Fields[4].Note = ""
-	KubeletConfigDoc.Fields[4].Description = "The `registerWithFQDN` field is used to force kubelet to use the node FQDN for registration.\nThis is required in clouds like AWS."
-	KubeletConfigDoc.Fields[4].Comments[encoder.LineComment] = "The `registerWithFQDN` field is used to force kubelet to use the node FQDN for registration."
-	KubeletConfigDoc.Fields[4].Values = []string{
+	KubeletConfigDoc.Fields[4].Description = "The `extraConfig` field is used to provide kubelet configuration overrides.\n\nSome fields are not allowed to be overridden: authentication and authorization, cgroups\nconfiguration, ports, etc."
+	KubeletConfigDoc.Fields[4].Comments[encoder.LineComment] = "The `extraConfig` field is used to provide kubelet configuration overrides."
+
+	KubeletConfigDoc.Fields[4].AddExample("", kubeletExtraConfigExample)
+	KubeletConfigDoc.Fields[5].Name = "registerWithFQDN"
+	KubeletConfigDoc.Fields[5].Type = "bool"
+	KubeletConfigDoc.Fields[5].Note = ""
+	KubeletConfigDoc.Fields[5].Description = "The `registerWithFQDN` field is used to force kubelet to use the node FQDN for registration.\nThis is required in clouds like AWS."
+	KubeletConfigDoc.Fields[5].Comments[encoder.LineComment] = "The `registerWithFQDN` field is used to force kubelet to use the node FQDN for registration."
+	KubeletConfigDoc.Fields[5].Values = []string{
 		"true",
 		"yes",
 		"false",
 		"no",
 	}
-	KubeletConfigDoc.Fields[5].Name = "nodeIP"
-	KubeletConfigDoc.Fields[5].Type = "KubeletNodeIPConfig"
-	KubeletConfigDoc.Fields[5].Note = ""
-	KubeletConfigDoc.Fields[5].Description = "The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.\nThis is used when a node has multiple addresses to choose from."
-	KubeletConfigDoc.Fields[5].Comments[encoder.LineComment] = "The `nodeIP` field is used to configure `--node-ip` flag for the kubelet."
+	KubeletConfigDoc.Fields[6].Name = "nodeIP"
+	KubeletConfigDoc.Fields[6].Type = "KubeletNodeIPConfig"
+	KubeletConfigDoc.Fields[6].Note = ""
+	KubeletConfigDoc.Fields[6].Description = "The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.\nThis is used when a node has multiple addresses to choose from."
+	KubeletConfigDoc.Fields[6].Comments[encoder.LineComment] = "The `nodeIP` field is used to configure `--node-ip` flag for the kubelet."
 
-	KubeletConfigDoc.Fields[5].AddExample("", kubeletNodeIPExample)
+	KubeletConfigDoc.Fields[6].AddExample("", kubeletNodeIPExample)
 
 	KubeletNodeIPConfigDoc.Type = "KubeletNodeIPConfig"
 	KubeletNodeIPConfigDoc.Comments[encoder.LineComment] = "KubeletNodeIPConfig represents the kubelet node IP configuration."

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/talos-systems/talos/pkg/machinery/config"
 	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1/machine"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/kubelet"
 	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
 )
 
@@ -730,6 +731,12 @@ func (k *KubeletConfig) Validate() ([]string, error) {
 
 		if _, err := talosnet.ParseCIDR(cidr); err != nil {
 			result = multierror.Append(result, fmt.Errorf("kubelet nodeIP subnet is not valid: %q", cidr))
+		}
+	}
+
+	for _, field := range kubelet.ProtectedConfigurationFields {
+		if _, exists := k.KubeletExtraConfig.Object[field]; exists {
+			result = multierror.Append(result, fmt.Errorf("kubelet configuration field %q can't be overridden", field))
 		}
 	}
 

--- a/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
+++ b/pkg/machinery/config/types/v1alpha1/v1alpha1_validation_test.go
@@ -926,6 +926,30 @@ func TestValidate(t *testing.T) {
 				"\t* kubelet nodeIP subnet is not valid: \"[fd00::169:254:2:53]:344\"\n" +
 				"\n",
 		},
+		{
+			name: "BadKubeletExtraConfig",
+			config: &v1alpha1.Config{
+				ConfigVersion: "v1alpha1",
+				MachineConfig: &v1alpha1.MachineConfig{
+					MachineType: "worker",
+					MachineKubelet: &v1alpha1.KubeletConfig{
+						KubeletExtraConfig: v1alpha1.Unstructured{
+							Object: map[string]interface{}{
+								"port": 345,
+							},
+						},
+					},
+				},
+				ClusterConfig: &v1alpha1.ClusterConfig{
+					ControlPlane: &v1alpha1.ControlPlaneConfig{
+						Endpoint: &v1alpha1.Endpoint{
+							endpointURL,
+						},
+					},
+				},
+			},
+			expectedError: "1 error occurred:\n\t* kubelet configuration field \"port\" can't be overridden\n\n",
+		},
 	} {
 		test := test
 

--- a/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/machinery/config/types/v1alpha1/zz_generated.deepcopy.go
@@ -947,6 +947,7 @@ func (in *KubeletConfig) DeepCopyInto(out *KubeletConfig) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	in.KubeletExtraConfig.DeepCopyInto(&out.KubeletExtraConfig)
 	in.KubeletNodeIP.DeepCopyInto(&out.KubeletNodeIP)
 	return
 }

--- a/pkg/machinery/kubelet/kubelet.go
+++ b/pkg/machinery/kubelet/kubelet.go
@@ -1,0 +1,23 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package kubelet defines Talos interface for the kubelet.
+package kubelet
+
+// ProtectedConfigurationFields is a list of kubelet config fields that can't be overridden
+// with the machine configuration.
+var ProtectedConfigurationFields = []string{
+	"apiVersion",
+	"authentication",
+	"authorization",
+	"cgroupRoot",
+	"kind",
+	"kubeletCgroups",
+	"port",
+	"protectKernelDefaults",
+	"resolvConf",
+	"rotateCertificates",
+	"systemCgroups",
+	"staticPodPath",
+}

--- a/pkg/machinery/resources/k8s/kubelet_config.go
+++ b/pkg/machinery/resources/k8s/kubelet_config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/cosi-project/runtime/pkg/resource"
 	"github.com/cosi-project/runtime/pkg/resource/meta"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 )
 
 // KubeletConfigType is type of KubeletConfig resource.
@@ -26,12 +28,13 @@ type KubeletConfig struct {
 
 // KubeletConfigSpec holds the source of kubelet configuration.
 type KubeletConfigSpec struct {
-	Image                 string            `yaml:"image"`
-	ClusterDNS            []string          `yaml:"clusterDNS"`
-	ClusterDomain         string            `yaml:"clusterDomain"`
-	ExtraArgs             map[string]string `yaml:"extraArgs,omitempty"`
-	ExtraMounts           []specs.Mount     `yaml:"extraMounts,omitempty"`
-	CloudProviderExternal bool              `yaml:"cloudProviderExternal"`
+	Image                 string                 `yaml:"image"`
+	ClusterDNS            []string               `yaml:"clusterDNS"`
+	ClusterDomain         string                 `yaml:"clusterDomain"`
+	ExtraArgs             map[string]string      `yaml:"extraArgs,omitempty"`
+	ExtraMounts           []specs.Mount          `yaml:"extraMounts,omitempty"`
+	ExtraConfig           map[string]interface{} `yaml:"extraConfig,omitempty"`
+	CloudProviderExternal bool                   `yaml:"cloudProviderExternal"`
 }
 
 // NewKubeletConfig initializes an empty KubeletConfig resource.
@@ -68,6 +71,9 @@ func (r *KubeletConfig) DeepCopy() resource.Resource {
 		extraArgs[k] = v
 	}
 
+	extraConfig := &v1alpha1.Unstructured{Object: r.spec.ExtraConfig}
+	extraConfig = extraConfig.DeepCopy()
+
 	return &KubeletConfig{
 		md: r.md,
 		spec: &KubeletConfigSpec{
@@ -76,6 +82,7 @@ func (r *KubeletConfig) DeepCopy() resource.Resource {
 			ClusterDomain:         r.spec.ClusterDomain,
 			ExtraArgs:             extraArgs,
 			ExtraMounts:           append([]specs.Mount(nil), r.spec.ExtraMounts...),
+			ExtraConfig:           extraConfig.Object,
 			CloudProviderExternal: r.spec.CloudProviderExternal,
 		},
 	}

--- a/website/content/docs/v0.15/Reference/configuration.md
+++ b/website/content/docs/v0.15/Reference/configuration.md
@@ -336,6 +336,10 @@ kubelet:
     #         - rshared
     #         - rw
 
+    # # The `extraConfig` field is used to provide kubelet configuration overrides.
+    # extraConfig:
+    #     serverTLSBootstrap: true
+
     # # The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.
     # nodeIP:
     #     # The `validSubnets` field configures the networks to pick kubelet node IP from.
@@ -1649,6 +1653,10 @@ extraArgs:
 #         - rshared
 #         - rw
 
+# # The `extraConfig` field is used to provide kubelet configuration overrides.
+# extraConfig:
+#     serverTLSBootstrap: true
+
 # # The `nodeIP` field is used to configure `--node-ip` flag for the kubelet.
 # nodeIP:
 #     # The `validSubnets` field configures the networks to pick kubelet node IP from.
@@ -1753,6 +1761,32 @@ extraMounts:
         - bind
         - rshared
         - rw
+```
+
+
+</div>
+
+<hr />
+<div class="dd">
+
+<code>extraConfig</code>  <i>Unstructured</i>
+
+</div>
+<div class="dt">
+
+The `extraConfig` field is used to provide kubelet configuration overrides.
+
+Some fields are not allowed to be overridden: authentication and authorization, cgroups
+configuration, ports, etc.
+
+
+
+Examples:
+
+
+``` yaml
+extraConfig:
+    serverTLSBootstrap: true
 ```
 
 


### PR DESCRIPTION
Fixes #4629

Note: some fields are enforced by Talos and are not overridable.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5045)
<!-- Reviewable:end -->
