### PR TITLE
fix: split regular network operation configuration and virtual IP

### DIFF
--- a/internal/app/machined/pkg/controllers/network/operator_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_config_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-retry/retry"
-	"inet.af/netaddr"
 
 	netctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
 	"github.com/talos-systems/talos/pkg/logging"
@@ -394,86 +393,6 @@ func (suite *OperatorConfigSuite) TestMachineConfigurationDHCP6() {
 		func() error {
 			return suite.assertNoOperators([]string{
 				"configuration/dhcp6/eth1",
-			})
-		}))
-}
-
-func (suite *OperatorConfigSuite) TestMachineConfigurationVIP() {
-	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.OperatorConfigController{}))
-
-	suite.startRuntime()
-
-	u, err := url.Parse("https://foo:6443")
-	suite.Require().NoError(err)
-
-	cfg := config.NewMachineConfig(&v1alpha1.Config{
-		ConfigVersion: "v1alpha1",
-		MachineConfig: &v1alpha1.MachineConfig{
-			MachineNetwork: &v1alpha1.NetworkConfig{
-				NetworkInterfaces: []*v1alpha1.Device{
-					{
-						DeviceInterface: "eth1",
-						DeviceDHCP:      true,
-						DeviceVIPConfig: &v1alpha1.DeviceVIPConfig{
-							SharedIP: "2.3.4.5",
-						},
-					},
-					{
-						DeviceInterface: "eth2",
-						DeviceDHCP:      true,
-						DeviceVIPConfig: &v1alpha1.DeviceVIPConfig{
-							SharedIP: "fd7a:115c:a1e0:ab12:4843:cd96:6277:2302",
-						},
-					},
-					{
-						DeviceInterface: "eth3",
-						DeviceDHCP:      true,
-						DeviceVlans: []*v1alpha1.Vlan{
-							{
-								VlanID: 26,
-								VlanVIP: &v1alpha1.DeviceVIPConfig{
-									SharedIP: "5.5.4.4",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		ClusterConfig: &v1alpha1.ClusterConfig{
-			ControlPlane: &v1alpha1.ControlPlaneConfig{
-				Endpoint: &v1alpha1.Endpoint{
-					URL: u,
-				},
-			},
-		},
-	})
-
-	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
-
-	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
-		func() error {
-			return suite.assertOperators([]string{
-				"configuration/vip/eth1",
-				"configuration/vip/eth2",
-				"configuration/vip/eth3.26",
-			}, func(r *network.OperatorSpec) error {
-				suite.Assert().Equal(network.OperatorVIP, r.TypedSpec().Operator)
-				suite.Assert().True(r.TypedSpec().RequireUp)
-
-				switch r.Metadata().ID() {
-				case "configuration/vip/eth1":
-					suite.Assert().Equal("eth1", r.TypedSpec().LinkName)
-					suite.Assert().EqualValues(netaddr.MustParseIP("2.3.4.5"), r.TypedSpec().VIP.IP)
-				case "configuration/vip/eth2":
-					suite.Assert().Equal("eth2", r.TypedSpec().LinkName)
-					suite.Assert().EqualValues(netaddr.MustParseIP("fd7a:115c:a1e0:ab12:4843:cd96:6277:2302"), r.TypedSpec().VIP.IP)
-				case "configuration/vip/eth3.26":
-					suite.Assert().Equal("eth3.26", r.TypedSpec().LinkName)
-					suite.Assert().EqualValues(netaddr.MustParseIP("5.5.4.4"), r.TypedSpec().VIP.IP)
-				}
-
-				return nil
 			})
 		}))
 }

--- a/internal/app/machined/pkg/controllers/network/operator_vip_config.go
+++ b/internal/app/machined/pkg/controllers/network/operator_vip_config.go
@@ -1,0 +1,240 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/AlekSi/pointer"
+	"github.com/cosi-project/runtime/pkg/controller"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/hashicorp/go-multierror"
+	"github.com/talos-systems/go-procfs/procfs"
+	"go.uber.org/zap"
+	"inet.af/netaddr"
+
+	"github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network/operator/vip"
+	talosconfig "github.com/talos-systems/talos/pkg/machinery/config"
+	"github.com/talos-systems/talos/pkg/machinery/resources/config"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
+)
+
+// OperatorVIPConfigController manages network.OperatorSpec for virtual IPs based on machine configuration.
+type OperatorVIPConfigController struct {
+	Cmdline *procfs.Cmdline
+}
+
+// Name implements controller.Controller interface.
+func (ctrl *OperatorVIPConfigController) Name() string {
+	return "network.OperatorVIPConfigController"
+}
+
+// Inputs implements controller.Controller interface.
+func (ctrl *OperatorVIPConfigController) Inputs() []controller.Input {
+	return []controller.Input{
+		{
+			Namespace: config.NamespaceName,
+			Type:      config.MachineConfigType,
+			ID:        pointer.ToString(config.V1Alpha1ID),
+			Kind:      controller.InputWeak,
+		},
+	}
+}
+
+// Outputs implements controller.Controller interface.
+func (ctrl *OperatorVIPConfigController) Outputs() []controller.Output {
+	return []controller.Output{
+		{
+			Type: network.OperatorSpecType,
+			Kind: controller.OutputShared,
+		},
+	}
+}
+
+// Run implements controller.Controller interface.
+//
+//nolint:gocyclo,cyclop
+func (ctrl *OperatorVIPConfigController) Run(ctx context.Context, r controller.Runtime, logger *zap.Logger) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.EventCh():
+		}
+
+		touchedIDs := make(map[resource.ID]struct{})
+
+		var cfgProvider talosconfig.Provider
+
+		cfg, err := r.Get(ctx, resource.NewMetadata(config.NamespaceName, config.MachineConfigType, config.V1Alpha1ID, resource.VersionUndefined))
+		if err != nil {
+			if !state.IsNotFoundError(err) {
+				return fmt.Errorf("error getting config: %w", err)
+			}
+		} else {
+			cfgProvider = cfg.(*config.MachineConfig).Config()
+		}
+
+		ignoredInterfaces := map[string]struct{}{}
+
+		if ctrl.Cmdline != nil {
+			var settings CmdlineNetworking
+
+			settings, err = ParseCmdlineNetwork(ctrl.Cmdline)
+			if err != nil {
+				logger.Warn("ignored cmdline parse failure", zap.Error(err))
+			}
+
+			for _, link := range settings.IgnoreInterfaces {
+				ignoredInterfaces[link] = struct{}{}
+			}
+		}
+
+		var (
+			specs      []network.OperatorSpecSpec
+			specErrors *multierror.Error
+		)
+
+		// operators from the config
+		if cfgProvider != nil {
+			for _, device := range cfgProvider.Machine().Network().Devices() {
+				if device.Ignore() {
+					ignoredInterfaces[device.Interface()] = struct{}{}
+				}
+
+				if _, ignore := ignoredInterfaces[device.Interface()]; ignore {
+					continue
+				}
+
+				if device.VIPConfig() != nil {
+					if spec, specErr := handleVIP(ctx, device.VIPConfig(), device.Interface(), logger); specErr != nil {
+						specErrors = multierror.Append(specErrors, specErr)
+					} else {
+						specs = append(specs, spec)
+					}
+				}
+
+				for _, vlan := range device.Vlans() {
+					if vlan.VIPConfig() != nil {
+						linkName := fmt.Sprintf("%s.%d", device.Interface(), vlan.ID())
+						if spec, specErr := handleVIP(ctx, vlan.VIPConfig(), linkName, logger); specErr != nil {
+							specErrors = multierror.Append(specErrors, specErr)
+						} else {
+							specs = append(specs, spec)
+						}
+					}
+				}
+			}
+		}
+
+		var ids []string
+
+		ids, err = ctrl.apply(ctx, r, specs)
+		if err != nil {
+			return fmt.Errorf("error applying operator specs: %w", err)
+		}
+
+		for _, id := range ids {
+			touchedIDs[id] = struct{}{}
+		}
+
+		// list specs for cleanup
+		list, err := r.List(ctx, resource.NewMetadata(network.ConfigNamespaceName, network.OperatorSpecType, "", resource.VersionUndefined))
+		if err != nil {
+			return fmt.Errorf("error listing resources: %w", err)
+		}
+
+		for _, res := range list.Items {
+			if res.Metadata().Owner() != ctrl.Name() {
+				// skip specs created by other controllers
+				continue
+			}
+
+			if _, ok := touchedIDs[res.Metadata().ID()]; !ok {
+				if err = r.Destroy(ctx, res.Metadata()); err != nil {
+					return fmt.Errorf("error cleaning up routes: %w", err)
+				}
+			}
+		}
+
+		// last, check if some specs failed to build; fail last so that other operator specs are applied successfully
+		if err = specErrors.ErrorOrNil(); err != nil {
+			return err
+		}
+	}
+}
+
+//nolint:dupl
+func (ctrl *OperatorVIPConfigController) apply(ctx context.Context, r controller.Runtime, specs []network.OperatorSpecSpec) ([]resource.ID, error) {
+	ids := make([]string, 0, len(specs))
+
+	for _, spec := range specs {
+		spec := spec
+		id := network.LayeredID(spec.ConfigLayer, network.OperatorID(spec.Operator, spec.LinkName))
+
+		if err := r.Modify(
+			ctx,
+			network.NewOperatorSpec(network.ConfigNamespaceName, id),
+			func(r resource.Resource) error {
+				*r.(*network.OperatorSpec).TypedSpec() = spec
+
+				return nil
+			},
+		); err != nil {
+			return ids, err
+		}
+
+		ids = append(ids, id)
+	}
+
+	return ids, nil
+}
+
+func handleVIP(ctx context.Context, vlanConfig talosconfig.VIPConfig, deviceName string, logger *zap.Logger) (network.OperatorSpecSpec, error) {
+	var sharedIP netaddr.IP
+
+	sharedIP, err := netaddr.ParseIP(vlanConfig.IP())
+	if err != nil {
+		logger.Warn("ignoring vip parse failure", zap.Error(err), zap.String("link", deviceName))
+
+		return network.OperatorSpecSpec{}, err
+	}
+
+	spec := network.OperatorSpecSpec{
+		Operator:  network.OperatorVIP,
+		LinkName:  deviceName,
+		RequireUp: true,
+		VIP: network.VIPOperatorSpec{
+			IP:            sharedIP,
+			GratuitousARP: true,
+		},
+		ConfigLayer: network.ConfigMachineConfiguration,
+	}
+
+	switch {
+	// Equinix Metal VIP
+	case vlanConfig.EquinixMetal() != nil:
+		spec.VIP.GratuitousARP = false
+		spec.VIP.EquinixMetal.APIToken = vlanConfig.EquinixMetal().APIToken()
+
+		if err = vip.GetProjectAndDeviceIDs(ctx, &spec.VIP.EquinixMetal); err != nil {
+			return network.OperatorSpecSpec{}, err
+		}
+	// Hetzner Cloud VIP
+	case vlanConfig.HCloud() != nil:
+		spec.VIP.GratuitousARP = false
+		spec.VIP.HCloud.APIToken = vlanConfig.HCloud().APIToken()
+
+		if err = vip.GetNetworkAndDeviceIDs(ctx, &spec.VIP.HCloud, sharedIP); err != nil {
+			return network.OperatorSpecSpec{}, err
+		}
+	// Regular layer 2 VIP
+	default:
+	}
+
+	return spec, nil
+}

