### PR TITLE
fix: ignore connection reset errors on k8s upgrade

### DIFF
--- a/pkg/kubernetes/errors.go
+++ b/pkg/kubernetes/errors.go
@@ -19,8 +19,10 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
-	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNREFUSED) {
-		return true
+	for _, retryableError := range []error{io.EOF, io.ErrUnexpectedEOF, syscall.ECONNREFUSED, syscall.ECONNRESET} {
+		if errors.Is(err, retryableError) {
+			return true
+		}
 	}
 
 	var netErr net.Error


### PR DESCRIPTION
This fixes `talosctl upgrade-k8s`:

```
Get "https://172.21.0.1:6443/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app+%3D+kube-apiserver": read tcp 172.21.0.1:51416->172.21.0.1:6443: read: connection reset by peer
```

The error happens when the `kube-apiserver` is restarted during the
control plane upgrade, and it should be ignored as a transient error.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5146)
<!-- Reviewable:end -->
