### PR TITLE
feat: allow hardlinks in the system extension images

### DIFF
--- a/internal/pkg/extensions/validate.go
+++ b/internal/pkg/extensions/validate.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	hashiversion "github.com/hashicorp/go-version"
 
@@ -68,18 +67,6 @@ func (ext *Extension) validateContents() error {
 		// check for -------w-
 		if d.Type().Perm()&0o002 > 0 {
 			return fmt.Errorf("world-writeable files are not allowed: %q", itemPath)
-		}
-
-		var st fs.FileInfo
-
-		st, err = d.Info()
-		if err != nil {
-			return err
-		}
-
-		// no hardlinks
-		if !d.IsDir() && st.Sys().(*syscall.Stat_t).Nlink > 1 {
-			return fmt.Errorf("hardlinks are not allowed: %q", itemPath)
 		}
 
 		// no special files


### PR DESCRIPTION
They should cause no harm as every extension as an image on its own, so
hardlinks are only available between the files in one image only.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5162)
<!-- Reviewable:end -->
