### PR TITLE
fix: set route to metaserver

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/scaleway.go
@@ -67,6 +67,21 @@ func (s *Scaleway) ParseMetadata(metadataConfig *instance.Metadata) (*runtime.Pl
 		ConfigLayer: network.ConfigPlatform,
 	})
 
+	gw, _ := netaddr.ParseIPPrefix("169.254.42.42/32") //nolint:errcheck
+	route := network.RouteSpecSpec{
+		ConfigLayer: network.ConfigPlatform,
+		OutLinkName: "eth0",
+		Destination: gw,
+		Table:       nethelpers.TableMain,
+		Protocol:    nethelpers.ProtocolStatic,
+		Type:        nethelpers.TypeUnicast,
+		Family:      nethelpers.FamilyInet4,
+		Priority:    1024,
+	}
+
+	route.Normalize()
+	networkConfig.Routes = []network.RouteSpecSpec{route}
+
 	networkConfig.Operators = append(networkConfig.Operators, network.OperatorSpecSpec{
 		Operator:  network.OperatorDHCP4,
 		LinkName:  "eth0",

--- a/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected.yaml
+++ b/internal/app/machined/pkg/runtime/v1alpha1/platform/scaleway/testdata/expected.yaml
@@ -14,6 +14,18 @@ links:
       type: netrom
       layer: platform
 routes:
+    - family: inet4
+      dst: 169.254.42.42/32
+      src: ""
+      gateway: ""
+      outLinkName: eth0
+      table: main
+      priority: 1024
+      scope: link
+      type: unicast
+      flags: ""
+      protocol: static
+      layer: platform
     - family: inet6
       dst: ""
       src: ""


### PR DESCRIPTION
Set default route to meta-server, which exists only on eth0 interface.

This changes affect dual network setup. 
In dual network solution you have to set 169.254.42.42/32 route by your self.
After that you will lost ipv6 auto configuration.

So we can set up route 169.254.42.42/32 automatically.

# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)

## Why? (reasoning)

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [x] you formatted your code (`make fmt`)
- [x] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5046)
<!-- Reviewable:end -->
