### PR TITLE
feat: pause the boot process on some failures instead of rebooting

### DIFF
--- a/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
+++ b/internal/app/machined/internal/server/v1alpha1/v1alpha1_server.go
@@ -343,6 +343,10 @@ func (s *Server) Rollback(ctx context.Context, in *machine.RollbackRequest) (*ma
 func (s *Server) Bootstrap(ctx context.Context, in *machine.BootstrapRequest) (reply *machine.BootstrapResponse, err error) {
 	log.Printf("bootstrap request received")
 
+	if !s.Controller.Runtime().IsBootstrapAllowed() {
+		return nil, status.Error(codes.FailedPrecondition, "bootstrap is not available yet")
+	}
+
 	if s.Controller.Runtime().Config().Machine().Type() == machinetype.TypeWorker {
 		return nil, status.Error(codes.FailedPrecondition, "bootstrap can only be performed on a control plane node")
 	}
@@ -1891,7 +1895,16 @@ func (s *Server) EtcdSnapshot(in *machine.EtcdSnapshotRequest, srv machine.Machi
 }
 
 // EtcdRecover implements the machine.MachineServer interface.
+//nolint:gocyclo
 func (s *Server) EtcdRecover(srv machine.MachineService_EtcdRecoverServer) error {
+	if _, err := os.Stat(filepath.Dir(constants.EtcdRecoverySnapshotPath)); err != nil {
+		if os.IsNotExist(err) {
+			return status.Error(codes.FailedPrecondition, "etcd service is not ready for recovery yet")
+		}
+
+		return err
+	}
+
 	if err := s.checkControlplane("etcd recover"); err != nil {
 		return err
 	}

--- a/internal/app/machined/main.go
+++ b/internal/app/machined/main.go
@@ -252,7 +252,10 @@ func run() error {
 	}
 
 	// Start the machine API.
-	system.Services(c.Runtime()).LoadAndStart(&services.Machined{Controller: c})
+	system.Services(c.Runtime()).LoadAndStart(
+		&services.Machined{Controller: c},
+		&services.APID{},
+	)
 
 	// Boot the machine.
 	if err = c.Run(ctx, runtime.SequenceBoot, nil); err != nil && !errors.Is(err, context.Canceled) {

--- a/internal/app/machined/pkg/runtime/runtime.go
+++ b/internal/app/machined/pkg/runtime/runtime.go
@@ -18,4 +18,5 @@ type Runtime interface {
 	Events() EventStream
 	Logging() LoggingManager
 	NodeName() (string, error)
+	IsBootstrapAllowed() bool
 }

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer.go
@@ -220,10 +220,10 @@ func (*Sequencer) Boot(r runtime.Runtime) []runtime.Phase {
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
 		"userDisks",
-		MountUserDisks,
+		pauseOnFailure(MountUserDisks, constants.FailurePauseTimeout),
 	).Append(
 		"userSetup",
-		WriteUserFiles,
+		pauseOnFailure(WriteUserFiles, constants.FailurePauseTimeout),
 	).AppendWhen(
 		r.State().Platform().Mode() != runtime.ModeContainer,
 		"lvm",

--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -672,7 +672,6 @@ func StartAllServices(seq runtime.Sequence, data interface{}) (runtime.TaskExecu
 		svcs := system.Services(r)
 
 		svcs.Load(
-			&services.APID{},
 			&services.CRI{},
 		)
 
@@ -1847,4 +1846,28 @@ func StopDBus(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc
 
 		return nil
 	}, "stopDBus"
+}
+
+func pauseOnFailure(callback func(runtime.Sequence, interface{}) (runtime.TaskExecutionFunc, string),
+	timeout time.Duration) func(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
+	return func(seq runtime.Sequence, data interface{}) (runtime.TaskExecutionFunc, string) {
+		f, name := callback(seq, data)
+
+		return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) error {
+			err := f(ctx, logger, r)
+			if err != nil {
+				logger.Printf("%s failed, rebooting in %.0f minutes. You can use talosctl apply-config or talosctl edit mc to fix the issues, error:\n%s", name, timeout.Minutes(), err)
+
+				timer := time.NewTimer(time.Minute * 5)
+				defer timer.Stop()
+
+				select {
+				case <-timer.C:
+				case <-ctx.Done():
+				}
+			}
+
+			return err
+		}, name
+	}
 }

--- a/pkg/cluster/bootstrap.go
+++ b/pkg/cluster/bootstrap.go
@@ -31,6 +31,7 @@ type APIBootstrapper struct {
 // Bootstrap the cluster via the API.
 //
 // Bootstrap implements Bootstrapper interface.
+//nolint:gocyclo
 func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 	cli, err := s.Client()
 	if err != nil {
@@ -81,6 +82,9 @@ func (s *APIBootstrapper) Bootstrap(ctx context.Context, out io.Writer) error {
 				return retry.ExpectedError(err)
 			// connection refused, including proxied connection refused via the endpoint to the node
 			case strings.Contains(err.Error(), "connection refused"):
+				return retry.ExpectedError(err)
+			// connection timeout
+			case strings.Contains(err.Error(), "error reading from server: EOF"):
 				return retry.ExpectedError(err)
 			}
 

--- a/pkg/machinery/constants/constants.go
+++ b/pkg/machinery/constants/constants.go
@@ -521,7 +521,10 @@ const (
 	DefaultDNSDomain = "cluster.local"
 
 	// BootTimeout is the timeout to run all services.
-	BootTimeout = 35 * time.Minute
+	BootTimeout = 70 * time.Minute
+
+	// FailurePauseTimeout is the timeout for the sequencer failures which can be fixed by updating the machine config.
+	FailurePauseTimeout = 35 * time.Minute
 
 	// EtcdJoinTimeout is the timeout for etcd to join the existing cluster.
 	//


### PR DESCRIPTION
Some failures can be fixed by updating the machine configuration.
Now `userDisks` and `userFiles` do not make Talos to enter into reboot
loop but pause for 35 minutes.

Additionally, `apid` and `machined` are now started right after
containerd is up and running.

That makes it possible for the operator to connect to the node using
talosctl and fix the config.

Fixes: https://github.com/talos-systems/talos/issues/4669
Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5129)
<!-- Reviewable:end -->
