### PR TITLE
feat: bond interfaces from kernel cmdline

### DIFF
--- a/hack/release.toml
+++ b/hack/release.toml
@@ -15,6 +15,13 @@ preface = """\
 
 [notes]
 
+    [notes.kernelParam]
+        title = "Kernel Parameters"
+        description = """\
+Talos now supports setting bond interface from Kernel cmdline using the `bond=` option.
+Reference: https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html
+"""
+
     [notes.equinixMetal]
         title = "Equinix Metal Platform"
         description="""\

--- a/internal/app/machined/pkg/controllers/network/cmdline.go
+++ b/internal/app/machined/pkg/controllers/network/cmdline.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/talos-systems/go-procfs/procfs"
 	"inet.af/netaddr"
 
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
 	"github.com/talos-systems/talos/pkg/machinery/constants"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
 )
 
 // CmdlineNetworking contains parsed cmdline networking settings.
@@ -26,6 +29,7 @@ type CmdlineNetworking struct {
 	DNSAddresses     []netaddr.IP
 	NTPAddresses     []netaddr.IP
 	IgnoreInterfaces []string
+	NetworkLinkSpecs []network.LinkSpecSpec
 }
 
 // splitIPArgument splits the `ip=` kernel argument honoring the IPv6 addresses in square brackets.
