### PR TITLE
fix: ignore pod CIDRs for kubelet node IPs

### DIFF
--- a/internal/app/machined/pkg/controllers/k8s/nodeip_config.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_config.go
@@ -89,6 +89,15 @@ func (ctrl *NodeIPConfigController) Run(ctx context.Context, r controller.Runtim
 
 				spec.ExcludeSubnets = nil
 
+				// filter out Pod & Service CIDRs, they can't be kubelet IPs
+				spec.ExcludeSubnets = append(
+					append(
+						spec.ExcludeSubnets,
+						cfgProvider.Cluster().Network().PodCIDRs()...,
+					),
+					cfgProvider.Cluster().Network().ServiceCIDRs()...,
+				)
+
 				// filter out any virtual IPs, they can't be node IPs either
 				for _, device := range cfgProvider.Machine().Network().Devices() {
 					if device.VIPConfig() != nil {

--- a/internal/app/machined/pkg/controllers/k8s/nodeip_config_test.go
+++ b/internal/app/machined/pkg/controllers/k8s/nodeip_config_test.go
@@ -125,7 +125,7 @@ func (suite *NodeIPConfigSuite) TestReconcileWithSubnets() {
 			spec := NodeIPConfig.(*k8s.NodeIPConfig).TypedSpec()
 
 			suite.Assert().Equal([]string{"10.0.0.0/24"}, spec.ValidSubnets)
-			suite.Assert().Equal([]string{"1.2.3.4", "5.6.7.8"}, spec.ExcludeSubnets)
+			suite.Assert().Equal([]string{"10.244.0.0/16", "10.96.0.0/12", "1.2.3.4", "5.6.7.8"}, spec.ExcludeSubnets)
 
 			return nil
 		},
@@ -168,7 +168,7 @@ func (suite *NodeIPConfigSuite) TestReconcileDefaults() {
 			spec := NodeIPConfig.(*k8s.NodeIPConfig).TypedSpec()
 
 			suite.Assert().Equal([]string{"0.0.0.0/0", "::/0"}, spec.ValidSubnets)
-			suite.Assert().Empty(spec.ExcludeSubnets)
+			suite.Assert().Equal([]string{"10.244.0.0/16", "fc00:db8:10::/56", "10.96.0.0/12", "fc00:db8:20::/112"}, spec.ExcludeSubnets)
 
 			return nil
 		},


### PR DESCRIPTION
I'm not sure how I haven't noticed that before, but that is easily
reproducible with virtual IP moving between the nodes: Talos incorrectly
assumes that pod IPs might be valid kubelet node IPs, and this might
lead to unexpected results if the kubelet node IP is picked to be equal
to pod CIDR.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5145)
<!-- Reviewable:end -->
