### PR TITLE
feat: add talosctl completions to copy, usage, logs, restart and service

### DIFF
--- a/cmd/talosctl/cmd/talos/copy.go
+++ b/cmd/talosctl/cmd/talos/copy.go
@@ -32,6 +32,16 @@ talosctl creates a directory if <local-path> doesn't exist. Command doesn't pres
 ownership and access mode for the files in extract mode, while  streamed .tar archive
 captures ownership and permission bits.`,
 	Args: cobra.ExactArgs(2),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return completePathFromNode(toComplete), cobra.ShellCompDirectiveNoFileComp
+		case 1:
+			return nil, cobra.ShellCompDirectiveDefault
+		}
+
+		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			if err := helpers.FailIfMultiNodes(ctx, "copy"); err != nil {

--- a/cmd/talosctl/cmd/talos/diskusage.go
+++ b/cmd/talosctl/cmd/talos/diskusage.go
@@ -30,6 +30,21 @@ var duCmd = &cobra.Command{
 	Aliases: []string{"du"},
 	Short:   "Retrieve a disk usage",
 	Long:    ``,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var completeOnlyPaths []string
+
+		for _, path := range completePathFromNode(toComplete) {
+			if path[len(path)-1:] == "/" {
+				completeOnlyPaths = append(completeOnlyPaths, path)
+			}
+		}
+
+		return completeOnlyPaths, cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			var paths []string

--- a/cmd/talosctl/cmd/talos/logs.go
+++ b/cmd/talosctl/cmd/talos/logs.go
@@ -34,6 +34,17 @@ var logsCmd = &cobra.Command{
 	Short: "Retrieve logs for a service",
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if kubernetes {
+			return getContainersFromNode(kubernetes), cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return mergeSuggestions(getServiceFromNode(), getContainersFromNode(kubernetes)), cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			var (

--- a/cmd/talosctl/cmd/talos/restart.go
+++ b/cmd/talosctl/cmd/talos/restart.go
@@ -22,6 +22,13 @@ var restartCmd = &cobra.Command{
 	Short: "Restart a process",
 	Long:  ``,
 	Args:  cobra.ExactArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return getContainersFromNode(kubernetes), cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return WithClient(func(ctx context.Context, c *client.Client) error {
 			var (

--- a/cmd/talosctl/cmd/talos/service.go
+++ b/cmd/talosctl/cmd/talos/service.go
@@ -27,6 +27,16 @@ var serviceCmd = &cobra.Command{
 If service ID is specified, default action 'status' is executed which shows status of a single list service.
 With actions 'start', 'stop', 'restart', service state is updated respectively.`,
 	Args: cobra.MaximumNArgs(2),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		switch len(args) {
+		case 0:
+			return getServiceFromNode(), cobra.ShellCompDirectiveNoFileComp
+		case 1:
+			return []string{"start", "stop", "restart", "status"}, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return nil, cobra.ShellCompDirectiveError | cobra.ShellCompDirectiveNoFileComp
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		action := "status"
 		serviceID := ""


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
talosctl copy: path completion of src node path, dst client path was done by default
talosctl usage: directory completion of node path
talosctl logs: service completion
talosctl restart: running container/pod completion
talosctl service: service and action completion

## Why? (reasoning)
Because I like pressing TAB

## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [X] you ran conformance (`make conformance`) -- GPG Identity  failed wich is explected
- [X] you formatted your code (`make fmt`)
- [ unable ] you linted your code (`make lint`) -- BROKEN for me:  /toolchain/bin/bash: golangci-lint: command not found
- [ ] you generated documentation (`make docs`)
- [ unable ] you ran unit-tests (`make unit-tests`) -- error: failed to solve: granting entitlement security.insecure is not allowed by build daemon configuration

> See `make help` for a description of the available targets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5109)
<!-- Reviewable:end -->
