### PR TITLE
fix: align list and diskusage command flags with their Linux analogs

### DIFF
--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -41,7 +41,7 @@ var duCmd = &cobra.Command{
 			}
 
 			stream, err := c.DiskUsage(ctx, &machineapi.DiskUsageRequest{
-				RecursionDepth: recursionDepth,
+				RecursionDepth: recursionDepth + 1,
 				All:            all,
 				Threshold:      threshold,
 				Paths:          paths,

--- a/internal/integration/cli/diskusage.go
+++ b/internal/integration/cli/diskusage.go
@@ -95,7 +95,7 @@ func (suite *DiskUsageSuite) TestSuccess() {
 		}))
 
 	// check total calculation
-	suite.RunCLI([]string{"usage", "--nodes", node, folder, "-d2", "--all"},
+	suite.RunCLI([]string{"usage", "--nodes", node, folder, "-d1", "--all"},
 		base.StdoutMatchFunc(func(stdout string) error {
 			lines := strings.Split(strings.TrimSpace(stdout), "\n")
 			if len(lines) == 1 {

--- a/internal/integration/cli/list.go
+++ b/internal/integration/cli/list.go
@@ -87,25 +87,14 @@ func (suite *ListSuite) TestDepth() {
 		{separators: 0},
 
 		{separators: 0, flags: []string{"--recurse=false"}},
-		{separators: 5, flags: []string{"--recurse=true"}},
 
 		{separators: 0, flags: []string{"--depth=-1"}},
 		{separators: 0, flags: []string{"--depth=0"}},
 		{separators: 0, flags: []string{"--depth=1"}},
-		{separators: 0, flags: []string{"--depth=2"}},
-		{separators: 0, flags: []string{"--depth=3"}},
+		{separators: 1, flags: []string{"--depth=2"}},
+		{separators: 2, flags: []string{"--depth=3"}},
 
-		{separators: 0, flags: []string{"--recurse=false", "--depth=-1"}},
-		{separators: 0, flags: []string{"--recurse=false", "--depth=0"}},
-		{separators: 0, flags: []string{"--recurse=false", "--depth=1"}},
-		{separators: 0, flags: []string{"--recurse=false", "--depth=2"}},
-		{separators: 0, flags: []string{"--recurse=false", "--depth=3"}},
-
-		{separators: 5, flags: []string{"--recurse=true", "--depth=-1"}},
-		{separators: 5, flags: []string{"--recurse=true", "--depth=0"}},
-		{separators: 0, flags: []string{"--recurse=true", "--depth=1"}},
-		{separators: 1, flags: []string{"--recurse=true", "--depth=2"}},
-		{separators: 2, flags: []string{"--recurse=true", "--depth=3"}},
+		{separators: 5, flags: []string{"--recurse=true"}},
 	} {
 		test := test
 		suite.Run(strings.Join(test.flags, ","), func() {

--- a/website/content/docs/v0.15/Reference/cli.md
+++ b/website/content/docs/v0.15/Reference/cli.md
@@ -1470,7 +1470,7 @@ talosctl list [path] [flags]
 ### Options
 
 ```
-  -d, --depth int32    maximum recursion depth
+  -d, --depth int32    maximum recursion depth (default 1)
   -h, --help           help for list
   -H, --humanize       humanize size and time in the output
   -l, --long           display additional file details


### PR DESCRIPTION
Fixes: https://github.com/talos-systems/talos/issues/3018

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5060)
<!-- Reviewable:end -->
