### PR TITLE
fix: invert the condition to skip kubelet kernel checks

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
+++ b/internal/app/machined/pkg/controllers/k8s/kubelet_spec.go
@@ -167,7 +167,7 @@ func (ctrl *KubeletSpecController) Run(ctx context.Context, r controller.Runtime
 		// If our platform is container, we cannot rely on the ability to change kernel parameters.
 		// Therefore, we need to NOT attempt to enforce the kernel parameter checking done by the kubelet
 		// when the `ProtectKernelDefaults` setting is enabled.
-		if ctrl.V1Alpha1Mode != v1alpha1runtime.ModeContainer {
+		if ctrl.V1Alpha1Mode == v1alpha1runtime.ModeContainer {
 			kubeletConfig.ProtectKernelDefaults = false
 		}
 


### PR DESCRIPTION
We should skip the checks on container platforms, as Talos has no way to
enforce conditions on the host kernel.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5139)
<!-- Reviewable:end -->