@@ -61,8 +65,9 @@ func splitIPArgument(val string) []string {
 //nolint:gocyclo,cyclop
 func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 	var (
-		settings CmdlineNetworking
-		err      error
+		settings      CmdlineNetworking
+		err           error
+		linkSpecSpecs []network.LinkSpecSpec
 	)
 
 	// process Talos specific kernel params
@@ -78,21 +83,117 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 
 	// standard ip=
 	ipSettings := cmdline.Get("ip").First()
-	if ipSettings == nil {
-		return settings, nil
+
+	// dracut bond=
+	// ref: https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html
+	bondSettings := cmdline.Get(constants.KernelParamBonding).First()
+
+	if ipSettings != nil {
+		// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
+		// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>
+		fields := splitIPArgument(*ipSettings)
+
+		// If dhcp is specified, we'll handle it as a normal discovered
+		// interface
+		if len(fields) == 1 && fields[0] == "dhcp" {
+			settings.DHCP = true
+		}
+
+		if !settings.DHCP {
+			for i := range fields {
+				if fields[i] == "" {
+					continue
+				}
+
+				switch i {
+				case 0:
+					var ip netaddr.IP
+
+					ip, err = netaddr.ParseIP(fields[0])
+					if err != nil {
+						return settings, fmt.Errorf("cmdline address parse failure: %s", err)
+					}
+
+					// default is to have complete address masked
+					settings.Address = netaddr.IPPrefixFrom(ip, ip.BitLen())
+				case 2:
+					settings.Gateway, err = netaddr.ParseIP(fields[2])
+					if err != nil {
+						return settings, fmt.Errorf("cmdline gateway parse failure: %s", err)
+					}
+				case 3:
+					var netmask netaddr.IP
+
+					netmask, err = netaddr.ParseIP(fields[3])
+					if err != nil {
+						return settings, fmt.Errorf("cmdline netmask parse failure: %s", err)
+					}
+
+					ones, _ := net.IPMask(netmask.IPAddr().IP).Size()
+
+					settings.Address = netaddr.IPPrefixFrom(settings.Address.IP(), uint8(ones))
+				case 4:
+					if settings.Hostname == "" {
+						settings.Hostname = fields[4]
+					}
+				case 5:
+					settings.LinkName = fields[5]
+				case 7, 8:
+					var dnsIP netaddr.IP
+
+					dnsIP, err = netaddr.ParseIP(fields[i])
+					if err != nil {
+						return settings, fmt.Errorf("error parsing DNS IP: %w", err)
+					}
+
+					settings.DNSAddresses = append(settings.DNSAddresses, dnsIP)
+				case 9:
+					var ntpIP netaddr.IP
+
+					ntpIP, err = netaddr.ParseIP(fields[i])
+					if err != nil {
+						return settings, fmt.Errorf("error parsing DNS IP: %w", err)
+					}
+
+					settings.NTPAddresses = append(settings.NTPAddresses, ntpIP)
+				}
+			}
+		}
+
+		// if interface name is not set, pick the first non-loopback interface
+		if settings.LinkName == "" {
+			ifaces, _ := net.Interfaces() //nolint:errcheck // ignoring error here as ifaces will be empty
+
+			sort.Slice(ifaces, func(i, j int) bool { return ifaces[i].Name < ifaces[j].Name })
+
+			for _, iface := range ifaces {
+				if iface.Flags&net.FlagLoopback != 0 {
+					continue
+				}
+
+				settings.LinkName = iface.Name
+
+				break
+			}
+		}
+
+		linkSpecSpecs = append(linkSpecSpecs, network.LinkSpecSpec{
+			Name:        settings.LinkName,
+			Up:          true,
+			ConfigLayer: network.ConfigCmdline,
+		})
 	}
 
-	// https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
-	// ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>
-	fields := splitIPArgument(*ipSettings)
+	if bondSettings != nil {
+		var (
+			bondName, bondMTU string
+			bondSlaves        []string
+			bondOptions       v1alpha1.Bond
+		)
 
-	// If dhcp is specified, we'll handle it as a normal discovered
-	// interface
-	if len(fields) == 1 && fields[0] == "dhcp" {
-		settings.DHCP = true
-	}
+		// bond=<bondname>[:<bondslaves>:[:<options>[:<mtu>]]]
+		fields := strings.Split(*bondSettings, ":")
 
-	if !settings.DHCP {
 		for i := range fields {
 			if fields[i] == "" {
 				continue
@@ -100,75 +201,189 @@ func ParseCmdlineNetwork(cmdline *procfs.Cmdline) (CmdlineNetworking, error) {
 
 			switch i {
 			case 0:
-				var ip netaddr.IP
-
-				ip, err = netaddr.ParseIP(fields[0])
-				if err != nil {
-					return settings, fmt.Errorf("cmdline address parse failure: %s", err)
-				}
-
-				// default is to have complete address masked
-				settings.Address = netaddr.IPPrefixFrom(ip, ip.BitLen())
+				bondName = fields[0]
+			case 1:
+				bondSlaves = strings.Split(fields[1], ",")
 			case 2:
-				settings.Gateway, err = netaddr.ParseIP(fields[2])
+				bondOptions, err = parseBondOptions(fields[2])
 				if err != nil {
-					return settings, fmt.Errorf("cmdline gateway parse failure: %s", err)
+					return settings, err
 				}
 			case 3:
-				var netmask netaddr.IP
-
-				netmask, err = netaddr.ParseIP(fields[3])
-				if err != nil {
-					return settings, fmt.Errorf("cmdline netmask parse failure: %s", err)
-				}
-
-				ones, _ := net.IPMask(netmask.IPAddr().IP).Size()
-
-				settings.Address = netaddr.IPPrefixFrom(settings.Address.IP(), uint8(ones))
-			case 4:
-				if settings.Hostname == "" {
-					settings.Hostname = fields[4]
-				}
-			case 5:
-				settings.LinkName = fields[5]
-			case 7, 8:
-				var dnsIP netaddr.IP
-
-				dnsIP, err = netaddr.ParseIP(fields[i])
-				if err != nil {
-					return settings, fmt.Errorf("error parsing DNS IP: %w", err)
-				}
-
-				settings.DNSAddresses = append(settings.DNSAddresses, dnsIP)
-			case 9:
-				var ntpIP netaddr.IP
-
-				ntpIP, err = netaddr.ParseIP(fields[i])
-				if err != nil {
-					return settings, fmt.Errorf("error parsing DNS IP: %w", err)
-				}
-
-				settings.NTPAddresses = append(settings.NTPAddresses, ntpIP)
+				bondMTU = fields[3]
 			}
+		}
+
+		// set defaults as per https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html
+		// Talos by default sets bond mode to balance-rr
+		if bondSlaves == nil {
+			bondSlaves = []string{
+				"eth0",
+				"eth1",
+			}
+		}
+
+		bondLinkSpec := network.LinkSpecSpec{
+			Name:        bondName,
+			Up:          true,
+			ConfigLayer: network.ConfigCmdline,
+		}
+
+		if bondMTU != "" {
+			mtu, err := strconv.Atoi(bondMTU)
+			if err != nil {
+				return settings, fmt.Errorf("error parsing bond MTU: %w", err)
+			}
+
+			bondLinkSpec.MTU = uint32(mtu)
+		}
+
+		if err := SetBondMaster(&bondLinkSpec, &bondOptions); err != nil {
+			return settings, fmt.Errorf("error setting bond master: %w", err)
+		}
+
+		linkSpecSpecs = append(linkSpecSpecs, bondLinkSpec)
+
+		for _, slave := range bondSlaves {
+			slaveLinkSpec := network.LinkSpecSpec{
+				Name:        slave,
+				Up:          true,
+				ConfigLayer: network.ConfigCmdline,
+			}
+			SetBondSlave(&slaveLinkSpec, bondName)
+			linkSpecSpecs = append(linkSpecSpecs, slaveLinkSpec)
 		}
 	}
 
-	// if interface name is not set, pick the first non-loopback interface
-	if settings.LinkName == "" {
-		ifaces, _ := net.Interfaces() //nolint:errcheck // ignoring error here as ifaces will be empty
-
-		sort.Slice(ifaces, func(i, j int) bool { return ifaces[i].Name < ifaces[j].Name })
-
-		for _, iface := range ifaces {
-			if iface.Flags&net.FlagLoopback != 0 {
-				continue
-			}
-
-			settings.LinkName = iface.Name
-
-			break
-		}
-	}
+	settings.NetworkLinkSpecs = linkSpecSpecs
 
 	return settings, nil
+}
+
+// parseBondOptions parses the options string into v1alpha1.Bond
+// v1alpha1.Bond was chosen to re-use the `SetBondMaster` and `SetBondSlave` functions
+// ref: modinfo bonding
+//nolint:gocyclo,cyclop
+func parseBondOptions(options string) (v1alpha1.Bond, error) {
+	var bond v1alpha1.Bond
+
+	bondOptions := strings.Split(options, ",")
+
+	for _, opt := range bondOptions {
+		optionPair := strings.Split(opt, "=")
+
+		switch optionPair[0] {
+		case "arp_ip_target":
+			bond.BondARPIPTarget = strings.Split(optionPair[1], ";")
+		case "mode":
+			bond.BondMode = optionPair[1]
+		case "xmit_hash_policy":
+			bond.BondHashPolicy = optionPair[1]
+		case "lacp_rate":
+			bond.BondLACPRate = optionPair[1]
+		case "arp_validate":
+			bond.BondARPValidate = optionPair[1]
+		case "arp_all_targets":
+			bond.BondARPAllTargets = optionPair[1]
+		case "primary":
+			bond.BondPrimary = optionPair[1]
+		case "primary_reselect":
+			bond.BondPrimaryReselect = optionPair[1]
+		case "fail_over_mac":
+			bond.BondFailOverMac = optionPair[1]
+		case "ad_select":
+			bond.BondADSelect = optionPair[1]
+		case "miimon":
+			miimon, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option miimon: %w", err)
+			}
+
+			bond.BondMIIMon = uint32(miimon)
+		case "updelay":
+			updelay, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option updelay: %w", err)
+			}
+
+			bond.BondUpDelay = uint32(updelay)
+		case "downdelay":
+			downdelay, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option downdelay: %w", err)
+			}
+
+			bond.BondDownDelay = uint32(downdelay)
+		case "arp_interval":
+			arpInterval, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option arp_interval: %w", err)
+			}
+
+			bond.BondARPInterval = uint32(arpInterval)
+		case "resend_igmp":
+			resendIGMP, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option resend_igmp: %w", err)
+			}
+
+			bond.BondResendIGMP = uint32(resendIGMP)
+		case "min_links":
+			minLinks, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option min_links: %w", err)
+			}
+
+			bond.BondMinLinks = uint32(minLinks)
+		case "lp_interval":
+			lpInterval, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option lp_interval: %w", err)
+			}
+
+			bond.BondLPInterval = uint32(lpInterval)
+		case "packets_per_slave":
+			packetsPerSlave, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option packets_per_slave: %w", err)
+			}
+
+			bond.BondPacketsPerSlave = uint32(packetsPerSlave)
+		case "num_grat_arp":
+			numGratArp, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option num_grat_arp: %w", err)
+			}
+
+			bond.BondNumPeerNotif = uint8(numGratArp)
+		case "num_unsol_na":
+			numGratArp, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option num_unsol_na: %w", err)
+			}
+
+			bond.BondNumPeerNotif = uint8(numGratArp)
+		case "all_slaves_active":
+			allSlavesActive, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option all_slaves_active: %w", err)
+			}
+
+			bond.BondAllSlavesActive = uint8(allSlavesActive)
+		case "use_carrier":
+			useCarrier, err := strconv.Atoi(optionPair[1])
+			if err != nil {
+				return bond, fmt.Errorf("error parsing bond option use_carrier: %w", err)
+			}
+
+			if useCarrier == 1 {
+				val := []bool{true}
+				bond.BondUseCarrier = &val[0]
+			}
+		default:
+			return bond, fmt.Errorf("unknown bond option: %s", optionPair[0])
+		}
+	}
+
+	return bond, nil
 }

