### PR TITLE
feat: bump boot partition size to 1000 MiB

### DIFF
--- a/cmd/installer/pkg/raw.go
+++ b/cmd/installer/pkg/raw.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// RAWDiskSize is the minimum size disk we can create.
-	RAWDiskSize = 546
+	RAWDiskSize = 1246
 )
 
 // CreateRawDisk creates a raw disk by invoking the `dd` command.

--- a/internal/pkg/partition/constants.go
+++ b/internal/pkg/partition/constants.go
@@ -32,7 +32,7 @@ const (
 
 	EFISize      = 100 * MiB
 	BIOSGrubSize = 1 * MiB
-	BootSize     = 300 * MiB
+	BootSize     = 1000 * MiB
 	MetaSize     = 1 * MiB
 	StateSize    = 100 * MiB
 )


### PR DESCRIPTION
With system extensions, size of the `initramfs` might increase
significantly. With 1000 MiB `/boot`, as we store `A` and `B` boot
directories, we have 500 MiB for each Talos boot (size of the kernel and
initramfs).

Fixes #5096

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5097)
<!-- Reviewable:end -->
