### PR TITLE
chore: re-enable kexec and default to UEFI booting in tests

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -370,9 +370,9 @@ local integration_cilium = Step("e2e-cilium-1.9.10", target="e2e-qemu", privileg
         "WITH_CONFIG_PATCH": '[{"op": "replace", "path": "/cluster/network/podSubnets", "value": ["10.0.0.0/8"]}]', # use Pod CIDRs as hardcoded in Cilium's quick-install
         "IMAGE_REGISTRY": local_registry,
 });
-local integration_uefi = Step("e2e-uefi", target="e2e-qemu", privileged=true, depends_on=[integration_cilium], environment={
+local integration_uefi = Step("e2e-bios", target="e2e-qemu", privileged=true, depends_on=[integration_cilium], environment={
         "SHORT_INTEGRATION_TEST": "yes",
-        "WITH_UEFI": "true",
+        "WITH_UEFI": "false",
         "IMAGE_REGISTRY": local_registry,
 });
 local integration_disk_image = Step("e2e-disk-image", target="e2e-qemu", privileged=true, depends_on=[integration_uefi], environment={

--- a/cmd/talosctl/cmd/mgmt/cluster/create.go
+++ b/cmd/talosctl/cmd/mgmt/cluster/create.go
@@ -812,7 +812,7 @@ func init() {
 	createCmd.Flags().StringVar(&nodeDiskImagePath, "disk-image-path", "", "disk image to use")
 	createCmd.Flags().BoolVar(&applyConfigEnabled, "with-apply-config", false, "enable apply config when the VM is starting in maintenance mode")
 	createCmd.Flags().BoolVar(&bootloaderEnabled, "with-bootloader", true, "enable bootloader to load kernel and initramfs from disk image after install")
-	createCmd.Flags().BoolVar(&uefiEnabled, "with-uefi", false, "enable UEFI on x86_64 architecture (always enabled for arm64)")
+	createCmd.Flags().BoolVar(&uefiEnabled, "with-uefi", true, "enable UEFI on x86_64 architecture (always enabled for arm64)")
 	createCmd.Flags().StringSliceVar(&extraUEFISearchPaths, "extra-uefi-search-paths", []string{}, "additional search paths for UEFI firmware (only applies when UEFI is enabled)")
 	createCmd.Flags().StringSliceVar(&registryMirrors, "registry-mirror", []string{}, "list of registry mirrors to use in format: <registry host>=<mirror URL>")
 	createCmd.Flags().StringSliceVar(&registryInsecure, "registry-insecure-skip-verify", []string{}, "list of registry hostnames to skip TLS verification for")

--- a/hack/test/e2e-qemu.sh
+++ b/hack/test/e2e-qemu.sh
@@ -29,9 +29,11 @@ case "${CUSTOM_CNI_URL:-false}" in
     ;;
 esac
 
-case "${WITH_UEFI:-false}" in
-  true)
-    QEMU_FLAGS="${QEMU_FLAGS} --with-uefi"
+case "${WITH_UEFI:-none}" in
+  none)
+    ;;
+  *)
+    QEMU_FLAGS="${QEMU_FLAGS} --with-uefi=${WITH_UEFI}"
     ;;
 esac
 

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -1758,11 +1758,6 @@ func KexecPrepare(seq runtime.Sequence, data interface{}) (runtime.TaskExecution
 			}
 		}
 
-		// disable kexec due to initramfs corruption: see https://github.com/talos-systems/talos/issues/4947
-		if true {
-			return nil
-		}
-
 		if r.Config() == nil {
 			return nil
 		}

--- a/internal/integration/provision/upgrade.go
+++ b/internal/integration/provision/upgrade.go
@@ -414,7 +414,11 @@ func (suite *UpgradeSuite) setupCluster() {
 			})
 	}
 
-	suite.Cluster, err = suite.provisioner.Create(suite.ctx, request, provision.WithBootlader(true), provision.WithTalosConfig(suite.configBundle.TalosConfig()))
+	suite.Cluster, err = suite.provisioner.Create(suite.ctx, request,
+		provision.WithBootlader(true),
+		provision.WithUEFI(true),
+		provision.WithTalosConfig(suite.configBundle.TalosConfig()),
+	)
 	suite.Require().NoError(err)
 
 	defaultTalosConfig, err := clientconfig.GetDefaultPath()

--- a/website/content/docs/v0.15/Reference/cli.md
+++ b/website/content/docs/v0.15/Reference/cli.md
@@ -145,7 +145,7 @@ talosctl cluster create [flags]
       --with-debug                               enable debug in Talos config to send service logs to the console
       --with-init-node                           create the cluster with an init node
       --with-kubespan                            enable KubeSpan system
-      --with-uefi                                enable UEFI on x86_64 architecture (always enabled for arm64)
+      --with-uefi                                enable UEFI on x86_64 architecture (always enabled for arm64) (default true)
       --workers int                              the number of workers to create (default 1)
 ```
 


### PR DESCRIPTION
Fixes #4947

It turns out there's something related to boot process in BIOS mode
which leads to initramfs corruption on later `kexec`.

Booting via GRUB is always successful.

Problem with kexec was confirmed with:

* direct boot via QEMU
* QEMU boot via iPXE (bundled with QEMU)

The root cause is not known, but the only visible difference is the
placement of RAMDISK with UEFI and BIOS boots:

```
[    0.005508] RAMDISK: [mem 0x312dd000-0x34965fff]
```

or:

```
[    0.003821] RAMDISK: [mem 0x711aa000-0x747a7fff]
```

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>