--- a/internal/app/machined/pkg/controllers/network/network.go
+++ b/internal/app/machined/pkg/controllers/network/network.go
@@ -5,5 +5,110 @@
 // Package network provides controllers which manage network resources.
 package network
 
+import (
+	"net"
+
+	networkadapter "github.com/talos-systems/talos/internal/app/machined/pkg/adapters/network"
+	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/nethelpers"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
+)
+
 // DefaultRouteMetric is the default route metric if no metric was specified explicitly.
 const DefaultRouteMetric = 1024
+
+// SetBondSlave sets the bond slave spec.
+func SetBondSlave(link *network.LinkSpecSpec, bondName string) {
+	link.MasterName = bondName
+}
+
+// SetBondMaster sets the bond master spec.
+//nolint:gocyclo
+func SetBondMaster(link *network.LinkSpecSpec, bond talosconfig.Bond) error {
+	link.Logical = true
+	link.Kind = network.LinkKindBond
+	link.Type = nethelpers.LinkEther
+
+	bondMode, err := nethelpers.BondModeByName(bond.Mode())
+	if err != nil {
+		return err
+	}
+
+	hashPolicy, err := nethelpers.BondXmitHashPolicyByName(bond.HashPolicy())
+	if err != nil {
+		return err
+	}
+
+	lacpRate, err := nethelpers.LACPRateByName(bond.LACPRate())
+	if err != nil {
+		return err
+	}
+
+	arpValidate, err := nethelpers.ARPValidateByName(bond.ARPValidate())
+	if err != nil {
+		return err
+	}
+
+	arpAllTargets, err := nethelpers.ARPAllTargetsByName(bond.ARPAllTargets())
+	if err != nil {
+		return err
+	}
+
+	var primary uint32
+
+	if bond.Primary() != "" {
+		var iface *net.Interface
+
+		iface, err = net.InterfaceByName(bond.Primary())
+		if err != nil {
+			return err
+		}
+
+		primary = uint32(iface.Index)
+	}
+
+	primaryReselect, err := nethelpers.PrimaryReselectByName(bond.PrimaryReselect())
+	if err != nil {
+		return err
+	}
+
+	failOverMAC, err := nethelpers.FailOverMACByName(bond.FailOverMac())
+	if err != nil {
+		return err
+	}
+
+	adSelect, err := nethelpers.ADSelectByName(bond.ADSelect())
+	if err != nil {
+		return err
+	}
+
+	link.BondMaster = network.BondMasterSpec{
+		Mode:            bondMode,
+		HashPolicy:      hashPolicy,
+		LACPRate:        lacpRate,
+		ARPValidate:     arpValidate,
+		ARPAllTargets:   arpAllTargets,
+		PrimaryIndex:    primary,
+		PrimaryReselect: primaryReselect,
+		FailOverMac:     failOverMAC,
+		ADSelect:        adSelect,
+		MIIMon:          bond.MIIMon(),
+		UpDelay:         bond.UpDelay(),
+		DownDelay:       bond.DownDelay(),
+		ARPInterval:     bond.ARPInterval(),
+		ResendIGMP:      bond.ResendIGMP(),
+		MinLinks:        bond.MinLinks(),
+		LPInterval:      bond.LPInterval(),
+		PacketsPerSlave: bond.PacketsPerSlave(),
+		NumPeerNotif:    bond.NumPeerNotif(),
+		TLBDynamicLB:    bond.TLBDynamicLB(),
+		AllSlavesActive: bond.AllSlavesActive(),
+		UseCarrier:      bond.UseCarrier(),
+		ADActorSysPrio:  bond.ADActorSysPrio(),
+		ADUserPortKey:   bond.ADUserPortKey(),
+		PeerNotifyDelay: bond.PeerNotifyDelay(),
+	}
+	networkadapter.BondMasterSpec(&link.BondMaster).FillDefaults()
+
+	return nil
+}

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -77,6 +77,9 @@ const (
 	// KernelParamNetworkInterfaceIgnore is the kernel parameter for specifying network interfaces which should be ignored by talos.
 	KernelParamNetworkInterfaceIgnore = "talos.network.interface.ignore"
 
+	// KernelParamBonding is the kernel parameter for specifying bonded network interfaces.
+	KernelParamBonding = "bond"
+
 	// KernelParamPanic is the kernel parameter name for specifying the time to wait until rebooting after kernel panic (0 disables reboot).
 	KernelParamPanic = "panic"
 

--- a/website/content/docs/v1.0/Reference/kernel.md
+++ b/website/content/docs/v1.0/Reference/kernel.md
@@ -40,6 +40,34 @@ Several of these are enforced by the Kernel Self Protection Project [KSPP](https
 
   IPv6 addresses can be specified by enclosing them in the square brackets, e.g. `ip=[2001:db8::a]:[2001:db8::b]:[fe80::1]::master1:eth1::[2001:4860:4860::6464]:[2001:4860:4860::64]:[2001:4860:4806::]`.
 
+#### `bond`
+
+  Bond interface configuration.
+
+  Full documentation is available in the [Dracut kernel docs](https://man7.org/linux/man-pages/man7/dracut.cmdline.7.html).
+
+  `bond=<bondname>:<bondslaves>:<options>:<mtu>`
+
+  Talos will use the `bond=` kernel parameter if supplied to set the initial bond configuration.
+  This parameter is useful in environments where the switch ports are suspended if the machine doesn't setup a LACP bond.
+
+  If only the bond name is supplied, the bond will be created with `eth0` and `eth1` as slaves and bond mode set as `balance-rr`
+
+  All these below configurations are equivalent:
+
+  * `bond=bond0`
+  * `bond=bond0:`
+  * `bond=bond0::`
+  * `bond=bond0:::`
+  * `bond=bond0:eth0:eth1`
+  * `bond=bond0:eth0:eth1:balance-rr`
+
+  An example of a bond configuration with all options specified:
+
+  `bond=bond1:eth3,eth4:mode=802.3ad,xmit_hash_policy=layer2+3:1450`
+
+  This will create a bond interface named `bond1` with `eth3` and `eth4` as slaves and set the bond mode to `802.3ad`, the transmit hash policy to `layer2+3` and bond interface MTU to 1450.
+
 #### `panic`
 
   The amount of time to wait after a panic before a reboot is issued.


### PR DESCRIPTION
Support bond interfaces from kernel cmdline using `bond=` format

Fixes: #4765

Signed-off-by: Noel Georgi <git@frezbo.dev>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5078)
<!-- Reviewable:end -->
