### PR TITLE
fix: trigger properly `udevd` on types and actions

### DIFF
--- a/internal/app/machined/pkg/system/services/udevd.go
+++ b/internal/app/machined/pkg/system/services/udevd.go
@@ -89,7 +89,11 @@ func (c *Udevd) Runner(r runtime.Runtime) (runner.Runner, error) {
 func (c *Udevd) HealthFunc(runtime.Runtime) health.Check {
 	return func(ctx context.Context) error {
 		if !c.triggered {
-			if _, err := cmd.RunContext(ctx, "/sbin/udevadm", "trigger"); err != nil {
+			if _, err := cmd.RunContext(ctx, "/sbin/udevadm", "trigger", "--type=devices", "--action=add"); err != nil {
+				return err
+			}
+
+			if _, err := cmd.RunContext(ctx, "/sbin/udevadm", "trigger", "--type=subsystems", "--action=add"); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
Default `--type` is `devices`, so trigger explicitly on both `devices`
and `subsystems` and use `add` action to mock initial events better.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/talos-systems/talos/5165)
<!-- Reviewable:end -->
