### PR TITLE
feat: update containerd to 1.5.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NAME = Talos
 
 ARTIFACTS := _out
 TOOLS ?= ghcr.io/talos-systems/tools:v0.9.0-2-gc89ed2c
-PKGS ?= v0.9.0-4-gc875fbe
+PKGS ?= v0.9.0-5-ga025ad8
 EXTRAS ?= v0.7.0-2-gb4c9d21
 GO_VERSION ?= 1.17
 GOFUMPT_VERSION ?= v0.1.1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -6,7 +6,7 @@ github_repo = "talos-systems/talos"
 match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
 
 # previous release
-previous = "v0.14.0"
+previous = "v0.14.1"
 
 pre_release = false
 
@@ -18,9 +18,7 @@ preface = """\
     [notes.updates]
         title = "Component Updates"
         description="""\
-* Linux: 5.15.23
-
-Talos is built with Go 1.17.7
+* containerd: 1.5.10
 """
 
 [make_deps]

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -337,7 +337,7 @@ const (
 	TrustdUserID = 51
 
 	// DefaultContainerdVersion is the default container runtime version.
-	DefaultContainerdVersion = "1.5.8"
+	DefaultContainerdVersion = "1.5.10"
 
 	// SystemContainerdNamespace is the Containerd namespace for Talos services.
 	SystemContainerdNamespace = "system"


### PR DESCRIPTION
(backport for Talos 0.14)

See

* https://github.com/containerd/containerd/security/advisories/GHSA-crp2-qrr5-8pq7
* https://github.com/talos-systems/pkgs/pull/409

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5070)
<!-- Reviewable:end -->