--- a/internal/app/machined/pkg/controllers/network/operator_vip_config_test.go
+++ b/internal/app/machined/pkg/controllers/network/operator_vip_config_test.go
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//nolint:dupl
+package network_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cosi-project/runtime/pkg/controller/runtime"
+	"github.com/cosi-project/runtime/pkg/resource"
+	"github.com/cosi-project/runtime/pkg/state"
+	"github.com/cosi-project/runtime/pkg/state/impl/inmem"
+	"github.com/cosi-project/runtime/pkg/state/impl/namespaced"
+	"github.com/stretchr/testify/suite"
+	"github.com/talos-systems/go-retry/retry"
+	"inet.af/netaddr"
+
+	netctrl "github.com/talos-systems/talos/internal/app/machined/pkg/controllers/network"
+	"github.com/talos-systems/talos/pkg/logging"
+	"github.com/talos-systems/talos/pkg/machinery/config/types/v1alpha1"
+	"github.com/talos-systems/talos/pkg/machinery/resources/config"
+	"github.com/talos-systems/talos/pkg/machinery/resources/network"
+)
+
+type OperatorVIPConfigSuite struct {
+	suite.Suite
+
+	state state.State
+
+	runtime *runtime.Runtime
+	wg      sync.WaitGroup
+
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+}
+
+func (suite *OperatorVIPConfigSuite) SetupTest() {
+	suite.ctx, suite.ctxCancel = context.WithTimeout(context.Background(), 3*time.Minute)
+
+	suite.state = state.WrapCore(namespaced.NewState(inmem.Build))
+
+	var err error
+
+	suite.runtime, err = runtime.NewRuntime(suite.state, logging.Wrap(log.Writer()))
+	suite.Require().NoError(err)
+}
+
+func (suite *OperatorVIPConfigSuite) startRuntime() {
+	suite.wg.Add(1)
+
+	go func() {
+		defer suite.wg.Done()
+
+		suite.Assert().NoError(suite.runtime.Run(suite.ctx))
+	}()
+}
+
+func (suite *OperatorVIPConfigSuite) assertOperators(requiredIDs []string, check func(*network.OperatorSpec) error) error {
+	missingIDs := make(map[string]struct{}, len(requiredIDs))
+
+	for _, id := range requiredIDs {
+		missingIDs[id] = struct{}{}
+	}
+
+	resources, err := suite.state.List(suite.ctx, resource.NewMetadata(network.ConfigNamespaceName, network.OperatorSpecType, "", resource.VersionUndefined))
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resources.Items {
+		_, required := missingIDs[res.Metadata().ID()]
+		if !required {
+			continue
+		}
+
+		delete(missingIDs, res.Metadata().ID())
+
+		if err = check(res.(*network.OperatorSpec)); err != nil {
+			return retry.ExpectedError(err)
+		}
+	}
+
+	if len(missingIDs) > 0 {
+		return retry.ExpectedError(fmt.Errorf("some resources are missing: %q", missingIDs))
+	}
+
+	return nil
+}
+
+func (suite *OperatorVIPConfigSuite) TestMachineConfigurationVIP() {
+	suite.Require().NoError(suite.runtime.RegisterController(&netctrl.OperatorVIPConfigController{}))
+
+	suite.startRuntime()
+
+	u, err := url.Parse("https://foo:6443")
+	suite.Require().NoError(err)
+
+	cfg := config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{
+			MachineNetwork: &v1alpha1.NetworkConfig{
+				NetworkInterfaces: []*v1alpha1.Device{
+					{
+						DeviceInterface: "eth1",
+						DeviceDHCP:      true,
+						DeviceVIPConfig: &v1alpha1.DeviceVIPConfig{
+							SharedIP: "2.3.4.5",
+						},
+					},
+					{
+						DeviceInterface: "eth2",
+						DeviceDHCP:      true,
+						DeviceVIPConfig: &v1alpha1.DeviceVIPConfig{
+							SharedIP: "fd7a:115c:a1e0:ab12:4843:cd96:6277:2302",
+						},
+					},
+					{
+						DeviceInterface: "eth3",
+						DeviceDHCP:      true,
+						DeviceVlans: []*v1alpha1.Vlan{
+							{
+								VlanID: 26,
+								VlanVIP: &v1alpha1.DeviceVIPConfig{
+									SharedIP: "5.5.4.4",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		ClusterConfig: &v1alpha1.ClusterConfig{
+			ControlPlane: &v1alpha1.ControlPlaneConfig{
+				Endpoint: &v1alpha1.Endpoint{
+					URL: u,
+				},
+			},
+		},
+	})
+
+	suite.Require().NoError(suite.state.Create(suite.ctx, cfg))
+
+	suite.Assert().NoError(retry.Constant(3*time.Second, retry.WithUnits(100*time.Millisecond)).Retry(
+		func() error {
+			return suite.assertOperators([]string{
+				"configuration/vip/eth1",
+				"configuration/vip/eth2",
+				"configuration/vip/eth3.26",
+			}, func(r *network.OperatorSpec) error {
+				suite.Assert().Equal(network.OperatorVIP, r.TypedSpec().Operator)
+				suite.Assert().True(r.TypedSpec().RequireUp)
+
+				switch r.Metadata().ID() {
+				case "configuration/vip/eth1":
+					suite.Assert().Equal("eth1", r.TypedSpec().LinkName)
+					suite.Assert().EqualValues(netaddr.MustParseIP("2.3.4.5"), r.TypedSpec().VIP.IP)
+				case "configuration/vip/eth2":
+					suite.Assert().Equal("eth2", r.TypedSpec().LinkName)
+					suite.Assert().EqualValues(netaddr.MustParseIP("fd7a:115c:a1e0:ab12:4843:cd96:6277:2302"), r.TypedSpec().VIP.IP)
+				case "configuration/vip/eth3.26":
+					suite.Assert().Equal("eth3.26", r.TypedSpec().LinkName)
+					suite.Assert().EqualValues(netaddr.MustParseIP("5.5.4.4"), r.TypedSpec().VIP.IP)
+				}
+
+				return nil
+			})
+		}))
+}
+
+func (suite *OperatorVIPConfigSuite) TearDownTest() {
+	suite.T().Log("tear down")
+
+	suite.ctxCancel()
+
+	suite.wg.Wait()
+
+	// trigger updates in resources to stop watch loops
+	err := suite.state.Create(context.Background(), config.NewMachineConfig(&v1alpha1.Config{
+		ConfigVersion: "v1alpha1",
+		MachineConfig: &v1alpha1.MachineConfig{},
+	}))
+	if state.IsConflictError(err) {
+		err = suite.state.Destroy(context.Background(), config.NewMachineConfig(nil).Metadata())
+	}
+
+	suite.Require().NoError(err)
+
+	suite.Assert().NoError(suite.state.Create(context.Background(), network.NewLinkStatus(network.ConfigNamespaceName, "bar")))
+}
+
+func TestOperatorVIPConfigSuite(t *testing.T) {
+	suite.Run(t, new(OperatorVIPConfigSuite))
+}

--- a/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
+++ b/internal/app/machined/pkg/runtime/v1alpha2/v1alpha2_controller.go
@@ -165,6 +165,9 @@ func (ctrl *Controller) Run(ctx context.Context, drainer *runtime.Drainer) error
 			V1alpha1Platform: ctrl.v1alpha1Runtime.State().Platform(),
 			State:            ctrl.v1alpha1Runtime.State().V1Alpha2().Resources(),
 		},
+		&network.OperatorVIPConfigController{
+			Cmdline: procfs.ProcCmdline(),
+		},
 		&network.PlatformConfigController{
 			V1alpha1Platform: ctrl.v1alpha1Runtime.State().Platform(),
 		},


### PR DESCRIPTION
The problem is that Virtual IP operator configuration might require
accessing platform metadata server (e.g. on Equinix Metal), while
regular operator sets up critical operators like DHCP.

The issue observed on Equinix Metal without the split:

* on initial boot, DHCP is set up on `eth2`
* platform network configuration is fetched and `bond0` configuration is
created
* node IP is assigned both to `eth2` and `bond0`, while `eth2` is a
slave to `bond0`
* networking is broken
* operator config controller is stuck trying to fetch EM VIP
configuration, as the network is broken, it fails to do so, but retries
for 3 minutes (in `download.Download`)
* network is broken for 3 minutes until `OperatorConfig` controller is
unblocked and cleans up DHCP operator for `eth2` as it should

The issue here is that DHCP operator setup is much more tricky on one
hand (depends on link status, other configuration items, etc.), while
VIP operator depends on DHCP operator setup, as it needs outbound
networking.

By splitting the controllers, we split the flows and remove
dependencies.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5144)
<!-- Reviewable:end -->
