### PR TITLE
fix: clean up custom udev rules if the config is cleared

### DIFF
--- a/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
+++ b/internal/app/machined/pkg/runtime/v1alpha1/v1alpha1_sequencer_tasks.go
@@ -633,10 +633,6 @@ func WriteUdevRules(seq runtime.Sequence, data interface{}) (runtime.TaskExecuti
 	return func(ctx context.Context, logger *log.Logger, r runtime.Runtime) (err error) {
 		rules := r.Config().Machine().Udev().Rules()
 
-		if len(rules) == 0 {
-			return nil
-		}
-
 		var content strings.Builder
 
 		for _, rule := range rules {


### PR DESCRIPTION
This fixes a case when udev rules are first created in the machine
config and then removed from the config.

As the file is on the overlayfs, it persists over reboots, so we need to
write it every time we boot Talos.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5163)
<!-- Reviewable:end -->
